### PR TITLE
Specify unauthorized

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 future>=0.15.2
-urllib3==1.20
 certifi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 future>=0.15.2
+urllib3==1.20
 certifi

--- a/telegram/error.py
+++ b/telegram/error.py
@@ -62,9 +62,7 @@ class TelegramError(Exception):
 
 
 class Unauthorized(TelegramError):
-
-    def __init__(self):
-        super(Unauthorized, self).__init__('Unauthorized')
+    pass
 
 
 class InvalidToken(TelegramError):

--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -183,7 +183,7 @@ class Request(object):
             raise NetworkError('Unknown HTTPError {0}'.format(resp.status))
 
         if resp.status in (401, 403):
-            raise Unauthorized()
+            raise Unauthorized(message)
         elif resp.status == 400:
             raise BadRequest(message)
         elif resp.status == 404:

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -33,13 +33,13 @@ class ChatTest(BaseTest, unittest.TestCase):
     """This object represents Tests for Telegram Chat."""
 
     def setUp(self):
-        self.id = -28767330
+        self._id = -28767330
         self.title = 'ToledosPalaceBot - Group'
         self.type = 'group'
         self.all_members_are_administrators = False
 
         self.json_dict = {
-            'id': self.id,
+            'id': self._id,
             'title': self.title,
             'type': self.type,
             'all_members_are_administrators': self.all_members_are_administrators
@@ -53,7 +53,7 @@ class ChatTest(BaseTest, unittest.TestCase):
     def test_group_chat_de_json(self):
         group_chat = telegram.Chat.de_json(self.json_dict, self._bot)
 
-        self.assertEqual(group_chat.id, self.id)
+        self.assertEqual(group_chat.id, self._id)
         self.assertEqual(group_chat.title, self.title)
         self.assertEqual(group_chat.type, self.type)
         self.assertEqual(group_chat.all_members_are_administrators,
@@ -68,7 +68,7 @@ class ChatTest(BaseTest, unittest.TestCase):
         group_chat = telegram.Chat.de_json(self.json_dict, self._bot)
 
         self.assertTrue(self.is_dict(group_chat.to_dict()))
-        self.assertEqual(group_chat['id'], self.id)
+        self.assertEqual(group_chat['id'], self._id)
         self.assertEqual(group_chat['title'], self.title)
         self.assertEqual(group_chat['type'], self.type)
         self.assertEqual(group_chat['all_members_are_administrators'],

--- a/tests/test_inlinequery.py
+++ b/tests/test_inlinequery.py
@@ -35,14 +35,14 @@ class InlineQueryTest(BaseTest, unittest.TestCase):
         user = telegram.User(1, 'First name')
         location = telegram.Location(8.8, 53.1)
 
-        self.id = 'id'
+        self._id = 'id'
         self.from_user = user
         self.query = 'query text'
         self.offset = 'offset'
         self.location = location
 
         self.json_dict = {
-            'id': self.id,
+            'id': self._id,
             'from': self.from_user.to_dict(),
             'query': self.query,
             'offset': self.offset,
@@ -52,7 +52,7 @@ class InlineQueryTest(BaseTest, unittest.TestCase):
     def test_inlinequery_de_json(self):
         inlinequery = telegram.InlineQuery.de_json(self.json_dict, self._bot)
 
-        self.assertEqual(inlinequery.id, self.id)
+        self.assertEqual(inlinequery.id, self._id)
         self.assertDictEqual(inlinequery.from_user.to_dict(), self.from_user.to_dict())
         self.assertDictEqual(inlinequery.location.to_dict(), self.location.to_dict())
         self.assertEqual(inlinequery.query, self.query)

--- a/tests/test_inlinequeryresultarticle.py
+++ b/tests/test_inlinequeryresultarticle.py
@@ -32,7 +32,7 @@ class InlineQueryResultArticleTest(BaseTest, unittest.TestCase):
     """This object represents Tests for Telegram InlineQueryResultArticle."""
 
     def setUp(self):
-        self.id = 'id'
+        self._id = 'id'
         self.type = 'article'
         self.title = 'title'
         self.input_message_content = telegram.InputTextMessageContent('input_message_content')
@@ -47,7 +47,7 @@ class InlineQueryResultArticleTest(BaseTest, unittest.TestCase):
 
         self.json_dict = {
             'type': self.type,
-            'id': self.id,
+            'id': self._id,
             'title': self.title,
             'input_message_content': self.input_message_content.to_dict(),
             'reply_markup': self.reply_markup.to_dict(),
@@ -63,7 +63,7 @@ class InlineQueryResultArticleTest(BaseTest, unittest.TestCase):
         article = telegram.InlineQueryResultArticle.de_json(self.json_dict, self._bot)
 
         self.assertEqual(article.type, self.type)
-        self.assertEqual(article.id, self.id)
+        self.assertEqual(article.id, self._id)
         self.assertEqual(article.title, self.title)
         self.assertDictEqual(article.input_message_content.to_dict(),
                              self.input_message_content.to_dict())

--- a/tests/test_inlinequeryresultaudio.py
+++ b/tests/test_inlinequeryresultaudio.py
@@ -32,7 +32,7 @@ class InlineQueryResultAudioTest(BaseTest, unittest.TestCase):
     """This object represents Tests for Telegram InlineQueryResultAudio."""
 
     def setUp(self):
-        self.id = 'id'
+        self._id = 'id'
         self.type = 'audio'
         self.audio_url = 'audio url'
         self.title = 'title'
@@ -45,7 +45,7 @@ class InlineQueryResultAudioTest(BaseTest, unittest.TestCase):
 
         self.json_dict = {
             'type': self.type,
-            'id': self.id,
+            'id': self._id,
             'audio_url': self.audio_url,
             'title': self.title,
             'performer': self.performer,
@@ -59,7 +59,7 @@ class InlineQueryResultAudioTest(BaseTest, unittest.TestCase):
         audio = telegram.InlineQueryResultAudio.de_json(self.json_dict, self._bot)
 
         self.assertEqual(audio.type, self.type)
-        self.assertEqual(audio.id, self.id)
+        self.assertEqual(audio.id, self._id)
         self.assertEqual(audio.audio_url, self.audio_url)
         self.assertEqual(audio.title, self.title)
         self.assertEqual(audio.performer, self.performer)

--- a/tests/test_inlinequeryresultcachedaudio.py
+++ b/tests/test_inlinequeryresultcachedaudio.py
@@ -33,7 +33,7 @@ class InlineQueryResultCachedAudioTest(BaseTest, unittest.TestCase):
     InlineQueryResultCachedAudio."""
 
     def setUp(self):
-        self.id = 'id'
+        self._id = 'id'
         self.type = 'audio'
         self.audio_file_id = 'audio file id'
         self.caption = 'caption'
@@ -43,7 +43,7 @@ class InlineQueryResultCachedAudioTest(BaseTest, unittest.TestCase):
 
         self.json_dict = {
             'type': self.type,
-            'id': self.id,
+            'id': self._id,
             'audio_file_id': self.audio_file_id,
             'caption': self.caption,
             'input_message_content': self.input_message_content.to_dict(),
@@ -54,7 +54,7 @@ class InlineQueryResultCachedAudioTest(BaseTest, unittest.TestCase):
         audio = telegram.InlineQueryResultCachedAudio.de_json(self.json_dict, self._bot)
 
         self.assertEqual(audio.type, self.type)
-        self.assertEqual(audio.id, self.id)
+        self.assertEqual(audio.id, self._id)
         self.assertEqual(audio.audio_file_id, self.audio_file_id)
         self.assertEqual(audio.caption, self.caption)
         self.assertDictEqual(audio.input_message_content.to_dict(),

--- a/tests/test_inlinequeryresultcacheddocument.py
+++ b/tests/test_inlinequeryresultcacheddocument.py
@@ -33,7 +33,7 @@ class InlineQueryResultCachedDocumentTest(BaseTest, unittest.TestCase):
     InlineQueryResultCachedDocument."""
 
     def setUp(self):
-        self.id = 'id'
+        self._id = 'id'
         self.type = 'document'
         self.document_file_id = 'document file id'
         self.title = 'title'
@@ -43,7 +43,7 @@ class InlineQueryResultCachedDocumentTest(BaseTest, unittest.TestCase):
         self.reply_markup = telegram.InlineKeyboardMarkup(
             [[telegram.InlineKeyboardButton('reply_markup')]])
         self.json_dict = {
-            'id': self.id,
+            'id': self._id,
             'type': self.type,
             'document_file_id': self.document_file_id,
             'title': self.title,
@@ -56,7 +56,7 @@ class InlineQueryResultCachedDocumentTest(BaseTest, unittest.TestCase):
     def test_document_de_json(self):
         document = telegram.InlineQueryResultCachedDocument.de_json(self.json_dict, self._bot)
 
-        self.assertEqual(document.id, self.id)
+        self.assertEqual(document.id, self._id)
         self.assertEqual(document.type, self.type)
         self.assertEqual(document.document_file_id, self.document_file_id)
         self.assertEqual(document.title, self.title)

--- a/tests/test_inlinequeryresultcachedgif.py
+++ b/tests/test_inlinequeryresultcachedgif.py
@@ -32,7 +32,7 @@ class InlineQueryResultCachedGifTest(BaseTest, unittest.TestCase):
     """This object represents Tests for Telegram InlineQueryResultCachedGif."""
 
     def setUp(self):
-        self.id = 'id'
+        self._id = 'id'
         self.type = 'gif'
         self.gif_file_id = 'gif file id'
         self.title = 'title'
@@ -43,7 +43,7 @@ class InlineQueryResultCachedGifTest(BaseTest, unittest.TestCase):
 
         self.json_dict = {
             'type': self.type,
-            'id': self.id,
+            'id': self._id,
             'gif_file_id': self.gif_file_id,
             'title': self.title,
             'caption': self.caption,
@@ -55,7 +55,7 @@ class InlineQueryResultCachedGifTest(BaseTest, unittest.TestCase):
         gif = telegram.InlineQueryResultCachedGif.de_json(self.json_dict, self._bot)
 
         self.assertEqual(gif.type, self.type)
-        self.assertEqual(gif.id, self.id)
+        self.assertEqual(gif.id, self._id)
         self.assertEqual(gif.gif_file_id, self.gif_file_id)
         self.assertEqual(gif.title, self.title)
         self.assertEqual(gif.caption, self.caption)

--- a/tests/test_inlinequeryresultcachedmpeg4gif.py
+++ b/tests/test_inlinequeryresultcachedmpeg4gif.py
@@ -33,7 +33,7 @@ class InlineQueryResultCachedMpeg4GifTest(BaseTest, unittest.TestCase):
     InlineQueryResultCachedMpeg4Gif."""
 
     def setUp(self):
-        self.id = 'id'
+        self._id = 'id'
         self.type = 'mpeg4_gif'
         self.mpeg4_file_id = 'mpeg4 file id'
         self.title = 'title'
@@ -44,7 +44,7 @@ class InlineQueryResultCachedMpeg4GifTest(BaseTest, unittest.TestCase):
 
         self.json_dict = {
             'type': self.type,
-            'id': self.id,
+            'id': self._id,
             'mpeg4_file_id': self.mpeg4_file_id,
             'title': self.title,
             'caption': self.caption,
@@ -56,7 +56,7 @@ class InlineQueryResultCachedMpeg4GifTest(BaseTest, unittest.TestCase):
         mpeg4 = telegram.InlineQueryResultCachedMpeg4Gif.de_json(self.json_dict, self._bot)
 
         self.assertEqual(mpeg4.type, self.type)
-        self.assertEqual(mpeg4.id, self.id)
+        self.assertEqual(mpeg4.id, self._id)
         self.assertEqual(mpeg4.mpeg4_file_id, self.mpeg4_file_id)
         self.assertEqual(mpeg4.title, self.title)
         self.assertEqual(mpeg4.caption, self.caption)

--- a/tests/test_inlinequeryresultcachedphoto.py
+++ b/tests/test_inlinequeryresultcachedphoto.py
@@ -33,7 +33,7 @@ class InlineQueryResultCachedPhotoTest(BaseTest, unittest.TestCase):
     InlineQueryResultCachedPhoto."""
 
     def setUp(self):
-        self.id = 'id'
+        self._id = 'id'
         self.type = 'photo'
         self.photo_file_id = 'photo file id'
         self.title = 'title'
@@ -45,7 +45,7 @@ class InlineQueryResultCachedPhotoTest(BaseTest, unittest.TestCase):
 
         self.json_dict = {
             'type': self.type,
-            'id': self.id,
+            'id': self._id,
             'photo_file_id': self.photo_file_id,
             'title': self.title,
             'description': self.description,
@@ -58,7 +58,7 @@ class InlineQueryResultCachedPhotoTest(BaseTest, unittest.TestCase):
         photo = telegram.InlineQueryResultCachedPhoto.de_json(self.json_dict, self._bot)
 
         self.assertEqual(photo.type, self.type)
-        self.assertEqual(photo.id, self.id)
+        self.assertEqual(photo.id, self._id)
         self.assertEqual(photo.photo_file_id, self.photo_file_id)
         self.assertEqual(photo.title, self.title)
         self.assertEqual(photo.description, self.description)

--- a/tests/test_inlinequeryresultcachedsticker.py
+++ b/tests/test_inlinequeryresultcachedsticker.py
@@ -33,7 +33,7 @@ class InlineQueryResultCachedStickerTest(BaseTest, unittest.TestCase):
     InlineQueryResultCachedSticker."""
 
     def setUp(self):
-        self.id = 'id'
+        self._id = 'id'
         self.type = 'sticker'
         self.sticker_file_id = 'sticker file id'
         self.input_message_content = telegram.InputTextMessageContent('input_message_content')
@@ -42,7 +42,7 @@ class InlineQueryResultCachedStickerTest(BaseTest, unittest.TestCase):
 
         self.json_dict = {
             'type': self.type,
-            'id': self.id,
+            'id': self._id,
             'sticker_file_id': self.sticker_file_id,
             'input_message_content': self.input_message_content.to_dict(),
             'reply_markup': self.reply_markup.to_dict(),
@@ -52,7 +52,7 @@ class InlineQueryResultCachedStickerTest(BaseTest, unittest.TestCase):
         sticker = telegram.InlineQueryResultCachedSticker.de_json(self.json_dict, self._bot)
 
         self.assertEqual(sticker.type, self.type)
-        self.assertEqual(sticker.id, self.id)
+        self.assertEqual(sticker.id, self._id)
         self.assertEqual(sticker.sticker_file_id, self.sticker_file_id)
         self.assertDictEqual(sticker.input_message_content.to_dict(),
                              self.input_message_content.to_dict())

--- a/tests/test_inlinequeryresultcachedvideo.py
+++ b/tests/test_inlinequeryresultcachedvideo.py
@@ -33,7 +33,7 @@ class InlineQueryResultCachedVideoTest(BaseTest, unittest.TestCase):
     InlineQueryResultCachedVideo."""
 
     def setUp(self):
-        self.id = 'id'
+        self._id = 'id'
         self.type = 'video'
         self.video_file_id = 'video file id'
         self.title = 'title'
@@ -45,7 +45,7 @@ class InlineQueryResultCachedVideoTest(BaseTest, unittest.TestCase):
 
         self.json_dict = {
             'type': self.type,
-            'id': self.id,
+            'id': self._id,
             'video_file_id': self.video_file_id,
             'title': self.title,
             'caption': self.caption,
@@ -58,7 +58,7 @@ class InlineQueryResultCachedVideoTest(BaseTest, unittest.TestCase):
         video = telegram.InlineQueryResultCachedVideo.de_json(self.json_dict, self._bot)
 
         self.assertEqual(video.type, self.type)
-        self.assertEqual(video.id, self.id)
+        self.assertEqual(video.id, self._id)
         self.assertEqual(video.video_file_id, self.video_file_id)
         self.assertEqual(video.title, self.title)
         self.assertEqual(video.description, self.description)

--- a/tests/test_inlinequeryresultcachedvoice.py
+++ b/tests/test_inlinequeryresultcachedvoice.py
@@ -33,7 +33,7 @@ class InlineQueryResultCachedVoiceTest(BaseTest, unittest.TestCase):
     InlineQueryResultCachedVoice."""
 
     def setUp(self):
-        self.id = 'id'
+        self._id = 'id'
         self.type = 'voice'
         self.voice_file_id = 'voice file id'
         self.title = 'title'
@@ -44,7 +44,7 @@ class InlineQueryResultCachedVoiceTest(BaseTest, unittest.TestCase):
 
         self.json_dict = {
             'type': self.type,
-            'id': self.id,
+            'id': self._id,
             'voice_file_id': self.voice_file_id,
             'title': self.title,
             'caption': self.caption,
@@ -56,7 +56,7 @@ class InlineQueryResultCachedVoiceTest(BaseTest, unittest.TestCase):
         voice = telegram.InlineQueryResultCachedVoice.de_json(self.json_dict, self._bot)
 
         self.assertEqual(voice.type, self.type)
-        self.assertEqual(voice.id, self.id)
+        self.assertEqual(voice.id, self._id)
         self.assertEqual(voice.voice_file_id, self.voice_file_id)
         self.assertEqual(voice.title, self.title)
         self.assertEqual(voice.caption, self.caption)

--- a/tests/test_inlinequeryresultcontact.py
+++ b/tests/test_inlinequeryresultcontact.py
@@ -32,7 +32,7 @@ class InlineQueryResultContactTest(BaseTest, unittest.TestCase):
     """This object represents Tests for Telegram InlineQueryResultContact."""
 
     def setUp(self):
-        self.id = 'id'
+        self._id = 'id'
         self.type = 'contact'
         self.phone_number = 'phone_number'
         self.first_name = 'first_name'
@@ -44,7 +44,7 @@ class InlineQueryResultContactTest(BaseTest, unittest.TestCase):
         self.reply_markup = telegram.InlineKeyboardMarkup(
             [[telegram.InlineKeyboardButton('reply_markup')]])
         self.json_dict = {
-            'id': self.id,
+            'id': self._id,
             'type': self.type,
             'phone_number': self.phone_number,
             'first_name': self.first_name,
@@ -59,7 +59,7 @@ class InlineQueryResultContactTest(BaseTest, unittest.TestCase):
     def test_contact_de_json(self):
         contact = telegram.InlineQueryResultContact.de_json(self.json_dict, self._bot)
 
-        self.assertEqual(contact.id, self.id)
+        self.assertEqual(contact.id, self._id)
         self.assertEqual(contact.type, self.type)
         self.assertEqual(contact.phone_number, self.phone_number)
         self.assertEqual(contact.first_name, self.first_name)

--- a/tests/test_inlinequeryresultdocument.py
+++ b/tests/test_inlinequeryresultdocument.py
@@ -32,7 +32,7 @@ class InlineQueryResultDocumentTest(BaseTest, unittest.TestCase):
     """This object represents Tests for Telegram InlineQueryResultDocument."""
 
     def setUp(self):
-        self.id = 'id'
+        self._id = 'id'
         self.type = 'document'
         self.document_url = 'document url'
         self.title = 'title'
@@ -46,7 +46,7 @@ class InlineQueryResultDocumentTest(BaseTest, unittest.TestCase):
         self.reply_markup = telegram.InlineKeyboardMarkup(
             [[telegram.InlineKeyboardButton('reply_markup')]])
         self.json_dict = {
-            'id': self.id,
+            'id': self._id,
             'type': self.type,
             'document_url': self.document_url,
             'title': self.title,
@@ -63,7 +63,7 @@ class InlineQueryResultDocumentTest(BaseTest, unittest.TestCase):
     def test_document_de_json(self):
         document = telegram.InlineQueryResultDocument.de_json(self.json_dict, self._bot)
 
-        self.assertEqual(document.id, self.id)
+        self.assertEqual(document.id, self._id)
         self.assertEqual(document.type, self.type)
         self.assertEqual(document.document_url, self.document_url)
         self.assertEqual(document.title, self.title)

--- a/tests/test_inlinequeryresultgif.py
+++ b/tests/test_inlinequeryresultgif.py
@@ -32,7 +32,7 @@ class InlineQueryResultGifTest(BaseTest, unittest.TestCase):
     """This object represents Tests for Telegram InlineQueryResultGif."""
 
     def setUp(self):
-        self.id = 'id'
+        self._id = 'id'
         self.type = 'gif'
         self.gif_url = 'gif url'
         self.gif_width = 10
@@ -46,7 +46,7 @@ class InlineQueryResultGifTest(BaseTest, unittest.TestCase):
 
         self.json_dict = {
             'type': self.type,
-            'id': self.id,
+            'id': self._id,
             'gif_url': self.gif_url,
             'gif_width': self.gif_width,
             'gif_height': self.gif_height,
@@ -61,7 +61,7 @@ class InlineQueryResultGifTest(BaseTest, unittest.TestCase):
         gif = telegram.InlineQueryResultGif.de_json(self.json_dict, self._bot)
 
         self.assertEqual(gif.type, self.type)
-        self.assertEqual(gif.id, self.id)
+        self.assertEqual(gif.id, self._id)
         self.assertEqual(gif.gif_url, self.gif_url)
         self.assertEqual(gif.gif_width, self.gif_width)
         self.assertEqual(gif.gif_height, self.gif_height)

--- a/tests/test_inlinequeryresultlocation.py
+++ b/tests/test_inlinequeryresultlocation.py
@@ -32,7 +32,7 @@ class InlineQueryResultLocationTest(BaseTest, unittest.TestCase):
     """This object represents Tests for Telegram InlineQueryResultLocation."""
 
     def setUp(self):
-        self.id = 'id'
+        self._id = 'id'
         self.type = 'location'
         self.latitude = 'latitude'
         self.longitude = 'longitude'
@@ -44,7 +44,7 @@ class InlineQueryResultLocationTest(BaseTest, unittest.TestCase):
         self.reply_markup = telegram.InlineKeyboardMarkup(
             [[telegram.InlineKeyboardButton('reply_markup')]])
         self.json_dict = {
-            'id': self.id,
+            'id': self._id,
             'type': self.type,
             'latitude': self.latitude,
             'longitude': self.longitude,
@@ -59,7 +59,7 @@ class InlineQueryResultLocationTest(BaseTest, unittest.TestCase):
     def test_location_de_json(self):
         location = telegram.InlineQueryResultLocation.de_json(self.json_dict, self._bot)
 
-        self.assertEqual(location.id, self.id)
+        self.assertEqual(location.id, self._id)
         self.assertEqual(location.type, self.type)
         self.assertEqual(location.latitude, self.latitude)
         self.assertEqual(location.longitude, self.longitude)

--- a/tests/test_inlinequeryresultmpeg4gif.py
+++ b/tests/test_inlinequeryresultmpeg4gif.py
@@ -32,7 +32,7 @@ class InlineQueryResultMpeg4GifTest(BaseTest, unittest.TestCase):
     """This object represents Tests for Telegram InlineQueryResultMpeg4Gif."""
 
     def setUp(self):
-        self.id = 'id'
+        self._id = 'id'
         self.type = 'mpeg4_gif'
         self.mpeg4_url = 'mpeg4 url'
         self.mpeg4_width = 10
@@ -46,7 +46,7 @@ class InlineQueryResultMpeg4GifTest(BaseTest, unittest.TestCase):
 
         self.json_dict = {
             'type': self.type,
-            'id': self.id,
+            'id': self._id,
             'mpeg4_url': self.mpeg4_url,
             'mpeg4_width': self.mpeg4_width,
             'mpeg4_height': self.mpeg4_height,
@@ -61,7 +61,7 @@ class InlineQueryResultMpeg4GifTest(BaseTest, unittest.TestCase):
         mpeg4 = telegram.InlineQueryResultMpeg4Gif.de_json(self.json_dict, self._bot)
 
         self.assertEqual(mpeg4.type, self.type)
-        self.assertEqual(mpeg4.id, self.id)
+        self.assertEqual(mpeg4.id, self._id)
         self.assertEqual(mpeg4.mpeg4_url, self.mpeg4_url)
         self.assertEqual(mpeg4.mpeg4_width, self.mpeg4_width)
         self.assertEqual(mpeg4.mpeg4_height, self.mpeg4_height)

--- a/tests/test_inlinequeryresultphoto.py
+++ b/tests/test_inlinequeryresultphoto.py
@@ -32,7 +32,7 @@ class InlineQueryResultPhotoTest(BaseTest, unittest.TestCase):
     """This object represents Tests for Telegram InlineQueryResultPhoto."""
 
     def setUp(self):
-        self.id = 'id'
+        self._id = 'id'
         self.type = 'photo'
         self.photo_url = 'photo url'
         self.photo_width = 10
@@ -47,7 +47,7 @@ class InlineQueryResultPhotoTest(BaseTest, unittest.TestCase):
 
         self.json_dict = {
             'type': self.type,
-            'id': self.id,
+            'id': self._id,
             'photo_url': self.photo_url,
             'photo_width': self.photo_width,
             'photo_height': self.photo_height,
@@ -63,7 +63,7 @@ class InlineQueryResultPhotoTest(BaseTest, unittest.TestCase):
         photo = telegram.InlineQueryResultPhoto.de_json(self.json_dict, self._bot)
 
         self.assertEqual(photo.type, self.type)
-        self.assertEqual(photo.id, self.id)
+        self.assertEqual(photo.id, self._id)
         self.assertEqual(photo.photo_url, self.photo_url)
         self.assertEqual(photo.photo_width, self.photo_width)
         self.assertEqual(photo.photo_height, self.photo_height)

--- a/tests/test_inlinequeryresultvenue.py
+++ b/tests/test_inlinequeryresultvenue.py
@@ -32,7 +32,7 @@ class InlineQueryResultVenueTest(BaseTest, unittest.TestCase):
     """This object represents Tests for Telegram InlineQueryResultVenue."""
 
     def setUp(self):
-        self.id = 'id'
+        self._id = 'id'
         self.type = 'venue'
         self.latitude = 'latitude'
         self.longitude = 'longitude'
@@ -46,7 +46,7 @@ class InlineQueryResultVenueTest(BaseTest, unittest.TestCase):
         self.reply_markup = telegram.InlineKeyboardMarkup(
             [[telegram.InlineKeyboardButton('reply_markup')]])
         self.json_dict = {
-            'id': self.id,
+            'id': self._id,
             'type': self.type,
             'latitude': self.latitude,
             'longitude': self.longitude,
@@ -63,7 +63,7 @@ class InlineQueryResultVenueTest(BaseTest, unittest.TestCase):
     def test_venue_de_json(self):
         venue = telegram.InlineQueryResultVenue.de_json(self.json_dict, self._bot)
 
-        self.assertEqual(venue.id, self.id)
+        self.assertEqual(venue.id, self._id)
         self.assertEqual(venue.type, self.type)
         self.assertEqual(venue.latitude, self.latitude)
         self.assertEqual(venue.longitude, self.longitude)

--- a/tests/test_inlinequeryresultvideo.py
+++ b/tests/test_inlinequeryresultvideo.py
@@ -32,7 +32,7 @@ class InlineQueryResultVideoTest(BaseTest, unittest.TestCase):
     """This object represents Tests for Telegram InlineQueryResultVideo."""
 
     def setUp(self):
-        self.id = 'id'
+        self._id = 'id'
         self.type = 'video'
         self.video_url = 'video url'
         self.mime_type = 'mime type'
@@ -49,7 +49,7 @@ class InlineQueryResultVideoTest(BaseTest, unittest.TestCase):
 
         self.json_dict = {
             'type': self.type,
-            'id': self.id,
+            'id': self._id,
             'video_url': self.video_url,
             'mime_type': self.mime_type,
             'video_width': self.video_width,
@@ -67,7 +67,7 @@ class InlineQueryResultVideoTest(BaseTest, unittest.TestCase):
         video = telegram.InlineQueryResultVideo.de_json(self.json_dict, self._bot)
 
         self.assertEqual(video.type, self.type)
-        self.assertEqual(video.id, self.id)
+        self.assertEqual(video.id, self._id)
         self.assertEqual(video.video_url, self.video_url)
         self.assertEqual(video.mime_type, self.mime_type)
         self.assertEqual(video.video_width, self.video_width)

--- a/tests/test_inlinequeryresultvoice.py
+++ b/tests/test_inlinequeryresultvoice.py
@@ -32,7 +32,7 @@ class InlineQueryResultVoiceTest(BaseTest, unittest.TestCase):
     """This object represents Tests for Telegram InlineQueryResultVoice."""
 
     def setUp(self):
-        self.id = 'id'
+        self._id = 'id'
         self.type = 'voice'
         self.voice_url = 'voice url'
         self.title = 'title'
@@ -44,7 +44,7 @@ class InlineQueryResultVoiceTest(BaseTest, unittest.TestCase):
 
         self.json_dict = {
             'type': self.type,
-            'id': self.id,
+            'id': self._id,
             'voice_url': self.voice_url,
             'title': self.title,
             'voice_duration': self.voice_duration,
@@ -57,7 +57,7 @@ class InlineQueryResultVoiceTest(BaseTest, unittest.TestCase):
         voice = telegram.InlineQueryResultVoice.de_json(self.json_dict, self._bot)
 
         self.assertEqual(voice.type, self.type)
-        self.assertEqual(voice.id, self.id)
+        self.assertEqual(voice.id, self._id)
         self.assertEqual(voice.voice_url, self.voice_url)
         self.assertEqual(voice.title, self.title)
         self.assertEqual(voice.voice_duration, self.voice_duration)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -693,7 +693,7 @@ class UpdaterTest(BaseTest, unittest.TestCase):
     def test_bootstrap_retries_unauth(self):
         retries = 3
         self._setup_updater(
-            '', messages=0, bootstrap_retries=retries, bootstrap_err=Unauthorized())
+            '', messages=0, bootstrap_retries=retries, bootstrap_err=Unauthorized("Unauthorized"))
 
         self.assertRaises(Unauthorized, self.updater._bootstrap, retries, False, 'path', None)
         self.assertEqual(self.updater.bot.bootstrap_attempts, 1)


### PR DESCRIPTION
For some reason somewhere along the line the [urllib push ](https://github.com/python-telegram-bot/python-telegram-bot/commit/45414761439d1df86e11f47ec14026f73c8c48a8) from @jh0ker fell out from master. So this also adds it to requirements again.

I modified the tests because the nosetestrunner from pycharm has a hard time handling testclasses that define a `self.id`. I refractored them to `self._id`

lastly I passed the message received with unauthorized errors to the `Unauthorized` exception so users will see why it was unauthorized in the raised error.
This fixes #558 