### PR TITLE
entities add

### DIFF
--- a/telegram/ext/messagehandler.py
+++ b/telegram/ext/messagehandler.py
@@ -35,7 +35,10 @@ class Filters(object):
 
     @staticmethod
     def command(message):
-        return message.text and message.text.startswith('/')
+        if len(message.entities) == 1:
+            return bool(message.entities[0].type == 'bot_command')
+        else:
+            return False
 
     @staticmethod
     def audio(message):
@@ -74,12 +77,83 @@ class Filters(object):
         return bool(message.venue)
 
     @staticmethod
+    def mention(message):
+        if len(message.entities) == 1:
+            return bool(message.entities[0].type == 'mention')
+        else:
+            return False
+
+    @staticmethod
+    def hashtag(message):
+        if len(message.entities) == 1:
+            return bool(message.entities[0].type == 'hashtag')
+        else:
+            return False
+
+    @staticmethod
+    def url(message):
+        if len(message.entities) == 1:
+            return bool(message.entities[0].type == 'url')
+        else:
+            return False
+
+    @staticmethod
+    def email(message):
+        if len(message.entities) == 1:
+            return bool(message.entities[0].type == 'email')
+        else:
+            return False
+
+    @staticmethod
+    def bold(message):
+        if len(message.entities) == 1:
+            return bool(message.entities[0].type == 'bold')
+        else:
+            return False
+
+    @staticmethod
+    def italic(message):
+        if len(message.entities) == 1:
+            return bool(message.entities[0].type == 'italic')
+        else:
+            return False
+
+    @staticmethod
+    def code(message):
+        if len(message.entities) == 1:
+            return bool(message.entities[0].type == 'code')
+        else:
+            return False
+
+    @staticmethod
+    def pre(message):
+        if len(message.entities) == 1:
+            return bool(message.entities[0].type == 'pre')
+        else:
+            return False
+
+    @staticmethod
+    def text_link(message):
+        if len(message.entities) == 1:
+            return bool(message.entities[0].type == 'text_link')
+        else:
+            return False
+
+    @staticmethod
+    def text_mention(message):
+        if len(message.entities) == 1:
+            return bool(message.entities[0].type == 'text_mention')
+        else:
+            return False
+
+    @staticmethod
     def status_update(message):
         return bool(message.new_chat_member or message.left_chat_member or message.new_chat_title
                     or message.new_chat_photo or message.delete_chat_photo
                     or message.group_chat_created or message.supergroup_chat_created
                     or message.channel_chat_created or message.migrate_to_chat_id
                     or message.migrate_from_chat_id or message.pinned_message)
+
 
 
 class MessageHandler(Handler):


### PR DESCRIPTION
Telegram's update message has new entities, described here https://core.telegram.org/bots/API#messageentity
I've added some, and fix command, according to docs.
If bot receives smth like test@test.com /start, update has such tuple:
'entities': [{'length': 12, 'offset': 0, 'type': 'email'}, {'length': 5, 'offset': 0, 'type': 'bot_command'}]
which is neither a bot_command nor an email

Still, devs can parse an entity, using indexes of the dicts and a length in an entity list