### PR TITLE
ConversationHandler breaks when bot is also used in Channels

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -32,6 +32,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `overquota <https://github.com/overquota>`_
 - `Patrick Hofmann <https://github.com/PH89>`_
 - `Rahiel Kasim <https://github.com/rahiel>`_
+- `Joscha Götzer <https://github.com/Rostgnom>`_
 - `Shelomentsev D <https://github.com/shelomentsevd>`_
 - `sooyhwang <https://github.com/sooyhwang>`_
 - `Valentijn <https://github.com/Faalentijn>`_

--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -116,6 +116,10 @@ class ConversationHandler(Handler):
         if not isinstance(update, Update):
             return False
 
+        # Ignore messages in channels
+        if update.channel_post:
+            return False
+
         chat, user = extract_chat_and_user(update)
 
         key = (chat.id, user.id) if chat else (None, user.id)

--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -28,7 +28,9 @@ from telegram.utils.promise import Promise
 
 class ConversationHandler(Handler):
     """
-    A handler to hold a conversation with a user by managing four collections of other handlers.
+    A handler to hold a conversation with a single user by managing four collections of other
+    handlers. Note that neither posts in Telegram Channels, nor group interactions with multiple
+    users are managed by instances of this class.
 
     The first collection, a ``list`` named ``entry_points``, is used to initiate the conversation,
     for example with a ``CommandHandler`` or ``RegexHandler``.
@@ -113,11 +115,8 @@ class ConversationHandler(Handler):
 
     def check_update(self, update):
 
-        if not isinstance(update, Update):
-            return False
-
         # Ignore messages in channels
-        if update.channel_post:
+        if not isinstance(update, Update) or update.channel_post:
             return False
 
         chat, user = extract_chat_and_user(update)


### PR DESCRIPTION
When using a `ConversationHandler` for private and group chats in conjunction to having the bot added to a Channel, it will throw a None type exception because it cannot retrieve a chat/user id from the update.

I suggest completely ignoring all channel_posts, because the interactivity that a ConversationHandler provides is not useful in channels anyway.