### PR TITLE
hide inline keyboard in conversationbot example

### DIFF
--- a/examples/conversationbot.py
+++ b/examples/conversationbot.py
@@ -17,7 +17,7 @@ Press Ctrl-C on the command line or send a signal to the process to stop the
 bot.
 """
 
-from telegram import (ReplyKeyboardMarkup)
+from telegram import (ReplyKeyboardMarkup, ReplyKeyboardHide)
 from telegram.ext import (Updater, CommandHandler, MessageHandler, Filters, RegexHandler,
                           ConversationHandler)
 
@@ -48,7 +48,8 @@ def gender(bot, update):
     user = update.message.from_user
     logger.info("Gender of %s: %s" % (user.first_name, update.message.text))
     update.message.reply_text('I see! Please send me a photo of yourself, '
-                              'so I know what you look like, or send /skip if you don\'t want to.')
+                              'so I know what you look like, or send /skip if you don\'t want to.',
+                              reply_markup=ReplyKeyboardHide())
 
     return PHOTO
 
@@ -104,7 +105,8 @@ def bio(bot, update):
 def cancel(bot, update):
     user = update.message.from_user
     logger.info("User %s canceled the conversation." % user.first_name)
-    update.message.reply_text('Bye! I hope we can talk again some day.')
+    update.message.reply_text('Bye! I hope we can talk again some day.',
+                              reply_markup=ReplyKeyboardHide())
 
     return ConversationHandler.END
 


### PR DESCRIPTION
It was just a minor thing that bugged me while going through the examples: as per Telegram [docs](https://core.telegram.org/bots/api/#replykeyboardmarkup), using `one_time_keyboard=True` only hides the inline keyboard, but does not disable it completely, leaving a button that the user can press to get the keyboard back.

This little change to the `conversationbot.py` example script makes it so that the inline keyboard is properly hidden after usage or when the conversation is halted.
