### PR TITLE
jobqueue: add support for specifying next_t in datetime.datetime or datetime.time

### DIFF
--- a/telegram/ext/jobqueue.py
+++ b/telegram/ext/jobqueue.py
@@ -79,17 +79,9 @@ class JobQueue(object):
         job.job_queue = self
 
         if next_t is None:
-            interval = job.interval
+            next_t = job.interval
 
-            if isinstance(interval, Number):
-                next_t = interval
-            elif isinstance(interval, datetime.timedelta):
-                next_t = interval.total_seconds()
-            else:
-                raise ValueError("The interval argument should be of type datetime.timedelta,"
-                                 " int or float")
-
-        elif isinstance(next_t, datetime.datetime):
+        if isinstance(next_t, datetime.datetime):
             next_t = next_t - datetime.datetime.now()
 
         elif isinstance(next_t, datetime.time):
@@ -273,6 +265,10 @@ class Job(object):
 
         if interval is None and repeat:
             raise ValueError("You must either set an interval or set 'repeat' to 'False'")
+
+        if not (isinstance(interval, Number) or isinstance(interval, datetime.timedelta)):
+            raise ValueError("The 'interval' argument must be of type 'datetime.timedelta',"
+                             " 'int' or 'float'")
 
         self.days = days
         self.name = callback.__name__

--- a/tests/test_jobqueue.py
+++ b/tests/test_jobqueue.py
@@ -62,9 +62,6 @@ class JobQueueTest(BaseTest, unittest.TestCase):
         if self.jq is not None:
             self.jq.stop()
 
-    def getSeconds(self):
-        return int(ceil(time.time()))
-
     def job1(self, bot, job):
         self.result += 1
 
@@ -79,7 +76,7 @@ class JobQueueTest(BaseTest, unittest.TestCase):
         self.result += job.context
 
     def job5(self, bot, job):
-        self.job_time = self.getSeconds()
+        self.job_time = time.time()
 
     def test_basic(self):
         self.jq.put(Job(self.job1, 0.1))
@@ -181,22 +178,56 @@ class JobQueueTest(BaseTest, unittest.TestCase):
 
     def test_time_unit_int(self):
         # Testing seconds in int
-        seconds_interval = 5
-        expected_time = self.getSeconds() + seconds_interval
+        seconds_interval = 2
+        expected_time = time.time() + seconds_interval
 
         self.jq.put(Job(self.job5, seconds_interval, repeat=False))
-        sleep(6)
-        self.assertEqual(self.job_time, expected_time)
+        sleep(2.5)
+        self.assertAlmostEqual(self.job_time, expected_time, delta=0.1)
 
-    def test_time_unit_dt_time(self):
+    def test_time_unit_dt_timedelta(self):
         # Testing seconds, minutes and hours as datetime.timedelta object
         # This is sufficient to test that it actually works.
-        interval = datetime.timedelta(seconds=5)
-        expected_time = self.getSeconds() + interval.total_seconds()
+        interval = datetime.timedelta(seconds=2)
+        expected_time = time.time() + interval.total_seconds()
 
         self.jq.put(Job(self.job5, interval, repeat=False))
-        sleep(6)
-        self.assertEqual(self.job_time, expected_time)
+        sleep(2.5)
+        self.assertAlmostEqual(self.job_time, expected_time, delta=0.1)
+
+    def test_time_unit_dt_datetime(self):
+        # Testing running at a specific datetime
+        delta = datetime.timedelta(seconds=2)
+        next_t = datetime.datetime.now() + delta
+        expected_time = time.time() + delta.total_seconds()
+
+        self.jq.put(Job(self.job5, repeat=False), next_t=next_t)
+        sleep(2.5)
+        self.assertAlmostEqual(self.job_time, expected_time, delta=0.1)
+
+    def test_time_unit_dt_time_today(self):
+        # Testing running at a specific time today
+        delta = 2
+        current_time = datetime.datetime.now().time()
+        next_t = datetime.time(current_time.hour, current_time.minute, current_time.second + delta,
+                               current_time.microsecond)
+        expected_time = time.time() + delta
+
+        self.jq.put(Job(self.job5, repeat=False), next_t=next_t)
+        sleep(2.5)
+        self.assertAlmostEqual(self.job_time, expected_time, delta=0.1)
+
+    def test_time_unit_dt_time_tomorrow(self):
+        # Testing running at a specific time that has passed today. Since we can't wait a day, we
+        # test if the jobs next_t has been calculated correctly
+        delta = -2
+        current_time = datetime.datetime.now().time()
+        next_t = datetime.time(current_time.hour, current_time.minute, current_time.second + delta,
+                               current_time.microsecond)
+        expected_time = time.time() + delta + 60 * 60 * 24
+
+        self.jq.put(Job(self.job5, repeat=False), next_t=next_t)
+        self.assertAlmostEqual(self.jq.queue.get(False)[0], expected_time, delta=0.1)
 
 
 if __name__ == '__main__':

--- a/tests/test_jobqueue.py
+++ b/tests/test_jobqueue.py
@@ -178,10 +178,10 @@ class JobQueueTest(BaseTest, unittest.TestCase):
 
     def test_time_unit_int(self):
         # Testing seconds in int
-        seconds_interval = 2
-        expected_time = time.time() + seconds_interval
+        delta = 2
+        expected_time = time.time() + delta
 
-        self.jq.put(Job(self.job5, seconds_interval, repeat=False))
+        self.jq.put(Job(self.job5, delta, repeat=False))
         sleep(2.5)
         self.assertAlmostEqual(self.job_time, expected_time, delta=0.1)
 
@@ -228,6 +228,128 @@ class JobQueueTest(BaseTest, unittest.TestCase):
 
         self.jq.put(Job(self.job5, repeat=False), next_t=next_t)
         self.assertAlmostEqual(self.jq.queue.get(False)[0], expected_time, delta=0.1)
+
+    def test_one_time_job(self):
+        delta = 2
+        expected_time = time.time() + delta
+
+        self.jq.one_time_job(self.job5, delta)
+        sleep(2.5)
+        self.assertAlmostEqual(self.job_time, expected_time, delta=0.1)
+
+    def test_repeating_job(self):
+        interval = 0.1
+        first = 1.5
+
+        self.jq.repeating_job(self.job1, interval, first=first)
+        sleep(2.505)
+        self.assertAlmostEqual(self.result, 10, delta=1)
+
+    def test_daily_job(self):
+        delta = 1
+        current_time = datetime.datetime.now().time()
+        time_of_day = datetime.time(current_time.hour, current_time.minute,
+                                    current_time.second + delta, current_time.microsecond)
+
+        expected_time = time.time() + 60 * 60 * 24 + delta
+
+        self.jq.daily_job(self.job1, time_of_day)
+        sleep(2 * delta)
+        self.assertEqual(self.result, 1)
+        self.assertAlmostEqual(self.jq.queue.get(False)[0], expected_time, delta=0.1)
+
+    def test_update_job_due_time(self):
+        job = self.jq.one_time_job(self.job1, datetime.datetime(2030, 1, 1))
+
+        sleep(0.5)
+        self.assertEqual(self.result, 0)
+
+        self.jq.update_job_due_time(job, time.time() + 1)
+
+        sleep(0.5)
+        self.assertEqual(self.result, 0)
+
+        sleep(1.5)
+        self.assertEqual(self.result, 1)
+
+    def test_job_run_immediately_one_time(self):
+        job = self.jq.one_time_job(self.job1, datetime.datetime(2030, 1, 1))
+
+        sleep(0.5)
+        self.assertEqual(self.result, 0)
+
+        job.run_immediately()
+
+        sleep(0.5)
+        self.assertEqual(self.result, 1)
+
+    def test_job_run_immediately_skip(self):
+        job = self.jq.repeating_job(self.job1, 1, first=2)
+
+        sleep(0.5)  # 0.5s | no runs
+        self.assertEqual(self.result, 0)
+
+        job.run_immediately(keep_schedule=False, skip_next=True)
+
+        sleep(0.5)  # 1s | first run at 0.5s, rescheduled with interval=1 but skipping the next run
+        self.assertEqual(self.result, 1)
+
+        sleep(1)  # 2s | run at 1.5s was skipped
+        self.assertEqual(self.result, 1)
+
+        sleep(1)  # 3s | run at 2.5s was back to normal
+        self.assertEqual(self.result, 2)
+
+        sleep(1)  # 4s | just to confirm
+        self.assertEqual(self.result, 3)
+
+    def test_job_run_immediately_keep(self):
+        job = self.jq.repeating_job(self.job1, 1)
+
+        sleep(0.5)  # 0.5s | no runs
+        self.assertEqual(self.result, 0)
+
+        job.run_immediately(keep_schedule=True, skip_next=False)
+
+        # 0.75s | first run at 0.5s, rescheduled with interval=0.5 to keep up with the schedule
+        sleep(0.25)
+        self.assertEqual(self.result, 1)
+
+        sleep(0.5)  # 1.25s | run at 1s, rescheduled with interval=1
+        self.assertEqual(self.result, 2)
+
+        sleep(0.5)  # 1.75s | last run still at 1s
+        self.assertEqual(self.result, 2)
+
+        sleep(1)  # 2.25s | run at 2s was back to normal
+        self.assertEqual(self.result, 3)
+
+        sleep(1)  # 3.25s | just to confirm
+        self.assertEqual(self.result, 4)
+
+    def test_job_run_immediately_keep_skip(self):
+        job = self.jq.repeating_job(self.job1, 1)
+
+        sleep(0.5)  # 0.5s | no runs
+        self.assertEqual(self.result, 0)
+
+        job.run_immediately(keep_schedule=True, skip_next=True)
+
+        # 0.75s | first run at 0.5s, rescheduled with interval=0.5 to keep up with the schedule...
+        sleep(0.25)
+        self.assertEqual(self.result, 1)
+
+        sleep(0.5)  # 1.25s | ...but run at 1s was skipped, rescheduled with interval=1
+        self.assertEqual(self.result, 1)
+
+        sleep(0.5)  # 1.75s | last run still at 1s
+        self.assertEqual(self.result, 1)
+
+        sleep(1)  # 2.25s | the run at 2s was back to normal
+        self.assertEqual(self.result, 2)
+
+        sleep(1)  # 3.25s | just to confirm
+        self.assertEqual(self.result, 3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Title says it all, I guess. Many people asked for it, so here we go. You can now specify the `next_t` parameter of `JobQueue.put` as `datetime.datetime` or `datetime.time`, so the job will run at exactly the specified (date and) time.

```python
>>> from datetime import datetime, time, timedelta
>>> job_queue.put(happy_new_year_job, next_t=datetime(2017, 1, 1))
>>> job_queue.put(alarm_clock_job, next_t=time(8, 30))
>>> midnight_job = Job(midnight_callback, timedelta(days=1))
>>> job_queue.put(midnight_job, next_t=time(0, 0))
```

If you pass a `datetime.time` object for `next_t` and it's already later than the specified time (eg it's 10:00 and `next_t` is `time(8, 30)`), the job will execute the next day.

I made the `interval` parameter for `Job` optional, so you can just leave it for non-repeating jobs (however, you must explicitly pass `repeat=False`)