### PR TITLE
ChatMigrated exception

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -22,6 +22,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `njittam <https://github.com/njittam>`_
 - `Noam Meltzer <https://github.com/tsnoam>`_
 - `Oleg Shlyazhko <https://github.com/ollmer>`_
+- `overquota <https://github.com/overquota>`_
 - `Rahiel Kasim <https://github.com/rahiel>`_
 - `Shelomentsev D <https://github.com/shelomentsevd>`_
 - `sooyhwang <https://github.com/sooyhwang>`_

--- a/telegram/error.py
+++ b/telegram/error.py
@@ -97,5 +97,5 @@ class ChatMigrated(TelegramError):
         Returns:
 
         """
-        super(ChatMigrated, self).__init__('Chat migrated to {0}'.format(new_chat_id))
+        super(ChatMigrated, self).__init__('Chat migrated')
         self.new_chat_id = new_chat_id

--- a/telegram/error.py
+++ b/telegram/error.py
@@ -97,5 +97,5 @@ class ChatMigrated(TelegramError):
         Returns:
 
         """
-        super(ChatMigrated, self).__init__('Chat migrated to {}'.format(new_chat_id))
+        super(ChatMigrated, self).__init__('Chat migrated to {0}'.format(new_chat_id))
         self.new_chat_id = new_chat_id

--- a/telegram/error.py
+++ b/telegram/error.py
@@ -39,13 +39,10 @@ def _lstrip_str(in_s, lstr):
 class TelegramError(Exception):
     """This object represents a Telegram Error."""
 
-    def __init__(self, message, **kwargs):
+    def __init__(self, message):
         """
         Args:
             message (str):
-
-        Kwargs:
-            chat_id (int):
 
         Returns:
 
@@ -59,7 +56,6 @@ class TelegramError(Exception):
             # api_error - capitalize the msg...
             msg = msg.capitalize()
         self.message = msg
-        self.chat_id = kwargs.get('chat_id')
 
     def __str__(self):
         return '%s' % (self.message)
@@ -92,4 +88,14 @@ class TimedOut(NetworkError):
 
 
 class ChatMigrated(TelegramError):
-    pass
+
+    def __init__(self, new_chat_id):
+        """
+        Args:
+            new_chat_id (int):
+
+        Returns:
+
+        """
+        super(ChatMigrated, self).__init__('Chat migrated to {}'.format(new_chat_id))
+        self.new_chat_id = new_chat_id

--- a/telegram/error.py
+++ b/telegram/error.py
@@ -39,10 +39,13 @@ def _lstrip_str(in_s, lstr):
 class TelegramError(Exception):
     """This object represents a Telegram Error."""
 
-    def __init__(self, message):
+    def __init__(self, message, **kwargs):
         """
         Args:
             message (str):
+
+        Kwargs:
+            chat_id (int):
 
         Returns:
 
@@ -56,6 +59,7 @@ class TelegramError(Exception):
             # api_error - capitalize the msg...
             msg = msg.capitalize()
         self.message = msg
+        self.chat_id = kwargs.get('chat_id')
 
     def __str__(self):
         return '%s' % (self.message)
@@ -85,6 +89,7 @@ class TimedOut(NetworkError):
 
     def __init__(self):
         super(TimedOut, self).__init__('Timed out')
+
 
 class ChatMigrated(TelegramError):
     pass

--- a/telegram/error.py
+++ b/telegram/error.py
@@ -85,3 +85,6 @@ class TimedOut(NetworkError):
 
     def __init__(self):
         super(TimedOut, self).__init__('Timed out')
+
+class ChatMigrated(TelegramError):
+    pass

--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -138,13 +138,12 @@ def _parse(json_data):
     if not data.get('ok'):
         description = data.get('description')
         parameters = data.get('parameters')
+        if parameters:
+            migrate_to_chat_id = parameters.get('migrate_to_chat_id')
+            if migrate_to_chat_id:
+                raise ChatMigrated(migrate_to_chat_id)
         if description:
-            if parameters:
-                migrate_to_chat_id = parameters.get('migrate_to_chat_id')
-                if migrate_to_chat_id:
-                    raise ChatMigrated(description, chat_id=int(migrate_to_chat_id))
-            else:
-                return description
+            return description
 
     return data['result']
 

--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -136,12 +136,18 @@ def _parse(json_data):
         raise TelegramError('Invalid server response')
 
     if not data.get('ok'):
-        if data.get('parameters') and data['parameters'].get('migrate_to_chat_id'):
-            raise ChatMigrated(str(data['parameters']['migrate_to_chat_id']))
-        if data.get('description'):
-            return data['description']
+        description = data.get('description')
+        parameters = data.get('parameters')
+        if description:
+            if parameters:
+                migrate_to_chat_id = parameters.get('migrate_to_chat_id')
+                if migrate_to_chat_id:
+                    raise ChatMigrated(description, chat_id=int(migrate_to_chat_id))
+            else:
+                return description
 
     return data['result']
+
 
 def _request_wrapper(*args, **kwargs):
     """Wraps urllib3 request for handling known exceptions.

--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -135,11 +135,13 @@ def _parse(json_data):
     except ValueError:
         raise TelegramError('Invalid server response')
 
-    if not data.get('ok') and data.get('description'):
-        return data['description']
+    if not data.get('ok'):
+        if data.get('parameters') and data['parameters'].get('migrate_to_chat_id'):
+            raise ChatMigrated(str(data['parameters']['migrate_to_chat_id']))
+        if data.get('description'):
+            return data['description']
 
     return data['result']
-
 
 def _request_wrapper(*args, **kwargs):
     """Wraps urllib3 request for handling known exceptions.

--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -28,7 +28,7 @@ import urllib3
 from urllib3.connection import HTTPConnection
 
 from telegram import (InputFile, TelegramError)
-from telegram.error import Unauthorized, NetworkError, TimedOut, BadRequest
+from telegram.error import Unauthorized, NetworkError, TimedOut, BadRequest, ChatMigrated
 
 _CON_POOL = None
 """:type: urllib3.PoolManager"""


### PR DESCRIPTION
When converting telegram group (OLD_CHAT_ID) to supergroup (NEW_CHAT_ID), chat id changes
After this, when trying to post message to OLD_CHAT_ID, Telegram API returns error with message:
{u'error_code': 400, u'ok': False, u'description': u'Bad Request: group chat is migrated to a supergroup chat', u'parameters': {u'migrate_to_chat_id': NEW_CHAT_ID}}

So this pull requests creates new exception ChatMigrated which returns NEW_CHAT_ID
With this functionality we can postpone fix our inconsistency data in database when user converts group to supergroup and we cannot update this info in database at the same time (eg datacenter failed or network lag)

Sorry for my English :)