### PR TITLE
Fix Bug #571 (second try)

### DIFF
--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -167,7 +167,8 @@ class ConversationHandler(Handler):
         # Ignore messages in channels
         if (not isinstance(update, Update) or update.channel_post or self.per_chat
                 and (update.inline_query or update.chosen_inline_result) or self.per_message
-                and not update.callback_query):
+                and not update.callback_query or update.callback_query and self.per_chat
+                and not update.callback_query.message):
             return False
 
         key = self._get_key(update)

--- a/tests/test_conversationhandler.py
+++ b/tests/test_conversationhandler.py
@@ -344,6 +344,14 @@ class ConversationHandlerTest(BaseTest, unittest.TestCase):
         # Assert that the Promise has been resolved and the conversation ended.
         self.assertEquals(len(handler.conversations), 0)
 
+    def test_perChatMessageWithoutChat(self):
+        handler = ConversationHandler(
+            entry_points=[CommandHandler('start', self.start_end)], states={}, fallbacks=[])
+        user = User(first_name="Misses Test", id=123)
+        cbq = CallbackQuery(0, user, None, None)
+        update = Update(0, callback_query=cbq)
+        handler.check_update(update)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
ConversationHandler will not process CallbackQuery if per_chat=True and
the CallbackQuery has no message attached to it (as is the case with
buttons on inline results)