### PR TITLE
set timeout for post message with file object

### DIFF
--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -196,7 +196,9 @@ class Request(object):
 
         if InputFile.is_inputfile(data):
             data = InputFile(data)
-            result = self._request_wrapper('POST', url, body=data.to_form(), headers=data.headers)
+            result = self._request_wrapper('POST', url, body=data.to_form(),
+                                           headers=data.headers,
+                                           **urlopen_kwargs)
         else:
             data = json.dumps(data)
             result = self._request_wrapper(


### PR DESCRIPTION
Timeout is not set for POST method when the message contains file object, for example for the sendPhoto method.