### PR TITLE
Use explicit kwargs

### DIFF
--- a/telegram/audio.py
+++ b/telegram/audio.py
@@ -35,13 +35,12 @@ class Audio(TelegramObject):
     Args:
         file_id (str):
         duration (int):
-        **kwargs: Arbitrary keyword arguments.
-
-    Keyword Args:
         performer (Optional[str]):
         title (Optional[str]):
         mime_type (Optional[str]):
         file_size (Optional[int]):
+        **kwargs: Arbitrary keyword arguments.
+
     """
 
     def __init__(self,

--- a/telegram/audio.py
+++ b/telegram/audio.py
@@ -44,15 +44,22 @@ class Audio(TelegramObject):
         file_size (Optional[int]):
     """
 
-    def __init__(self, file_id, duration, **kwargs):
+    def __init__(self,
+                 file_id,
+                 duration,
+                 performer='',
+                 title='',
+                 mime_type='',
+                 file_size=0,
+                 **kwargs):
         # Required
         self.file_id = str(file_id)
         self.duration = int(duration)
         # Optionals
-        self.performer = kwargs.get('performer', '')
-        self.title = kwargs.get('title', '')
-        self.mime_type = str(kwargs.get('mime_type', ''))
-        self.file_size = int(kwargs.get('file_size', 0))
+        self.performer = performer
+        self.title = title
+        self.mime_type = str(mime_type)
+        self.file_size = int(file_size)
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -182,7 +182,16 @@ class Bot(TelegramObject):
 
     @log
     @message
-    def sendMessage(self, chat_id, text, parse_mode=None, disable_web_page_preview=None, **kwargs):
+    def sendMessage(self,
+                    chat_id,
+                    text,
+                    parse_mode=None,
+                    disable_web_page_preview=None,
+                    disable_notification=False,
+                    reply_to_message_id=None,
+                    reply_markup=None,
+                    timeout=None,
+                    **kwargs):
         """Use this method to send text messages.
 
         Args:
@@ -233,7 +242,13 @@ class Bot(TelegramObject):
 
     @log
     @message
-    def forwardMessage(self, chat_id, from_chat_id, message_id, **kwargs):
+    def forwardMessage(self,
+                       chat_id,
+                       from_chat_id,
+                       message_id,
+                       disable_notification=False,
+                       timeout=None,
+                       **kwargs):
         """Use this method to forward messages of any kind.
 
         Args:
@@ -276,7 +291,15 @@ class Bot(TelegramObject):
 
     @log
     @message
-    def sendPhoto(self, chat_id, photo, caption=None, **kwargs):
+    def sendPhoto(self,
+                  chat_id,
+                  photo,
+                  caption=None,
+                  disable_notification=False,
+                  reply_to_message_id=None,
+                  reply_markup=None,
+                  timeout=None,
+                  **kwargs):
         """Use this method to send photos.
 
         Args:
@@ -323,7 +346,17 @@ class Bot(TelegramObject):
 
     @log
     @message
-    def sendAudio(self, chat_id, audio, duration=None, performer=None, title=None, **kwargs):
+    def sendAudio(self,
+                  chat_id,
+                  audio,
+                  duration=None,
+                  performer=None,
+                  title=None,
+                  disable_notification=False,
+                  reply_to_message_id=None,
+                  reply_markup=None,
+                  timeout=None,
+                  **kwargs):
         """Use this method to send audio files, if you want Telegram clients to
         display them in the music player. Your audio must be in an .mp3 format.
         On success, the sent Message is returned. Bots can currently send audio
@@ -386,7 +419,16 @@ class Bot(TelegramObject):
 
     @log
     @message
-    def sendDocument(self, chat_id, document, filename=None, caption=None, **kwargs):
+    def sendDocument(self,
+                     chat_id,
+                     document,
+                     filename=None,
+                     caption=None,
+                     disable_notification=False,
+                     reply_to_message_id=None,
+                     reply_markup=None,
+                     timeout=None,
+                     **kwargs):
         """Use this method to send general files.
 
         Args:
@@ -438,7 +480,14 @@ class Bot(TelegramObject):
 
     @log
     @message
-    def sendSticker(self, chat_id, sticker, **kwargs):
+    def sendSticker(self,
+                    chat_id,
+                    sticker,
+                    disable_notification=False,
+                    reply_to_message_id=None,
+                    reply_markup=None,
+                    timeout=None,
+                    **kwargs):
         """Use this method to send .webp stickers.
 
         Args:
@@ -479,7 +528,16 @@ class Bot(TelegramObject):
 
     @log
     @message
-    def sendVideo(self, chat_id, video, duration=None, caption=None, **kwargs):
+    def sendVideo(self,
+                  chat_id,
+                  video,
+                  duration=None,
+                  caption=None,
+                  disable_notification=False,
+                  reply_to_message_id=None,
+                  reply_markup=None,
+                  timeout=None,
+                  **kwargs):
         """Use this method to send video files, Telegram clients support mp4
         videos (other formats may be sent as telegram.Document).
 
@@ -531,7 +589,15 @@ class Bot(TelegramObject):
 
     @log
     @message
-    def sendVoice(self, chat_id, voice, duration=None, **kwargs):
+    def sendVoice(self,
+                  chat_id,
+                  voice,
+                  duration=None,
+                  disable_notification=False,
+                  reply_to_message_id=None,
+                  reply_markup=None,
+                  timeout=None,
+                  **kwargs):
         """Use this method to send audio files, if you want Telegram clients to
         display the file as a playable voice message. For this to work, your
         audio must be in an .ogg file encoded with OPUS (other formats may be
@@ -582,7 +648,15 @@ class Bot(TelegramObject):
 
     @log
     @message
-    def sendLocation(self, chat_id, latitude, longitude, **kwargs):
+    def sendLocation(self,
+                     chat_id,
+                     latitude,
+                     longitude,
+                     disable_notification=False,
+                     reply_to_message_id=None,
+                     reply_markup=None,
+                     timeout=None,
+                     **kwargs):
         """Use this method to send point on the map.
 
         Args:
@@ -623,7 +697,17 @@ class Bot(TelegramObject):
 
     @log
     @message
-    def sendVenue(self, chat_id, latitude, longitude, title, address, foursquare_id=None,
+    def sendVenue(self,
+                  chat_id,
+                  latitude,
+                  longitude,
+                  title,
+                  address,
+                  foursquare_id=None,
+                  disable_notification=False,
+                  reply_to_message_id=None,
+                  reply_markup=None,
+                  timeout=None,
                   **kwargs):
         """
         Use this method to send information about a venue.
@@ -680,7 +764,16 @@ class Bot(TelegramObject):
 
     @log
     @message
-    def sendContact(self, chat_id, phone_number, first_name, last_name=None, **kwargs):
+    def sendContact(self,
+                    chat_id,
+                    phone_number,
+                    first_name,
+                    last_name=None,
+                    disable_notification=False,
+                    reply_to_message_id=None,
+                    reply_markup=None,
+                    timeout=None,
+                    **kwargs):
         """
         Use this method to send phone contacts.
 
@@ -763,6 +856,7 @@ class Bot(TelegramObject):
                           next_offset=None,
                           switch_pm_text=None,
                           switch_pm_parameter=None,
+                          timeout=None,
                           **kwargs):
         """Use this method to send answers to an inline query. No more than
         50 results per query are allowed.
@@ -771,6 +865,8 @@ class Bot(TelegramObject):
             inline_query_id (str): Unique identifier for the answered query.
             results (list[:class:`telegram.InlineQueryResult`]): A list of
                 results for the inline query.
+
+        Keyword Args:
             cache_time (Optional[int]): The maximum amount of time the
                 result of the inline query may be cached on the server.
             is_personal (Optional[bool]): Pass `True`, if results may be
@@ -788,8 +884,6 @@ class Bot(TelegramObject):
                 with the parameter switch_pm_parameter.
             switch_pm_parameter (Optional[str]): Parameter for the start
                 message sent to the bot when user presses the switch button.
-
-        Keyword Args:
             timeout (Optional[float]): If this value is specified, use it as
                 the definitive timeout (in seconds) for urlopen() operations.
 
@@ -818,12 +912,12 @@ class Bot(TelegramObject):
         if switch_pm_parameter:
             data['switch_pm_parameter'] = switch_pm_parameter
 
-        result = self._request.post(url, data, timeout=kwargs.get('timeout'))
+        result = self._request.post(url, data, timeout=timeout)
 
         return result
 
     @log
-    def getUserProfilePhotos(self, user_id, offset=None, limit=100, **kwargs):
+    def getUserProfilePhotos(self, user_id, offset=None, limit=100, timeout=None, **kwargs):
         """Use this method to get a list of profile pictures for a user.
 
         Args:
@@ -858,12 +952,12 @@ class Bot(TelegramObject):
         if limit:
             data['limit'] = limit
 
-        result = self._request.post(url, data, timeout=kwargs.get('timeout'))
+        result = self._request.post(url, data, timeout=timeout)
 
         return UserProfilePhotos.de_json(result, self)
 
     @log
-    def getFile(self, file_id, **kwargs):
+    def getFile(self, file_id, timeout=None, **kwargs):
         """Use this method to get basic info about a file and prepare it for
         downloading. For the moment, bots can download files of up to 20MB in
         size.
@@ -889,7 +983,7 @@ class Bot(TelegramObject):
 
         data = {'file_id': file_id}
 
-        result = self._request.post(url, data, timeout=kwargs.get('timeout'))
+        result = self._request.post(url, data, timeout=timeout)
 
         if result.get('file_path'):
             result['file_path'] = '%s/%s' % (self.base_file_url, result['file_path'])
@@ -897,7 +991,7 @@ class Bot(TelegramObject):
         return File.de_json(result, self)
 
     @log
-    def kickChatMember(self, chat_id, user_id, **kwargs):
+    def kickChatMember(self, chat_id, user_id, timeout=None, **kwargs):
         """Use this method to kick a user from a group or a supergroup. In the
         case of supergroups, the user will not be able to return to the group
         on their own using invite links, etc., unless unbanned first. The bot
@@ -926,12 +1020,12 @@ class Bot(TelegramObject):
 
         data = {'chat_id': chat_id, 'user_id': user_id}
 
-        result = self._request.post(url, data, timeout=kwargs.get('timeout'))
+        result = self._request.post(url, data, timeout=timeout)
 
         return result
 
     @log
-    def unbanChatMember(self, chat_id, user_id, **kwargs):
+    def unbanChatMember(self, chat_id, user_id, timeout=None, **kwargs):
         """Use this method to unban a previously kicked user in a supergroup.
         The user will not return to the group automatically, but will be able
         to join via link, etc. The bot must be an administrator in the group
@@ -960,12 +1054,17 @@ class Bot(TelegramObject):
 
         data = {'chat_id': chat_id, 'user_id': user_id}
 
-        result = self._request.post(url, data, timeout=kwargs.get('timeout'))
+        result = self._request.post(url, data, timeout=timeout)
 
         return result
 
     @log
-    def answerCallbackQuery(self, callback_query_id, text=None, show_alert=False, **kwargs):
+    def answerCallbackQuery(self,
+                            callback_query_id,
+                            text=None,
+                            show_alert=False,
+                            timeout=None,
+                            **kwargs):
         """Use this method to send answers to callback queries sent from
         inline keyboards. The answer will be displayed to the user as a
         notification at the top of the chat screen or as an alert.
@@ -982,10 +1081,6 @@ class Bot(TelegramObject):
         Keyword Args:
             timeout (Optional[float]): If this value is specified, use it as
                 the definitive timeout (in seconds) for urlopen() operations.
-            network_delay (Optional[float]): If using the timeout (which is
-                a `timeout` for the Telegram servers operation),
-                then `network_delay` as an extra delay (in seconds) to
-                compensate for network latency. Defaults to 2.
 
         Returns:
             bool: On success, `True` is returned.
@@ -1004,7 +1099,7 @@ class Bot(TelegramObject):
         if show_alert:
             data['show_alert'] = show_alert
 
-        result = self._request.post(url, data, timeout=kwargs.get('timeout'))
+        result = self._request.post(url, data, timeout=timeout)
 
         return result
 
@@ -1017,6 +1112,8 @@ class Bot(TelegramObject):
                         inline_message_id=None,
                         parse_mode=None,
                         disable_web_page_preview=None,
+                        reply_markup=None,
+                        timeout=None,
                         **kwargs):
         """Use this method to edit text messages sent by the bot or via the bot
         (for inline bots).
@@ -1084,6 +1181,8 @@ class Bot(TelegramObject):
                            message_id=None,
                            inline_message_id=None,
                            caption=None,
+                           reply_markup=None,
+                           timeout=None,
                            **kwargs):
         """Use this method to edit captions of messages sent by the bot or
         via the bot (for inline bots).
@@ -1136,6 +1235,8 @@ class Bot(TelegramObject):
                                chat_id=None,
                                message_id=None,
                                inline_message_id=None,
+                               reply_markup=None,
+                               timeout=None,
                                **kwargs):
         """Use this method to edit only the reply markup of messages sent by
         the bot or via the bot (for inline bots).
@@ -1228,7 +1329,7 @@ class Bot(TelegramObject):
         return [Update.de_json(u, self) for u in result]
 
     @log
-    def setWebhook(self, webhook_url=None, certificate=None, **kwargs):
+    def setWebhook(self, webhook_url=None, certificate=None, timeout=None, **kwargs):
         """Use this method to specify a url and receive incoming updates via an
         outgoing webhook. Whenever there is an update for the bot, we will send
         an HTTPS POST request to the specified url, containing a
@@ -1261,12 +1362,12 @@ class Bot(TelegramObject):
         if certificate:
             data['certificate'] = certificate
 
-        result = self._request.post(url, data, timeout=kwargs.get('timeout'))
+        result = self._request.post(url, data, timeout=timeout)
 
         return result
 
     @log
-    def leaveChat(self, chat_id, **kwargs):
+    def leaveChat(self, chat_id, timeout=None, **kwargs):
         """Use this method for your bot to leave a group, supergroup or
         channel.
 
@@ -1291,12 +1392,12 @@ class Bot(TelegramObject):
 
         data = {'chat_id': chat_id}
 
-        result = self._request.post(url, data, timeout=kwargs.get('timeout'))
+        result = self._request.post(url, data, timeout=timeout)
 
         return result
 
     @log
-    def getChat(self, chat_id, **kwargs):
+    def getChat(self, chat_id, timeout=None, **kwargs):
         """Use this method to get up to date information about the chat
         (current name of the user for one-on-one conversations, current
         username of a user, group or channel, etc.).
@@ -1323,12 +1424,12 @@ class Bot(TelegramObject):
 
         data = {'chat_id': chat_id}
 
-        result = self._request.post(url, data, timeout=kwargs.get('timeout'))
+        result = self._request.post(url, data, timeout=timeout)
 
         return Chat.de_json(result, self)
 
     @log
-    def getChatAdministrators(self, chat_id, **kwargs):
+    def getChatAdministrators(self, chat_id, timeout=None, **kwargs):
         """Use this method to get a list of administrators in a chat. On
         success, returns an Array of ChatMember objects that contains
         information about all chat administrators except other bots. If the
@@ -1358,12 +1459,12 @@ class Bot(TelegramObject):
 
         data = {'chat_id': chat_id}
 
-        result = self._request.post(url, data, timeout=kwargs.get('timeout'))
+        result = self._request.post(url, data, timeout=timeout)
 
         return [ChatMember.de_json(x, self) for x in result]
 
     @log
-    def getChatMembersCount(self, chat_id, **kwargs):
+    def getChatMembersCount(self, chat_id, timeout=None, **kwargs):
         """Use this method to get the number of members in a chat.
 
         Args:
@@ -1388,12 +1489,12 @@ class Bot(TelegramObject):
 
         data = {'chat_id': chat_id}
 
-        result = self._request.post(url, data, timeout=kwargs.get('timeout'))
+        result = self._request.post(url, data, timeout=timeout)
 
         return result
 
     @log
-    def getChatMember(self, chat_id, user_id, **kwargs):
+    def getChatMember(self, chat_id, user_id, timeout=None, **kwargs):
         """Use this method to get information about a member of a chat.
 
         Args:
@@ -1421,7 +1522,7 @@ class Bot(TelegramObject):
 
         data = {'chat_id': chat_id, 'user_id': user_id}
 
-        result = self._request.post(url, data, timeout=kwargs.get('timeout'))
+        result = self._request.post(url, data, timeout=timeout)
 
         return ChatMember.de_json(result, self)
 
@@ -1443,7 +1544,8 @@ class Bot(TelegramObject):
         return (self.__class__, (self.token, self.base_url.replace(self.token, ''),
                                  self.base_file_url.replace(self.token, '')))
 
-    # snake_case (PEP8) aliases
+# snake_case (PEP8) aliases
+
     get_me = getMe
     send_message = sendMessage
     forward_message = forwardMessage

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -163,15 +163,13 @@ class Bot(TelegramObject):
         """A simple method for testing your bot's auth token.
 
         Returns:
-            :class:`telegram.User`: A :class:`telegram.User` instance
-            representing that bot if the credentials are valid, `None`
-            otherwise.
+            :class:`telegram.User`: A :class:`telegram.User` instance representing that bot if the
+                credentials are valid, `None` otherwise.
 
         Raises:
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/getMe'.format(self.base_url)
 
         result = self._request.get(url)
@@ -205,9 +203,6 @@ class Bot(TelegramObject):
                 URLs in your bot's message.
             disable_web_page_preview (Optional[bool]): Disables link previews
                 for links in this message.
-            **kwargs (dict): Arbitrary keyword arguments.
-
-        Keyword Args:
             disable_notification (Optional[bool]): Sends the message silently.
                 iOS users will not receive a notification, Android users will
                 receive a notification with no sound.
@@ -219,16 +214,15 @@ class Bot(TelegramObject):
                 keyboard or to force a reply from the user.
             timeout (Optional[float]): If this value is specified, use it as
                 the definitive timeout (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
-            :class:`telegram.Message`: On success, the sent message is
-            returned.
+            :class:`telegram.Message`: On success, the sent message is returned.
 
         Raises:
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/sendMessage'.format(self.base_url)
 
         data = {'chat_id': chat_id, 'text': text}
@@ -252,30 +246,23 @@ class Bot(TelegramObject):
         """Use this method to forward messages of any kind.
 
         Args:
-          chat_id:
-            Unique identifier for the message recipient - Chat id.
-          from_chat_id:
-            Unique identifier for the chat where the original message was sent
-            - Chat id.
-          message_id:
-            Unique message identifier.
-
-        Keyword Args:
-            disable_notification (Optional[bool]): Sends the message silently.
-                iOS users will not receive a notification, Android users will
-                receive a notification with no sound.
+            chat_id: Unique identifier for the message recipient - Chat id.
+            from_chat_id: Unique identifier for the chat where the original message was sent
+                - Chat id.
+            message_id: Unique message identifier.
+            disable_notification (Optional[bool]): Sends the message silently. iOS users will not
+                receive a notification, Android users will receive a notification with no sound.
             timeout (Optional[float]): If this value is specified, use it as
                 the definitive timeout (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
-            :class:`telegram.Message`: On success, instance representing the
-            message forwarded.
+            :class:`telegram.Message`: On success, instance representing the message forwarded.
 
         Raises:
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/forwardMessage'.format(self.base_url)
 
         data = {}
@@ -303,38 +290,29 @@ class Bot(TelegramObject):
         """Use this method to send photos.
 
         Args:
-          chat_id:
-            Unique identifier for the message recipient - Chat id.
-          photo:
-            Photo to send. You can either pass a file_id as String to resend a
-            photo that is already on the Telegram servers, or upload a new
-            photo using multipart/form-data.
-          caption:
-            Photo caption (may also be used when resending photos by file_id).
-            [Optional]
-
-        Keyword Args:
-            disable_notification (Optional[bool]): Sends the message silently.
-                iOS users will not receive a notification, Android users will
-                receive a notification with no sound.
-            reply_to_message_id (Optional[int]): If the message is a reply,
-                ID of the original message.
-            reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional
-                interface options. A JSON-serialized object for an inline
-                keyboard, custom reply keyboard, instructions to hide reply
-                keyboard or to force a reply from the user.
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            chat_id: Unique identifier for the message recipient - Chat id.
+            photo: Photo to send. You can either pass a file_id as String to resend a photo that is
+                already on the Telegram servers, or upload a new photo using multipart/form-data.
+            caption (Optional[str]): Photo caption (may also be used when resending photos by
+                file_id).
+            disable_notification (Optional[bool]): Sends the message silently. iOS users will not
+                receive a notification, Android users will receive a notification with no sound.
+            reply_to_message_id (Optional[int]): If the message is a reply, ID of the original
+                message.
+            reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional interface options. A
+                JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
+                to hide reply keyboard or to force a reply from the user.
+            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
+                (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
-            :class:`telegram.Message`: On success, instance representing the
-            message posted.
+            :class:`telegram.Message`: On success, instance representing the message posted.
 
         Raises:
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/sendPhoto'.format(self.base_url)
 
         data = {'chat_id': chat_id, 'photo': photo}
@@ -369,41 +347,31 @@ class Bot(TelegramObject):
         use sendVoice method instead.
 
         Args:
-          chat_id:
-            Unique identifier for the message recipient - Chat id.
-          audio:
-            Audio file to send. You can either pass a file_id as String to
-            resend an audio that is already on the Telegram servers, or upload
-            a new audio file using multipart/form-data.
-          duration:
-            Duration of sent audio in seconds. [Optional]
-          performer:
-            Performer of sent audio. [Optional]
-          title:
-            Title of sent audio. [Optional]
-
-        Keyword Args:
-            disable_notification (Optional[bool]): Sends the message silently.
-                iOS users will not receive a notification, Android users will
-                receive a notification with no sound.
-            reply_to_message_id (Optional[int]): If the message is a reply,
-                ID of the original message.
-            reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional
-                interface options. A JSON-serialized object for an inline
-                keyboard, custom reply keyboard, instructions to hide reply
-                keyboard or to force a reply from the user.
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            chat_id: Unique identifier for the message recipient - Chat id.
+            audio Audio file to send. You can either pass a file_id as String to resend an audio
+                that is already on the Telegram servers, or upload a new audio file using
+                multipart/form-data.
+            duration (Optional[int]): Duration of sent audio in seconds.
+            performer: Performer of sent audio. [Optional]
+            title: Title of sent audio. [Optional]
+            disable_notification (Optional[bool]): Sends the message silently. iOS users will not
+                receive a notification, Android users will receive a notification with no sound.
+            reply_to_message_id (Optional[int]): If the message is a reply, ID of the original
+                message.
+            reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional interface options. A
+                JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
+                to hide reply keyboard or to force a reply from the user.
+            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
+                (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
-            :class:`telegram.Message`: On success, instance representing the
-            message posted.
+            :class:`telegram.Message`: On success, instance representing the message posted.
 
         Raises:
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/sendAudio'.format(self.base_url)
 
         data = {'chat_id': chat_id, 'audio': audio}
@@ -432,41 +400,31 @@ class Bot(TelegramObject):
         """Use this method to send general files.
 
         Args:
-          chat_id:
-            Unique identifier for the message recipient - Chat id.
-          document:
-            File to send. You can either pass a file_id as String to resend a
-            file that is already on the Telegram servers, or upload a new file
-            using multipart/form-data.
-          filename:
-            File name that shows in telegram message (it is usefull when you
-            send file generated by temp module, for example). [Optional]
-          caption:
-            Document caption (may also be used when resending documents by
-            file_id), 0-200 characters. [Optional]
-
-        Keyword Args:
-            disable_notification (Optional[bool]): Sends the message silently.
-                iOS users will not receive a notification, Android users will
-                receive a notification with no sound.
-            reply_to_message_id (Optional[int]): If the message is a reply,
-                ID of the original message.
-            reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional
-                interface options. A JSON-serialized object for an inline
-                keyboard, custom reply keyboard, instructions to hide reply
-                keyboard or to force a reply from the user.
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            chat_id: Unique identifier for the message recipient - Chat id.
+            document: File to send. You can either pass a file_id as String to resend a file that
+                is already on the Telegram servers, or upload a new file using multipart/form-data.
+            filename: File name that shows in telegram message (it is usefull when you send file
+                generated by temp module, for example). [Optional]
+            caption (Optional[str]): Document caption (may also be used when resending documents by
+                file_id), 0-200 characters.
+            disable_notification (Optional[bool]): Sends the message silently. iOS users will not
+                receive a notification, Android users will receive a notification with no sound.
+            reply_to_message_id (Optional[int]): If the message is a reply, ID of the original
+                message.
+            reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional interface options. A
+                JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
+                to hide reply keyboard or to force a reply from the user.
+            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
+                (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
-            :class:`telegram.Message`: On success, instance representing the
-            message posted.
+            :class:`telegram.Message`: On success, instance representing the message posted.
 
         Raises:
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/sendDocument'.format(self.base_url)
 
         data = {'chat_id': chat_id, 'document': document}
@@ -491,35 +449,28 @@ class Bot(TelegramObject):
         """Use this method to send .webp stickers.
 
         Args:
-          chat_id:
-            Unique identifier for the message recipient - Chat id.
-          sticker:
-            Sticker to send. You can either pass a file_id as String to resend
-            a sticker that is already on the Telegram servers, or upload a new
-            sticker using multipart/form-data.
-
-        Keyword Args:
-            disable_notification (Optional[bool]): Sends the message silently.
-                iOS users will not receive a notification, Android users will
-                receive a notification with no sound.
-            reply_to_message_id (Optional[int]): If the message is a reply,
-                ID of the original message.
-            reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional
-                interface options. A JSON-serialized object for an inline
-                keyboard, custom reply keyboard, instructions to hide reply
-                keyboard or to force a reply from the user.
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            chat_id: Unique identifier for the message recipient - Chat id.
+            sticker: Sticker to send. You can either pass a file_id as String to resend a sticker
+                that is already on the Telegram servers, or upload a new sticker using
+                multipart/form-data.
+            disable_notification (Optional[bool]): Sends the message silently. iOS users will not
+                receive a notification, Android users will receive a notification with no sound.
+            reply_to_message_id (Optional[int]): If the message is a reply, ID of the original
+                message.
+            reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional interface options. A
+                JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
+                to hide reply keyboard or to force a reply from the user.
+            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
+                (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
-            :class:`telegram.Message`: On success, instance representing the
-            message posted.
+            :class:`telegram.Message`: On success, instance representing the message posted.
 
         Raises:
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/sendSticker'.format(self.base_url)
 
         data = {'chat_id': chat_id, 'sticker': sticker}
@@ -542,40 +493,30 @@ class Bot(TelegramObject):
         videos (other formats may be sent as telegram.Document).
 
         Args:
-          chat_id:
-            Unique identifier for the message recipient - Chat id.
-          video:
-            Video to send. You can either pass a file_id as String to resend a
-            video that is already on the Telegram servers, or upload a new
-            video file using multipart/form-data.
-          duration:
-            Duration of sent video in seconds. [Optional]
-          caption:
-            Video caption (may also be used when resending videos by file_id).
-            [Optional]
-
-        Keyword Args:
-            disable_notification (Optional[bool]): Sends the message silently.
-                iOS users will not receive a notification, Android users will
-                receive a notification with no sound.
-            reply_to_message_id (Optional[int]): If the message is a reply,
-                ID of the original message.
-            reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional
-                interface options. A JSON-serialized object for an inline
-                keyboard, custom reply keyboard, instructions to hide reply
-                keyboard or to force a reply from the user.
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            chat_id: Unique identifier for the message recipient - Chat id.
+            video: Video to send. You can either pass a file_id as String to resend a video that is
+                already on the Telegram servers, or upload a new video file using
+                multipart/form-data.
+            duration (Optional[int]): Duration of sent video in seconds.
+            caption (Optional[str]): Video caption (may also be used when resending videos by
+                file_id).
+            disable_notification (Optional[bool]): Sends the message silently. iOS users will not
+                receive a notification, Android users will receive a notification with no sound.
+            reply_to_message_id (Optional[int]): If the message is a reply, ID of the original
+                message.
+            reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional interface options. A
+                JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
+                to hide reply keyboard or to force a reply from the user.
+            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
+                (in seconds) for urlopen() operations.
 
         Returns:
-            :class:`telegram.Message`: On success, instance representing the
-            message posted.
+            :class:`telegram.Message`: On success, instance representing the message posted.
 
         Raises:
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/sendVideo'.format(self.base_url)
 
         data = {'chat_id': chat_id, 'video': video}
@@ -598,45 +539,36 @@ class Bot(TelegramObject):
                   reply_markup=None,
                   timeout=None,
                   **kwargs):
-        """Use this method to send audio files, if you want Telegram clients to
-        display the file as a playable voice message. For this to work, your
-        audio must be in an .ogg file encoded with OPUS (other formats may be
-        sent as Audio or Document). On success, the sent Message is returned.
-        Bots can currently send audio files of up to 50 MB in size, this limit
-        may be changed in the future.
+        """Use this method to send audio files, if you want Telegram clients to display the file as
+        a playable voice message. For this to work, your audio must be in an .ogg file encoded with
+        OPUS (other formats may be sent as Audio or Document). On success, the sent Message is
+        returned. Bots can currently send audio files of up to 50 MB in size, this limit may be
+        changed in the future.
 
         Args:
-          chat_id:
-            Unique identifier for the message recipient - Chat id.
-          voice:
-            Audio file to send. You can either pass a file_id as String to
-            resend an audio that is already on the Telegram servers, or upload
-            a new audio file using multipart/form-data.
-          duration:
-            Duration of sent audio in seconds. [Optional]
-
-        Keyword Args:
-            disable_notification (Optional[bool]): Sends the message silently.
-                iOS users will not receive a notification, Android users will
-                receive a notification with no sound.
-            reply_to_message_id (Optional[int]): If the message is a reply,
-                ID of the original message.
-            reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional
-                interface options. A JSON-serialized object for an inline
-                keyboard, custom reply keyboard, instructions to hide reply
-                keyboard or to force a reply from the user.
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            chat_id: Unique identifier for the message recipient - Chat id.
+            voice: Audio file to send. You can either pass a file_id as String to resend an audio
+                that is already on the Telegram servers, or upload a new audio file using
+                multipart/form-data.
+            duration (Optional[int]): Duration of sent audio in seconds.
+            disable_notification (Optional[bool]): Sends the message silently. iOS users will not
+                receive a notification, Android users will receive a notification with no sound.
+            reply_to_message_id (Optional[int]): If the message is a reply, ID of the original
+                message.
+            reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional interface options. A
+                JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
+                to hide reply keyboard or to force a reply from the user.
+            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
+                (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
-            :class:`telegram.Message`: On success, instance representing the
-            message posted.
+            :class:`telegram.Message`: On success, instance representing the message posted.
 
         Raises:
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/sendVoice'.format(self.base_url)
 
         data = {'chat_id': chat_id, 'voice': voice}
@@ -660,35 +592,27 @@ class Bot(TelegramObject):
         """Use this method to send point on the map.
 
         Args:
-          chat_id:
-            Unique identifier for the message recipient - Chat id.
-          latitude:
-            Latitude of location.
-          longitude:
-            Longitude of location.
-
-        Keyword Args:
-            disable_notification (Optional[bool]): Sends the message silently.
-                iOS users will not receive a notification, Android users will
-                receive a notification with no sound.
-            reply_to_message_id (Optional[int]): If the message is a reply,
-                ID of the original message.
-            reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional
-                interface options. A JSON-serialized object for an inline
-                keyboard, custom reply keyboard, instructions to hide reply
-                keyboard or to force a reply from the user.
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            chat_id: Unique identifier for the message recipient - Chat id.
+            latitude (float): Latitude of location.
+            longitude (float): Longitude of location.
+            disable_notification (Optional[bool]): Sends the message silently. iOS users will not
+                receive a notification, Android users will receive a notification with no sound.
+            reply_to_message_id (Optional[int]): If the message is a reply, ID of the original
+                message.
+            reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional interface options. A
+                JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
+                to hide reply keyboard or to force a reply from the user.
+            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
+                (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
-            :class:`telegram.Message`: On success, instance representing the
-            message posted.
+            :class:`telegram.Message`: On success, instance representing the message posted.
 
         Raises:
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/sendLocation'.format(self.base_url)
 
         data = {'chat_id': chat_id, 'latitude': latitude, 'longitude': longitude}
@@ -713,42 +637,31 @@ class Bot(TelegramObject):
         Use this method to send information about a venue.
 
         Args:
-            chat_id:
-                Unique identifier for the target chat or username of the target
-                channel (in the format @channelusername).
-            latitude:
-                Latitude of the venue.
-            longitude:
-                Longitude of the venue.
-            title:
-                Name of the venue.
-            address:
-                Address of the venue.
-            foursquare_id:
-                Foursquare identifier of the venue.
-
-        Keyword Args:
-            disable_notification (Optional[bool]): Sends the message silently.
-                iOS users will not receive a notification, Android users will
-                receive a notification with no sound.
-            reply_to_message_id (Optional[int]): If the message is a reply,
-                ID of the original message.
-            reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional
-                interface options. A JSON-serialized object for an inline
-                keyboard, custom reply keyboard, instructions to hide reply
-                keyboard or to force a reply from the user.
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            chat_id: Unique identifier for the target chat or username of the target channel (in
+                the format @channelusername).
+            latitude (float): Latitude of the venue.
+            longitude (float): Longitude of the venue.
+            title (str): Name of the venue.
+            address (str): Address of the venue.
+            foursquare_id (Optional[str]): Foursquare identifier of the venue.
+            disable_notification (Optional[bool]): Sends the message silently. iOS users will not
+                receive a notification, Android users will receive a notification with no sound.
+            reply_to_message_id (Optional[int]): If the message is a reply, ID of the original
+                message.
+            reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional interface options. A
+                JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
+                to hide reply keyboard or to force a reply from the user.
+            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
+                (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
-            :class:`telegram.Message`: On success, instance representing the
-            message posted.
+            :class:`telegram.Message`: On success, instance representing the message posted.
 
         Raises:
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/sendVenue'.format(self.base_url)
 
         data = {'chat_id': chat_id,
@@ -778,38 +691,29 @@ class Bot(TelegramObject):
         Use this method to send phone contacts.
 
         Args:
-            chat_id:
-                Unique identifier for the target chat or username of the target
-                channel (in the format @channelusername).
-            phone_number:
-                Contact's phone number.
-            first_name:
-                Contact's first name.
-            last_name:
-                Contact's last name.
-
-        Keyword Args:
-            disable_notification (Optional[bool]): Sends the message silently.
-                iOS users will not receive a notification, Android users will
-                receive a notification with no sound.
-            reply_to_message_id (Optional[int]): If the message is a reply,
-                ID of the original message.
-            reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional
-                interface options. A JSON-serialized object for an inline
-                keyboard, custom reply keyboard, instructions to hide reply
-                keyboard or to force a reply from the user.
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            chat_id: Unique identifier for the target chat or username of the target channel (in
+                the format @channelusername).
+            phone_number (str): Contact's phone number.
+            first_name (str): Contact's first name.
+            last_name (Optional[str]): Contact's last name.
+            disable_notification (Optional[bool]): Sends the message silently. iOS users will not
+                receive a notification, Android users will receive a notification with no sound.
+            reply_to_message_id (Optional[int]): If the message is a reply, ID of the original
+                message.
+            reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional interface options. A
+                JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
+                to hide reply keyboard or to force a reply from the user.
+            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
+                (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
-            :class:`telegram.Message`: On success, instance representing the
-            message posted.
+            :class:`telegram.Message`: On success, instance representing the message posted.
 
         Raises:
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/sendContact'.format(self.base_url)
 
         data = {'chat_id': chat_id, 'phone_number': phone_number, 'first_name': first_name}
@@ -822,25 +726,23 @@ class Bot(TelegramObject):
     @log
     @message
     def sendChatAction(self, chat_id, action, **kwargs):
-        """Use this method when you need to tell the user that something is
-        happening on the bot's side. The status is set for 5 seconds or less
-        (when a message arrives from your bot, Telegram clients clear its
-        typing status).
+        """Use this method when you need to tell the user that something is happening on the bot's
+        side. The status is set for 5 seconds or less (when a message arrives from your bot,
+        Telegram clients clear its typing status).
 
         Args:
-          chat_id:
-            Unique identifier for the message recipient - Chat id.
-          action:
-            Type of action to broadcast. Choose one, depending on what the user
-            is about to receive:
-            - ChatAction.TYPING for text messages,
-            - ChatAction.UPLOAD_PHOTO for photos,
-            - ChatAction.UPLOAD_VIDEO for videos,
-            - ChatAction.UPLOAD_AUDIO for audio files,
-            - ChatAction.UPLOAD_DOCUMENT for general files,
-            - ChatAction.FIND_LOCATION for location data.
-        """
+            chat_id: Unique identifier for the message recipient - Chat id.
+            action: Type of action to broadcast. Choose one, depending on what the user is about to
+                receive:
+                    - ChatAction.TYPING for text messages,
+                    - ChatAction.UPLOAD_PHOTO for photos,
+                    - ChatAction.UPLOAD_VIDEO for videos,
+                    - ChatAction.UPLOAD_AUDIO for audio files,
+                    - ChatAction.UPLOAD_DOCUMENT for general files,
+                    - ChatAction.FIND_LOCATION for location data.
+            **kwargs (dict): Arbitrary keyword arguments.
 
+        """
         url = '{0}/sendChatAction'.format(self.base_url)
 
         data = {'chat_id': chat_id, 'action': action}
@@ -858,34 +760,30 @@ class Bot(TelegramObject):
                           switch_pm_parameter=None,
                           timeout=None,
                           **kwargs):
-        """Use this method to send answers to an inline query. No more than
-        50 results per query are allowed.
+        """Use this method to send answers to an inline query. No more than 50 results per query
+        are allowed.
 
         Args:
             inline_query_id (str): Unique identifier for the answered query.
-            results (list[:class:`telegram.InlineQueryResult`]): A list of
-                results for the inline query.
-
-        Keyword Args:
-            cache_time (Optional[int]): The maximum amount of time the
-                result of the inline query may be cached on the server.
-            is_personal (Optional[bool]): Pass `True`, if results may be
-                cached on the server side only for the user that sent the
-                query. By default, results may be returned to any user who
-                sends the same query.
-            next_offset (Optional[str]): Pass the offset that a client
-                should send in the next query with the same text to receive
-                more results. Pass an empty string if there are no more
-                results or if you don't support pagination. Offset length
-                can't exceed 64 bytes.
-            switch_pm_text (Optional[str]): If passed, clients will display
-                a button with specified text that switches the user to a
-                private chat with the bot and sends the bot a start message
-                with the parameter switch_pm_parameter.
-            switch_pm_parameter (Optional[str]): Parameter for the start
-                message sent to the bot when user presses the switch button.
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            results (list[:class:`telegram.InlineQueryResult`]): A list of results for the inline
+                query.
+            cache_time (Optional[int]): The maximum amount of time the result of the inline query
+                may be cached on the server.
+            is_personal (Optional[bool]): Pass `True`, if results may be cached on the server side
+                only for the user that sent the query. By default, results may be returned to any
+                user who sends the same query.
+            next_offset (Optional[str]): Pass the offset that a client should send in the next
+                query with the same text to receive more results. Pass an empty string if there are
+                no more results or if you don't support pagination. Offset length can't exceed 64
+                bytes.
+            switch_pm_text (Optional[str]): If passed, clients will display a button with specified
+                text that switches the user to a private chat with the bot and sends the bot a
+                start message with the parameter switch_pm_parameter.
+            switch_pm_parameter (Optional[str]): Parameter for the start message sent to the bot
+                when user presses the switch button.
+            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
+                (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
             bool: On success, `True` is returned.
@@ -894,7 +792,6 @@ class Bot(TelegramObject):
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/answerInlineQuery'.format(self.base_url)
 
         results = [res.to_dict() for res in results]
@@ -921,28 +818,23 @@ class Bot(TelegramObject):
         """Use this method to get a list of profile pictures for a user.
 
         Args:
-          user_id:
-            Unique identifier of the target user.
-          offset:
-            Sequential number of the first photo to be returned. By default,
-            all photos are returned. [Optional]
-          limit:
-            Limits the number of photos to be retrieved. Values between 1-100
-            are accepted. Defaults to 100. [Optional]
-
-        Keyword Args:
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            user_id: Unique identifier of the target user.
+            offset (Optional[int]: Sequential number of the first photo to be returned. By default,
+                all photos are returned.
+            limit (Optional[int]): Limits the number of photos to be retrieved. Values between
+                1-100 are accepted. Defaults to 100.
+            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
+                (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
-            list[:class:`telegram.UserProfilePhotos`]: A list of
-            :class:`telegram.UserProfilePhotos` objects are returned.
+            list[:class:`telegram.UserProfilePhotos`]: A list of user profile photos objects is
+                returned.
 
         Raises:
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/getUserProfilePhotos'.format(self.base_url)
 
         data = {'user_id': user_id}
@@ -958,27 +850,22 @@ class Bot(TelegramObject):
 
     @log
     def getFile(self, file_id, timeout=None, **kwargs):
-        """Use this method to get basic info about a file and prepare it for
-        downloading. For the moment, bots can download files of up to 20MB in
-        size.
+        """Use this method to get basic info about a file and prepare it for downloading. For the
+        moment, bots can download files of up to 20MB in size.
 
         Args:
-          file_id:
-            File identifier to get info about.
-
-        Keyword Args:
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            file_id: File identifier to get info about.
+            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
+                (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
-            :class:`telegram.File`: On success, a :class:`telegram.File`
-            object is returned.
+            :class:`telegram.File`: On success, a :class:`telegram.File` object is returned.
 
         Raises:
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/getFile'.format(self.base_url)
 
         data = {'file_id': file_id}
@@ -992,21 +879,19 @@ class Bot(TelegramObject):
 
     @log
     def kickChatMember(self, chat_id, user_id, timeout=None, **kwargs):
-        """Use this method to kick a user from a group or a supergroup. In the
-        case of supergroups, the user will not be able to return to the group
-        on their own using invite links, etc., unless unbanned first. The bot
-        must be an administrator in the group for this to work.
+        """Use this method to kick a user from a group or a supergroup.
+
+        In the case of supergroups, the user will not be able to return to the group on their own
+        using invite links, etc., unless unbanned first. The bot must be an administrator in the
+        group for this to work.
 
         Args:
-          chat_id:
-            Unique identifier for the target group or username of the target
-            supergroup (in the format @supergroupusername).
-          user_id:
-            Unique identifier of the target user.
-
-        Keyword Args:
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            chat_id: Unique identifier for the target group or username of the target supergroup
+                (in the format @supergroupusername).
+            user_id: Unique identifier of the target user.
+            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
+                (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
             bool: On success, `True` is returned.
@@ -1015,7 +900,6 @@ class Bot(TelegramObject):
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/kickChatMember'.format(self.base_url)
 
         data = {'chat_id': chat_id, 'user_id': user_id}
@@ -1027,20 +911,16 @@ class Bot(TelegramObject):
     @log
     def unbanChatMember(self, chat_id, user_id, timeout=None, **kwargs):
         """Use this method to unban a previously kicked user in a supergroup.
-        The user will not return to the group automatically, but will be able
-        to join via link, etc. The bot must be an administrator in the group
-        for this to work.
+        The user will not return to the group automatically, but will be able to join via link,
+        etc. The bot must be an administrator in the group for this to work.
 
         Args:
-          chat_id:
-            Unique identifier for the target group or username of the target
-            supergroup (in the format @supergroupusername).
-          user_id:
-            Unique identifier of the target user.
-
-        Keyword Args:
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            chat_id: Unique identifier for the target group or username of the target supergroup
+                (in the format @supergroupusername).
+          user_id: Unique identifier of the target user.
+            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
+                (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
             bool: On success, `True` is returned.
@@ -1049,7 +929,6 @@ class Bot(TelegramObject):
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/unbanChatMember'.format(self.base_url)
 
         data = {'chat_id': chat_id, 'user_id': user_id}
@@ -1065,22 +944,19 @@ class Bot(TelegramObject):
                             show_alert=False,
                             timeout=None,
                             **kwargs):
-        """Use this method to send answers to callback queries sent from
-        inline keyboards. The answer will be displayed to the user as a
-        notification at the top of the chat screen or as an alert.
+        """Use this method to send answers to callback queries sent from inline keyboards. The
+        answer will be displayed to the user as a notification at the top of the chat screen or as
+        an alert.
 
         Args:
-            callback_query_id (str): Unique identifier for the query to be
-                answered.
-            text (Optional[str]): Text of the notification. If not
-                specified, nothing will be shown to the user.
-            show_alert (Optional[bool]): If `True`, an alert will be shown
-                by the client instead of a notification at the top of the chat
-                screen. Defaults to `False`.
-
-        Keyword Args:
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            callback_query_id (str): Unique identifier for the query to be answered.
+            text (Optional[str]): Text of the notification. If not specified, nothing will be shown
+                to the user.
+            show_alert (Optional[bool]): If `True`, an alert will be shown by the client instead of
+                a notification at the top of the chat screen. Defaults to `False`.
+            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
+            (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
             bool: On success, `True` is returned.
@@ -1089,7 +965,6 @@ class Bot(TelegramObject):
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/answerCallbackQuery'.format(self.base_url)
 
         data = {'callback_query_id': callback_query_id}
@@ -1115,48 +990,35 @@ class Bot(TelegramObject):
                         reply_markup=None,
                         timeout=None,
                         **kwargs):
-        """Use this method to edit text messages sent by the bot or via the bot
-        (for inline bots).
+        """Use this method to edit text messages sent by the bot or via the bot (for inline bots).
 
         Args:
-          text:
-            New text of the message.
-          chat_id:
-            Required if inline_message_id is not specified. Unique identifier
-            for the target chat or username of the target channel (in the
-            format @channelusername).
-          message_id:
-            Required if inline_message_id is not specified. Unique identifier
-            of the sent message.
-          inline_message_id:
-            Required if chat_id and message_id are not specified. Identifier of
-            the inline message.
-          parse_mode:
-            Send Markdown or HTML, if you want Telegram apps to show bold,
-            italic, fixed-width text or inline URLs in your bot's message.
-          disable_web_page_preview:
-            Disables link previews for links in this message.
-          reply_markup:
-            A JSON-serialized object for an inline keyboard.
-
-        Keyword Args:
-            reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional
-                interface options. A JSON-serialized object for an inline
-                keyboard, custom reply keyboard, instructions to hide reply
-                keyboard or to force a reply from the user.
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            text: New text of the message.
+            chat_id: Required if inline_message_id is not specified. Unique identifier for the
+                target chat or username of the target channel (in the format @channelusername).
+            message_id: Required if inline_message_id is not specified. Unique identifier of the
+                sent message.
+            inline_message_id: Required if chat_id and message_id are not specified. Identifier of
+                the inline message.
+            parse_mode: Send Markdown or HTML, if you want Telegram apps to show bold, italic,
+                fixed-width text or inline URLs in your bot's message.
+            disable_web_page_preview: Disables link previews for links in this message.
+            reply_markup: A JSON-serialized object for an inline keyboard.
+            reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional interface options. A
+                JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
+                to hide reply keyboard or to force a reply from the user.
+            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
+                (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
-            :class:`telegram.Message`: On success, if edited message is sent by
-            the bot, the edited message is returned, otherwise `True` is
-            returned.
+            :class:`telegram.Message`: On success, if edited message is sent by the bot, the edited
+                message is returned, otherwise `True` is returned.
 
         Raises:
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/editMessageText'.format(self.base_url)
 
         data = {'text': text}
@@ -1184,30 +1046,27 @@ class Bot(TelegramObject):
                            reply_markup=None,
                            timeout=None,
                            **kwargs):
-        """Use this method to edit captions of messages sent by the bot or
-        via the bot (for inline bots).
+        """Use this method to edit captions of messages sent by the bot or via the bot (for inline
+            bots).
 
         Args:
-            chat_id (Optional[str]): Required if inline_message_id is not
-                specified. Unique identifier for the target chat or username of
-                the target channel (in the format @channelusername).
-            message_id (Optional[str]): Required if inline_message_id is not
-                specified. Unique identifier of the sent message.
-            inline_message_id (Optional[str]): Required if chat_id and
-                message_id are not specified. Identifier of the inline message.
+            chat_id (Optional[str]): Required if inline_message_id is not specified. Unique
+                identifier for the target chat or username of the target channel (in the format
+                @channelusername).
+            message_id (Optional[str]): Required if inline_message_id is not specified. Unique
+                identifier of the sent message.
+            inline_message_id (Optional[str]): Required if chat_id and message_id are not
+                specified. Identifier of the inline message.
             caption (Optional[str]): New caption of the message.
-            **kwargs (Optional[dict]): Arbitrary keyword arguments.
-
-        Keyword Args:
-            reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]):
-                A JSON-serialized object for an inline keyboard.
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]): A JSON-serialized
+                object for an inline keyboard.
+            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
+                (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
-            :class:`telegram.Message`: On success, if edited message is sent by
-            the bot, the edited message is returned, otherwise `True` is
-            returned.
+            :class:`telegram.Message`: On success, if edited message is sent by the bot, the edited
+                message is returned, otherwise `True` is returned.
 
         Raises:
             :class:`telegram.TelegramError`
@@ -1242,24 +1101,22 @@ class Bot(TelegramObject):
                                reply_markup=None,
                                timeout=None,
                                **kwargs):
-        """Use this method to edit only the reply markup of messages sent by
-        the bot or via the bot (for inline bots).
+        """Use this method to edit only the reply markup of messages sent by the bot or via the bot
+        (for inline bots).
 
         Args:
-            chat_id (Optional[str]): Required if inline_message_id is not
-                specified. Unique identifier for the target chat or username of
-                the target channel (in the format @channelusername).
-            message_id (Optional[str]): Required if inline_message_id is not
-                specified. Unique identifier of the sent message.
-            inline_message_id (Optional[str]): Required if chat_id and
-                message_id are not specified. Identifier of the inline message.
-            **kwargs (Optional[dict]): Arbitrary keyword arguments.
-
-        Keyword Args:
-            reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]):
-                A JSON-serialized object for an inline keyboard.
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            chat_id (Optional[str]): Required if inline_message_id is not specified. Unique
+                identifier for the target chat or username of the target channel (in the format
+                @channelusername).
+            message_id (Optional[str]): Required if inline_message_id is not specified. Unique
+                identifier of the sent message.
+            inline_message_id (Optional[str]): Required if chat_id and message_id are not
+                specified. Identifier of the inline message.
+            reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]): A JSON-serialized
+                object for an inline keyboard.
+            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
+                (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
             :class:`telegram.Message`: On success, if edited message is sent by
@@ -1293,20 +1150,20 @@ class Bot(TelegramObject):
         """Use this method to receive incoming updates using long polling.
 
         Args:
-          offset (Optional[int]):
-            Identifier of the first update to be returned. Must be greater by  one than the highest
-            among the identifiers of previously received updates. By default, updates starting with
-            the earliest unconfirmed update are returned. An update is considered confirmed as soon
-            as getUpdates is called with an offset higher than its update_id.
-          limit (Optional[int]):
-            Limits the number of updates to be retrieved. Values between 1-100 are accepted.
-            Defaults to 100.
-          timeout (Optional[int]):
-            Timeout in seconds for long polling. Defaults to 0, i.e. usual short polling.
-          network_delay (Optional[float]):
-            Additional timeout in seconds to allow the response from Telegram servers. This should
-            cover network latency around the globe, SSL handshake and slowness of the Telegram
-            servers (which unfortunately happens a lot recently - 2016-05-28). Defaults to 5.
+            offset (Optional[int]): Identifier of the first update to be returned. Must be greater
+                by one than the highest among the identifiers of previously received updates. By
+                default, updates starting with the earliest unconfirmed update are returned. An
+                update is considered confirmed as soon as getUpdates is called with an offset
+                higher than its update_id.
+            limit (Optional[int]): Limits the number of updates to be retrieved. Values between
+                1-100 are accepted. Defaults to 100.
+            timeout (Optional[int]): Timeout in seconds for long polling. Defaults to 0, i.e. usual
+                short polling.
+            network_delay (Optional[float]): Additional timeout in seconds to allow the response
+                from Telegram servers. This should cover network latency around the globe, SSL
+                handshake and slowness of the Telegram servers (which unfortunately happens a lot
+                recently - 2016-05-28). Defaults to 5.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
             list[:class:`telegram.Update`]
@@ -1315,7 +1172,6 @@ class Bot(TelegramObject):
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/getUpdates'.format(self.base_url)
 
         data = {'timeout': timeout}
@@ -1338,20 +1194,17 @@ class Bot(TelegramObject):
 
     @log
     def setWebhook(self, webhook_url=None, certificate=None, timeout=None, **kwargs):
-        """Use this method to specify a url and receive incoming updates via an
-        outgoing webhook. Whenever there is an update for the bot, we will send
-        an HTTPS POST request to the specified url, containing a
-        JSON-serialized Update. In case of an unsuccessful request, we will
-        give up after a reasonable amount of attempts.
+        """Use this method to specify a url and receive incoming updates via an outgoing webhook.
+        Whenever there is an update for the bot, we will send an HTTPS POST request to the
+        specified url, containing a JSON-serialized Update. In case of an unsuccessful request, we
+        will give up after a reasonable amount of attempts.
 
         Args:
-          webhook_url:
-            HTTPS url to send updates to.
-            Use an empty string to remove webhook integration
-
-        Keyword Args:
+            webhook_url: HTTPS url to send updates to. Use an empty string to remove webhook
+                integration
             timeout (Optional[float]): If this value is specified, use it as
                 the definitive timeout (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
             bool: On success, `True` is returned.
@@ -1360,7 +1213,6 @@ class Bot(TelegramObject):
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/setWebhook'.format(self.base_url)
 
         data = {}
@@ -1376,17 +1228,14 @@ class Bot(TelegramObject):
 
     @log
     def leaveChat(self, chat_id, timeout=None, **kwargs):
-        """Use this method for your bot to leave a group, supergroup or
-        channel.
+        """Use this method for your bot to leave a group, supergroup or channel.
 
         Args:
-          chat_id:
-            Unique identifier for the target chat or username of the target
-            channel (in the format @channelusername).
-
-        Keyword Args:
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            chat_id: Unique identifier for the target chat or username of the target channel (in
+                the format @channelusername).
+            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
+                (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
             bool: On success, `True` is returned.
@@ -1395,7 +1244,6 @@ class Bot(TelegramObject):
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/leaveChat'.format(self.base_url)
 
         data = {'chat_id': chat_id}
@@ -1406,18 +1254,15 @@ class Bot(TelegramObject):
 
     @log
     def getChat(self, chat_id, timeout=None, **kwargs):
-        """Use this method to get up to date information about the chat
-        (current name of the user for one-on-one conversations, current
-        username of a user, group or channel, etc.).
+        """Use this method to get up to date information about the chat (current name of the user
+        for one-on-one conversations, current username of a user, group or channel, etc.).
 
         Args:
-          chat_id:
-            Unique identifier for the target chat or username of the target
-            channel (in the format @channelusername).
-
-        Keyword Args:
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            chat_id: Unique identifier for the target chat or username of the target channel (in
+                the format @channelusername).
+            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
+                (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
             :class:`telegram.Chat`: On success, :class:`telegram.Chat` is
@@ -1427,7 +1272,6 @@ class Bot(TelegramObject):
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/getChat'.format(self.base_url)
 
         data = {'chat_id': chat_id}
@@ -1438,31 +1282,25 @@ class Bot(TelegramObject):
 
     @log
     def getChatAdministrators(self, chat_id, timeout=None, **kwargs):
-        """Use this method to get a list of administrators in a chat. On
-        success, returns an Array of ChatMember objects that contains
-        information about all chat administrators except other bots. If the
-        chat is a group or a supergroup and no administrators were appointed,
-        only the creator will be returned.
+        """Use this method to get a list of administrators in a chat. On success, returns an Array
+        of ChatMember objects that contains information about all chat administrators except other
+        bots. If the chat is a group or a supergroup and no administrators were appointed, only the
+        creator will be returned.
 
         Args:
-          chat_id:
-            Unique identifier for the target chat or username of the target
-            channel (in the format @channelusername).
-
-
-        Keyword Args:
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            chat_id: Unique identifier for the target chat or username of the target channel (in
+                the format @channelusername).
+            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
+                (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
-            list[:class:`telegram.ChatMember`]: On success, a list of
-            :class:`telegram.ChatMember` objects are returned.
+            list[:class:`telegram.ChatMember`]: A list of chat member objects.
 
         Raises:
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/getChatAdministrators'.format(self.base_url)
 
         data = {'chat_id': chat_id}
@@ -1476,14 +1314,11 @@ class Bot(TelegramObject):
         """Use this method to get the number of members in a chat.
 
         Args:
-          chat_id:
-            Unique identifier for the target chat or username of the target
-            channel (in the format @channelusername).
-
-
-        Keyword Args:
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            chat_id: Unique identifier for the target chat or username of the target channel (in
+                the format @channelusername).
+            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
+                (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
             int: On success, an `int` is returned.
@@ -1492,7 +1327,6 @@ class Bot(TelegramObject):
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/getChatMembersCount'.format(self.base_url)
 
         data = {'chat_id': chat_id}
@@ -1506,26 +1340,20 @@ class Bot(TelegramObject):
         """Use this method to get information about a member of a chat.
 
         Args:
-          chat_id:
-            Unique identifier for the target chat or username of the target
-            channel (in the format @channelusername).
-          user_id:
-            Unique identifier of the target user.
-
-
-        Keyword Args:
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            chat_id: Unique identifier for the target chat or username of the target channel (in
+                the format @channelusername).
+            user_id: Unique identifier of the target user.
+            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
+                (in seconds) for urlopen() operations.
+            **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
-            :class:`telegram.ChatMember`: On success,
-            :class:`telegram.ChatMember` is returned.
+            :class:`telegram.ChatMember`: On success, chat member object is returned.
 
         Raises:
             :class:`telegram.TelegramError`
 
         """
-
         url = '{0}/getChatMember'.format(self.base_url)
 
         data = {'chat_id': chat_id, 'user_id': user_id}
@@ -1552,8 +1380,7 @@ class Bot(TelegramObject):
         return (self.__class__, (self.token, self.base_url.replace(self.token, ''),
                                  self.base_file_url.replace(self.token, '')))
 
-# snake_case (PEP8) aliases
-
+    # snake_case (PEP8) aliases
     get_me = getMe
     send_message = sendMessage
     forward_message = forwardMessage

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -24,7 +24,7 @@ import logging
 
 from telegram import (User, Message, Update, Chat, ChatMember, UserProfilePhotos, File,
                       ReplyMarkup, TelegramObject)
-from telegram.error import InvalidToken
+from telegram.error import InvalidToken, TelegramError
 from telegram.utils.request import Request
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
@@ -1213,6 +1213,10 @@ class Bot(TelegramObject):
             :class:`telegram.TelegramError`
 
         """
+        if inline_message_id is None and (chat_id is None or message_id is None):
+            raise TelegramError(
+                'editMessageCaption: Both chat_id and message_id are required when '
+                'inline_message_id is not specified')
 
         url = '{0}/editMessageCaption'.format(self.base_url)
 
@@ -1266,6 +1270,10 @@ class Bot(TelegramObject):
             :class:`telegram.TelegramError`
 
         """
+        if inline_message_id is None and (chat_id is None or message_id is None):
+            raise TelegramError(
+                'editMessageCaption: Both chat_id and message_id are required when '
+                'inline_message_id is not specified')
 
         url = '{0}/editMessageReplyMarkup'.format(self.base_url)
 

--- a/telegram/callbackquery.py
+++ b/telegram/callbackquery.py
@@ -25,14 +25,15 @@ from telegram import TelegramObject, Message, User
 class CallbackQuery(TelegramObject):
     """This object represents a Telegram CallbackQuery."""
 
-    def __init__(self, id, from_user, data, bot=None, **kwargs):
+    def __init__(self, id, from_user, data, message=None, inline_message_id='', bot=None,
+                 **kwargs):
         # Required
         self.id = id
         self.from_user = from_user
         self.data = data
         # Optionals
-        self.message = kwargs.get('message')
-        self.inline_message_id = kwargs.get('inline_message_id', '')
+        self.message = message
+        self.inline_message_id = inline_message_id
 
         self.bot = bot
 

--- a/telegram/chat.py
+++ b/telegram/chat.py
@@ -36,13 +36,14 @@ class Chat(TelegramObject):
     Args:
         id (int):
         type (str):
-        **kwargs: Arbitrary keyword arguments.
-
-    Keyword Args:
-        type (Optional[str]):
+        title (Optional[str]):
+        username(Optional[str]):
+        first_name(Optional[str]):
+        last_name(Optional[str]):
         bot (Optional[Bot]): The Bot to use for instance methods
-    """
+        **kwargs (dict): Arbitrary keyword arguments.
 
+    """
     PRIVATE = 'private'
     GROUP = 'group'
     SUPERGROUP = 'supergroup'

--- a/telegram/chat.py
+++ b/telegram/chat.py
@@ -48,15 +48,23 @@ class Chat(TelegramObject):
     SUPERGROUP = 'supergroup'
     CHANNEL = 'channel'
 
-    def __init__(self, id, type, bot=None, **kwargs):
+    def __init__(self,
+                 id,
+                 type,
+                 title='',
+                 username='',
+                 first_name='',
+                 last_name='',
+                 bot=None,
+                 **kwargs):
         # Required
         self.id = int(id)
         self.type = type
         # Optionals
-        self.title = kwargs.get('title', '')
-        self.username = kwargs.get('username', '')
-        self.first_name = kwargs.get('first_name', '')
-        self.last_name = kwargs.get('last_name', '')
+        self.title = title
+        self.username = username
+        self.first_name = first_name
+        self.last_name = last_name
 
         self.bot = bot
 

--- a/telegram/chatmember.py
+++ b/telegram/chatmember.py
@@ -32,8 +32,9 @@ class ChatMember(TelegramObject):
     Args:
         user (:class:`telegram.User`):
         status (str):
-    """
+        **kwargs (dict): Arbitrary keyword arguments.
 
+    """
     CREATOR = 'creator'
     ADMINISTRATOR = 'administrator'
     MEMBER = 'member'

--- a/telegram/choseninlineresult.py
+++ b/telegram/choseninlineresult.py
@@ -33,11 +33,16 @@ class ChosenInlineResult(TelegramObject):
         result_id (str):
         from_user (:class:`telegram.User`):
         query (str):
+        location (:class:`telegram.Location`):
+        inline_message_id (str):
 
     Args:
         result_id (str):
         from_user (:class:`telegram.User`):
         query (str):
+        location (Optional[:class:`telegram.Location`]):
+        inline_message_id (Optional[str]):
+        **kwargs (dict): Arbitrary keyword arguments.
 
     """
 

--- a/telegram/contact.py
+++ b/telegram/contact.py
@@ -33,11 +33,10 @@ class Contact(TelegramObject):
     Args:
         phone_number (str):
         first_name (str):
-        **kwargs: Arbitrary keyword arguments.
-
-    Keyword Args:
         last_name (Optional[str]):
         user_id (Optional[int]):
+        **kwargs: Arbitrary keyword arguments.
+
     """
 
     def __init__(self, phone_number, first_name, last_name='', user_id=0, **kwargs):

--- a/telegram/contact.py
+++ b/telegram/contact.py
@@ -40,13 +40,13 @@ class Contact(TelegramObject):
         user_id (Optional[int]):
     """
 
-    def __init__(self, phone_number, first_name, **kwargs):
+    def __init__(self, phone_number, first_name, last_name='', user_id=0, **kwargs):
         # Required
         self.phone_number = str(phone_number)
         self.first_name = first_name
         # Optionals
-        self.last_name = kwargs.get('last_name', '')
-        self.user_id = int(kwargs.get('user_id', 0))
+        self.last_name = last_name
+        self.user_id = int(user_id)
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/document.py
+++ b/telegram/document.py
@@ -33,13 +33,12 @@ class Document(TelegramObject):
 
     Args:
         file_id (str):
-        **kwargs: Arbitrary keyword arguments.
-
-    Keyword Args:
         thumb (Optional[:class:`telegram.PhotoSize`]):
         file_name (Optional[str]):
         mime_type (Optional[str]):
         file_size (Optional[int]):
+        **kwargs (dict): Arbitrary keyword arguments.
+
     """
 
     def __init__(self, file_id, thumb=None, file_name='', mime_type='', file_size=0, **kwargs):

--- a/telegram/document.py
+++ b/telegram/document.py
@@ -42,14 +42,14 @@ class Document(TelegramObject):
         file_size (Optional[int]):
     """
 
-    def __init__(self, file_id, **kwargs):
+    def __init__(self, file_id, thumb=None, file_name='', mime_type='', file_size=0, **kwargs):
         # Required
         self.file_id = str(file_id)
         # Optionals
-        self.thumb = kwargs.get('thumb')
-        self.file_name = kwargs.get('file_name', '')
-        self.mime_type = str(kwargs.get('mime_type', ''))
-        self.file_size = int(kwargs.get('file_size', 0))
+        self.thumb = thumb
+        self.file_name = file_name
+        self.mime_type = str(mime_type)
+        self.file_size = int(file_size)
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/file.py
+++ b/telegram/file.py
@@ -42,13 +42,13 @@ class File(TelegramObject):
 
     """
 
-    def __init__(self, file_id, bot, **kwargs):
+    def __init__(self, file_id, bot, file_size=0, file_path='', **kwargs):
         # Required
         self.file_id = str(file_id)
 
         # Optionals
-        self.file_size = int(kwargs.get('file_size', 0))
-        self.file_path = str(kwargs.get('file_path', ''))
+        self.file_size = int(file_size)
+        self.file_path = str(file_path)
 
         self.bot = bot
 

--- a/telegram/file.py
+++ b/telegram/file.py
@@ -34,11 +34,9 @@ class File(TelegramObject):
     Args:
         file_id (str):
         bot (telegram.Bot):
-        **kwargs: Arbitrary keyword arguments.
-
-    Keyword Args:
         file_size (Optional[int]):
         file_path (Optional[str]):
+        **kwargs (dict): Arbitrary keyword arguments.
 
     """
 

--- a/telegram/forcereply.py
+++ b/telegram/forcereply.py
@@ -30,10 +30,9 @@ class ForceReply(ReplyMarkup):
 
     Args:
         force_reply (bool):
-        **kwargs: Arbitrary keyword arguments.
-
-    Keyword Args:
         selective (Optional[bool]):
+        **kwargs (dict): Arbitrary keyword arguments.
+
     """
 
     def __init__(self, force_reply=True, selective=False, **kwargs):

--- a/telegram/forcereply.py
+++ b/telegram/forcereply.py
@@ -36,11 +36,11 @@ class ForceReply(ReplyMarkup):
         selective (Optional[bool]):
     """
 
-    def __init__(self, force_reply=True, **kwargs):
+    def __init__(self, force_reply=True, selective=False, **kwargs):
         # Required
         self.force_reply = bool(force_reply)
         # Optionals
-        self.selective = bool(kwargs.get('selective', False))
+        self.selective = bool(selective)
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/inlinekeyboardbutton.py
+++ b/telegram/inlinekeyboardbutton.py
@@ -42,14 +42,14 @@ class InlineKeyboardButton(TelegramObject):
 
     """
 
-    def __init__(self, text, **kwargs):
+    def __init__(self, text, url=None, callback_data=None, switch_inline_query=None, **kwargs):
         # Required
         self.text = text
 
         # Optionals
-        self.url = kwargs.get('url')
-        self.callback_data = kwargs.get('callback_data')
-        self.switch_inline_query = kwargs.get('switch_inline_query')
+        self.url = url
+        self.callback_data = callback_data
+        self.switch_inline_query = switch_inline_query
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/inlinekeyboardbutton.py
+++ b/telegram/inlinekeyboardbutton.py
@@ -33,12 +33,10 @@ class InlineKeyboardButton(TelegramObject):
 
     Args:
         text (str):
-        **kwargs: Arbitrary keyword arguments.
-
-    Keyword Args:
         url (Optional[str]):
         callback_data (Optional[str]):
         switch_inline_query (Optional[str]):
+        **kwargs (dict): Arbitrary keyword arguments.
 
     """
 

--- a/telegram/inlinekeyboardmarkup.py
+++ b/telegram/inlinekeyboardmarkup.py
@@ -30,6 +30,7 @@ class InlineKeyboardMarkup(ReplyMarkup):
 
     Args:
         inline_keyboard (List[List[:class:`telegram.InlineKeyboardButton`]]):
+        **kwargs (dict): Arbitrary keyword arguments.
 
     """
 
@@ -46,6 +47,7 @@ class InlineKeyboardMarkup(ReplyMarkup):
 
         Returns:
             telegram.InlineKeyboardMarkup:
+
         """
         data = super(InlineKeyboardMarkup, InlineKeyboardMarkup).de_json(data, bot)
 

--- a/telegram/inlinequery.py
+++ b/telegram/inlinequery.py
@@ -45,7 +45,7 @@ class InlineQuery(TelegramObject):
         bot (Optional[Bot]): The Bot to use for instance methods
     """
 
-    def __init__(self, id, from_user, query, offset, bot=None, **kwargs):
+    def __init__(self, id, from_user, query, offset, location=None, bot=None, **kwargs):
         # Required
         self.id = id
         self.from_user = from_user
@@ -53,7 +53,7 @@ class InlineQuery(TelegramObject):
         self.offset = offset
 
         # Optional
-        self.location = kwargs.get('location')
+        self.location = location
 
         self.bot = bot
 

--- a/telegram/inlinequery.py
+++ b/telegram/inlinequery.py
@@ -38,11 +38,10 @@ class InlineQuery(TelegramObject):
         from_user (:class:`telegram.User`):
         query (str):
         offset (str):
-        **kwargs: Arbitrary keyword arguments.
-
-    Keyword Args:
         location (optional[:class:`telegram.Location`]):
         bot (Optional[Bot]): The Bot to use for instance methods
+        **kwargs (dict): Arbitrary keyword arguments.
+
     """
 
     def __init__(self, id, from_user, query, offset, location=None, bot=None, **kwargs):

--- a/telegram/inlinequeryresult.py
+++ b/telegram/inlinequeryresult.py
@@ -26,12 +26,13 @@ class InlineQueryResult(TelegramObject):
     """This object represents a Telegram InlineQueryResult.
 
     Attributes:
-        type (str):
-        id (str):
+        type (str): Type of the result.
+        id (str): Unique identifier for this result, 1-64 Bytes
 
     Args:
-        type (str):
+        type (str): Type of the result.
         id (str): Unique identifier for this result, 1-64 Bytes
+        **kwargs (dict): Arbitrary keyword arguments.
 
     """
 

--- a/telegram/inlinequeryresultarticle.py
+++ b/telegram/inlinequeryresultarticle.py
@@ -42,21 +42,20 @@ class InlineQueryResultArticle(InlineQueryResult):
 
         parse_mode (str): Use :class:`InputTextMessageContent` instead.
 
-        disable_web_page_preview (bool): Use :class:`InputTextMessageContent`
-        instead.
+        disable_web_page_preview (bool): Use :class:`InputTextMessageContent` instead.
 
     Args:
         id (str): Unique identifier for this result, 1-64 Bytes
         title (str):
         reply_markup (:class:`telegram.ReplyMarkup`):
-
-    Keyword Args:
         url (Optional[str]):
         hide_url (Optional[bool]):
         description (Optional[str]):
         thumb_url (Optional[str]):
         thumb_width (Optional[int]):
         thumb_height (Optional[int]):
+        **kwargs (dict): Arbitrary keyword arguments.
+
     """
 
     def __init__(self,

--- a/telegram/inlinequeryresultaudio.py
+++ b/telegram/inlinequeryresultaudio.py
@@ -34,28 +34,24 @@ class InlineQueryResultAudio(InlineQueryResult):
         performer (Optional[str]):
         audio_duration (Optional[str]):
         reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]):
-        input_message_content (Optional[
-            :class:`telegram.input_message_content`]):
+        input_message_content (Optional[:class:`telegram.input_message_content`]):
 
     Deprecated: 4.0
         message_text (str): Use :class:`InputTextMessageContent` instead.
 
         parse_mode (str): Use :class:`InputTextMessageContent` instead.
 
-        disable_web_page_preview (bool): Use :class:`InputTextMessageContent`
-        instead.
+        disable_web_page_preview (bool): Use :class:`InputTextMessageContent` instead.
 
     Args:
         audio_url (str):
         title (str):
-        **kwargs: Arbitrary keyword arguments.
-
-    Keyword Args:
         performer (Optional[str]):
         audio_duration (Optional[str]):
         reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]):
-        input_message_content (Optional[
-            :class:`telegram.input_message_content`]):
+        input_message_content (Optional[:class:`telegram.input_message_content`]):
+        **kwargs (dict): Arbitrary keyword arguments.
+
     """
 
     def __init__(self,

--- a/telegram/inlinequeryresultcachedaudio.py
+++ b/telegram/inlinequeryresultcachedaudio.py
@@ -23,34 +23,29 @@ from telegram import InlineQueryResult, InlineKeyboardMarkup, InputMessageConten
 
 
 class InlineQueryResultCachedAudio(InlineQueryResult):
-    """Represents a link to an mp3 audio file stored on the Telegram
-    servers. By default, this audio file will be sent by the user.
-    Alternatively, you can use input_message_content to send a message with
-    the specified content instead of the audio.
+    """Represents a link to an mp3 audio file stored on the Telegram servers. By default, this
+    audio file will be sent by the user. Alternatively, you can use input_message_content to send a
+    message with the specified content instead of the audio.
 
     Attributes:
         id (str):
         audio_file_id (str):
         reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]):
-        input_message_content (Optional[
-            :class:`telegram.input_message_content`]):
+        input_message_content (Optional[:class:`telegram.input_message_content`]):
 
     Deprecated: 4.0
         message_text (str): Use :class:`InputTextMessageContent` instead.
 
         parse_mode (str): Use :class:`InputTextMessageContent` instead.
 
-        disable_web_page_preview (bool): Use :class:`InputTextMessageContent`
-        instead.
+        disable_web_page_preview (bool): Use :class:`InputTextMessageContent` instead.
 
     Args:
         audio_file_id (str):
-        **kwargs: Arbitrary keyword arguments.
-
-    Keyword Args:
         reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]):
-        input_message_content (Optional[
-            :class:`telegram.input_message_content`]):
+        input_message_content (Optional[:class:`telegram.input_message_content`]):
+        **kwargs (dict): Arbitrary keyword arguments.
+
     """
 
     def __init__(self, id, audio_file_id, reply_markup=None, input_message_content=None, **kwargs):

--- a/telegram/inlinequeryresultcacheddocument.py
+++ b/telegram/inlinequeryresultcacheddocument.py
@@ -16,13 +16,38 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-"""This module contains the classes that represent Telegram
-InlineQueryResultCachedDocument"""
+"""This module contains the classes that represent Telegram InlineQueryResultCachedDocument"""
 
 from telegram import InlineQueryResult, InlineKeyboardMarkup, InputMessageContent
 
 
 class InlineQueryResultCachedDocument(InlineQueryResult):
+    """Represents a link to a file stored on the Telegram servers. By default, this file will be
+    sent by the user with an optional caption. Alternatively, you can use input_message_content to
+    send a message with the specified content instead of the file. Currently, only pdf-files and
+    zip archives can be sent using this method.
+
+    Attributes:
+        title (str): Title for the result.
+        document_file_id (str): A valid file identifier for the file.
+        description (Optional[str]): Short description of the result.
+        caption	(Optional[str]): Caption of the document to be sent, 0-200 characters.
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]): Inline keyboard attached
+            to the message.
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]): Content of the
+            message to be sent instead of the file.
+
+    Args:
+        id (str):
+        title (str):
+        document_file_id (str):
+        description (Optional[str]):
+        caption	(Optional[str]):
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]):
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]):
+        **kwargs (dict): Arbitrary keyword arguments.
+
+        """
 
     def __init__(self,
                  id,

--- a/telegram/inlinequeryresultcachedgif.py
+++ b/telegram/inlinequeryresultcachedgif.py
@@ -23,6 +23,29 @@ from telegram import InlineQueryResult, InlineKeyboardMarkup, InputMessageConten
 
 
 class InlineQueryResultCachedGif(InlineQueryResult):
+    """Represents a link to an animated GIF file stored on the Telegram servers. By default, this
+    animated GIF file will be sent by the user with an optional caption. Alternatively, you can use
+    input_message_content to send a message with specified content instead of the animation.
+
+    Attributes:
+        gif_file_id (str): A valid file identifier for the GIF file.
+        title (Optional[str]): Title for the result.
+        caption (Optional[str]): Caption of the GIF file to be sent, 0-200 characters.
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]): Inline keyboard attached
+            to the message.
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]): Content of the
+            message to be sent instead of the GIF animation.
+
+    Args:
+        id (str):
+        gif_file_id (str):
+        title (Optional[str]):
+        caption (Optional[str]):
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]):
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]):
+        **kwargs (dict): Arbitrary keyword arguments.
+
+    """
 
     def __init__(self,
                  id,

--- a/telegram/inlinequeryresultcachedmpeg4gif.py
+++ b/telegram/inlinequeryresultcachedmpeg4gif.py
@@ -23,6 +23,30 @@ from telegram import InlineQueryResult, InlineKeyboardMarkup, InputMessageConten
 
 
 class InlineQueryResultCachedMpeg4Gif(InlineQueryResult):
+    """Represents a link to a video animation (H.264/MPEG-4 AVC video without sound) stored on the
+    Telegram servers. By default, this animated MPEG-4 file will be sent by the user with an
+    optional caption. Alternatively, you can use input_message_content to send a message with the
+    specified content instead of the animation.
+
+    Attributes:
+        mpeg4_file_id (str): A valid file identifier for the MP4 file.
+        title (Optional[str]): Title for the result.
+        caption	(Optional[str]): Caption of the MPEG-4 file to be sent, 0-200 characters.
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]): Inline keyboard attached
+            to the message.
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]): Content of the
+            message to be sent instead of the video animation
+
+    Args:
+        id (str):
+        mpeg4_file_id (str):
+        title (Optional[str]):
+        caption	(Optional[str]):
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]):
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]):
+         **kwargs (dict): Arbitrary keyword arguments.
+
+    """
 
     def __init__(self,
                  id,

--- a/telegram/inlinequeryresultcachedphoto.py
+++ b/telegram/inlinequeryresultcachedphoto.py
@@ -16,13 +16,37 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-"""This module contains the classes that represent Telegram
-InlineQueryResultPhoto"""
+"""This module contains the classes that represent Telegram InlineQueryResultPhoto"""
 
 from telegram import InlineQueryResult, InlineKeyboardMarkup, InputMessageContent
 
 
 class InlineQueryResultCachedPhoto(InlineQueryResult):
+    """Represents a link to a photo stored on the Telegram servers. By default, this photo will be
+    sent by the user with an optional caption. Alternatively, you can use input_message_content to
+    send a message with the specified content instead of the photo.
+
+    Attributes:
+        photo_file_id (str): A valid file identifier of the photo.
+        title (Optional[str]): Title for the result.
+        description (Optional[str]): Short description of the result.
+        caption (Optional[str]): Caption of the photo to be sent, 0-200 characters.
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]): Inline keyboard attached
+            to the message.
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]): Content of the
+            message to be sent instead of the photo
+
+    Args:
+        id (str):
+        photo_file_id (str):
+        title (Optional[str]):
+        description (Optional[str]):
+        caption (Optional[str]):
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]):
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]):
+        **kwargs (dict): Arbitrary keyword arguments.
+
+    """
 
     def __init__(self,
                  id,

--- a/telegram/inlinequeryresultcachedsticker.py
+++ b/telegram/inlinequeryresultcachedsticker.py
@@ -16,13 +16,31 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-"""This module contains the classes that represent Telegram
-InlineQueryResultCachedSticker"""
+"""This module contains the classes that represent Telegram InlineQueryResultCachedSticker"""
 
 from telegram import InlineQueryResult, InlineKeyboardMarkup, InputMessageContent
 
 
 class InlineQueryResultCachedSticker(InlineQueryResult):
+    """Represents a link to a sticker stored on the Telegram servers. By default, this sticker will
+    be sent by the user. Alternatively, you can use input_message_content to send a message with
+    the specified content instead of the sticker.
+
+    Attributes:
+        sticker_file_id (str): A valid file identifier of the sticker.
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]): Inline keyboard attached
+            to the message.
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]): Content of the
+            message to be sent instead of the sticker.
+
+    Args:
+        id (str):
+        sticker_file_id (str):
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]):
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]):
+        **kwargs (dict): Arbitrary keyword arguments.
+
+    """
 
     def __init__(self,
                  id,

--- a/telegram/inlinequeryresultcachedvideo.py
+++ b/telegram/inlinequeryresultcachedvideo.py
@@ -16,13 +16,37 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-"""This module contains the classes that represent Telegram
-InlineQueryResultCachedVideo"""
+"""This module contains the classes that represent Telegram InlineQueryResultCachedVideo"""
 
 from telegram import InlineQueryResult, InlineKeyboardMarkup, InputMessageContent
 
 
 class InlineQueryResultCachedVideo(InlineQueryResult):
+    """Represents a link to a video file stored on the Telegram servers. By default, this video
+    file will be sent by the user with an optional caption. Alternatively, you can use
+    input_message_content to send a message with the specified content instead of the video.
+
+    Attributes:
+        video_file_id (str): A valid file identifier for the video file.
+        title (str): Title for the result.
+        description (Optional[str]): Short description of the result.
+        caption (Optional[str]): Caption of the video to be sent, 0-200 characters.
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]): Inline keyboard attached
+            to the message
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]): Content of the
+            message to be sent instead of the video
+
+    Args:
+        id (str):
+        video_file_id (str):
+        title (str):
+        description (Optional[str]):
+        caption (Optional[str]):
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]):
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]):
+        **kwargs (dict): Arbitrary keyword arguments.
+
+    """
 
     def __init__(self,
                  id,

--- a/telegram/inlinequeryresultcachedvoice.py
+++ b/telegram/inlinequeryresultcachedvoice.py
@@ -16,13 +16,35 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-"""This module contains the classes that represent Telegram
-InlineQueryResultCachedVoice"""
+"""This module contains the classes that represent Telegram InlineQueryResultCachedVoice"""
 
 from telegram import InlineQueryResult, InlineKeyboardMarkup, InputMessageContent
 
 
 class InlineQueryResultCachedVoice(InlineQueryResult):
+    """Represents a link to a voice message stored on the Telegram servers. By default, this voice
+    message will be sent by the user. Alternatively, you can use input_message_content to send a
+    message with the specified content instead of the voice message.
+
+    Attributes:
+        voice_file_id (str): A valid file identifier for the voice message.
+        title (str): Voice message title.
+        caption (Optional[str]): Caption, 0-200 characters.
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]): Inline keyboard attached
+            to the message.
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]): Content of the
+            message to be sent instead of the voice message.
+
+    Args:
+        id (str):
+        voice_file_id (str):
+        title (str):
+        caption (Optional[str]):
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]):
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]):
+        **kwargs (dict): Arbitrary keyword arguments.
+
+    """
 
     def __init__(self,
                  id,

--- a/telegram/inlinequeryresultcontact.py
+++ b/telegram/inlinequeryresultcontact.py
@@ -16,13 +16,41 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-"""This module contains the classes that represent Telegram
-InlineQueryResultContact"""
+"""This module contains the classes that represent Telegram InlineQueryResultContact"""
 
 from telegram import InlineQueryResult, InlineKeyboardMarkup, InputMessageContent
 
 
 class InlineQueryResultContact(InlineQueryResult):
+    """Represents a contact with a phone number. By default, this contact will be sent by the user.
+    Alternatively, you can use input_message_content to send a message with the specified content
+    instead of the contact.
+
+    Attributes:
+        phone_number (str): Contact's phone number.
+        first_name (str): Contact's first name.
+        last_name (Optional[str]): Contact's last name.
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]): Inline keyboard attached
+            to the message.
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]): Content of the
+            message to be sent instead of the contact.
+        thumb_url (Optional[str]): Url of the thumbnail for the result.
+        thumb_width (Optional[int]): Thumbnail width.
+        thumb_height (Optional[int]): Thumbnail height.
+
+    Args:
+        id (str):
+        phone_number (str):
+        first_name (str):
+        last_name (Optional[str]):
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]):
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]):
+        thumb_url (Optional[str]): Url of the thumbnail for the result.
+        thumb_width (Optional[int]):
+        thumb_height (Optional[int]):
+        **kwargs (dict): Arbitrary keyword arguments.
+
+    """
 
     def __init__(self,
                  id,

--- a/telegram/inlinequeryresultdocument.py
+++ b/telegram/inlinequeryresultdocument.py
@@ -16,13 +16,46 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-"""This module contains the classes that represent Telegram
-InlineQueryResultDocument"""
+"""This module contains the classes that represent Telegram InlineQueryResultDocument"""
 
 from telegram import InlineQueryResult, InlineKeyboardMarkup, InputMessageContent
 
 
 class InlineQueryResultDocument(InlineQueryResult):
+    """Represents a link to a file. By default, this file will be sent by the user with an optional
+    caption. Alternatively, you can use input_message_content to send a message with the specified
+    content instead of the file. Currently, only .PDF and .ZIP files can be sent using this method.
+
+    Attributes:
+        title (str): Title for the result.
+        caption (Optional[str]): Caption of the document to be sent, 0-200 characters.
+        document_url (Optional[str]): A valid URL for the file.
+        mime_type (Optional[str]): Mime type of the content of the file, either "application/pdf"
+            or "application/zip".
+        description	(Optional[str]): Short description of the result.
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]): Inline keyboard attached
+            to the message.
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]): Content of the
+            message to be sent instead of the file.
+        thumb_url (Optional[str]): URL of the thumbnail (jpeg only) for the file.
+        thumb_width (Optional[int]): Thumbnail width.
+        thumb_height (Optional[int]): Thumbnail height.
+
+    Args:
+        id (str):
+        document_url (str):
+        title (str):
+        mime_type (str):
+        caption (Optional[str]):
+        description	(Optional[str]):
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]):
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]):
+        thumb_url (Optional[str]):
+        thumb_width (Optional[int]):
+        thumb_height (Optional[int]):
+        **kwargs (dict): Arbitrary keyword arguments.
+
+    """
 
     def __init__(self,
                  id,

--- a/telegram/inlinequeryresultgif.py
+++ b/telegram/inlinequeryresultgif.py
@@ -23,6 +23,35 @@ from telegram import InlineQueryResult, InlineKeyboardMarkup, InputMessageConten
 
 
 class InlineQueryResultGif(InlineQueryResult):
+    """Represents a link to an animated GIF file. By default, this animated GIF file will be sent
+    by the user with optional caption. Alternatively, you can use input_message_content to send a
+    message with the specified content instead of the animation.
+
+    Attributes:
+        gif_url (str): A valid URL for the GIF file. File size must not exceed 1MB.
+        thumb_url (str): URL of the static thumbnail for the result (jpeg or gif).
+        gif_width (Optional[int]): Width of the GIF.
+        gif_height (Optional[int]): Height of the GIF.
+        title (Optional[str]): Title for the result.
+        caption	(Optional[str]): Caption of the GIF file to be sent, 0-200 characters.
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]): Inline keyboard attached
+            to the message.
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]): Content of the
+            message to be sent instead of the GIF animation.
+
+    Args:
+        id (str):
+        gif_url (str):
+        thumb_url (str):
+        gif_width (Optional[int]):
+        gif_height (Optional[int]):
+        title (Optional[str]):
+        caption	(Optional[str]):
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]):
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]):
+        **kwargs (dict): Arbitrary keyword arguments.
+
+    """
 
     def __init__(self,
                  id,

--- a/telegram/inlinequeryresultlocation.py
+++ b/telegram/inlinequeryresultlocation.py
@@ -16,13 +16,42 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-"""This module contains the classes that represent Telegram
-InlineQueryResultLocation"""
+"""This module contains the classes that represent Telegram InlineQueryResultLocation"""
 
 from telegram import InlineQueryResult, InlineKeyboardMarkup, InputMessageContent
 
 
 class InlineQueryResultLocation(InlineQueryResult):
+    """Represents a location on a map. By default, the location will be sent by the user.
+    Alternatively, you can use input_message_content to send a message with the specified content
+    instead of the location.
+
+    Attributes:
+        latitude (float): Location latitude in degrees.
+        longitude (float): Location longitude in degrees.
+        title (str): Location title.
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]): Inline keyboard attached
+            to the message.
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]): Content of the
+            message to be sent instead of the location.
+        thumb_url (Optional[str]): Url of the thumbnail for the result.
+        thumb_width (Optional[int]): Thumbnail width.
+        thumb_height (Optional[int]): Thumbnail height.
+
+    Args:
+        latitude (float): Location latitude in degrees.
+        longitude (float): Location longitude in degrees.
+        title (str): Location title.
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]): Inline keyboard attached
+            to the message.
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]): Content of the
+            message to be sent instead of the location.
+        thumb_url (Optional[str]): Url of the thumbnail for the result.
+        thumb_width (Optional[int]): Thumbnail width.
+        thumb_height (Optional[int]): Thumbnail height.
+        **kwargs (dict): Arbitrary keyword arguments.
+
+    """
 
     def __init__(self,
                  id,

--- a/telegram/inlinequeryresultmpeg4gif.py
+++ b/telegram/inlinequeryresultmpeg4gif.py
@@ -16,13 +16,43 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-"""This module contains the classes that represent Telegram
-InlineQueryResultMpeg4Gif"""
+"""This module contains the classes that represent Telegram InlineQueryResultMpeg4Gif"""
 
 from telegram import InlineQueryResult, InlineKeyboardMarkup, InputMessageContent
 
 
 class InlineQueryResultMpeg4Gif(InlineQueryResult):
+    """Represents a link to a video animation (H.264/MPEG-4 AVC video without sound). By default,
+    this animated MPEG-4 file will be sent by the user with optional caption. Alternatively, you
+    can use input_message_content to send a message with the specified content instead of the
+    animation.
+
+    Attributes:
+        mpeg4_url (str): A valid URL for the MP4 file. File size must not exceed 1MB.
+        thumb_url (str): URL of the static thumbnail (jpeg or gif) for the result.
+        mpeg4_width (Optional[int]): Video width.
+        mpeg4_height (Optional[int]): Video height.
+        title (Optional[str]): Title for the result.
+        caption	(Optional[str]): Caption of the MPEG-4 file to be sent, 0-200 characters.
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]): Inline keyboard attached
+            to the message.
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]): Content of the
+            message to be sent instead of the video animation.
+
+    Args:
+        mpeg4_url (str): A valid URL for the MP4 file. File size must not exceed 1MB.
+        thumb_url (str): URL of the static thumbnail (jpeg or gif) for the result.
+        mpeg4_width (Optional[int]): Video width.
+        mpeg4_height (Optional[int]): Video height.
+        title (Optional[str]): Title for the result.
+        caption	(Optional[str]): Caption of the MPEG-4 file to be sent, 0-200 characters.
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]): Inline keyboard attached
+            to the message.
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]): Content of the
+            message to be sent instead of the video animation.
+        **kwargs (dict): Arbitrary keyword arguments.
+
+    """
 
     def __init__(self,
                  id,

--- a/telegram/inlinequeryresultphoto.py
+++ b/telegram/inlinequeryresultphoto.py
@@ -16,13 +16,31 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-"""This module contains the classes that represent Telegram
-InlineQueryResultPhoto"""
+"""This module contains the classes that represent Telegram InlineQueryResultPhoto"""
 
 from telegram import InlineQueryResult, InlineKeyboardMarkup, InputMessageContent
 
 
 class InlineQueryResultPhoto(InlineQueryResult):
+    """Represents a link to a photo. By default, this photo will be sent by the user with optional
+    caption. Alternatively, you can use input_message_content to send a message with the specified
+    content instead of the photo.
+
+    Attributes:
+        photo_url (str): A valid URL of the photo. Photo must be in jpeg format. Photo size must
+            not exceed 5MB.
+        thumb_url (str): URL of the thumbnail for the photo.
+        photo_width (Optional[int]): Width of the photo.
+        photo_height (Optional[int]): Height of the photo.
+        title (Optional[str]): Title for the result.
+        description	(Optional[str]): Short description of the result.
+        caption (Optional[str]): Caption of the photo to be sent, 0-200 characters.
+        reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]): Inline keyboard attached
+            to the message.
+        input_message_content (Optional[:class:`telegram.InputMessageContent`]): Content of the
+            message to be sent instead of the photo.
+
+    """
 
     def __init__(self,
                  id,

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -106,41 +106,77 @@ class Message(TelegramObject):
         bot (Optional[Bot]): The Bot to use for instance methods
     """
 
-    def __init__(self, message_id, from_user, date, chat, bot=None, **kwargs):
+    def __init__(self,
+                 message_id,
+                 from_user,
+                 date,
+                 chat,
+                 forward_from=None,
+                 forward_from_chat=None,
+                 forward_date=None,
+                 reply_to_message=None,
+                 edit_date=None,
+                 text='',
+                 entities=None,
+                 audio=None,
+                 document=None,
+                 photo=None,
+                 sticker=None,
+                 video=None,
+                 voice=None,
+                 caption='',
+                 contact=None,
+                 location=None,
+                 venue=None,
+                 new_chat_member=None,
+                 left_chat_member=None,
+                 new_chat_title='',
+                 new_chat_photo=None,
+                 delete_chat_photo=False,
+                 group_chat_created=False,
+                 supergroup_chat_created=False,
+                 migrate_to_chat_id=0,
+                 migrate_from_chat_id=0,
+                 channel_chat_created=False,
+                 pinned_message=None,
+                 bot=None,
+                 **kwargs):
         # Required
         self.message_id = int(message_id)
         self.from_user = from_user
         self.date = date
         self.chat = chat
         # Optionals
-        self.forward_from = kwargs.get('forward_from')
-        self.forward_from_chat = kwargs.get('forward_from_chat')
-        self.forward_date = kwargs.get('forward_date')
-        self.reply_to_message = kwargs.get('reply_to_message')
-        self.edit_date = kwargs.get('edit_date')
-        self.text = kwargs.get('text', '')
-        self.entities = kwargs.get('entities', list())
-        self.audio = kwargs.get('audio')
-        self.document = kwargs.get('document')
-        self.photo = kwargs.get('photo')
-        self.sticker = kwargs.get('sticker')
-        self.video = kwargs.get('video')
-        self.voice = kwargs.get('voice')
-        self.caption = kwargs.get('caption', '')
-        self.contact = kwargs.get('contact')
-        self.location = kwargs.get('location')
-        self.venue = kwargs.get('venue')
-        self.new_chat_member = kwargs.get('new_chat_member')
-        self.left_chat_member = kwargs.get('left_chat_member')
-        self.new_chat_title = kwargs.get('new_chat_title', '')
-        self.new_chat_photo = kwargs.get('new_chat_photo')
-        self.delete_chat_photo = bool(kwargs.get('delete_chat_photo', False))
-        self.group_chat_created = bool(kwargs.get('group_chat_created', False))
-        self.supergroup_chat_created = bool(kwargs.get('supergroup_chat_created', False))
-        self.migrate_to_chat_id = int(kwargs.get('migrate_to_chat_id', 0))
-        self.migrate_from_chat_id = int(kwargs.get('migrate_from_chat_id', 0))
-        self.channel_chat_created = bool(kwargs.get('channel_chat_created', False))
-        self.pinned_message = kwargs.get('pinned_message')
+        self.forward_from = forward_from
+        self.forward_from_chat = forward_from_chat
+        self.forward_date = forward_date
+        self.reply_to_message = reply_to_message
+        self.edit_date = edit_date
+        self.text = text
+        if entities is None:
+            entities = list()
+        self.entities = entities
+        self.audio = audio
+        self.document = document
+        self.photo = photo
+        self.sticker = sticker
+        self.video = video
+        self.voice = voice
+        self.caption = caption
+        self.contact = contact
+        self.location = location
+        self.venue = venue
+        self.new_chat_member = new_chat_member
+        self.left_chat_member = left_chat_member
+        self.new_chat_title = new_chat_title
+        self.new_chat_photo = new_chat_photo
+        self.delete_chat_photo = bool(delete_chat_photo)
+        self.group_chat_created = bool(group_chat_created)
+        self.supergroup_chat_created = bool(supergroup_chat_created)
+        self.migrate_to_chat_id = int(migrate_to_chat_id)
+        self.migrate_from_chat_id = int(migrate_from_chat_id)
+        self.channel_chat_created = bool(channel_chat_created)
+        self.pinned_message = pinned_message
 
         self.bot = bot
 

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -153,9 +153,7 @@ class Message(TelegramObject):
         self.reply_to_message = reply_to_message
         self.edit_date = edit_date
         self.text = text
-        if entities is None:
-            entities = list()
-        self.entities = entities
+        self.entities = entities or list()
         self.audio = audio
         self.document = document
         self.photo = photo

--- a/telegram/messageentity.py
+++ b/telegram/messageentity.py
@@ -34,14 +34,14 @@ class MessageEntity(TelegramObject):
         user (Optional[:class:`telegram.User`]):
     """
 
-    def __init__(self, type, offset, length, **kwargs):
+    def __init__(self, type, offset, length, url=None, user=None, **kwargs):
         # Required
         self.type = type
         self.offset = offset
         self.length = length
         # Optionals
-        self.url = kwargs.get('url')
-        self.user = kwargs.get('user')
+        self.url = url
+        self.user = user
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/photosize.py
+++ b/telegram/photosize.py
@@ -40,13 +40,13 @@ class PhotoSize(TelegramObject):
         file_size (Optional[int]):
     """
 
-    def __init__(self, file_id, width, height, **kwargs):
+    def __init__(self, file_id, width, height, file_size=0, **kwargs):
         # Required
         self.file_id = str(file_id)
         self.width = int(width)
         self.height = int(height)
         # Optionals
-        self.file_size = int(kwargs.get('file_size', 0))
+        self.file_size = int(file_size)
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):

--- a/telegram/replykeyboardhide.py
+++ b/telegram/replykeyboardhide.py
@@ -37,11 +37,11 @@ class ReplyKeyboardHide(ReplyMarkup):
         selective (Optional[bool]):
     """
 
-    def __init__(self, hide_keyboard=True, **kwargs):
+    def __init__(self, hide_keyboard=True, selective=False, **kwargs):
         # Required
         self.hide_keyboard = bool(hide_keyboard)
         # Optionals
-        self.selective = bool(kwargs.get('selective', False))
+        self.selective = bool(selective)
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/replykeyboardmarkup.py
+++ b/telegram/replykeyboardmarkup.py
@@ -41,13 +41,18 @@ class ReplyKeyboardMarkup(ReplyMarkup):
         selective (Optional[bool]):
     """
 
-    def __init__(self, keyboard, **kwargs):
+    def __init__(self,
+                 keyboard,
+                 resize_keyboard=False,
+                 one_time_keyboard=False,
+                 selective=False,
+                 **kwargs):
         # Required
         self.keyboard = keyboard
         # Optionals
-        self.resize_keyboard = bool(kwargs.get('resize_keyboard', False))
-        self.one_time_keyboard = bool(kwargs.get('one_time_keyboard', False))
-        self.selective = bool(kwargs.get('selective', False))
+        self.resize_keyboard = bool(resize_keyboard)
+        self.one_time_keyboard = bool(one_time_keyboard)
+        self.selective = bool(selective)
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/sticker.py
+++ b/telegram/sticker.py
@@ -44,15 +44,15 @@ class Sticker(TelegramObject):
         file_size (Optional[int]):
     """
 
-    def __init__(self, file_id, width, height, **kwargs):
+    def __init__(self, file_id, width, height, thumb=None, emoji='', file_size=0, **kwargs):
         # Required
         self.file_id = str(file_id)
         self.width = int(width)
         self.height = int(height)
         # Optionals
-        self.thumb = kwargs.get('thumb')
-        self.emoji = kwargs.get('emoji', '')
-        self.file_size = int(kwargs.get('file_size', 0))
+        self.thumb = thumb
+        self.emoji = emoji
+        self.file_size = int(file_size)
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/update.py
+++ b/telegram/update.py
@@ -44,15 +44,22 @@ class Update(TelegramObject):
         callback_query (Optional[:class:`telegram.CallbackQuery`]):
     """
 
-    def __init__(self, update_id, **kwargs):
+    def __init__(self,
+                 update_id,
+                 message=None,
+                 edited_message=None,
+                 inline_query=None,
+                 chosen_inline_result=None,
+                 callback_query=None,
+                 **kwargs):
         # Required
         self.update_id = int(update_id)
         # Optionals
-        self.message = kwargs.get('message')
-        self.edited_message = kwargs.get('edited_message')
-        self.inline_query = kwargs.get('inline_query')
-        self.chosen_inline_result = kwargs.get('chosen_inline_result')
-        self.callback_query = kwargs.get('callback_query')
+        self.message = message
+        self.edited_message = edited_message
+        self.inline_query = inline_query
+        self.chosen_inline_result = chosen_inline_result
+        self.callback_query = callback_query
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/user.py
+++ b/telegram/user.py
@@ -44,14 +44,14 @@ class User(TelegramObject):
         bot (Optional[Bot]): The Bot to use for instance methods
     """
 
-    def __init__(self, id, first_name, bot=None, **kwargs):
+    def __init__(self, id, first_name, type='', last_name='', username='', bot=None, **kwargs):
         # Required
         self.id = int(id)
         self.first_name = first_name
         # Optionals
-        self.type = kwargs.get('type', '')
-        self.last_name = kwargs.get('last_name', '')
-        self.username = kwargs.get('username', '')
+        self.type = type
+        self.last_name = last_name
+        self.username = username
 
         self.bot = bot
 

--- a/telegram/video.py
+++ b/telegram/video.py
@@ -46,16 +46,24 @@ class Video(TelegramObject):
         file_size (Optional[int]):
     """
 
-    def __init__(self, file_id, width, height, duration, **kwargs):
+    def __init__(self,
+                 file_id,
+                 width,
+                 height,
+                 duration,
+                 thumb=None,
+                 mime_type='',
+                 file_size=0,
+                 **kwargs):
         # Required
         self.file_id = str(file_id)
         self.width = int(width)
         self.height = int(height)
         self.duration = int(duration)
         # Optionals
-        self.thumb = kwargs.get('thumb')
-        self.mime_type = str(kwargs.get('mime_type', ''))
-        self.file_size = int(kwargs.get('file_size', 0))
+        self.thumb = thumb
+        self.mime_type = str(mime_type)
+        self.file_size = int(file_size)
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/voice.py
+++ b/telegram/voice.py
@@ -32,21 +32,21 @@ class Voice(TelegramObject):
 
     Args:
         file_id (str):
+        duration (Optional[int]):
         **kwargs: Arbitrary keyword arguments.
 
     Keyword Args:
-        duration (Optional[int]):
         mime_type (Optional[str]):
         file_size (Optional[int]):
     """
 
-    def __init__(self, file_id, **kwargs):
+    def __init__(self, file_id, duration, mime_type='', file_size=0, **kwargs):
         # Required
         self.file_id = str(file_id)
+        self.duration = int(duration)
         # Optionals
-        self.duration = int(kwargs.get('duration', 0))
-        self.mime_type = str(kwargs.get('mime_type', ''))
-        self.file_size = int(kwargs.get('file_size', 0))
+        self.mime_type = str(mime_type)
+        self.file_size = int(file_size)
 
     @staticmethod
     def de_json(data, bot):


### PR DESCRIPTION
Closes #424 
This should improve IDEs' autocompletion since most just look at the signature of the method and not the whole docstring (especially not the docstring of the containing class).
`**kwargs` is kept for future compatibility if (when) telegram changes their API.