### PR TITLE
make tests more independent from specific bot and its token

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -17,6 +17,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `macrojames <https://github.com/macrojames>`_
 - `njittam <https://github.com/njittam>`_
 - `Rahiel Kasim <https://github.com/rahiel>`_
+- `Roman Vetrov <https://github.com/rvetrov>`_
 - `sooyhwang <https://github.com/sooyhwang>`_
 - `wjt <https://github.com/wjt>`_
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -26,6 +26,19 @@ import json
 import telegram
 
 
+def specific_bot_required(test_function):
+    local_test = os.environ.get('LOCAL_TEST')
+
+    def wrapper(*args, **kwargs):
+        if local_test:
+            print('Skip test "%s" since it requires specific bot token' % test_function.__name__)
+            return
+        else:
+            test_function(*args, **kwargs)
+
+    return wrapper
+
+
 class BaseTest(object):
     """This object represents a Base test and its sets of functions."""
 

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -107,6 +107,24 @@ class AudioTest(BaseTest, unittest.TestCase):
         self.assertEqual(audio.mime_type, self.mime_type)
         self.assertEqual(audio.file_size, self.file_size)
 
+        print('Testing bot.sendAudio - Resend by file_id')
+
+        file_id = audio.file_id
+        message = self._bot.sendAudio(chat_id=self._chat_id,
+                                      audio=file_id,
+                                      duration=self.duration,
+                                      performer=self.performer,
+                                      title=self.title)
+
+        audio = message.audio
+
+        self.assertEqual(audio.file_id, file_id)
+        self.assertEqual(audio.duration, self.duration)
+        self.assertEqual(audio.performer, self.performer)
+        self.assertEqual(audio.title, self.title)
+        self.assertEqual(audio.mime_type, self.mime_type)
+        self.assertEqual(audio.file_size, self.file_size)
+
     def test_send_audio_mp3_file_custom_filename(self):
         """Test telegram.Bot sendAudio method"""
         print('Testing bot.sendAudio - MP3 File with custom filename')
@@ -127,24 +145,6 @@ class AudioTest(BaseTest, unittest.TestCase):
         self.assertEqual(audio.title, self.title)
         self.assertEqual(audio.mime_type, self.mime_type)
         self.assertEqual(audio.file_size, self.file_size)
-
-    def test_send_audio_resend(self):
-        """Test telegram.Bot sendAudio method"""
-        print('Testing bot.sendAudio - Resend by file_id')
-
-        message = self._bot.sendAudio(chat_id=self._chat_id,
-                                      audio=self.audio_file_id,
-                                      duration=self.duration,
-                                      performer=self.performer,
-                                      title=self.title)
-
-        audio = message.audio
-
-        self.assertEqual(audio.file_id, self.audio_file_id)
-        self.assertEqual(audio.duration, self.duration)
-        self.assertEqual(audio.performer, self.performer)
-        self.assertEqual(audio.title, self.title)
-        self.assertEqual(audio.mime_type, self.mime_type)
 
     def test_audio_de_json(self):
         """Test Audio.de_json() method"""

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -19,19 +19,19 @@
 
 """This module contains a object that represents Tests for Telegram Bot"""
 
-import os
 import unittest
 from datetime import datetime
 import sys
 sys.path.append('.')
 
 import telegram
-from tests.base import BaseTest
+from tests.base import BaseTest, specific_bot_required
 
 
 class BotTest(BaseTest, unittest.TestCase):
     """This object represents Tests for Telegram Bot."""
 
+    @specific_bot_required
     def testGetMe(self):
         '''Test the telegram.Bot getMe method'''
         print('Testing getMe')
@@ -45,7 +45,7 @@ class BotTest(BaseTest, unittest.TestCase):
         self.assertEqual(bot.name, '@PythonTelegramBot')
 
     def testSendMessage(self):
-        '''Test the telegram.Bot sendMessage method'''
+        '''Test the telegram.Bot sendMessage and forwardMessage methods'''
         print('Testing sendMessage')
         message = self._bot.sendMessage(chat_id=self._chat_id,
                                         text='Моё судно на воздушной подушке полно угрей')
@@ -53,6 +53,17 @@ class BotTest(BaseTest, unittest.TestCase):
         self.assertTrue(self.is_json(message.to_json()))
         self.assertEqual(message.text, u'Моё судно на воздушной подушке полно угрей')
         self.assertTrue(isinstance(message.date, datetime))
+
+        print('Testing forwardMessage')
+        message_id = message.message_id
+        message = self._bot.forwardMessage(chat_id=self._chat_id,
+                                           from_chat_id=self._chat_id,
+                                           message_id=message_id)
+
+        self.assertTrue(self.is_json(message.to_json()))
+        self.assertEqual(message.text, u'Моё судно на воздушной подушке полно угрей')
+        self.assertEqual(message.forward_from.username, self._bot.username)
+        self.assertTrue(isinstance(message.forward_date, datetime))
 
     def testGetUpdates(self):
         '''Test the telegram.Bot getUpdates method'''
@@ -62,18 +73,6 @@ class BotTest(BaseTest, unittest.TestCase):
         if updates:
             self.assertTrue(self.is_json(updates[0].to_json()))
             self.assertTrue(isinstance(updates[0], telegram.Update))
-
-    def testForwardMessage(self):
-        '''Test the telegram.Bot forwardMessage method'''
-        print('Testing forwardMessage')
-        message = self._bot.forwardMessage(chat_id=self._chat_id,
-                                           from_chat_id=self._chat_id,
-                                           message_id=2398)
-
-        self.assertTrue(self.is_json(message.to_json()))
-        self.assertEqual(message.text, 'teste')
-        self.assertEqual(message.forward_from.username, 'leandrotoledo')
-        self.assertTrue(isinstance(message.forward_date, datetime))
 
     def testSendPhoto(self):
         '''Test the telegram.Bot sendPhoto method'''
@@ -86,14 +85,13 @@ class BotTest(BaseTest, unittest.TestCase):
         self.assertEqual(message.photo[0].file_size, 1451)
         self.assertEqual(message.caption, 'testSendPhoto')
 
-    def testResendPhoto(self):
-        '''Test the telegram.Bot sendPhoto method'''
         print('Testing sendPhoto - Resend')
-        message = self._bot.sendPhoto(photo='AgADAQADyKcxGx8j9Qdp6d-gpUsw4Gja1i8ABEVJsVqQk8LfJ3wAAgI',
+        photo_id = message.photo[0].file_id
+        message = self._bot.sendPhoto(photo=photo_id,
                                       chat_id=self._chat_id)
 
         self.assertTrue(self.is_json(message.to_json()))
-        self.assertEqual(message.photo[0].file_id, 'AgADAQADyKcxGx8j9Qdp6d-gpUsw4Gja1i8ABEVJsVqQk8LfJ3wAAgI')
+        self.assertEqual(message.photo[0].file_id, photo_id)
 
     def testSendJPGURLPhoto(self):
         '''Test the telegram.Bot sendPhoto method'''
@@ -129,6 +127,7 @@ class BotTest(BaseTest, unittest.TestCase):
         self._bot.sendChatAction(action=telegram.ChatAction.TYPING,
                                  chat_id=self._chat_id)
 
+    @specific_bot_required
     def testGetUserProfilePhotos(self):
         '''Test the telegram.Bot getUserProfilePhotos method'''
         print('Testing getUserProfilePhotos')

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -66,6 +66,19 @@ class DocumentTest(BaseTest, unittest.TestCase):
         self.assertEqual(document.mime_type, self.mime_type)
         self.assertEqual(document.file_size, self.file_size)
 
+        print('Testing bot.sendDocument - Resend by file_id')
+        document_file_id = document.file_id
+
+        message = self._bot.sendDocument(chat_id=self._chat_id,
+                                         document=document_file_id)
+
+        document = message.document
+
+        self.assertEqual(document.file_id, document_file_id)
+        self.assertTrue(isinstance(document.thumb, telegram.PhotoSize))
+        self.assertEqual(document.file_name, self.file_name)
+        self.assertEqual(document.mime_type, self.mime_type)
+
     def test_send_document_png_file_with_custom_file_name(self):
         """Test telegram.Bot sendDocument method"""
         print('Testing bot.sendDocument - PNG File with custom filename')
@@ -98,20 +111,6 @@ class DocumentTest(BaseTest, unittest.TestCase):
         self.assertEqual(document.file_name, 'image.gif')
         self.assertEqual(document.mime_type, 'image/gif')
         self.assertEqual(document.file_size, 3878)
-
-    def test_send_document_resend(self):
-        """Test telegram.Bot sendDocument method"""
-        print('Testing bot.sendDocument - Resend by file_id')
-
-        message = self._bot.sendDocument(chat_id=self._chat_id,
-                                         document=self.document_file_id)
-
-        document = message.document
-
-        self.assertEqual(document.file_id, self.document_file_id)
-        self.assertTrue(isinstance(document.thumb, telegram.PhotoSize))
-        self.assertEqual(document.file_name, self.file_name)
-        self.assertEqual(document.mime_type, self.mime_type)
 
     def test_document_de_json(self):
         """Test Document.de_json() method"""

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -24,7 +24,7 @@ import sys
 sys.path.append('.')
 
 import telegram
-from tests.base import BaseTest
+from tests.base import BaseTest, specific_bot_required
 
 
 class FileTest(BaseTest, unittest.TestCase):
@@ -44,6 +44,7 @@ class FileTest(BaseTest, unittest.TestCase):
             'file_size': 28232
         }
 
+    @specific_bot_required
     def test_get_and_download_file_audio(self):
         """Test telegram.Bot getFile method - Audio"""
         print('Testing bot.getFile - With Audio.file_id')
@@ -58,6 +59,7 @@ class FileTest(BaseTest, unittest.TestCase):
 
         self.assertTrue(os.path.isfile('telegram.mp3'))
 
+    @specific_bot_required
     def test_get_and_download_file_document(self):
         """Test telegram.Bot getFile method - Document"""
         print('Testing bot.getFile - With Document.file_id')
@@ -72,6 +74,7 @@ class FileTest(BaseTest, unittest.TestCase):
 
         self.assertTrue(os.path.isfile('telegram.png'))
 
+    @specific_bot_required
     def test_get_and_download_file_sticker(self):
         """Test telegram.Bot getFile method - Sticker"""
         print('Testing bot.getFile - With Sticker.file_id')
@@ -86,6 +89,7 @@ class FileTest(BaseTest, unittest.TestCase):
 
         self.assertTrue(os.path.isfile('telegram.webp'))
 
+    @specific_bot_required
     def test_get_and_download_file_video(self):
         """Test telegram.Bot getFile method - Video"""
         print('Testing bot.getFile - With Video.file_id')
@@ -100,6 +104,7 @@ class FileTest(BaseTest, unittest.TestCase):
 
         self.assertTrue(os.path.isfile('telegram.mp4'))
 
+    @specific_bot_required
     def test_get_and_download_file_voice(self):
         """Test telegram.Bot getFile method - Voice"""
         print('Testing bot.getFile - With Voice.file_id')

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -24,7 +24,7 @@ import sys
 sys.path.append('.')
 
 import telegram
-from tests.base import BaseTest
+from tests.base import BaseTest, specific_bot_required
 
 
 class VideoTest(BaseTest, unittest.TestCase):
@@ -138,6 +138,7 @@ class VideoTest(BaseTest, unittest.TestCase):
 
         self.assertEqual(message.caption, self.caption)
 
+    @specific_bot_required
     def test_send_video_resend(self):
         """Test telegram.Bot sendVideo method"""
         print('Testing bot.sendVideo - Resend by file_id')

--- a/tests/test_voice.py
+++ b/tests/test_voice.py
@@ -24,7 +24,7 @@ import sys
 sys.path.append('.')
 
 import telegram
-from tests.base import BaseTest
+from tests.base import BaseTest, specific_bot_required
 
 
 class VoiceTest(BaseTest, unittest.TestCase):
@@ -110,6 +110,7 @@ class VoiceTest(BaseTest, unittest.TestCase):
         self.assertEqual(voice.mime_type, self.mime_type)
         self.assertEqual(voice.file_size, self.file_size)
 
+    @specific_bot_required
     def test_send_voice_resend(self):
         """Test telegram.Bot sendVoice method"""
         print('Testing bot.sendVoice - Resend by file_id')


### PR DESCRIPTION
- merge some tests 
- for those tests that are strong related to PythonTelegramBot and its resources: do not perform them when LOCAL_TEST environmental variable is set

Now every contributor can run tests locally using their bots.
May be it will be usefull to add some tips about running tests to the help.

Fix for  #16