### PR TITLE
Enable downloading to existing file-objects, instead of using file paths

### DIFF
--- a/telegram/file.py
+++ b/telegram/file.py
@@ -89,4 +89,5 @@ class File(TelegramObject):
 
         """
         url = self.file_path
-        self.bot.request.download(url, file_object)
+        
+        self.bot.request.download_to(url, file_object)

--- a/telegram/file.py
+++ b/telegram/file.py
@@ -81,3 +81,12 @@ class File(TelegramObject):
             filename = basename(url)
 
         self.bot.request.download(url, filename)
+
+    def download_to(self, file_object):
+        """
+        Args:
+            file_object (file-like):
+
+        """
+        url = self.file_path
+        self.bot.request.download(url, file_object)

--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -212,6 +212,18 @@ class Request(object):
             The filename within the path to download the file.
 
         """
-        buf = self._request_wrapper('GET', url)
         with open(filename, 'wb') as fobj:
-            fobj.write(buf)
+            self.download_to(url, fobj)
+    
+    def download_to(self, url, file_object):
+        """Downloads a file by its URL using an existing file object.
+        Args:
+          url:
+            The web location we want to retrieve.
+          
+          file_object:
+            A file-like object that supports write().
+        
+        """
+        buf = self._request_wrapper('GET', url)
+        file_object.write(buf)


### PR DESCRIPTION
I would like to propose to introduce a new method, `download_to`, that uses a file-like object where data is written. This allows to download to memory as well as to temporary files, without having the user to know the file path.

This may be useful for bots where the file does not need to be stored, for example for describe-the-image bots or bots that modify the image on-the-fly and send it back, without having to store it.
