### PR TITLE
Issue 422: Too Many Requests error on start_polling with clean=True

### DIFF
--- a/telegram/ext/updater.py
+++ b/telegram/ext/updater.py
@@ -329,6 +329,7 @@ class Updater(object):
                     # Disable webhook for cleaning
                     self.bot.setWebhook(webhook_url='')
                     self._clean_updates()
+                    sleep(1)
 
                 self.bot.setWebhook(webhook_url=webhook_url, certificate=cert)
             except (Unauthorized, InvalidToken):


### PR DESCRIPTION
Issue 422: Fixed start_polling with clean=True can cause 'Too Many Requests' error from Telegram.