### PR TITLE
declare support for python 3.5, drop old py 3.2 reference

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
   - "pypy"
   - "pypy3"
 install:

--- a/README.rst
+++ b/README.rst
@@ -121,6 +121,7 @@ Python Version *Supported?*
 2.7            Yes
 3.3            Yes
 3.4            Yes
+3.5            Yes
 PyPy           Yes
 PyPy3          Yes
 ============== ============

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,8 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
 )


### PR DESCRIPTION
We weren't testing python 3.2, and it was declared end-of-life on [2016-02-20](https://docs.python.org/devguide/#status-of-python-branches). This adds testing for 3.5.