### PR TITLE
API changes of December 04 (Bot API 2.3.1)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ make the development of bots easy and straightforward. These classes are contain
 Telegram API support
 ====================
 
-As of **3. Oct 2016**, all types and methods of the Telegram Bot API are supported.
+As of **4. Dec 2016**, all types and methods of the Telegram Bot API are supported.
 
 ==========
 Installing

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -1713,6 +1713,7 @@ class Bot(TelegramObject):
     edit_message_reply_markup = editMessageReplyMarkup
     get_updates = getUpdates
     set_webhook = setWebhook
+    delete_webhook = deleteWebhook
     leave_chat = leaveChat
     get_chat = getChat
     get_chat_administrators = getChatAdministrators

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -1204,9 +1204,9 @@ class Bot(TelegramObject):
     def getUpdates(self,
                    offset=None,
                    limit=100,
-                   allowed_updates=None,
                    timeout=0,
                    network_delay=5.,
+                   allowed_updates=None,
                    **kwargs):
         """Use this method to receive incoming updates using long polling.
 
@@ -1267,9 +1267,9 @@ class Bot(TelegramObject):
     def setWebhook(self,
                    url=None,
                    certificate=None,
+                   timeout=None,
                    max_connections=40,
                    allowed_updates=None,
-                   timeout=None,
                    **kwargs):
         """Use this method to specify a url and receive incoming updates via an outgoing webhook.
         Whenever there is an update for the bot, we will send an HTTPS POST request to the
@@ -1309,6 +1309,10 @@ class Bot(TelegramObject):
         if 'webhook_url' in kwargs:
             warnings.warn("The 'webhook_url' parameter has been renamed to 'url' in accordance "
                           "with the API")
+
+            if url is not None:
+                raise ValueError("The parameters 'url' and 'webhook_url' are mutually exclusive")
+
             url = kwargs['webhook_url']
             del kwargs['webhook_url']
 

--- a/telegram/ext/updater.py
+++ b/telegram/ext/updater.py
@@ -328,7 +328,7 @@ class Updater(object):
             try:
                 if clean:
                     # Disable webhook for cleaning
-                    self.bot.setWebhook(webhook_url='')
+                    self.bot.deleteWebhook()
                     self._clean_updates()
                     sleep(1)
 

--- a/telegram/webhookinfo.py
+++ b/telegram/webhookinfo.py
@@ -40,13 +40,23 @@ class WebhookInfo(TelegramObject):
 
     """
 
-    def __init__(self, url, has_custom_certificate, pending_update_count, **kwargs):
+    def __init__(self,
+                 url,
+                 has_custom_certificate=None,
+                 pending_update_count=None,
+                 last_error_date=None,
+                 last_error_message=None,
+                 max_connections=None,
+                 allowed_updates=None,
+                 **kwargs):
         # Required
         self.url = url
         self.has_custom_certificate = has_custom_certificate
         self.pending_update_count = pending_update_count
-        self.last_error_date = kwargs.get('last_error_date', '')
-        self.last_error_message = kwargs.get('last_error_message', '')
+        self.last_error_date = last_error_date
+        self.last_error_message = last_error_message
+        self.max_connections = max_connections
+        self.allowed_updates = allowed_updates
 
     @staticmethod
     def de_json(data, bot):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -85,6 +85,7 @@ class BotTest(BaseTest, unittest.TestCase):
     @flaky(3, 1)
     @timeout(10)
     def testGetUpdates(self):
+        self._bot.delete_webhook()  # make sure there is no webhook set if webhook tests failed
         updates = self._bot.getUpdates(timeout=1)
 
         if updates:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -291,7 +291,7 @@ class BotTest(BaseTest, unittest.TestCase):
 
     @flaky(3, 1)
     @timeout(10)
-    def test_forward_channel_messgae(self):
+    def test_forward_channel_message(self):
         text = 'test forward message'
         msg = self._bot.sendMessage(self._channel_id, text)
         self.assertEqual(text, msg.text)
@@ -301,12 +301,25 @@ class BotTest(BaseTest, unittest.TestCase):
 
     @flaky(3, 1)
     @timeout(10)
-    def test_get_webhook_info(self):
+    def test_set_webhook_get_webhook_info(self):
+        url = 'https://python-telegram-bot.org/test/webhook'
+        max_connections = 7
+        allowed_updates = ['message']
+        self._bot.set_webhook(url, max_connections=7, allowed_updates=['message'])
+        info = self._bot.getWebhookInfo()
+        self._bot.delete_webhook()
+        self.assertEqual(url, info.url)
+        self.assertEqual(max_connections, info.max_connections)
+        self.assertListEqual(allowed_updates, info.allowed_updates)
+
+    @flaky(3, 1)
+    @timeout(10)
+    def test_delete_webhook(self):
         url = 'https://python-telegram-bot.org/test/webhook'
         self._bot.set_webhook(url)
+        self._bot.delete_webhook()
         info = self._bot.getWebhookInfo()
-        self._bot.set_webhook('')
-        self.assertEqual(url, info.url)
+        self.assertEqual(info.url, '')
 
     @flaky(3, 1)
     @timeout(10)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -801,7 +801,7 @@ class MockBot(object):
 
         return update
 
-    def setWebhook(self, webhook_url=None, certificate=None):
+    def setWebhook(self, url=None, certificate=None):
         if self.bootstrap_retries is None:
             return
 
@@ -809,7 +809,21 @@ class MockBot(object):
             self.bootstrap_attempts += 1
             raise self.bootstrap_err
 
-    def getUpdates(self, offset=None, limit=100, timeout=0, network_delay=None, read_latency=2.):
+    def deleteWebhook(self):
+        if self.bootstrap_retries is None:
+            return
+
+        if self.bootstrap_attempts < self.bootstrap_retries:
+            self.bootstrap_attempts += 1
+            raise self.bootstrap_err
+
+    def getUpdates(self,
+                   offset=None,
+                   limit=100,
+                   timeout=0,
+                   network_delay=None,
+                   read_latency=2.,
+                   allowed_updates=None):
 
         if self.raise_error:
             raise TelegramError('Test Error 2')


### PR DESCRIPTION
- Use the new field max_connections in setWebhook to optimize your bot's server load
- Use allowed_updates in setWebhook and getUpdates to selectively subscribe to updates of a certain type. Among other things, this allows you to stop getting updates about new posts in channels where your bot is an admin.
- deleteWebhook moved out of setWebhook to get a whole separate method for itself.

I also renamed the `webhook_url` parameter of `setWebhook` to `url` like in the official API. The old name is still supported through `kwargs`.