### PR TITLE
Fix telegram API change, returning '404 Not found' 

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,6 +13,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `bimmlerd <https://github.com/bimmlerd>`_
 - `Eli Gao <https://github.com/eligao>`_
 - `ErgoZ Riftbit Vaper <https://github.com/ergoz>`_
+- `Eugene Lisitsky <https://github.com/lisitsky>`_
 - `franciscod <https://github.com/franciscod>`_
 - `Jacob Bom <https://github.com/bomjacob>`_
 - `JASON0916 <https://github.com/JASON0916>`_

--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -31,8 +31,8 @@ import urllib3
 from urllib3.connection import HTTPConnection
 
 from telegram import (InputFile, TelegramError)
-from telegram.error import Unauthorized, NetworkError, TimedOut, BadRequest, ChatMigrated, \
-    RetryAfter
+from telegram.error import Unauthorized, InvalidToken, NetworkError, TimedOut, BadRequest, \
+    ChatMigrated, RetryAfter
 
 logging.getLogger('urllib3').setLevel(logging.WARNING)
 
@@ -151,7 +151,7 @@ class Request(object):
         elif resp.status == 400:
             raise BadRequest(repr(message))
         elif resp.status == 404:
-            raise TelegramError('Invalid server response')
+            raise InvalidToken()
         elif resp.status == 502:
             raise NetworkError('Bad Gateway')
         else:

--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -150,6 +150,8 @@ class Request(object):
             raise Unauthorized()
         elif resp.status == 400:
             raise BadRequest(repr(message))
+        elif resp.status == 404:
+            raise TelegramError('Invalid server response')
         elif resp.status == 502:
             raise NetworkError('Bad Gateway')
         else:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -227,7 +227,7 @@ class BotTest(BaseTest, unittest.TestCase):
             bot.getMe()
 
     def testInvalidSrvResp(self):
-        with self.assertRaisesRegexp(telegram.TelegramError, 'Invalid server response'):
+        with self.assertRaisesRegexp(telegram.error.InvalidToken, 'Invalid token'):
             # bypass the valid token check
             newbot_cls = type(
                 'NoTokenValidateBot', (telegram.Bot,), dict(_validate_token=lambda x, y: None))


### PR DESCRIPTION
For bots with incorrect credentials telegram [returns](https://api.telegram.org/bot12) 
```
HTTP/1.1 404 Not Found
... headers skipped ...

{
    "description": "Not Found",
    "error_code": 404,
    "ok": false
}
```

Because of 404 response status http library raises naive NotFound exception, which is not meant to be caught by a request wrapper. As a result test is broken. This patch catches the exception and raises an internal `telegram.TelegramError('Invalid server response')` as it was conceived before in test [testInvalidSrvResp](https://github.com/python-telegram-bot/python-telegram-bot/blob/master/tests/test_bot.py#L229).

P.S. I'm new to python-telegram-bot, so comments are welcome ;)