### PR TITLE
More regex handlers

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,6 +13,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `bimmlerd <https://github.com/bimmlerd>`_
 - `ErgoZ Riftbit Vaper <https://github.com/ergoz>`_
 - `franciscod <https://github.com/franciscod>`_
+- `Jacob Bom <https://github.com/bomjacob>`_
 - `JASON0916 <https://github.com/JASON0916>`_
 - `jh0ker <https://github.com/jh0ker>`_
 - `JRoot3D <https://github.com/JRoot3D>`_

--- a/telegram/ext/callbackqueryhandler.py
+++ b/telegram/ext/callbackqueryhandler.py
@@ -29,7 +29,8 @@ from .handler import Handler
 
 class CallbackQueryHandler(Handler):
     """
-    Handler class to handle Telegram callback queries. Optionally based on a regex. Read the documentation of the ``re`` module for more information.
+    Handler class to handle Telegram callback queries. Optionally based on a regex.
+    Read the documentation of the ``re`` module for more information.
 
     Args:
         callback (function): A function that takes ``bot, update`` as
@@ -43,7 +44,8 @@ class CallbackQueryHandler(Handler):
             ``job_queue`` will be passed to the callback function. It will be a ``JobQueue``
             instance created by the ``Updater`` which can be used to schedule new jobs.
             Default is ``False``.
-        pattern (optional[str or Pattern]): Optional regex pattern. If not ``None`` The ``re.match`` function is used to determine if an update should be handled by this handler.
+        pattern (optional[str or Pattern]): Optional regex pattern. If not ``None`` ``re.match``
+            is used to determine if an update should be handled by this handler.
         pass_groups (optional[bool]): If the callback should be passed the
             result of ``re.match(pattern, data).groups()`` as a keyword
             argument called ``groups``. Default is ``False``

--- a/telegram/ext/callbackqueryhandler.py
+++ b/telegram/ext/callbackqueryhandler.py
@@ -18,14 +18,18 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """ This module contains the CallbackQueryHandler class """
 
-from .handler import Handler
+import re
+
+from future.utils import string_types
+
 from telegram import Update
 from telegram.utils.deprecate import deprecate
+from .handler import Handler
 
 
 class CallbackQueryHandler(Handler):
     """
-    Handler class to handle Telegram callback queries.
+    Handler class to handle Telegram callback queries. Optionally based on a regex. Read the documentation of the ``re`` module for more information.
 
     Args:
         callback (function): A function that takes ``bot, update`` as
@@ -39,22 +43,56 @@ class CallbackQueryHandler(Handler):
             ``job_queue`` will be passed to the callback function. It will be a ``JobQueue``
             instance created by the ``Updater`` which can be used to schedule new jobs.
             Default is ``False``.
+        pattern (optional[str or Pattern]): Optional regex pattern. If not ``None`` The ``re.match`` function is used to determine if an update should be handled by this handler.
+        pass_groups (optional[bool]): If the callback should be passed the
+            result of ``re.match(pattern, data).groups()`` as a keyword
+            argument called ``groups``. Default is ``False``
+        pass_groupdict (optional[bool]): If the callback should be passed the
+            result of ``re.match(pattern, data).groupdict()`` as a keyword
+            argument called ``groupdict``. Default is ``False``
     """
 
-    def __init__(self, callback, pass_update_queue=False, pass_job_queue=False):
+    def __init__(self,
+                 callback,
+                 pass_update_queue=False,
+                 pass_job_queue=False,
+                 pattern=None,
+                 pass_groups=False,
+                 pass_groupdict=False):
         super(CallbackQueryHandler, self).__init__(callback,
                                                    pass_update_queue=pass_update_queue,
                                                    pass_job_queue=pass_job_queue)
 
+        if isinstance(pattern, string_types):
+            pattern = re.compile(pattern)
+
+        self.pattern = pattern
+        self.pass_groups = pass_groups
+        self.pass_groupdict = pass_groupdict
+
     def check_update(self, update):
-        return isinstance(update, Update) and update.callback_query
+        if isinstance(update, Update) and update.callback_query:
+            if self.pattern:
+                if update.callback_query.data:
+                    match = re.match(self.pattern, update.callback_query.data)
+                    return bool(match)
+            else:
+                return True
 
     def handle_update(self, update, dispatcher):
         optional_args = self.collect_optional_args(dispatcher)
+        if self.pattern:
+            match = re.match(self.pattern, update.callback_query.data)
+
+            if self.pass_groups:
+                optional_args['groups'] = match.groups()
+            if self.pass_groupdict:
+                optional_args['groupdict'] = match.groupdict()
 
         return self.callback(dispatcher.bot, update, **optional_args)
 
-    # old non-PEP8 Handler methods
+# old non-PEP8 Handler methods
+
     m = "telegram.CallbackQueryHandler."
     checkUpdate = deprecate(check_update, m + "checkUpdate", m + "check_update")
     handleUpdate = deprecate(handle_update, m + "handleUpdate", m + "handle_update")

--- a/telegram/ext/callbackqueryhandler.py
+++ b/telegram/ext/callbackqueryhandler.py
@@ -92,7 +92,6 @@ class CallbackQueryHandler(Handler):
         return self.callback(dispatcher.bot, update, **optional_args)
 
     # old non-PEP8 Handler methods
-
     m = "telegram.CallbackQueryHandler."
     checkUpdate = deprecate(check_update, m + "checkUpdate", m + "check_update")
     handleUpdate = deprecate(handle_update, m + "handleUpdate", m + "handle_update")

--- a/telegram/ext/callbackqueryhandler.py
+++ b/telegram/ext/callbackqueryhandler.py
@@ -91,7 +91,7 @@ class CallbackQueryHandler(Handler):
 
         return self.callback(dispatcher.bot, update, **optional_args)
 
-# old non-PEP8 Handler methods
+    # old non-PEP8 Handler methods
 
     m = "telegram.CallbackQueryHandler."
     checkUpdate = deprecate(check_update, m + "checkUpdate", m + "check_update")

--- a/telegram/ext/inlinequeryhandler.py
+++ b/telegram/ext/inlinequeryhandler.py
@@ -91,7 +91,6 @@ class InlineQueryHandler(Handler):
         return self.callback(dispatcher.bot, update, **optional_args)
 
     # old non-PEP8 Handler methods
-
     m = "telegram.InlineQueryHandler."
     checkUpdate = deprecate(check_update, m + "checkUpdate", m + "check_update")
     handleUpdate = deprecate(handle_update, m + "handleUpdate", m + "handle_update")

--- a/telegram/ext/inlinequeryhandler.py
+++ b/telegram/ext/inlinequeryhandler.py
@@ -28,7 +28,8 @@ from .handler import Handler
 
 class InlineQueryHandler(Handler):
     """
-    Handler class to handle Telegram inline queries. Optionally based on a regex. Read the documentation of the ``re`` module for more information.
+    Handler class to handle Telegram inline queries. Optionally based on a regex. Read the
+    documentation of the ``re`` module for more information.
 
     Args:
         callback (function): A function that takes ``bot, update`` as
@@ -42,7 +43,8 @@ class InlineQueryHandler(Handler):
             ``job_queue`` will be passed to the callback function. It will be a ``JobQueue``
             instance created by the ``Updater`` which can be used to schedule new jobs.
             Default is ``False``.
-        pattern (optional[str or Pattern]): Optional regex pattern. If not ``None`` The ``re.match`` function is used to determine if an update should be handled by this handler.
+        pattern (optional[str or Pattern]): Optional regex pattern. If not ``None`` ``re.match``
+            is used to determine if an update should be handled by this handler.
         pass_groups (optional[bool]): If the callback should be passed the
             result of ``re.match(pattern, query).groups()`` as a keyword
             argument called ``groups``. Default is ``False``

--- a/telegram/ext/inlinequeryhandler.py
+++ b/telegram/ext/inlinequeryhandler.py
@@ -90,7 +90,7 @@ class InlineQueryHandler(Handler):
 
         return self.callback(dispatcher.bot, update, **optional_args)
 
-# old non-PEP8 Handler methods
+    # old non-PEP8 Handler methods
 
     m = "telegram.InlineQueryHandler."
     checkUpdate = deprecate(check_update, m + "checkUpdate", m + "check_update")

--- a/telegram/ext/inlinequeryhandler.py
+++ b/telegram/ext/inlinequeryhandler.py
@@ -17,15 +17,18 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """ This module contains the InlineQueryHandler class """
+import re
 
-from .handler import Handler
+from future.utils import string_types
+
 from telegram import Update
 from telegram.utils.deprecate import deprecate
+from .handler import Handler
 
 
 class InlineQueryHandler(Handler):
     """
-    Handler class to handle Telegram inline queries.
+    Handler class to handle Telegram inline queries. Optionally based on a regex. Read the documentation of the ``re`` module for more information.
 
     Args:
         callback (function): A function that takes ``bot, update`` as
@@ -39,22 +42,56 @@ class InlineQueryHandler(Handler):
             ``job_queue`` will be passed to the callback function. It will be a ``JobQueue``
             instance created by the ``Updater`` which can be used to schedule new jobs.
             Default is ``False``.
+        pattern (optional[str or Pattern]): Optional regex pattern. If not ``None`` The ``re.match`` function is used to determine if an update should be handled by this handler.
+        pass_groups (optional[bool]): If the callback should be passed the
+            result of ``re.match(pattern, query).groups()`` as a keyword
+            argument called ``groups``. Default is ``False``
+        pass_groupdict (optional[bool]): If the callback should be passed the
+            result of ``re.match(pattern, query).groupdict()`` as a keyword
+            argument called ``groupdict``. Default is ``False``
     """
 
-    def __init__(self, callback, pass_update_queue=False, pass_job_queue=False):
+    def __init__(self,
+                 callback,
+                 pass_update_queue=False,
+                 pass_job_queue=False,
+                 pattern=None,
+                 pass_groups=False,
+                 pass_groupdict=False):
         super(InlineQueryHandler, self).__init__(callback,
                                                  pass_update_queue=pass_update_queue,
                                                  pass_job_queue=pass_job_queue)
 
+        if isinstance(pattern, string_types):
+            pattern = re.compile(pattern)
+
+        self.pattern = pattern
+        self.pass_groups = pass_groups
+        self.pass_groupdict = pass_groupdict
+
     def check_update(self, update):
-        return isinstance(update, Update) and update.inline_query
+        if isinstance(update, Update) and update.inline_query:
+            if self.pattern:
+                if update.inline_query.query:
+                    match = re.match(self.pattern, update.inline_query.query)
+                    return bool(match)
+            else:
+                return True
 
     def handle_update(self, update, dispatcher):
         optional_args = self.collect_optional_args(dispatcher)
+        if self.pattern:
+            match = re.match(self.pattern, update.inline_query.query)
+
+            if self.pass_groups:
+                optional_args['groups'] = match.groups()
+            if self.pass_groupdict:
+                optional_args['groupdict'] = match.groupdict()
 
         return self.callback(dispatcher.bot, update, **optional_args)
 
-    # old non-PEP8 Handler methods
+# old non-PEP8 Handler methods
+
     m = "telegram.InlineQueryHandler."
     checkUpdate = deprecate(check_update, m + "checkUpdate", m + "check_update")
     handleUpdate = deprecate(handle_update, m + "handleUpdate", m + "handle_update")


### PR DESCRIPTION
Adds regular expression handling to both CallbackQueryHandler and InlineQueryHandler. It is done with the optional `pattern` parameter. If it's not supplied or `None` it skips regex checking completely.

Note: I couldn't get tests to work properly, but have run my own preliminary tests. It would probably be a good idea to write some unit/nose tests for them though at some point. The code also needs yapf formatting, especially string wrapping (I didn't wanna do it manually if it's gonna change it anyways).