### PR TITLE
Changed promises to handle exceptions

### DIFF
--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -128,10 +128,16 @@ class ConversationHandler(Handler):
             self.logger.debug('waiting for promise...')
 
             old_state, new_state = state
-            new_state.result(timeout=self.run_async_timeout)
+            error = False
+            try:
+                res = new_state.result(timeout=self.run_async_timeout)
+            except Exception as exc:
+                self.logger.exception("promise function raised exception: %s" %
+                                      exc)
+                error = True
 
-            if new_state.done.is_set():
-                self.update_state(new_state.result(), key)
+            if not error and new_state.done.is_set():
+                self.update_state(res, key)
                 state = self.conversations.get(key)
 
             else:

--- a/telegram/ext/dispatcher.py
+++ b/telegram/ext/dispatcher.py
@@ -159,11 +159,7 @@ class Dispatcher(object):
                                   len(self.__async_threads))
                 break
 
-            try:
-                promise.run()
-
-            except:
-                self.logger.exception("run_async function raised exception")
+            promise.run()
 
     def run_async(self, func, *args, **kwargs):
         """Queue a function (with given args/kwargs) to be run asynchronously.

--- a/telegram/utils/promise.py
+++ b/telegram/utils/promise.py
@@ -30,17 +30,23 @@ class Promise(object):
         self.kwargs = kwargs
         self.done = Event()
         self._result = None
+        self._exception = None
 
     def run(self):
         try:
             self._result = self.pooled_function(*self.args, **self.kwargs)
 
-        except:
-            raise
+        except Exception as exc:
+            self._exception = exc
 
         finally:
             self.done.set()
 
+    def __call__(self):
+        self.run()
+
     def result(self, timeout=None):
         self.done.wait(timeout=timeout)
+        if self._exception is not None:
+            raise self._exception
         return self._result


### PR DESCRIPTION
- Now `Promise` saves exception in instance if caught, and reraises it when `Promise`'s result is get, instead of rerasing it during run (possibly even in unknown thread)

- `__call__` method added to `Promise`, so now promises look more like normal callables and are more convenient to use (old run method saved for backwards-compat.)

- Promises handling changed in `Dispatcher`, so that now dispatcher just runs promises and doesn't need to deal with any possible exceptions as it's work of Promise. Earlier it just logged that something went wrong in case of exceptions.

- Promise handling logic is changed in `ConversationHandler`, assuming that changed promise may now raise exceptions on res, in that case logger is used for handling

These changes are 1st step on the way to introducing [`MessageQueue`](https://gist.github.com/thodnev/d00e5eb406995541eea0b8a118a22602). Had a conversation with @jh0ker about this change proposal

Test results are added below.
[test_results.txt](https://github.com/python-telegram-bot/python-telegram-bot/files/802311/test_results.txt)

