### PR TITLE
Add switch_inline_query_current_chat

### DIFF
--- a/telegram/inlinekeyboardbutton.py
+++ b/telegram/inlinekeyboardbutton.py
@@ -30,6 +30,7 @@ class InlineKeyboardButton(TelegramObject):
         url (str):
         callback_data (str):
         switch_inline_query (str):
+        switch_inline_query_current_chat (str):
 
     Args:
         text (str):
@@ -39,6 +40,7 @@ class InlineKeyboardButton(TelegramObject):
         url (Optional[str]):
         callback_data (Optional[str]):
         switch_inline_query (Optional[str]):
+        switch_inline_query_current_chat (Optional[str]):
 
     """
 
@@ -50,6 +52,7 @@ class InlineKeyboardButton(TelegramObject):
         self.url = kwargs.get('url')
         self.callback_data = kwargs.get('callback_data')
         self.switch_inline_query = kwargs.get('switch_inline_query')
+        self.switch_inline_query_current_chat = kwargs.get('switch_inline_query_current_chat')
 
     @staticmethod
     def de_json(data, bot):


### PR DESCRIPTION
Add really useful option which is happened at last (3 Oct) update https://core.telegram.org/bots/api-changelog

So, now if you use switch_inline_query_current_chat="test" as an InlineKeyboardButton option, telegram automatically insert text "test" to current chat input box.