### PR TITLE
Compatibility with GAE via urllib3.contrib package

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -24,6 +24,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Jacob Bom <https://github.com/bomjacob>`_
 - `JASON0916 <https://github.com/JASON0916>`_
 - `jh0ker <https://github.com/jh0ker>`_
+- `John Yong <https://github.com/whipermr5>`_
 - `jossalgon <https://github.com/jossalgon>`_
 - `JRoot3D <https://github.com/JRoot3D>`_
 - `jlmadurga <https://github.com/jlmadurga>`_

--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -28,6 +28,7 @@ except ImportError:
 
 import certifi
 import urllib3
+import urllib3.contrib.appengine
 from urllib3.connection import HTTPConnection
 from urllib3.util.timeout import Timeout
 try:
@@ -93,7 +94,11 @@ class Request(object):
             proxy_url = os.environ.get('HTTPS_PROXY') or os.environ.get('https_proxy')
 
         if not proxy_url:
-            mgr = urllib3.PoolManager(**kwargs)
+            if urllib3.contrib.appengine.is_appengine_sandbox():
+                # Use URLFetch service if running in App Engine
+                mgr = urllib3.contrib.appengine.AppEngineManager()
+            else:
+                mgr = urllib3.PoolManager(**kwargs)
         else:
             kwargs.update(urllib3_proxy_kwargs)
             if proxy_url.startswith('socks'):


### PR DESCRIPTION
Fixes #334

Checks whether app is running inside Google App Engine; uses `urllib3.contrib.appengine.AppEngineManager` instead of `urllib3.PoolManager` if it is (more info about the `urllib3.contrib` package [here](http://urllib3.readthedocs.io/en/latest/reference/urllib3.contrib.html)). This makes use of App Engine's URLFetch service instead of the sockets API, which is not available in non-billable apps.