### PR TITLE
Add edit_* class methods

### DIFF
--- a/telegram/callbackquery.py
+++ b/telegram/callbackquery.py
@@ -69,3 +69,52 @@ class CallbackQuery(TelegramObject):
     def answer(self, *args, **kwargs):
         """Shortcut for ``bot.answerCallbackQuery(update.callback_query.id, *args, **kwargs)``"""
         return self.bot.answerCallbackQuery(self.id, *args, **kwargs)
+
+    def edit_message_text(self, *args, **kwargs):
+        """
+        Shortcut for either ``bot.editMessageText(chat_id=update.callback_query.message.chat_id, \
+message_id=update.callback_query.message.message_id, \
+*args, **kwargs)``
+        or ``bot.editMessageText(inline_message_id=update.callback_query.inline_message_id, \
+*args, **kwargs)``
+        """
+        if self.inline_message_id:
+            return self.bot.edit_message_text(
+                inline_message_id=self.inline_message_id, *args, **kwargs)
+        else:
+            return self.bot.edit_message_text(
+                chat_id=self.message.chat_id, message_id=self.message.message_id, *args, **kwargs)
+
+    def edit_message_caption(self, *args, **kwargs):
+        """
+        Shortcut for either
+        ``bot.editMessageCaption(chat_id=update.callback_query.message.chat_id, \
+message_id=update.callback_query.message.message_id, \
+*args, **kwargs)``
+        or
+        ``bot.editMessageCaption(inline_message_id=update.callback_query.inline_message_id, \
+*args, **kwargs)``
+        """
+        if self.inline_message_id:
+            return self.bot.edit_message_caption(
+                inline_message_id=self.inline_message_id, *args, **kwargs)
+        else:
+            return self.bot.edit_message_caption(
+                chat_id=self.message.chat_id, message_id=self.message.message_id, *args, **kwargs)
+
+    def edit_message_reply_markup(self, *args, **kwargs):
+        """
+        Shortcut for either
+        ``bot.editMessageReplyMarkup(chat_id=update.callback_query.message.chat_id, \
+message_id=update.callback_query.message.message_id, \
+*args, **kwargs)``
+        or
+        ``bot.editMessageReplyMarkup(inline_message_id=update.callback_query.inline_message_id, \
+*args, **kwargs)``
+        """
+        if self.inline_message_id:
+            return self.bot.edit_message_reply_markup(
+                inline_message_id=self.inline_message_id, *args, **kwargs)
+        else:
+            return self.bot.edit_message_reply_markup(
+                chat_id=self.message.chat_id, message_id=self.message.message_id, *args, **kwargs)

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -412,6 +412,48 @@ class Message(TelegramObject):
             disable_notification=disable_notification,
             message_id=self.message_id)
 
+    def edit_text(self, *args, **kwargs):
+        """
+        Shortcut for ``bot.editMessageText(chat_id=message.chat_id,
+                                       message_id=message.message_id,
+                                       *args, **kwargs)``
+
+        Note:
+            You can only edit messages that the bot sent itself,
+            therefore this method can only be used on the
+            return value of the bot.send_* family of methods.
+        """
+        return self.bot.edit_message_text(
+            chat_id=self.chat_id, message_id=self.message_id, *args, **kwargs)
+
+    def edit_caption(self, *args, **kwargs):
+        """
+        Shortcut for ``bot.editMessageCaption(chat_id=message.chat_id,
+                                              message_id=message.message_id,
+                                              *args, **kwargs)``
+
+        Note:
+            You can only edit messages that the bot sent itself,
+            therefore this method can only be used on the
+            return value of the bot.send_* family of methods.
+        """
+        return self.bot.edit_message_caption(
+            chat_id=self.chat_id, message_id=self.message_id, *args, **kwargs)
+
+    def edit_reply_markup(self, *args, **kwargs):
+        """
+        Shortcut for ``bot.editReplyMarkup(chat_id=message.chat_id,
+                                           message_id=message.message_id,
+                                           *args, **kwargs)``
+
+        Note:
+            You can only edit messages that the bot sent itself,
+            therefore this method can only be used on the
+            return value of the bot.send_* family of methods.
+        """
+        return self.bot.edit_message_caption(
+            chat_id=self.chat_id, message_id=self.message_id, *args, **kwargs)
+
     def parse_entity(self, entity):
         """
         Returns the text from a given :class:`telegram.MessageEntity`.

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -76,6 +76,15 @@ class MessageTest(BaseTest, unittest.TestCase):
         self.assertTrue(self.is_json(message.to_json()))
         self.assertEqual(message.text, 'Testing class method')
 
+    @flaky(3, 1)
+    def test_edit_text(self):
+        """Test for Message.edit_text"""
+        message = self._bot.sendMessage(self._chat_id, '.')
+        message = message.edit_text('Testing class method')
+
+        self.assertTrue(self.is_json(message.to_json()))
+        self.assertEqual(message.text, 'Testing class method')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds edit_* methods to message and callbackquery.
The ones in callbackquery check if the query came from a normal or inline message and acts accordingly.

Only thing I'm not sure about is how to test the edit_message_* methods in CallbackQuery, since we can't exactly send a callbackquery to the test bot every time we run tests, can we?

I'd also love to hear if anyone has got a better way to do the docstring for edit_message_text to also make it look good in source (currently I'm prioritising it looking good in the sphinx build).