### PR TITLE
Add entities filter

### DIFF
--- a/telegram/ext/messagehandler.py
+++ b/telegram/ext/messagehandler.py
@@ -95,8 +95,8 @@ class Filters(object):
             If you want AND filtering instead, you have to specify multiple of this filter in the
             `filters` attribute. Example:
 
-                >>> MessageHandler([Filters.entities(TEXT_MENTION, MENTION),
-                ...                 Filters.entities(HASHTAG)], callback)
+                >>> MessageHandler([Filters.entities([TEXT_MENTION, MENTION]),
+                ...                 Filters.entities([HASHTAG])], callback)
 
             Will require either a one type of mention AND a hashtag in the message.
 

--- a/telegram/ext/messagehandler.py
+++ b/telegram/ext/messagehandler.py
@@ -86,29 +86,19 @@ class Filters(object):
         return bool(message.forward_date)
 
     @staticmethod
-    def entities(entity_types):
+    def entity(entity_type):
         """Filters messages to only allow those which have a :class:`telegram.MessageEntity`
-        that match `entity_types`.
-
-        Note:
-            This filter functions as an OR filter, meaning that just one of the entity_type.
-            If you want AND filtering instead, you have to specify multiple of this filter in the
-            `filters` attribute. Example:
-
-                >>> MessageHandler([Filters.entities([TEXT_MENTION, MENTION]),
-                ...                 Filters.entities([HASHTAG])], callback)
-
-            Will require either a one type of mention AND a hashtag in the message.
+        where their `type` matches `entity_type`.
 
         Args:
-            entity_types: List of entity types to check for. All types can be found as constants
+            entity_type: Entity type to check for. All types can be found as constants
                 in :class:`telegram.MessageEntity`.
 
         Returns: function to use as filter
         """
 
         def entities_filter(message):
-            return any([entity.type in entity_types for entity in message.entities])
+            return any([entity.type == entity_type for entity in message.entities])
 
         return entities_filter
 
@@ -168,7 +158,8 @@ class MessageHandler(Handler):
 
         return self.callback(dispatcher.bot, update, **optional_args)
 
-    # old non-PEP8 Handler methods
+# old non-PEP8 Handler methods
+
     m = "telegram.MessageHandler."
     checkUpdate = deprecate(check_update, m + "checkUpdate", m + "check_update")
     handleUpdate = deprecate(handle_update, m + "handleUpdate", m + "handle_update")

--- a/telegram/ext/messagehandler.py
+++ b/telegram/ext/messagehandler.py
@@ -85,6 +85,33 @@ class Filters(object):
     def forwarded(message):
         return bool(message.forward_date)
 
+    @staticmethod
+    def entities(entity_types):
+        """Filters messages to only allow those which have a :class:`telegram.MessageEntity`
+        that match `entity_types`.
+
+        Note:
+            This filter functions as an OR filter, meaning that just one of the entity_type.
+            If you want AND filtering instead, you have to specify multiple of this filter in the
+            `filters` attribute. Example:
+
+                >>> MessageHandler([Filters.entities(TEXT_MENTION, MENTION),
+                ...                 Filters.entities(HASHTAG)], callback)
+
+            Will require either a one type of mention AND a hashtag in the message.
+
+        Args:
+            entity_types: List of entity types to check for. All types can be found as constants
+                in :class:`telegram.MessageEntity`.
+
+        Returns: function to use as filter
+        """
+
+        def entities_filter(message):
+            return any([entity_types in entity.type for entity in message.entities])
+
+        return entities_filter
+
 
 class MessageHandler(Handler):
     """

--- a/telegram/ext/messagehandler.py
+++ b/telegram/ext/messagehandler.py
@@ -108,7 +108,7 @@ class Filters(object):
         """
 
         def entities_filter(message):
-            return any([entity_types in entity.type for entity in message.entities])
+            return any([entity.type in entity_types for entity in message.entities])
 
         return entities_filter
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -23,10 +23,11 @@ This module contains a object that represents Tests for MessageHandler.Filters
 import sys
 import unittest
 from datetime import datetime
+import functools
 
 sys.path.append('.')
 
-from telegram import Message, User, Chat
+from telegram import Message, User, Chat, MessageEntity
 from telegram.ext import Filters
 from tests.base import BaseTest
 
@@ -149,6 +150,27 @@ class FiltersTest(BaseTest, unittest.TestCase):
         self.message.pinned_message = 'test'
         self.assertTrue(Filters.status_update(self.message))
         self.message.pinned_message = None
+
+    def test_entities_filter(self):
+        e = functools.partial(MessageEntity, offset=0, length=0)
+
+        self.message.entities = [e(MessageEntity.MENTION)]
+        self.assertTrue(Filters.entities([MessageEntity.MENTION])(self.message))
+
+        self.message.entities = []
+        self.assertFalse(Filters.entities([MessageEntity.MENTION])(self.message))
+
+        self.message.entities = [e(MessageEntity.BOLD)]
+        self.assertFalse(Filters.entities([MessageEntity.MENTION])(self.message))
+
+        self.message.entities = [e(MessageEntity.MENTION)]
+        self.assertTrue(
+            Filters.entities([MessageEntity.MENTION, MessageEntity.BOLD])(self.message))
+        self.message.entities = [e(MessageEntity.BOLD)]
+        self.assertTrue(
+            Filters.entities([MessageEntity.MENTION, MessageEntity.BOLD])(self.message))
+        self.assertFalse(
+            Filters.entities([MessageEntity.MENTION, MessageEntity.TEXT_MENTION])(self.message))
 
 
 if __name__ == '__main__':

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -155,22 +155,16 @@ class FiltersTest(BaseTest, unittest.TestCase):
         e = functools.partial(MessageEntity, offset=0, length=0)
 
         self.message.entities = [e(MessageEntity.MENTION)]
-        self.assertTrue(Filters.entities([MessageEntity.MENTION])(self.message))
+        self.assertTrue(Filters.entity(MessageEntity.MENTION)(self.message))
 
         self.message.entities = []
-        self.assertFalse(Filters.entities([MessageEntity.MENTION])(self.message))
+        self.assertFalse(Filters.entity(MessageEntity.MENTION)(self.message))
 
         self.message.entities = [e(MessageEntity.BOLD)]
-        self.assertFalse(Filters.entities([MessageEntity.MENTION])(self.message))
+        self.assertFalse(Filters.entity(MessageEntity.MENTION)(self.message))
 
-        self.message.entities = [e(MessageEntity.MENTION)]
-        self.assertTrue(
-            Filters.entities([MessageEntity.MENTION, MessageEntity.BOLD])(self.message))
-        self.message.entities = [e(MessageEntity.BOLD)]
-        self.assertTrue(
-            Filters.entities([MessageEntity.MENTION, MessageEntity.BOLD])(self.message))
-        self.assertFalse(
-            Filters.entities([MessageEntity.MENTION, MessageEntity.TEXT_MENTION])(self.message))
+        self.message.entities = [e(MessageEntity.BOLD), e(MessageEntity.MENTION)]
+        self.assertTrue(Filters.entity(MessageEntity.MENTION)(self.message))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Should ideally superseed #375.
We could also add individual filters for each Entity (which use this function)...

Not entirely happy with the docstring at line [98-99](https://github.com/python-telegram-bot/python-telegram-bot/compare/entities-filter?expand=1#diff-e1f433e10f5cf4b4c310490777ac95d2R98), but I think it's the best we can do.

This is the first of two revisions to the filter system (the second one will change the way to AND/OR them).