### PR TITLE
Urllib3 stability

### DIFF
--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -158,8 +158,13 @@ class Bot(TelegramObject):
         return decorator
 
     @log
-    def getMe(self, **kwargs):
+    def getMe(self, timeout=None, **kwargs):
         """A simple method for testing your bot's auth token.
+
+        Args:
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
 
         Returns:
             :class:`telegram.User`: A :class:`telegram.User` instance representing that bot if the
@@ -171,7 +176,7 @@ class Bot(TelegramObject):
         """
         url = '{0}/getMe'.format(self.base_url)
 
-        result = self._request.get(url)
+        result = self._request.get(url, timeout=timeout)
 
         self.bot = User.de_json(result, self)
 
@@ -211,8 +216,9 @@ class Bot(TelegramObject):
                 interface options. A JSON-serialized object for an inline
                 keyboard, custom reply keyboard, instructions to remove reply
                 keyboard or to force a reply from the user.
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -251,8 +257,9 @@ class Bot(TelegramObject):
             message_id: Unique message identifier.
             disable_notification (Optional[bool]): Sends the message silently. iOS users will not
                 receive a notification, Android users will receive a notification with no sound.
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -301,8 +308,9 @@ class Bot(TelegramObject):
             reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional interface options. A
                 JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
                 to remove reply keyboard or to force a reply from the user.
-            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
-                (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -362,8 +370,9 @@ class Bot(TelegramObject):
             reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional interface options. A
                 JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
                 to remove reply keyboard or to force a reply from the user.
-            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
-                (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -417,8 +426,9 @@ class Bot(TelegramObject):
             reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional interface options. A
                 JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
                 to remove reply keyboard or to force a reply from the user.
-            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
-                (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -463,8 +473,9 @@ class Bot(TelegramObject):
             reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional interface options. A
                 JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
                 to remove reply keyboard or to force a reply from the user.
-            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
-                (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -510,8 +521,9 @@ class Bot(TelegramObject):
             reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional interface options. A
                 JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
                 to remove reply keyboard or to force a reply from the user.
-            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
-                (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
 
         Returns:
             :class:`telegram.Message`: On success, instance representing the message posted.
@@ -563,8 +575,9 @@ class Bot(TelegramObject):
             reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional interface options. A
                 JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
                 to remove reply keyboard or to force a reply from the user.
-            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
-                (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -609,8 +622,9 @@ class Bot(TelegramObject):
             reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional interface options. A
                 JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
                 to remove reply keyboard or to force a reply from the user.
-            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
-                (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -658,8 +672,9 @@ class Bot(TelegramObject):
             reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional interface options. A
                 JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
                 to remove reply keyboard or to force a reply from the user.
-            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
-                (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -712,8 +727,9 @@ class Bot(TelegramObject):
             reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional interface options. A
                 JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
                 to remove reply keyboard or to force a reply from the user.
-            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
-                (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -734,7 +750,7 @@ class Bot(TelegramObject):
 
     @log
     @message
-    def sendGame(self, chat_id, game_short_name, **kwargs):
+    def sendGame(self, chat_id, game_short_name, timeout=None, **kwargs):
         """Use this method to send a game.
 
         Args:
@@ -751,8 +767,9 @@ class Bot(TelegramObject):
             reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional interface options.
                 A JSON-serialized object for an inline keyboard, custom reply keyboard,
                 instructions to remove reply keyboard or to force a reply from the user.
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
 
         Returns:
             :class:`telegram.Message`: On success, the sent message is returned.
@@ -769,7 +786,7 @@ class Bot(TelegramObject):
 
     @log
     @message
-    def sendChatAction(self, chat_id, action, **kwargs):
+    def sendChatAction(self, chat_id, action, timeout=None, **kwargs):
         """Use this method when you need to tell the user that something is happening on the bot's
         side. The status is set for 5 seconds or less (when a message arrives from your bot,
         Telegram clients clear its typing status).
@@ -785,6 +802,9 @@ class Bot(TelegramObject):
                     - ChatAction.UPLOAD_AUDIO for audio files,
                     - ChatAction.UPLOAD_DOCUMENT for general files,
                     - ChatAction.FIND_LOCATION for location data.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         """
@@ -826,8 +846,9 @@ class Bot(TelegramObject):
                 start message with the parameter switch_pm_parameter.
             switch_pm_parameter (Optional[str]): Parameter for the start message sent to the bot
                 when user presses the switch button.
-            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
-                (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -868,8 +889,9 @@ class Bot(TelegramObject):
                 default, all photos are returned.
             limit (Optional[int]): Limits the number of photos to be retrieved. Values between
                 1-100 are accepted. Defaults to 100.
-            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
-                (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -900,8 +922,9 @@ class Bot(TelegramObject):
 
         Args:
             file_id: File identifier to get info about.
-            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
-                (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -934,8 +957,9 @@ class Bot(TelegramObject):
             chat_id: Unique identifier for the target group or username of the target supergroup
                 (in the format @supergroupusername).
             user_id: Unique identifier of the target user.
-            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
-                (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -963,8 +987,9 @@ class Bot(TelegramObject):
             chat_id: Unique identifier for the target group or username of the target supergroup
                 (in the format @supergroupusername).
             user_id: Unique identifier of the target user.
-            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
-                (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -1005,8 +1030,9 @@ class Bot(TelegramObject):
             cache_time (Optional[int]): The maximum amount of time in seconds that the result of
                 the callback query may be cached client-side. Telegram apps will support caching
                 starting in version 3.14. Defaults to 0.
-            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
-                (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -1062,8 +1088,9 @@ class Bot(TelegramObject):
             reply_markup (Optional[:class:`telegram.ReplyMarkup`]): Additional interface options. A
                 JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
                 to remove reply keyboard or to force a reply from the user.
-            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
-                (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -1115,8 +1142,9 @@ class Bot(TelegramObject):
             caption (Optional[str]): New caption of the message.
             reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]): A JSON-serialized
                 object for an inline keyboard.
-            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
-                (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -1169,8 +1197,9 @@ class Bot(TelegramObject):
                 specified. Identifier of the inline message.
             reply_markup (Optional[:class:`telegram.InlineKeyboardMarkup`]): A JSON-serialized
                 object for an inline keyboard.
-            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
-                (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -1201,7 +1230,13 @@ class Bot(TelegramObject):
         return url, data
 
     @log
-    def getUpdates(self, offset=None, limit=100, timeout=0, network_delay=5., **kwargs):
+    def getUpdates(self,
+                   offset=None,
+                   limit=100,
+                   timeout=0,
+                   network_delay=None,
+                   read_latency=2.,
+                   **kwargs):
         """Use this method to receive incoming updates using long polling.
 
         Args:
@@ -1213,12 +1248,24 @@ class Bot(TelegramObject):
             limit (Optional[int]): Limits the number of updates to be retrieved. Values between
                 1-100 are accepted. Defaults to 100.
             timeout (Optional[int]): Timeout in seconds for long polling. Defaults to 0, i.e. usual
-                short polling.
-            network_delay (Optional[float]): Additional timeout in seconds to allow the response
-                from Telegram servers. This should cover network latency around the globe, SSL
-                handshake and slowness of the Telegram servers (which unfortunately happens a lot
-                recently - 2016-05-28). Defaults to 5.
+                short polling. Be careful not to set this timeout too high, as the connection might
+                be dropped and there's no way of knowing it immediately (so most likely the failure
+                will be detected after the timeout had passed).
+            network_delay: Deprecated. Will be honoured as `read_latency` for a while but will be
+                removed in the future.
+            read_latency (Optional[float|int]): Grace time in seconds for receiving the reply from
+                server. Will be added to the `timeout` value and used as the read timeout from
+                server (Default: 2).
             **kwargs (dict): Arbitrary keyword arguments.
+
+        Notes:
+            The main problem with long polling is that a connection will be dropped and we won't
+            be getting the notification in time for it. For that, we need to use long polling, but
+            not too long as well read latency which is short, but not too short.
+            Long polling improves performance, but if it's too long and the connection is dropped
+            on many cases we won't know the connection dropped before the long polling timeout and
+            the read latency time had passed. If you experience connection timeouts, you should
+            tune these settings.
 
         Returns:
             list[:class:`telegram.Update`]
@@ -1229,6 +1276,10 @@ class Bot(TelegramObject):
         """
         url = '{0}/getUpdates'.format(self.base_url)
 
+        if network_delay is not None:
+            warnings.warn('network_delay is deprecated, use read_latency instead')
+            read_latency = network_delay
+
         data = {'timeout': timeout}
 
         if offset:
@@ -1236,9 +1287,12 @@ class Bot(TelegramObject):
         if limit:
             data['limit'] = limit
 
-        urlopen_timeout = timeout + network_delay
-
-        result = self._request.post(url, data, timeout=urlopen_timeout)
+        # Ideally we'd use an aggressive read timeout for the polling. However,
+        # * Short polling should return within 2 seconds.
+        # * Long polling poses a different problem: the connection might have been dropped while
+        #   waiting for the server to return and there's no way of knowing the connection had been
+        #   dropped in real time.
+        result = self._request.post(url, data, timeout=float(read_latency) + float(timeout))
 
         if result:
             self.logger.debug('Getting updates: %s', [u['update_id'] for u in result])
@@ -1256,9 +1310,10 @@ class Bot(TelegramObject):
 
         Args:
             webhook_url: HTTPS url to send updates to. Use an empty string to remove webhook
-                integration
-            timeout (Optional[float]): If this value is specified, use it as
-                the definitive timeout (in seconds) for urlopen() operations.
+                integration.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -1288,8 +1343,9 @@ class Bot(TelegramObject):
         Args:
             chat_id: Unique identifier for the target chat or username of the target channel (in
                 the format @channelusername).
-            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
-                (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -1315,8 +1371,9 @@ class Bot(TelegramObject):
         Args:
             chat_id: Unique identifier for the target chat or username of the target channel (in
                 the format @channelusername).
-            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
-                (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -1345,8 +1402,9 @@ class Bot(TelegramObject):
         Args:
             chat_id: Unique identifier for the target chat or username of the target channel (in
                 the format @channelusername).
-            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
-                (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -1371,8 +1429,9 @@ class Bot(TelegramObject):
         Args:
             chat_id: Unique identifier for the target chat or username of the target channel (in
                 the format @channelusername).
-            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
-                (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -1398,8 +1457,9 @@ class Bot(TelegramObject):
             chat_id: Unique identifier for the target chat or username of the target channel (in
                 the format @channelusername).
             user_id: Unique identifier of the target user.
-            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
-                (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
             **kwargs (dict): Arbitrary keyword arguments.
 
         Returns:
@@ -1417,10 +1477,15 @@ class Bot(TelegramObject):
 
         return ChatMember.de_json(result, self)
 
-    def getWebhookInfo(self, **kwargs):
+    def getWebhookInfo(self, timeout=None, **kwargs):
         """Use this method to get current webhook status.
 
         If the bot is using getUpdates, will return an object with the url field empty.
+
+        Args:
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
 
         Returns:
             :class: `telegram.WebhookInfo`
@@ -1430,7 +1495,7 @@ class Bot(TelegramObject):
 
         data = {}
 
-        result = self._request.post(url, data, timeout=kwargs.get('timeout'))
+        result = self._request.post(url, data, timeout=timeout)
 
         return WebhookInfo.de_json(result, self)
 
@@ -1443,6 +1508,7 @@ class Bot(TelegramObject):
                      edit_message=None,
                      force=None,
                      disable_edit_message=None,
+                     timeout=None,
                      **kwargs):
         """Use this method to set the score of the specified user in a game.
 
@@ -1462,10 +1528,9 @@ class Bot(TelegramObject):
                 automatically edited to include the current scoreboard.
             edit_message (Optional[bool]): Deprecated. Has the opposite logic for
                 `disable_edit_message`.
-
-        Keyword Args:
-            timeout (Optional[float]): If this value is specified, use it as the definitive timeout
-                (in seconds) for urlopen() operations.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
 
         Returns:
             :class:`telegram.Message` or True: The edited message, or if the
@@ -1493,7 +1558,7 @@ class Bot(TelegramObject):
             else:
                 warnings.warn('edit_message is ignored when disable_edit_message is used')
 
-        result = self._request.post(url, data, timeout=kwargs.get('timeout'))
+        result = self._request.post(url, data, timeout=timeout)
         if result is True:
             return result
         else:
@@ -1504,8 +1569,14 @@ class Bot(TelegramObject):
                           chat_id=None,
                           message_id=None,
                           inline_message_id=None,
+                          timeout=None,
                           **kwargs):
         """Use this method to get data for high score tables.
+
+        Args:
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
 
         Returns:
             list[:class:`telegram.GameHighScore`]: Scores of the specified user and several of his
@@ -1523,7 +1594,7 @@ class Bot(TelegramObject):
         if inline_message_id:
             data['inline_message_id'] = inline_message_id
 
-        result = self._request.post(url, data, timeout=kwargs.get('timeout'))
+        result = self._request.post(url, data, timeout=timeout)
 
         return [GameHighScore.de_json(hs, self) for hs in result]
 

--- a/telegram/file.py
+++ b/telegram/file.py
@@ -65,20 +65,24 @@ class File(TelegramObject):
 
         return File(bot=bot, **data)
 
-    def download(self, custom_path=None, out=None):
+    def download(self, custom_path=None, out=None, timeout=None):
         """
         Download this file. By default, the file is saved in the current working directory with its
         original filename as reported by Telegram. If a ``custom_path`` is supplied, it will be
         saved to that path instead. If ``out`` is defined, the file contents will be saved to that
         object using the ``out.write`` method. ``custom_path`` and ``out`` are mutually exclusive.
 
-        Keyword Args:
+        Args:
             custom_path (Optional[str]): Custom path.
             out (Optional[object]): A file-like object. Must be opened in binary mode, if
                 applicable.
+            timeout (Optional[int|float]): If this value is specified, use it as the read timeout
+                from the server (instead of the one specified during creation of the connection
+                pool).
 
         Raises:
             ValueError: If both ``custom_path`` and ``out`` are passed.
+
         """
 
         if custom_path is not None and out is not None:
@@ -96,4 +100,4 @@ class File(TelegramObject):
             else:
                 filename = basename(url)
 
-            self.bot.request.download(url, filename)
+            self.bot.request.download(url, filename, timeout=timeout)

--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -128,6 +128,12 @@ class Request(object):
             TelegramError
 
         """
+        # Make sure to hint Telegram servers that we reuse connections by sending
+        # "Connection: keep-alive" in the HTTP headers.
+        if 'headers' not in kwargs:
+            kwargs['headers'] = {}
+        kwargs['headers']['connection'] = 'keep-alive'
+
         try:
             resp = self._con_pool.request(*args, **kwargs)
         except urllib3.exceptions.TimeoutError:
@@ -196,11 +202,8 @@ class Request(object):
 
         if InputFile.is_inputfile(data):
             data = InputFile(data)
-            result = self._request_wrapper('POST',
-                                           url,
-                                           body=data.to_form(),
-                                           headers=data.headers,
-                                           **urlopen_kwargs)
+            result = self._request_wrapper(
+                'POST', url, body=data.to_form(), headers=data.headers, **urlopen_kwargs)
         else:
             data = json.dumps(data)
             result = self._request_wrapper(

--- a/tests/test_jobqueue.py
+++ b/tests/test_jobqueue.py
@@ -208,9 +208,7 @@ class JobQueueTest(BaseTest, unittest.TestCase):
     def test_time_unit_dt_time_today(self):
         # Testing running at a specific time today
         delta = 2
-        current_time = datetime.datetime.now().time()
-        next_t = datetime.time(current_time.hour, current_time.minute, current_time.second + delta,
-                               current_time.microsecond)
+        next_t = (datetime.datetime.now() + datetime.timedelta(seconds=delta)).time()
         expected_time = time.time() + delta
 
         self.jq.put(Job(self.job5, repeat=False), next_t=next_t)
@@ -221,9 +219,7 @@ class JobQueueTest(BaseTest, unittest.TestCase):
         # Testing running at a specific time that has passed today. Since we can't wait a day, we
         # test if the jobs next_t has been calculated correctly
         delta = -2
-        current_time = datetime.datetime.now().time()
-        next_t = datetime.time(current_time.hour, current_time.minute, current_time.second + delta,
-                               current_time.microsecond)
+        next_t = (datetime.datetime.now() + datetime.timedelta(seconds=delta)).time()
         expected_time = time.time() + delta + 60 * 60 * 24
 
         self.jq.put(Job(self.job5, repeat=False), next_t=next_t)
@@ -247,10 +243,7 @@ class JobQueueTest(BaseTest, unittest.TestCase):
 
     def test_run_daily(self):
         delta = 1
-        current_time = datetime.datetime.now().time()
-        time_of_day = datetime.time(current_time.hour, current_time.minute,
-                                    current_time.second + delta, current_time.microsecond)
-
+        time_of_day = (datetime.datetime.now() + datetime.timedelta(seconds=delta)).time()
         expected_time = time.time() + 60 * 60 * 24 + delta
 
         self.jq.run_daily(self.job1, time_of_day)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -809,7 +809,7 @@ class MockBot(object):
             self.bootstrap_attempts += 1
             raise self.bootstrap_err
 
-    def getUpdates(self, offset=None, limit=100, timeout=0, network_delay=2.):
+    def getUpdates(self, offset=None, limit=100, timeout=0, network_delay=None, read_latency=2.):
 
         if self.raise_error:
             raise TelegramError('Test Error 2')


### PR DESCRIPTION
Following the increasing reports about timeout errors and lost connections, this is an attempt to stabilize the infrastructure. This may or may not be related to changes in Telegram servers, but the plain fact of network programming is that you have to be smart with managing your TCP connections.

This is a copy/paste of a summary of the problem in the developers telegram group and the suggested solutions and what was finally chosen:

1. Q: What is the real problem?
A: The real problem is that a HTTP/TCP connection terminates and we don't know it in time.
Why? Too many reasons. But basically that's how the internet works.

2. Q: Where does this hurt us the most?
A: With getUpdates() long polling.
Why? We have 10 seconds (by default, user configurable) that we just wait and "trust" the server to return to us by that time. If the connection drops during that time, we just don't know it.

3. Q: If that so, why does sendMessage() (or other send methods) suffers similar problems?
A: Just like getUpdates() connection may drop, same can happen for sendMessage(). 
I suspect that another problem with sendMessage() is longer timeouts. However, I can't prove it at this time, because I failed of recreating it myself. I'll also need a tcpdump alongside it, checking the TCP flags and retransmits.

4. Q: We never had this before urllib3. What is this shit?!
A: Almost true. Before urllib3 we had many timeout errors during creating connections with Telegram servers. The entire TCP 3way handshake + SSL handshake (espeiclly the SSL handshake) was just too costy and caused lot of pain.
urllib3 allowed us to reuse existing connections and thus saving the expensive time of creating new connection each time. (we don't see this happen anymore) However, reusing connections opened us new problems like connections which we consider alive but they are actually not.
So here we are back to Q1.


Suggested solutions:
1. Add the HTTP header 'connection: keep-alive'. It's a hint to the remote server (Telegram server) that my intention to keep this connection for other uses, so please don't drop it.

2. Use agressive timeouts where possible. urllib3 (and also the standard-python urllib) allows to explicitly specify connect timeout and read timeout.
If urllib3 will decide to reuse existing connection, then the connection timeout will be ignored.
Now, what do we do with the read timeout: 
for getUpdates, I'll set the read timeout to 0.5 second longer than the long polling timeout. This will allow quicker recovery from dropped connection than what we have today. I believe that this will fix most of the problems.
about 'send' methods, I still need to think how to be agressive but not too much.

3. Fine tune the TCP keepalive.
Using SO_KEEPALIVE (like we do) is not enough. The defaults (if I recall correctly) is to send keepalives only after 5 minutes.
There is a way to control the frequency of TCP keepalives, however it is OS specific, so it requires some delicacy. (it's important to mention that I'm a Linux developer without access to MS-Windows, so that's an obstacle)


Eventually solutions 1 & 2 were implemented.
Solution 3 (TCP keepalive tunings)  were left aside for the moment as it requires per OS code (i.e. not portable) and we hope it won't be needed eventually.
