### PR TITLE
Properly split and handle arguments in CommandHandler

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,6 +11,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Avanatiker <https://github.com/Avanatiker>`_
 - `Balduro <https://github.com/Balduro>`_
 - `bimmlerd <https://github.com/bimmlerd>`_
+- `Eli Gao <https://github.com/eligao>`_
 - `ErgoZ Riftbit Vaper <https://github.com/ergoz>`_
 - `franciscod <https://github.com/franciscod>`_
 - `Jacob Bom <https://github.com/bomjacob>`_

--- a/telegram/ext/commandhandler.py
+++ b/telegram/ext/commandhandler.py
@@ -80,7 +80,7 @@ class CommandHandler(Handler):
         message = update.message or update.edited_message
 
         if self.pass_args:
-            optional_args['args'] = message.text.split(' ')[1:]
+            optional_args['args'] = message.text.split()[1:]
 
         return self.callback(dispatcher.bot, update, **optional_args)
 

--- a/telegram/ext/commandhandler.py
+++ b/telegram/ext/commandhandler.py
@@ -39,7 +39,8 @@ class CommandHandler(Handler):
         pass_args (optional[bool]): If the handler should be passed the
             arguments passed to the command as a keyword argument called `
             ``args``. It will contain a list of strings, which is the text
-            following the command split on spaces. Default is ``False``
+            following the command split on single or consecutive whitespace characters.
+            Default is ``False``
         pass_update_queue (optional[bool]): If set to ``True``, a keyword argument called
             ``update_queue`` will be passed to the callback function. It will be the ``Queue``
             instance used by the ``Updater`` and ``Dispatcher`` that contains new updates which can

--- a/telegram/ext/stringcommandhandler.py
+++ b/telegram/ext/stringcommandhandler.py
@@ -35,7 +35,8 @@ class StringCommandHandler(Handler):
         pass_args (optional[bool]): If the handler should be passed the
             arguments passed to the command as a keyword argument called `
             ``args``. It will contain a list of strings, which is the text
-            following the command split on spaces. Default is ``False``
+            following the command split on single or consecutive whitespace characters.
+            Default is ``False``
         pass_update_queue (optional[bool]): If set to ``True``, a keyword argument called
             ``update_queue`` will be passed to the callback function. It will be the ``Queue``
             instance used by the ``Updater`` and ``Dispatcher`` that contains new updates which can
@@ -65,7 +66,7 @@ class StringCommandHandler(Handler):
         optional_args = self.collect_optional_args(dispatcher)
 
         if self.pass_args:
-            optional_args['args'] = update.split(' ')[1:]
+            optional_args['args'] = update.split()[1:]
 
         return self.callback(dispatcher.bot, update, **optional_args)
 


### PR DESCRIPTION
Assume we got a command with more than one continuous white-space characters (which does happen) :

> /func[space][space]arg1[space]arg2[space][space]arg3[space][space][space]arg4

after `split(' ')`, we have
`['/func', '', 'arg1', 'arg2', '', 'arg3', '', '', 'arg4']`
which includes many unnecessary empty strings that leads to improper command handling.
This is also different from how the system handles standard `argv[]`.
However with `split()`, we have the proper parameters:
`['/func', 'arg1', 'arg2', 'arg3',  'arg4']`
Also it eliminates other unnecessary white-spaces like `\r`,`\n`, etc.