### PR TITLE
Fix #376: Execfile does not exist in python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,4 +54,4 @@ with codecs.open('README.rst', 'r', 'utf-8') as fd:
               'Programming Language :: Python :: 3.3',
               'Programming Language :: Python :: 3.4',
               'Programming Language :: Python :: 3.5',
-          ], )
+          ],)

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,13 @@ def requirements():
 
     return requirements_list
 
+
+def execfile(fn):
+    with open(fn) as f:
+        code = compile(f.read(), fn, 'exec')
+        exec(code)
+
+
 with codecs.open('README.rst', 'r', 'utf-8') as fd:
     execfile(os.path.join('telegram', 'version.py'))
 
@@ -47,4 +54,4 @@ with codecs.open('README.rst', 'r', 'utf-8') as fd:
               'Programming Language :: Python :: 3.3',
               'Programming Language :: Python :: 3.4',
               'Programming Language :: Python :: 3.5',
-          ],)
+          ], )


### PR DESCRIPTION
Simply adds a execfile function so that the library can once more be installed on python 3.
See issue #376 for more info.