### PR TITLE
Add install from source instructions to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,13 @@ You can install or upgrade python-telegram-bot with:
 
     $ pip install python-telegram-bot --upgrade
 
+Or you can install from source with:
+
+.. code:: shell
+
+    $ git clone https://github.com/python-telegram-bot/python-telegram-bot
+    $ cd python-telegram-bot
+    $ python setup.py install
 ===============
 Getting started
 ===============


### PR DESCRIPTION
Adds instructions to install from source to the readme. If this is the preferred way to use python-telegram-bot (as is suggested by the fact that in the new issues template you state that you only support the master branch) then this should also be specified. Currently the examples don't work with the PyPI version -- see [https://github.com/python-telegram-bot/python-telegram-bot/issues/418](https://github.com/python-telegram-bot/python-telegram-bot/issues/418)