### PR TITLE
Add filters to commandHandler

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -21,6 +21,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Jacob Bom <https://github.com/bomjacob>`_
 - `JASON0916 <https://github.com/JASON0916>`_
 - `jh0ker <https://github.com/jh0ker>`_
+- `jossalgon <https://github.com/jossalgon>`_
 - `JRoot3D <https://github.com/JRoot3D>`_
 - `jlmadurga <https://github.com/jlmadurga>`_
 - `Kjwon15 <https://github.com/kjwon15>`_

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -268,6 +268,34 @@ class UpdaterTest(BaseTest, unittest.TestCase):
         sleep(.1)
         self.assertTrue(None is self.received_message)
 
+    def test_filterPassTelegramCommandHandler(self):
+        self._setup_updater('', messages=0)
+        d = self.updater.dispatcher
+        handler = CommandHandler('test', self.telegramHandlerTest, lambda msg: True)
+        self.updater.dispatcher.add_handler(handler)
+        user = User(first_name="singelton", id=404)
+        bot = self.updater.bot
+        queue = self.updater.start_polling(0.01)
+
+        message = Message(0, user, None, None, text="/test", bot=bot)
+        queue.put(Update(update_id=0, message=message))
+        sleep(.1)
+        self.assertEqual(self.received_message, '/test')
+
+    def test_filterNotPassTelegramCommandHandler(self):
+        self._setup_updater('', messages=0)
+        d = self.updater.dispatcher
+        handler = CommandHandler('test', self.telegramHandlerTest, lambda msg: False)
+        self.updater.dispatcher.add_handler(handler)
+        user = User(first_name="singelton", id=404)
+        bot = self.updater.bot
+        queue = self.updater.start_polling(0.01)
+
+        message = Message(0, user, None, None, text="/test", bot=bot)
+        queue.put(Update(update_id=0, message=message))
+        sleep(.1)
+        self.assertTrue(None is self.received_message)
+
     def test_addRemoveStringRegexHandler(self):
         self._setup_updater('', messages=0)
         d = self.updater.dispatcher


### PR DESCRIPTION
Add filters to CommandHandler.

Now you can filter commands, for example to separate a command from group and private or any filter you want.

```python
updater = Updater(token=TG_TOKEN)
dp = updater.dispatcher

dp.add_handler(CommandHandler('start', start, filter_example))
```

 where filter_example is:
```python
def filter_example(msg):
    return msg.chat.type == 'private'
```

or
```python
updater = Updater(token=TG_TOKEN)
dp = updater.dispatcher

dp.add_handler(CommandHandler('start', start, lambda msg: msg.chat.type == 'private'))
```
