### PR TITLE
Add the ability to invert (not) filters

### DIFF
--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -32,9 +32,14 @@ class BaseFilter(object):
 
         >>> (Filters.audio | Filters.video)
 
+    Not:
+
+        >>> ~ Filters.command
+
     Also works with more than two filters:
 
         >>> (Filters.text & (Filters.entity(URL) | Filters.entity(TEXT_LINK)))
+        >>> Filters.text & (~ Filters.forwarded)
 
     If you want to create your own filters create a class inheriting from this class and implement
     a `filter` method that returns a boolean: `True` if the message should be handled, `False`
@@ -59,12 +64,22 @@ class BaseFilter(object):
 
 
 class InvertedFilter(BaseFilter):
+    """Represents a filter that has been inverted.
+
+    Args:
+        f: The filter to invert
+    """
 
     def __init__(self, f):
         self.f = f
 
     def filter(self, message):
         return not self.f(message)
+
+    def __str__(self):
+        return "<telegram.ext.filters.InvertedFilter inverting {}>".format(self.f)
+
+    __repr__ = __str__
 
 
 class MergedFilter(BaseFilter):

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -51,8 +51,20 @@ class BaseFilter(object):
     def __or__(self, other):
         return MergedFilter(self, or_filter=other)
 
+    def __invert__(self):
+        return InvertedFilter(self)
+
     def filter(self, message):
         raise NotImplementedError
+
+
+class InvertedFilter(BaseFilter):
+
+    def __init__(self, f):
+        self.f = f
+
+    def filter(self, message):
+        return not self.f(message)
 
 
 class MergedFilter(BaseFilter):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -226,6 +226,32 @@ class FiltersTest(BaseTest, unittest.TestCase):
             r"<telegram.ext.filters.(Filters.)?_Forwarded object at .*?> or "
             r"<telegram.ext.filters.(Filters.)?entity object at .*?>>>")
 
+    def test_inverted_filters(self):
+        self.message.text = '/test'
+        self.assertTrue((Filters.command)(self.message))
+        self.assertFalse((~Filters.command)(self.message))
+        self.message.text = 'test'
+        self.assertFalse((Filters.command)(self.message))
+        self.assertTrue((~Filters.command)(self.message))
+
+    def test_inverted_and_filters(self):
+        self.message.text = '/test'
+        self.message.forward_date = 1
+        self.assertTrue((Filters.forwarded & Filters.command)(self.message))
+        self.assertFalse((~Filters.forwarded & Filters.command)(self.message))
+        self.assertFalse((Filters.forwarded & ~Filters.command)(self.message))
+        self.assertFalse((~(Filters.forwarded & Filters.command))(self.message))
+        self.message.forward_date = None
+        self.assertFalse((Filters.forwarded & Filters.command)(self.message))
+        self.assertTrue((~Filters.forwarded & Filters.command)(self.message))
+        self.assertFalse((Filters.forwarded & ~Filters.command)(self.message))
+        self.assertTrue((~(Filters.forwarded & Filters.command))(self.message))
+        self.message.text = 'test'
+        self.assertFalse((Filters.forwarded & Filters.command)(self.message))
+        self.assertFalse((~Filters.forwarded & Filters.command)(self.message))
+        self.assertFalse((Filters.forwarded & ~Filters.command)(self.message))
+        self.assertTrue((~(Filters.forwarded & Filters.command))(self.message))
+
     def test_faulty_custom_filter(self):
 
         class _CustomFilter(BaseFilter):


### PR DESCRIPTION
Expands upon #411, allowing the python inversion (not) operator ~ to also be used with filters.