### PR TITLE
Make filters and/or-able using bitwise operators.

### DIFF
--- a/docs/source/telegram.ext.filters.rst
+++ b/docs/source/telegram.ext.filters.rst
@@ -1,0 +1,7 @@
+telegram.ext.filters module
+===========================
+
+.. automodule:: telegram.ext.filters
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/telegram.ext.rst
+++ b/docs/source/telegram.ext.rst
@@ -15,6 +15,7 @@ Submodules
     telegram.ext.commandhandler
     telegram.ext.inlinequeryhandler
     telegram.ext.messagehandler
+    telegram.ext.filters
     telegram.ext.regexhandler
     telegram.ext.stringcommandhandler
     telegram.ext.stringregexhandler

--- a/telegram/ext/__init__.py
+++ b/telegram/ext/__init__.py
@@ -27,7 +27,7 @@ from .commandhandler import CommandHandler
 from .handler import Handler
 from .inlinequeryhandler import InlineQueryHandler
 from .messagehandler import MessageHandler
-from .filters import Filters
+from .filters import BaseFilter, Filters
 from .regexhandler import RegexHandler
 from .stringcommandhandler import StringCommandHandler
 from .stringregexhandler import StringRegexHandler
@@ -36,5 +36,5 @@ from .conversationhandler import ConversationHandler
 
 __all__ = ('Dispatcher', 'JobQueue', 'Job', 'Updater', 'CallbackQueryHandler',
            'ChosenInlineResultHandler', 'CommandHandler', 'Handler', 'InlineQueryHandler',
-           'MessageHandler', 'Filters', 'RegexHandler', 'StringCommandHandler',
+           'MessageHandler', 'BaseFilter', 'Filters', 'RegexHandler', 'StringCommandHandler',
            'StringRegexHandler', 'TypeHandler', 'ConversationHandler')

--- a/telegram/ext/__init__.py
+++ b/telegram/ext/__init__.py
@@ -26,7 +26,8 @@ from .choseninlineresulthandler import ChosenInlineResultHandler
 from .commandhandler import CommandHandler
 from .handler import Handler
 from .inlinequeryhandler import InlineQueryHandler
-from .messagehandler import MessageHandler, Filters
+from .messagehandler import MessageHandler
+from .filters import Filters
 from .regexhandler import RegexHandler
 from .stringcommandhandler import StringCommandHandler
 from .stringregexhandler import StringRegexHandler

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -16,11 +16,31 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-""" This module contains the MessageHandler class """
+""" This module contains the Filters for use with the MessageHandler class """
 
 
 class BaseFilter(object):
-    """Base class for all Message Filters"""
+    """Base class for all Message Filters
+
+    Subclassing from this class filters to be combined using bitwise operators:
+
+    And:
+
+        >>> (Filters.text & Filters.entity(MENTION)
+
+    Or:
+
+        >>> (Filters.audio | Filters.video)
+
+    Also works with more than two filters:
+
+        >>> (Filters.text & (Filters.entity(URL |Filters.entity(TEXT_LINK))))
+
+    If you want to create your own filters create a class inheriting from this class and implement
+    a `filter` method that returns a boolean: `True` if the message should be handled, `False`
+    otherwise. Note that the filters work only as class instances, not actual class objects
+    (so remember to initialize your filter classes).
+    """
 
     def __call__(self, message):
         return self.filter(message)
@@ -52,88 +72,87 @@ class MergedFilter(BaseFilter):
 
 class Filters(object):
     """
-    Convenient namespace (class) & methods for the filter funcs of the
-    MessageHandler class.
+    Predefined filters for use with the `filter` argument of :class:`telegram.ext.MessageHandler`.
     """
 
-    class Text(BaseFilter):
+    class _Text(BaseFilter):
 
         def filter(self, message):
             return bool(message.text and not message.text.startswith('/'))
 
-    text = Text()
+    text = _Text()
 
-    class Command(BaseFilter):
+    class _Command(BaseFilter):
 
         def filter(self, message):
             return bool(message.text and message.text.startswith('/'))
 
-    command = Command()
+    command = _Command()
 
-    class Audio(BaseFilter):
+    class _Audio(BaseFilter):
 
         def filter(self, message):
             return bool(message.audio)
 
-    audio = Audio()
+    audio = _Audio()
 
-    class Document(BaseFilter):
+    class _Document(BaseFilter):
 
         def filter(self, message):
             return bool(message.document)
 
-    document = Document()
+    document = _Document()
 
-    class Photo(BaseFilter):
+    class _Photo(BaseFilter):
 
         def filter(self, message):
             return bool(message.photo)
 
-    photo = Photo()
+    photo = _Photo()
 
-    class Sticker(BaseFilter):
+    class _Sticker(BaseFilter):
 
         def filter(self, message):
             return bool(message.sticker)
 
-    sticker = Sticker()
+    sticker = _Sticker()
 
-    class Video(BaseFilter):
+    class _Video(BaseFilter):
 
         def filter(self, message):
             return bool(message.video)
 
-    video = Video()
+    video = _Video()
 
-    class Voice(BaseFilter):
+    class _Voice(BaseFilter):
 
         def filter(self, message):
             return bool(message.voice)
 
-    voice = Voice()
+    voice = _Voice()
 
-    class Contact(BaseFilter):
+    class _Contact(BaseFilter):
 
         def filter(self, message):
             return bool(message.contact)
 
-    contact = Contact()
+    contact = _Contact()
 
-    class Location(BaseFilter):
+    class _Location(BaseFilter):
 
         def filter(self, message):
             return bool(message.location)
 
-    location = Location()
+    location = _Location()
 
-    class Venue(BaseFilter):
+    class _Venue(BaseFilter):
 
         def filter(self, message):
             return bool(message.venue)
 
-    venue = Venue()
+    venue = _Venue()
 
-    class StatusUpdate(BaseFilter):
+    class _StatusUpdate(BaseFilter):
 
         def filter(self, message):
             return bool(message.new_chat_member or message.left_chat_member
@@ -143,16 +162,16 @@ class Filters(object):
                         or message.migrate_to_chat_id or message.migrate_from_chat_id
                         or message.pinned_message)
 
-    status_update = StatusUpdate()
+    status_update = _StatusUpdate()
 
-    class Forwarded(BaseFilter):
+    class _Forwarded(BaseFilter):
 
         def filter(self, message):
             return bool(message.forward_date)
 
-    forwarded = Forwarded()
+    forwarded = _Forwarded()
 
-    class Entity(BaseFilter):
+    class entity(BaseFilter):
         """Filters messages to only allow those which have a :class:`telegram.MessageEntity`
         where their `type` matches `entity_type`.
 
@@ -168,7 +187,3 @@ class Filters(object):
 
         def filter(self, message):
             return any([entity.type == self.entity_type for entity in message.entities])
-
-# We don't initialize since this filter accepts arguments.
-
-    entity = Entity

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -26,7 +26,7 @@ class BaseFilter(object):
 
     And:
 
-        >>> (Filters.text & Filters.entity(MENTION)
+        >>> (Filters.text & Filters.entity(MENTION))
 
     Or:
 
@@ -34,7 +34,7 @@ class BaseFilter(object):
 
     Also works with more than two filters:
 
-        >>> (Filters.text & (Filters.entity(URL |Filters.entity(TEXT_LINK))))
+        >>> (Filters.text & (Filters.entity(URL) | Filters.entity(TEXT_LINK)))
 
     If you want to create your own filters create a class inheriting from this class and implement
     a `filter` method that returns a boolean: `True` if the message should be handled, `False`
@@ -56,7 +56,13 @@ class BaseFilter(object):
 
 
 class MergedFilter(BaseFilter):
-    """Represents a filter consisting of two other filters."""
+    """Represents a filter consisting of two other filters.
+
+    Args:
+        base_filter: Filter 1 of the merged filter
+        and_filter: Optional filter to "and" with base_filter. Mutually exclusive with or_filter.
+        or_filter: Optional filter to "or" with base_filter. Mutually exclusive with and_filter.
+    """
 
     def __init__(self, base_filter, and_filter=None, or_filter=None):
         self.base_filter = base_filter

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+#
+# A library that provides a Python interface to the Telegram Bot API
+# Copyright (C) 2015-2016
+# Leandro Toledo de Souza <devs@python-telegram-bot.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+""" This module contains the MessageHandler class """
+
+
+class BaseFilter(object):
+    """Base class for all Message Filters"""
+
+    def __call__(self, message):
+        raise NotImplementedError('Please implement a call method in your filter.')
+
+    def __and__(self, other):
+        return MergedFilter(self, and_filter=other)
+
+    def __or__(self, other):
+        return MergedFilter(self, or_filter=other)
+
+
+class MergedFilter(BaseFilter):
+    """Represents a filter consisting of two other filters."""
+
+    def __init__(self, base_filter, and_filter=None, or_filter=None):
+        self.base_filter = base_filter
+        self.and_filter = and_filter
+        self.or_filter = or_filter
+
+    def __call__(self, message):
+        if self.and_filter:
+            return self.base_filter(message) and self.and_filter(message)
+        elif self.or_filter:
+            return self.base_filter(message) or self.or_filter(message)
+
+
+class Filters(object):
+    """
+    Convenient namespace (class) & methods for the filter funcs of the
+    MessageHandler class.
+    """
+
+    class Text(BaseFilter):
+
+        def __call__(self, message):
+            return bool(message.text and not message.text.startswith('/'))
+
+    text = Text()
+
+    class Command(BaseFilter):
+
+        def __call__(self, message):
+            return bool(message.text and message.text.startswith('/'))
+
+    command = Command()
+
+    class Audio(BaseFilter):
+
+        def __call__(self, message):
+            return bool(message.audio)
+
+    audio = Audio()
+
+    class Document(BaseFilter):
+
+        def __call__(self, message):
+            return bool(message.document)
+
+    document = Document()
+
+    class Photo(BaseFilter):
+
+        def __call__(self, message):
+            return bool(message.photo)
+
+    photo = Photo()
+
+    class Sticker(BaseFilter):
+
+        def __call__(self, message):
+            return bool(message.sticker)
+
+    sticker = Sticker()
+
+    class Video(BaseFilter):
+
+        def __call__(self, message):
+            return bool(message.video)
+
+    video = Video()
+
+    class Voice(BaseFilter):
+
+        def __call__(self, message):
+            return bool(message.voice)
+
+    voice = Voice()
+
+    class Contact(BaseFilter):
+
+        def __call__(self, message):
+            return bool(message.contact)
+
+    contact = Contact()
+
+    class Location(BaseFilter):
+
+        def __call__(self, message):
+            return bool(message.location)
+
+    location = Location()
+
+    class Venue(BaseFilter):
+
+        def __call__(self, message):
+            return bool(message.venue)
+
+    venue = Venue()
+
+    class StatusUpdate(BaseFilter):
+
+        def __call__(self, message):
+            return bool(message.new_chat_member or message.left_chat_member
+                        or message.new_chat_title or message.new_chat_photo
+                        or message.delete_chat_photo or message.group_chat_created
+                        or message.supergroup_chat_created or message.channel_chat_created
+                        or message.migrate_to_chat_id or message.migrate_from_chat_id
+                        or message.pinned_message)
+
+    status_update = StatusUpdate()
+
+    class Forwarded(BaseFilter):
+
+        def __call__(self, message):
+            return bool(message.forward_date)
+
+    forwarded = Forwarded()

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -69,6 +69,13 @@ class MergedFilter(BaseFilter):
         elif self.or_filter:
             return self.base_filter(message) or self.or_filter(message)
 
+    def __str__(self):
+        return ("<telegram.ext.filters.MergedFilter consisting of"
+                " {} {} {}>").format(self.base_filter, "and" if self.and_filter else "or",
+                                     self.and_filter or self.or_filter)
+
+    __repr__ = __str__
+
 
 class Filters(object):
     """

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -88,6 +88,13 @@ class Filters(object):
     Predefined filters for use with the `filter` argument of :class:`telegram.ext.MessageHandler`.
     """
 
+    class _All(BaseFilter):
+
+        def filter(self, message):
+            return True
+
+    all = _All()
+
     class _Text(BaseFilter):
 
         def filter(self, message):

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -23,7 +23,7 @@ class BaseFilter(object):
     """Base class for all Message Filters"""
 
     def __call__(self, message):
-        self.filter(message)
+        return self.filter(message)
 
     def __and__(self, other):
         return MergedFilter(self, and_filter=other)

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -23,13 +23,16 @@ class BaseFilter(object):
     """Base class for all Message Filters"""
 
     def __call__(self, message):
-        raise NotImplementedError('Please implement a call method in your filter.')
+        self.filter(message)
 
     def __and__(self, other):
         return MergedFilter(self, and_filter=other)
 
     def __or__(self, other):
         return MergedFilter(self, or_filter=other)
+
+    def filter(self, message):
+        raise NotImplementedError
 
 
 class MergedFilter(BaseFilter):
@@ -40,7 +43,7 @@ class MergedFilter(BaseFilter):
         self.and_filter = and_filter
         self.or_filter = or_filter
 
-    def __call__(self, message):
+    def filter(self, message):
         if self.and_filter:
             return self.base_filter(message) and self.and_filter(message)
         elif self.or_filter:
@@ -55,84 +58,84 @@ class Filters(object):
 
     class Text(BaseFilter):
 
-        def __call__(self, message):
+        def filter(self, message):
             return bool(message.text and not message.text.startswith('/'))
 
     text = Text()
 
     class Command(BaseFilter):
 
-        def __call__(self, message):
+        def filter(self, message):
             return bool(message.text and message.text.startswith('/'))
 
     command = Command()
 
     class Audio(BaseFilter):
 
-        def __call__(self, message):
+        def filter(self, message):
             return bool(message.audio)
 
     audio = Audio()
 
     class Document(BaseFilter):
 
-        def __call__(self, message):
+        def filter(self, message):
             return bool(message.document)
 
     document = Document()
 
     class Photo(BaseFilter):
 
-        def __call__(self, message):
+        def filter(self, message):
             return bool(message.photo)
 
     photo = Photo()
 
     class Sticker(BaseFilter):
 
-        def __call__(self, message):
+        def filter(self, message):
             return bool(message.sticker)
 
     sticker = Sticker()
 
     class Video(BaseFilter):
 
-        def __call__(self, message):
+        def filter(self, message):
             return bool(message.video)
 
     video = Video()
 
     class Voice(BaseFilter):
 
-        def __call__(self, message):
+        def filter(self, message):
             return bool(message.voice)
 
     voice = Voice()
 
     class Contact(BaseFilter):
 
-        def __call__(self, message):
+        def filter(self, message):
             return bool(message.contact)
 
     contact = Contact()
 
     class Location(BaseFilter):
 
-        def __call__(self, message):
+        def filter(self, message):
             return bool(message.location)
 
     location = Location()
 
     class Venue(BaseFilter):
 
-        def __call__(self, message):
+        def filter(self, message):
             return bool(message.venue)
 
     venue = Venue()
 
     class StatusUpdate(BaseFilter):
 
-        def __call__(self, message):
+        def filter(self, message):
             return bool(message.new_chat_member or message.left_chat_member
                         or message.new_chat_title or message.new_chat_photo
                         or message.delete_chat_photo or message.group_chat_created
@@ -144,7 +147,7 @@ class Filters(object):
 
     class Forwarded(BaseFilter):
 
-        def __call__(self, message):
+        def filter(self, message):
             return bool(message.forward_date)
 
     forwarded = Forwarded()

--- a/telegram/ext/messagehandler.py
+++ b/telegram/ext/messagehandler.py
@@ -23,69 +23,6 @@ from telegram import Update
 from telegram.utils.deprecate import deprecate
 
 
-class Filters(object):
-    """
-    Convenient namespace (class) & methods for the filter funcs of the
-    MessageHandler class.
-    """
-
-    @staticmethod
-    def text(message):
-        return message.text and not message.text.startswith('/')
-
-    @staticmethod
-    def command(message):
-        return message.text and message.text.startswith('/')
-
-    @staticmethod
-    def audio(message):
-        return bool(message.audio)
-
-    @staticmethod
-    def document(message):
-        return bool(message.document)
-
-    @staticmethod
-    def photo(message):
-        return bool(message.photo)
-
-    @staticmethod
-    def sticker(message):
-        return bool(message.sticker)
-
-    @staticmethod
-    def video(message):
-        return bool(message.video)
-
-    @staticmethod
-    def voice(message):
-        return bool(message.voice)
-
-    @staticmethod
-    def contact(message):
-        return bool(message.contact)
-
-    @staticmethod
-    def location(message):
-        return bool(message.location)
-
-    @staticmethod
-    def venue(message):
-        return bool(message.venue)
-
-    @staticmethod
-    def status_update(message):
-        return bool(message.new_chat_member or message.left_chat_member or message.new_chat_title
-                    or message.new_chat_photo or message.delete_chat_photo
-                    or message.group_chat_created or message.supergroup_chat_created
-                    or message.channel_chat_created or message.migrate_to_chat_id
-                    or message.migrate_from_chat_id or message.pinned_message)
-
-    @staticmethod
-    def forwarded(message):
-        return bool(message.forward_date)
-
-
 class MessageHandler(Handler):
     """
     Handler class to handle telegram messages. Messages are Telegram Updates

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -206,13 +206,22 @@ class FiltersTest(BaseTest, unittest.TestCase):
         self.assertTrue((Filters.text & (Filters.forwarded | Filters.entity(MessageEntity.MENTION))
                         )(self.message))
 
-        self.assertRegex(
-            str((Filters.text & (Filters.forwarded | Filters.entity(MessageEntity.MENTION)))),
-            r"<telegram.ext.filters.MergedFilter consisting of "
-            r"<telegram.ext.filters.Filters._Text object at .*?> and "
-            r"<telegram.ext.filters.MergedFilter consisting of "
-            r"<telegram.ext.filters.Filters._Forwarded object at .*?> or "
-            r"<telegram.ext.filters.Filters.entity object at .*?>>>")
+        try:
+            self.assertRegex(
+                str((Filters.text & (Filters.forwarded | Filters.entity(MessageEntity.MENTION)))),
+                r"<telegram.ext.filters.MergedFilter consisting of "
+                r"<telegram.ext.filters.Filters._Text object at .*?> and "
+                r"<telegram.ext.filters.MergedFilter consisting of "
+                r"<telegram.ext.filters.Filters._Forwarded object at .*?> or "
+                r"<telegram.ext.filters.Filters.entity object at .*?>>>")
+        except AttributeError:
+            self.assertRegexpMatches(
+                str((Filters.text & (Filters.forwarded | Filters.entity(MessageEntity.MENTION)))),
+                r"<telegram.ext.filters.MergedFilter consisting of "
+                r"<telegram.ext.filters.Filters._Text object at .*?> and "
+                r"<telegram.ext.filters.MergedFilter consisting of "
+                r"<telegram.ext.filters.Filters._Forwarded object at .*?> or "
+                r"<telegram.ext.filters.Filters.entity object at .*?>>>")
 
     def test_faulty_custom_filter(self):
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -150,6 +150,30 @@ class FiltersTest(BaseTest, unittest.TestCase):
         self.assertTrue(Filters.status_update(self.message))
         self.message.pinned_message = None
 
+    def test_and_filters(self):
+        # For now just test with forwarded as that's the only one that makes sense
+        # That'll change when we get a entities filter
+        self.message.text = 'test'
+        self.message.forward_date = True
+        self.assertTrue((Filters.text & Filters.forwarded)(self.message))
+        self.message.text = '/test'
+        self.assertFalse((Filters.text & Filters.forwarded)(self.message))
+        self.message.text = 'test'
+        self.message.forward_date = None
+        self.assertFalse((Filters.text & Filters.forwarded)(self.message))
+
+    def test_or_filters(self):
+        # For now just test with forwarded as that's the only one that makes sense
+        # That'll change when we get a entities filter
+        self.message.text = 'test'
+        self.assertTrue((Filters.text | Filters.status_update)(self.message))
+        self.message.group_chat_created = True
+        self.assertTrue((Filters.text | Filters.status_update)(self.message))
+        self.message.text = None
+        self.assertTrue((Filters.text | Filters.status_update)(self.message))
+        self.message.group_chat_created = False
+        self.assertFalse((Filters.text | Filters.status_update)(self.message))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """
-This module contains a object that represents Tests for MessageHandler.Filters
+This module contains a object that represents Tests for Filters for use with MessageHandler
 """
 
 import sys

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -208,11 +208,10 @@ class FiltersTest(BaseTest, unittest.TestCase):
 
         self.assertRegexpMatches(
             str((Filters.text & (Filters.forwarded | Filters.entity(MessageEntity.MENTION)))),
-            r"<telegram.ext.filters.MergedFilter consisting of "
-            r"<telegram.ext.filters.Filters._Text object at .*?> and "
-            r"<telegram.ext.filters.MergedFilter consisting of "
-            r"<telegram.ext.filters.Filters._Forwarded object at .*?> or "
-            r"<telegram.ext.filters.Filters.entity object at .*?>>>")
+            r"<telegram.ext.filters.MergedFilter consisting of <telegram.ext.filters.(Filters.)?_"
+            r"Text object at .*?> and <telegram.ext.filters.MergedFilter consisting of "
+            r"<telegram.ext.filters.(Filters.)?_Forwarded object at .*?> or "
+            r"<telegram.ext.filters.(Filters.)?entity object at .*?>>>")
 
     def test_faulty_custom_filter(self):
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -28,7 +28,7 @@ import functools
 sys.path.append('.')
 
 from telegram import Message, User, Chat, MessageEntity
-from telegram.ext import Filters
+from telegram.ext import Filters, BaseFilter
 from tests.base import BaseTest
 
 
@@ -205,6 +205,24 @@ class FiltersTest(BaseTest, unittest.TestCase):
         self.message.entities = [self.e(MessageEntity.MENTION)]
         self.assertTrue((Filters.text & (Filters.forwarded | Filters.entity(MessageEntity.MENTION))
                         )(self.message))
+
+        self.assertRegex(
+            str((Filters.text & (Filters.forwarded | Filters.entity(MessageEntity.MENTION)))),
+            r"<telegram.ext.filters.MergedFilter consisting of "
+            r"<telegram.ext.filters.Filters._Text object at .*?> and "
+            r"<telegram.ext.filters.MergedFilter consisting of "
+            r"<telegram.ext.filters.Filters._Forwarded object at .*?> or "
+            r"<telegram.ext.filters.Filters.entity object at .*?>>>")
+
+    def test_faulty_custom_filter(self):
+
+        class _CustomFilter(BaseFilter):
+            pass
+
+        custom = _CustomFilter()
+
+        with self.assertRaises(NotImplementedError):
+            (custom & Filters.text)(self.message)
 
 
 if __name__ == '__main__':

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -206,22 +206,13 @@ class FiltersTest(BaseTest, unittest.TestCase):
         self.assertTrue((Filters.text & (Filters.forwarded | Filters.entity(MessageEntity.MENTION))
                         )(self.message))
 
-        try:
-            self.assertRegex(
-                str((Filters.text & (Filters.forwarded | Filters.entity(MessageEntity.MENTION)))),
-                r"<telegram.ext.filters.MergedFilter consisting of "
-                r"<telegram.ext.filters.Filters._Text object at .*?> and "
-                r"<telegram.ext.filters.MergedFilter consisting of "
-                r"<telegram.ext.filters.Filters._Forwarded object at .*?> or "
-                r"<telegram.ext.filters.Filters.entity object at .*?>>>")
-        except AttributeError:
-            self.assertRegexpMatches(
-                str((Filters.text & (Filters.forwarded | Filters.entity(MessageEntity.MENTION)))),
-                r"<telegram.ext.filters.MergedFilter consisting of "
-                r"<telegram.ext.filters.Filters._Text object at .*?> and "
-                r"<telegram.ext.filters.MergedFilter consisting of "
-                r"<telegram.ext.filters.Filters._Forwarded object at .*?> or "
-                r"<telegram.ext.filters.Filters.entity object at .*?>>>")
+        self.assertRegexpMatches(
+            str((Filters.text & (Filters.forwarded | Filters.entity(MessageEntity.MENTION)))),
+            r"<telegram.ext.filters.MergedFilter consisting of "
+            r"<telegram.ext.filters.Filters._Text object at .*?> and "
+            r"<telegram.ext.filters.MergedFilter consisting of "
+            r"<telegram.ext.filters.Filters._Forwarded object at .*?> or "
+            r"<telegram.ext.filters.Filters.entity object at .*?>>>")
 
     def test_faulty_custom_filter(self):
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -182,7 +182,7 @@ class UpdaterTest(BaseTest, unittest.TestCase):
         self._setup_updater('Test', edited=True)
         d = self.updater.dispatcher
         from telegram.ext import Filters
-        handler = MessageHandler([Filters.text], self.telegramHandlerEditedTest, allow_edited=True)
+        handler = MessageHandler(Filters.text, self.telegramHandlerEditedTest, allow_edited=True)
         d.addHandler(handler)
         self.updater.start_polling(0.01)
         sleep(.1)
@@ -190,8 +190,7 @@ class UpdaterTest(BaseTest, unittest.TestCase):
 
         # Remove handler
         d.removeHandler(handler)
-        handler = MessageHandler(
-            [Filters.text], self.telegramHandlerEditedTest, allow_edited=False)
+        handler = MessageHandler(Filters.text, self.telegramHandlerEditedTest, allow_edited=False)
         d.addHandler(handler)
         self.reset()
 
@@ -201,7 +200,7 @@ class UpdaterTest(BaseTest, unittest.TestCase):
 
     def test_addTelegramMessageHandlerMultipleMessages(self):
         self._setup_updater('Multiple', 100)
-        self.updater.dispatcher.add_handler(MessageHandler([], self.telegramHandlerTest))
+        self.updater.dispatcher.add_handler(MessageHandler(Filters.all, self.telegramHandlerTest))
         self.updater.start_polling(0.0)
         sleep(2)
         self.assertEqual(self.received_message, 'Multiple')


### PR DESCRIPTION
Would allow filters to be and'ed/or'ed.
Using syntax like this:
```python
handler = MessageHandler((Filters.text | Filters.venue) & Filters.forwarded, callback)
```
Currently this isn't _too_ useful since the only filter that can be and'ed to any other is `forwarded`, but that should all change with #409.

The code currently requires all filters to be created as a class and then initiated before they can be used, which could be an inconvenience to the user if they want to create their own filters. To remedy this we could add a decorator like this:
```python
def Filter(f):
    def wrapper(self, message):
        return f(message)
    return type(f.__name__, (BaseFilter,), {'__call__': wrapper})()
```
That would allow users (and us) to make filters like this:
```python
@Filter
def Text(self, message):
    return bool(message.text and not message.text.startswith('/'))
```
The reason I didn't immediately go with this, is that it might be confusing if someone (especially someone new to python) reading the code stumbles upon a dynamic class creator.  
Thoughts?

- [x] Figure out implementation
- [x] Write the code
- [x] Write the docs
- [x] Add snippet to wiki
- [x] Wait for #409 to get merged?

Edit: After talking in dev group, the decorator has been declared too gross to look at :P