### PR TITLE
request: catch socket.error

### DIFF
--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -106,6 +106,9 @@ def _try_except_req(func):
         except HTTPException as error:
             raise NetworkError('HTTPException: {0!r}'.format(error))
 
+        except socket.error as error:
+            raise NetworkError('socket.error: {0!r}'.format(error))
+
     return decorator
 
 


### PR DESCRIPTION
socket.error is another exception which is thrown by the underlying
infrastacture and not handled by the urllib2 or httplib layers

fixes #236