### PR TITLE
getUpdates: fix timeout default and semantics

### DIFF
--- a/telegram/utils/deprecate.py
+++ b/telegram/utils/deprecate.py
@@ -29,3 +29,19 @@ def deprecate(func, old, new):
         return func(*args, **kwargs)
 
     return f
+
+
+def deprecate_network_delay(timeout, total_timeout, **kwargs):
+    if 'network_delay' in kwargs:
+        warnings.warn('start_polling(): network_delay is being deprecated, please use '
+                      'total_timeout from now on')
+        if timeout is not None:
+            network_delay = kwargs['network_delay']
+            if network_delay is not None:
+                total_timeout = timeout + network_delay
+            else:
+                warnings.warn('start_polling(): network_delay is ignored becuase it is None')
+        else:
+            warnings.warn('start_polling(): network_delay is ignored because timeout is None')
+
+    return total_timeout

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -637,7 +637,7 @@ class MockBot(object):
             self.bootstrap_attempts += 1
             raise self.bootstrap_err
 
-    def getUpdates(self, offset=None, limit=100, timeout=0, network_delay=2.):
+    def getUpdates(self, offset=None, limit=100, timeout=0, total_timeout=None):
 
         if self.raise_error:
             raise TelegramError('Test Error 2')


### PR DESCRIPTION
getUpdates() is a special method and REST RPC. Telegram servers allow a
special keyword 'timeout' to specify a timeout for the call in their
servers.
However, a bot developer should also take into account more parameters
like the network latency, and momentary slow SSL handshake with the
telegram server.

In addition, we have (unfortunately) confused the naive user by hiding
these parameters from him, trying unsuccesfully to make magic under the
hood.

So this commit brings back control and simplicity to the user by keeping
a much cleaner & closer semantics to the underlying layers:
1. timeout == telegram timeout on the REST RPC
2. total_timeout == timeout passed to urlopen. should include telegram
                    timeout and all other variables

fixes #309