### PR TITLE
fixes broken test cases with PhotoSize, Game and Animation classes

### DIFF
--- a/telegram/animation.py
+++ b/telegram/animation.py
@@ -37,10 +37,6 @@ class Animation(TelegramObject):
 
     def __init__(self,
                  file_id,
-                 thumb=None,
-                 file_name=None,
-                 mime_type=None,
-                 file_size=None,
                  **kwargs):
         self.file_id = file_id
         self.thumb = kwargs.get('thumb')

--- a/telegram/base.py
+++ b/telegram/base.py
@@ -74,17 +74,9 @@ class TelegramObject(object):
 
             value = self.__dict__[key]
             if value is not None:
-                if type(value) == list:
-                    l = list()
-                    for e in value:
-                        if hasattr(e, 'to_dict'):
-                            l.append(e.to_dict())
-                        else:
-                            l.append(e)
+                if hasattr(value, 'to_dict'):
+                    data[key] = value.to_dict()
                 else:
-                    if hasattr(value, 'to_dict'):
-                        data[key] = value.to_dict()
-                    else:
-                        data[key] = value
+                    data[key] = value
 
         return data

--- a/telegram/base.py
+++ b/telegram/base.py
@@ -74,9 +74,17 @@ class TelegramObject(object):
 
             value = self.__dict__[key]
             if value is not None:
-                if hasattr(value, 'to_dict'):
-                    data[key] = value.to_dict()
+                if type(value) == list:
+                    l = list()
+                    for e in value:
+                        if hasattr(e, 'to_dict'):
+                            l.append(e.to_dict())
+                        else:
+                            l.append(e)
                 else:
-                    data[key] = value
+                    if hasattr(value, 'to_dict'):
+                        data[key] = value.to_dict()
+                    else:
+                        data[key] = value
 
         return data

--- a/telegram/game.py
+++ b/telegram/game.py
@@ -79,6 +79,18 @@ class Game(TelegramObject):
 
         return Game(**data)
 
+    def to_dict(self):
+        """
+        Returns:
+            dict:
+        """
+        data = super(Game, self).to_dict()
+
+        data['photo'] = [p.to_dict() for p in self.photo]
+        data['text_entities'] = [x.to_dict() for x in self.text_entities]
+
+        return data
+
     def parse_text_entity(self, entity):
         """
         Returns the text from a given :class:`telegram.MessageEntity`.

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -292,7 +292,7 @@ class BotTest(BaseTest, unittest.TestCase):
 
         self.assertTrue(self.is_json(game.to_json()))
         self.assertEqual(message.game.description, game.game.description)
-        self.assertEqual(message.game.animation.file_id, game.game.animation)
+        self.assertEqual(message.game.animation, game.game.animation)
         self.assertEqual(message.game.photo[0].file_size, game.game.photo[0].file_size)
         self.assertNotEqual(message.game.text, game.game.text)
 

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -34,19 +34,33 @@ class GameTest(BaseTest, unittest.TestCase):
     def setUp(self):
         self.title = 'Python-telegram-bot Test Game'
         self.description = 'description'
-        self.photo = [telegram.PhotoSize(file_id='Blah', width=640, height=360)]
+        self.photo = [
+            {
+                'width': 640,
+                'height': 360,
+                'file_id': 'Blah',
+                'file_size': 0
+            }
+        ]
         self.text = 'Other description'
-        self.text_entities = [telegram.MessageEntity(
-            type=telegram.MessageEntity.URL, offset=13, length=17)]
-        self.animation = telegram.Animation(file_id='Bleh')
+        self.text_entities = [
+            {
+                'offset': 13,
+                'length': 17,
+                'type': telegram.MessageEntity.URL
+            }
+        ]
+        self.animation = {
+            'file_id': 'Blah'
+        }
 
         self.json_dict = {
             'title': self.title,
             'description': self.description,
             'photo': self.photo,
             'text': self.text,
-            'text_entities': [e.to_json() for e in self.text_entities],
-            'animation': self.animation.to_json()
+            'text_entities': self.text_entities,
+            'animation': self.animation
         }
 
     def test_game_de_json(self):
@@ -106,7 +120,12 @@ class AnimationTest(BaseTest, unittest.TestCase):
 
     def setUp(self):
         self.file_id = 'thisisafileid'
-        self.thumb = telegram.PhotoSize(file_id='Blah', width=640, height=360)
+        self.thumb = {
+            'width': 640,
+            'height': 360,
+            'file_id': 'Blah',
+            'file_size': 0
+        }
         self.file_name = 'File name'
         self.mime_type = 'something/gif'
         self.file_size = 42
@@ -123,7 +142,7 @@ class AnimationTest(BaseTest, unittest.TestCase):
         animation = telegram.Animation.de_json(self.json_dict, self._bot)
 
         self.assertEqual(animation.file_id, self.file_id)
-        self.assertEqual(animation.thumb, self.thumb)
+        self.assertTrue(isinstance(animation.thumb, telegram.PhotoSize))
         self.assertEqual(animation.file_name, self.file_name)
         self.assertEqual(animation.mime_type, self.mime_type)
         self.assertEqual(animation.file_size, self.file_size)


### PR DESCRIPTION
However **testSendGame** and **test_set_game_score** both produce:

**BadRequest: u'Wrong file identifier/HTTP URL specified** 

for the official **@pythontelegrambottests** test bot.

This is very probably the case because the test bot it not correctly configured to be a game. 

