### PR TITLE
release semaphore on exceptions

### DIFF
--- a/telegram/ext/dispatcher.py
+++ b/telegram/ext/dispatcher.py
@@ -61,10 +61,13 @@ def run_async(func):
         """
         A wrapper to run a thread in a thread pool
         """
-        result = func(*pargs, **kwargs)
-        semaphore.release()
-        with async_lock:
-            async_threads.remove(current_thread())
+        try:
+            result = func(*pargs, **kwargs)
+        finally:
+            semaphore.release()
+
+            with async_lock:
+                async_threads.remove(current_thread())
         return result
 
     @wraps(func)


### PR DESCRIPTION
If an exception was raised in a handler running with `@run_async`, it would not release the semaphore.