### PR TITLE
Remove deprecated argument from Updater docstring

### DIFF
--- a/telegram/ext/updater.py
+++ b/telegram/ext/updater.py
@@ -61,8 +61,6 @@ class Updater(object):
         bot (Optional[Bot]): A pre-initialized bot instance. If a pre-initizlied bot is used, it is
             the user's responsibility to create it using a `Request` instance with a large enough
             connection pool.
-        job_queue_tick_interval(Optional[float]): The interval the queue should
-            be checked for new tasks. Defaults to 1.0
 
     Raises:
         ValueError: If both `token` and `bot` are passed or none of them.


### PR DESCRIPTION
Argument (job_queue_tick_interval) was removed with commit 3aedd78 but the docstring in updater.py wasn't.