### PR TITLE
Start additional threads only when necessary

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -19,6 +19,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `JRoot3D <https://github.com/JRoot3D>`_
 - `jlmadurga <https://github.com/jlmadurga>`_
 - `macrojames <https://github.com/macrojames>`_
+- `Michael Elovskikh <https://github.com/wronglink>`_
 - `naveenvhegde <https://github.com/naveenvhegde>`_
 - `njittam <https://github.com/njittam>`_
 - `Noam Meltzer <https://github.com/tsnoam>`_

--- a/telegram/ext/dispatcher.py
+++ b/telegram/ext/dispatcher.py
@@ -84,6 +84,7 @@ class Dispatcher(object):
         self.bot = bot
         self.update_queue = update_queue
         self.job_queue = job_queue
+        self.workers = workers
 
         self.handlers = {}
         """:type: dict[int, list[Handler]"""
@@ -104,8 +105,6 @@ class Dispatcher(object):
                 self._set_singleton(self)
             else:
                 self._set_singleton(None)
-
-        self._init_async_threads(uuid4(), workers)
 
     @classmethod
     def _reset_singleton(cls):
@@ -193,6 +192,7 @@ class Dispatcher(object):
             self.logger.error(msg)
             raise TelegramError(msg)
 
+        self._init_async_threads(uuid4(), self.workers)
         self.running = True
         self.logger.debug('Dispatcher started')
 

--- a/telegram/ext/jobqueue.py
+++ b/telegram/ext/jobqueue.py
@@ -20,6 +20,7 @@
 
 import logging
 import time
+import warnings
 from threading import Thread, Lock, Event
 from queue import PriorityQueue, Empty
 
@@ -34,9 +35,14 @@ class JobQueue(object):
     Args:
         bot (Bot): The bot instance that should be passed to the jobs
 
+    Deprecated: 5.2
+        prevent_autostart (Optional[bool]): Thread does not start during initialisation.
     """
 
-    def __init__(self, bot):
+    def __init__(self, bot, prevent_autostart=None):
+        if prevent_autostart is not None:
+            warnings.warn("prevent_autostart is being deprecated, thread does not start during initialisation.")
+
         self.queue = PriorityQueue()
         self.bot = bot
         self.logger = logging.getLogger(self.__class__.__name__)
@@ -50,7 +56,7 @@ class JobQueue(object):
         self._running = False
 
     def put(self, job, next_t=None):
-        """Queue a new job. If the JobQueue is not running, it will be started.
+        """Queue a new job.
 
         Args:
             job (Job): The ``Job`` instance representing the new job

--- a/telegram/ext/jobqueue.py
+++ b/telegram/ext/jobqueue.py
@@ -37,11 +37,12 @@ class JobQueue(object):
 
     Deprecated: 5.2
         prevent_autostart (Optional[bool]): Thread does not start during initialisation.
+        Use `start` method instead.
     """
 
     def __init__(self, bot, prevent_autostart=None):
         if prevent_autostart is not None:
-            warnings.warn("prevent_autostart is being deprecated, thread does not start during initialisation.")
+            warnings.warn("prevent_autostart is being deprecated, use `start` method instead.")
 
         self.queue = PriorityQueue()
         self.bot = bot

--- a/telegram/ext/jobqueue.py
+++ b/telegram/ext/jobqueue.py
@@ -30,15 +30,13 @@ class JobQueue(object):
     Attributes:
         queue (PriorityQueue):
         bot (Bot):
-        prevent_autostart (Optional[bool]): If ``True``, the job queue will not be started
-                automatically. Defaults to ``False``
 
     Args:
         bot (Bot): The bot instance that should be passed to the jobs
 
     """
 
-    def __init__(self, bot, prevent_autostart=False):
+    def __init__(self, bot):
         self.queue = PriorityQueue()
         self.bot = bot
         self.logger = logging.getLogger(self.__class__.__name__)
@@ -50,10 +48,6 @@ class JobQueue(object):
         self._next_peek = None
         """:type: float"""
         self._running = False
-
-        if not prevent_autostart:
-            self.logger.debug('Auto-starting %s', self.__class__.__name__)
-            self.start()
 
     def put(self, job, next_t=None):
         """Queue a new job. If the JobQueue is not running, it will be started.

--- a/telegram/ext/updater.py
+++ b/telegram/ext/updater.py
@@ -157,6 +157,7 @@ class Updater(object):
                 self.running = True
 
                 # Create & start threads
+                self._init_thread(self.job_queue.start, "job_queue")
                 self._init_thread(self.dispatcher.start, "dispatcher")
                 self._init_thread(self._start_polling, "updater", poll_interval, timeout,
                                   network_delay, bootstrap_retries, clean)
@@ -208,6 +209,7 @@ class Updater(object):
                 self.running = True
 
                 # Create & start threads
+                self._init_thread(self.job_queue.start, "job_queue")
                 self._init_thread(self.dispatcher.start, "dispatcher"),
                 self._init_thread(self._start_webhook, "updater", listen, port, url_path, cert,
                                   key, bootstrap_retries, clean, webhook_url)

--- a/telegram/ext/updater.py
+++ b/telegram/ext/updater.py
@@ -157,7 +157,7 @@ class Updater(object):
                 self.running = True
 
                 # Create & start threads
-                self._init_thread(self.job_queue.start, "job_queue")
+                self.job_queue.start()
                 self._init_thread(self.dispatcher.start, "dispatcher")
                 self._init_thread(self._start_polling, "updater", poll_interval, timeout,
                                   network_delay, bootstrap_retries, clean)
@@ -209,7 +209,7 @@ class Updater(object):
                 self.running = True
 
                 # Create & start threads
-                self._init_thread(self.job_queue.start, "job_queue")
+                self.job_queue.start()
                 self._init_thread(self.dispatcher.start, "dispatcher"),
                 self._init_thread(self._start_webhook, "updater", listen, port, url_path, cert,
                                   key, bootstrap_retries, clean, webhook_url)

--- a/tests/test_jobqueue.py
+++ b/tests/test_jobqueue.py
@@ -51,6 +51,7 @@ class JobQueueTest(BaseTest, unittest.TestCase):
 
     def setUp(self):
         self.jq = JobQueue(MockBot('jobqueue_test'))
+        self.jq.start()
         self.result = 0
 
     def tearDown(self):
@@ -143,7 +144,6 @@ class JobQueueTest(BaseTest, unittest.TestCase):
     def test_error(self):
         self.jq.put(Job(self.job2, 0.1))
         self.jq.put(Job(self.job1, 0.2))
-        self.jq.start()
         sleep(0.5)
         self.assertEqual(2, self.result)
 
@@ -158,6 +158,7 @@ class JobQueueTest(BaseTest, unittest.TestCase):
 
     def test_inUpdater(self):
         u = Updater(bot="MockBot")
+        u.job_queue.start()
         try:
             u.job_queue.put(Job(self.job1, 0.5))
             sleep(0.75)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -427,10 +427,12 @@ class UpdaterTest(BaseTest, unittest.TestCase):
             q.put(current_thread().name)
             sleep(1.2)
 
-        d1 = Dispatcher(MockBot('disp1'), Queue(), workers=1)
-        d2 = Dispatcher(MockBot('disp2'), Queue(), workers=1)
+        d1 = Dispatcher(MockBot('disp1'), Queue())
+        d2 = Dispatcher(MockBot('disp2'), Queue())
         q1 = Queue()
         q2 = Queue()
+        d1._init_async_threads('test_1', workers=1)
+        d2._init_async_threads('test_2', workers=1)
 
         try:
             d1.run_async(get_dispatcher_name, q1)
@@ -622,9 +624,9 @@ class UpdaterTest(BaseTest, unittest.TestCase):
 
     def test_start_dispatcher_twice(self):
         self._setup_updater('', messages=0)
-        d = self.updater.dispatcher
         self.updater.start_polling(0.1)
-        d.start()
+        sleep(0.5)
+        self.updater.dispatcher.start()
 
     def test_bootstrap_retries_success(self):
         retries = 3


### PR DESCRIPTION
I have several troubles with `JobQueue` and `Dispatcher` automatically start new threads during it's initialisation. I guess it's quite unexpected behaviour to have a branch of threads just by creating new `Updater`, without starting it. Instead of it, I propose the `Updater` instance should start all necessary threads on inside it's start methods: `start_polling` and `start_webhook`.