### PR TITLE
Add equality rich comparision operators to telegram objects

### DIFF
--- a/telegram/animation.py
+++ b/telegram/animation.py
@@ -35,6 +35,8 @@ class Animation(TelegramObject):
 
     """
 
+    _id_keys = ('file_id',)
+
     def __init__(self,
                  file_id,
                  thumb=None,

--- a/telegram/animation.py
+++ b/telegram/animation.py
@@ -35,8 +35,6 @@ class Animation(TelegramObject):
 
     """
 
-    _id_keys = ('file_id',)
-
     def __init__(self,
                  file_id,
                  thumb=None,
@@ -49,6 +47,8 @@ class Animation(TelegramObject):
         self.file_name = file_name
         self.mime_type = mime_type
         self.file_size = file_size
+
+        self._id_attrs = (self.file_id,)
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/audio.py
+++ b/telegram/audio.py
@@ -43,6 +43,8 @@ class Audio(TelegramObject):
 
     """
 
+    _id_keys = ('file_id',)
+
     def __init__(self,
                  file_id,
                  duration,

--- a/telegram/audio.py
+++ b/telegram/audio.py
@@ -43,8 +43,6 @@ class Audio(TelegramObject):
 
     """
 
-    _id_keys = ('file_id',)
-
     def __init__(self,
                  file_id,
                  duration,
@@ -61,6 +59,8 @@ class Audio(TelegramObject):
         self.title = title
         self.mime_type = mime_type
         self.file_size = file_size
+
+        self._id_attrs = (self.file_id,)
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/base.py
+++ b/telegram/base.py
@@ -88,7 +88,7 @@ class TelegramObject(object):
         raise NotImplementedError
 
     def __eq__(self, other):
-        if isinstance(other, TelegramObject):
+        if isinstance(other, self.__class__):
             try:
                 return self._get_id() == other._get_id()
             except NotImplementedError:

--- a/telegram/base.py
+++ b/telegram/base.py
@@ -69,7 +69,7 @@ class TelegramObject(object):
         data = dict()
 
         for key in iter(self.__dict__):
-            if key == 'bot':
+            if key in ('bot', '_id_attrs'):
                 continue
 
             value = self.__dict__[key]
@@ -81,18 +81,14 @@ class TelegramObject(object):
 
         return data
 
-    _id_keys = ()
-
-    def _get_id(self):
-        return tuple(getattr(self, x) for x in self._id_keys)
+    _id_attrs = ()
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
-            return self._get_id() == other._get_id()
+            return self._id_attrs == other._id_attrs
         return super(TelegramObject, self).__eq__(other)
 
     def __hash__(self):
-        if self._id_keys:
-            return hash((self.__class__, self._get_id()))
-        else:
-            return super(TelegramObject, self).__hash__()
+        if self._id_attrs:
+            return hash((self.__class__, self._id_attrs))
+        return super(TelegramObject, self).__hash__()

--- a/telegram/base.py
+++ b/telegram/base.py
@@ -97,6 +97,8 @@ class TelegramObject(object):
 
     def __hash__(self):
         try:
-            return hash(self._get_id())
+            return hash((
+                self.__class__,
+                self._get_id(),))
         except NotImplementedError:
             return super().__hash__()

--- a/telegram/base.py
+++ b/telegram/base.py
@@ -101,4 +101,4 @@ class TelegramObject(object):
                 self.__class__,
                 self._get_id(),))
         except NotImplementedError:
-            return super().__hash__()
+            return super(TelegramObject, self).__hash__()

--- a/telegram/base.py
+++ b/telegram/base.py
@@ -81,24 +81,18 @@ class TelegramObject(object):
 
         return data
 
+    _id_keys = ()
+
     def _get_id(self):
-        for x in ['id', 'file_id', 'message_id', 'result_id', 'update_id']:
-            if hasattr(self, x):
-                return getattr(self, x)
-        raise NotImplementedError
+        return tuple(getattr(self, x) for x in self._id_keys)
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
-            try:
-                return self._get_id() == other._get_id()
-            except NotImplementedError:
-                pass  # return NotImplemented
-        return NotImplemented
+            return self._get_id() == other._get_id()
+        return super(TelegramObject, self).__eq__(other)
 
     def __hash__(self):
-        try:
-            return hash((
-                self.__class__,
-                self._get_id(),))
-        except NotImplementedError:
+        if self._id_keys:
+            return hash((self.__class__, self._get_id()))
+        else:
             return super(TelegramObject, self).__hash__()

--- a/telegram/base.py
+++ b/telegram/base.py
@@ -28,8 +28,8 @@ from abc import ABCMeta
 
 class TelegramObject(object):
     """Base class for most telegram objects."""
-
     __metaclass__ = ABCMeta
+    _id_attrs = ()
 
     def __str__(self):
         return str(self.to_dict())
@@ -80,8 +80,6 @@ class TelegramObject(object):
                     data[key] = value
 
         return data
-
-    _id_attrs = ()
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):

--- a/telegram/base.py
+++ b/telegram/base.py
@@ -84,7 +84,7 @@ class TelegramObject(object):
     def _get_id(self):
         for x in ['id', 'file_id', 'message_id', 'result_id', 'update_id']:
             if hasattr(self, x):
-                return self.__getattribute__(x)
+                return getattr(self, x)
         raise NotImplementedError
 
     def __eq__(self, other):

--- a/telegram/base.py
+++ b/telegram/base.py
@@ -82,7 +82,7 @@ class TelegramObject(object):
         return data
 
     def _get_id(self):
-        for x in ['id', 'file_id', 'message_id', 'result_id', 'update_id', 'phone_number']:
+        for x in ['id', 'file_id', 'message_id', 'result_id', 'update_id']:
             if hasattr(self, x):
                 return self.__getattribute__(x)
         raise NotImplementedError

--- a/telegram/base.py
+++ b/telegram/base.py
@@ -80,3 +80,23 @@ class TelegramObject(object):
                     data[key] = value
 
         return data
+
+    def _get_id(self):
+        for x in ['id', 'file_id', 'message_id', 'result_id', 'update_id', 'phone_number']:
+            if hasattr(self, x):
+                return self.__getattribute__(x)
+        raise NotImplementedError
+
+    def __eq__(self, other):
+        if isinstance(other, TelegramObject):
+            try:
+                return self._get_id() == other._get_id()
+            except NotImplementedError:
+                pass  # return NotImplemented
+        return NotImplemented
+
+    def __hash__(self):
+        try:
+            return hash(self._get_id())
+        except NotImplementedError:
+            return super().__hash__()

--- a/telegram/chat.py
+++ b/telegram/chat.py
@@ -50,8 +50,6 @@ class Chat(TelegramObject):
     SUPERGROUP = 'supergroup'
     CHANNEL = 'channel'
 
-    _id_keys = ('id',)
-
     def __init__(self,
                  id,
                  type,
@@ -73,6 +71,7 @@ class Chat(TelegramObject):
         self.all_members_are_administrators = all_members_are_administrators
 
         self.bot = bot
+        self._id_attrs = (self.id,)
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/chat.py
+++ b/telegram/chat.py
@@ -50,6 +50,8 @@ class Chat(TelegramObject):
     SUPERGROUP = 'supergroup'
     CHANNEL = 'channel'
 
+    _id_keys = ('id',)
+
     def __init__(self,
                  id,
                  type,

--- a/telegram/chatmember.py
+++ b/telegram/chatmember.py
@@ -71,4 +71,4 @@ class ChatMember(TelegramObject):
         return NotImplemented
 
     def __hash__(self):
-        return hash((self.user, self.status))
+        return hash((self.__class__, self.user, self.status))

--- a/telegram/chatmember.py
+++ b/telegram/chatmember.py
@@ -64,3 +64,11 @@ class ChatMember(TelegramObject):
         data['user'] = User.de_json(data.get('user'), bot)
 
         return ChatMember(**data)
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.user == other.user and self.status == other.status
+        return NotImplemented
+
+    def __hash__(self):
+        return hash((self.user, self.status))

--- a/telegram/chatmember.py
+++ b/telegram/chatmember.py
@@ -41,6 +41,8 @@ class ChatMember(TelegramObject):
     LEFT = 'left'
     KICKED = 'kicked'
 
+    _id_keys = ('user', 'status')
+
     def __init__(self, user, status, **kwargs):
         # Required
         self.user = user
@@ -64,11 +66,3 @@ class ChatMember(TelegramObject):
         data['user'] = User.de_json(data.get('user'), bot)
 
         return ChatMember(**data)
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.user == other.user and self.status == other.status
-        return NotImplemented
-
-    def __hash__(self):
-        return hash((self.__class__, self.user, self.status))

--- a/telegram/chatmember.py
+++ b/telegram/chatmember.py
@@ -41,12 +41,12 @@ class ChatMember(TelegramObject):
     LEFT = 'left'
     KICKED = 'kicked'
 
-    _id_keys = ('user', 'status')
-
     def __init__(self, user, status, **kwargs):
         # Required
         self.user = user
         self.status = status
+
+        self._id_attrs = (self.user, self.status)
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/choseninlineresult.py
+++ b/telegram/choseninlineresult.py
@@ -46,8 +46,6 @@ class ChosenInlineResult(TelegramObject):
 
     """
 
-    _id_keys = ('result_id',)
-
     def __init__(self,
                  result_id,
                  from_user,
@@ -62,6 +60,8 @@ class ChosenInlineResult(TelegramObject):
         # Optionals
         self.location = location
         self.inline_message_id = inline_message_id
+
+        self._id_attrs = (self.result_id,)
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/choseninlineresult.py
+++ b/telegram/choseninlineresult.py
@@ -46,6 +46,8 @@ class ChosenInlineResult(TelegramObject):
 
     """
 
+    _id_keys = ('result_id',)
+
     def __init__(self,
                  result_id,
                  from_user,

--- a/telegram/contact.py
+++ b/telegram/contact.py
@@ -39,8 +39,6 @@ class Contact(TelegramObject):
 
     """
 
-    _id_keys = ('phone_number',)
-
     def __init__(self, phone_number, first_name, last_name=None, user_id=None, **kwargs):
         # Required
         self.phone_number = str(phone_number)
@@ -48,6 +46,8 @@ class Contact(TelegramObject):
         # Optionals
         self.last_name = last_name
         self.user_id = user_id
+
+        self._id_attrs = (self.phone_number,)
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/contact.py
+++ b/telegram/contact.py
@@ -64,7 +64,7 @@ class Contact(TelegramObject):
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
-            return self.phone_number == self.phone_number
+            return self.phone_number == other.phone_number
         return NotImplemented
 
     def __hash__(self):

--- a/telegram/contact.py
+++ b/telegram/contact.py
@@ -39,6 +39,8 @@ class Contact(TelegramObject):
 
     """
 
+    _id_keys = ('phone_number',)
+
     def __init__(self, phone_number, first_name, last_name=None, user_id=None, **kwargs):
         # Required
         self.phone_number = str(phone_number)
@@ -61,11 +63,3 @@ class Contact(TelegramObject):
             return None
 
         return Contact(**data)
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.phone_number == other.phone_number
-        return NotImplemented
-
-    def __hash__(self):
-        return hash(self.phone_number)

--- a/telegram/contact.py
+++ b/telegram/contact.py
@@ -61,3 +61,11 @@ class Contact(TelegramObject):
             return None
 
         return Contact(**data)
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.phone_number == self.phone_number
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(self.phone_number)

--- a/telegram/document.py
+++ b/telegram/document.py
@@ -58,6 +58,8 @@ class Document(TelegramObject):
         self.mime_type = mime_type
         self.file_size = file_size
 
+        self._id_attrs = (self.file_id,)
+
     @staticmethod
     def de_json(data, bot):
         """

--- a/telegram/document.py
+++ b/telegram/document.py
@@ -41,6 +41,8 @@ class Document(TelegramObject):
 
     """
 
+    _id_keys = ('file_id',)
+
     def __init__(self,
                  file_id,
                  thumb=None,

--- a/telegram/file.py
+++ b/telegram/file.py
@@ -40,6 +40,8 @@ class File(TelegramObject):
 
     """
 
+    _id_keys = ('file_id',)
+
     def __init__(self, file_id, bot, file_size=None, file_path=None, **kwargs):
         # Required
         self.file_id = str(file_id)

--- a/telegram/file.py
+++ b/telegram/file.py
@@ -40,8 +40,6 @@ class File(TelegramObject):
 
     """
 
-    _id_keys = ('file_id',)
-
     def __init__(self, file_id, bot, file_size=None, file_path=None, **kwargs):
         # Required
         self.file_id = str(file_id)
@@ -52,6 +50,8 @@ class File(TelegramObject):
             self.file_path = str(file_path)
 
         self.bot = bot
+
+        self._id_attrs = (self.file_id,)
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/inlinequery.py
+++ b/telegram/inlinequery.py
@@ -44,6 +44,8 @@ class InlineQuery(TelegramObject):
 
     """
 
+    _id_keys = ('id',)
+
     def __init__(self, id, from_user, query, offset, location=None, bot=None, **kwargs):
         # Required
         self.id = id

--- a/telegram/inlinequery.py
+++ b/telegram/inlinequery.py
@@ -44,8 +44,6 @@ class InlineQuery(TelegramObject):
 
     """
 
-    _id_keys = ('id',)
-
     def __init__(self, id, from_user, query, offset, location=None, bot=None, **kwargs):
         # Required
         self.id = id
@@ -57,6 +55,7 @@ class InlineQuery(TelegramObject):
         self.location = location
 
         self.bot = bot
+        self._id_attrs = (self.id,)
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/inlinequeryresult.py
+++ b/telegram/inlinequeryresult.py
@@ -36,6 +36,8 @@ class InlineQueryResult(TelegramObject):
 
     """
 
+    _id_keys = ('id',)
+
     def __init__(self, type, id, **kwargs):
         # Required
         self.type = str(type)

--- a/telegram/inlinequeryresult.py
+++ b/telegram/inlinequeryresult.py
@@ -36,12 +36,12 @@ class InlineQueryResult(TelegramObject):
 
     """
 
-    _id_keys = ('id',)
-
     def __init__(self, type, id, **kwargs):
         # Required
         self.type = str(type)
         self.id = str(id)
+
+        self._id_attrs = (self.id,)
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/location.py
+++ b/telegram/location.py
@@ -33,6 +33,8 @@ class Location(TelegramObject):
         latitude (float):
     """
 
+    _id_keys = ('longitude', 'latitude')
+
     def __init__(self, longitude, latitude, **kwargs):
         # Required
         self.longitude = float(longitude)
@@ -52,11 +54,3 @@ class Location(TelegramObject):
             return None
 
         return Location(**data)
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.longitude == other.longitude and self.latitude == other.latitude
-        return NotImplemented
-
-    def __hash__(self):
-        return hash((self.__class__, self.longitude, self.latitude))

--- a/telegram/location.py
+++ b/telegram/location.py
@@ -33,12 +33,12 @@ class Location(TelegramObject):
         latitude (float):
     """
 
-    _id_keys = ('longitude', 'latitude')
-
     def __init__(self, longitude, latitude, **kwargs):
         # Required
         self.longitude = float(longitude)
         self.latitude = float(latitude)
+
+        self._id_attrs = (self.longitude, self.latitude)
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/location.py
+++ b/telegram/location.py
@@ -52,3 +52,11 @@ class Location(TelegramObject):
             return None
 
         return Location(**data)
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.longitude == other.longitude and self.latitude == other.latitude
+        return NotImplemented
+
+    def __hash__(self):
+        return hash((self.longitude, self.latitude))

--- a/telegram/location.py
+++ b/telegram/location.py
@@ -59,4 +59,4 @@ class Location(TelegramObject):
         return NotImplemented
 
     def __hash__(self):
-        return hash((self.longitude, self.latitude))
+        return hash((self.__class__, self.longitude, self.latitude))

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -106,8 +106,6 @@ class Message(TelegramObject):
         bot (Optional[Bot]): The Bot to use for instance methods
     """
 
-    _id_keys = ('message_id',)
-
     def __init__(self,
                  message_id,
                  from_user,
@@ -182,6 +180,8 @@ class Message(TelegramObject):
         self.forward_from_message_id = forward_from_message_id
 
         self.bot = bot
+
+        self._id_attrs = (self.message_id,)
 
     @property
     def chat_id(self):

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -106,6 +106,8 @@ class Message(TelegramObject):
         bot (Optional[Bot]): The Bot to use for instance methods
     """
 
+    _id_keys = ('message_id',)
+
     def __init__(self,
                  message_id,
                  from_user,

--- a/telegram/photosize.py
+++ b/telegram/photosize.py
@@ -40,6 +40,8 @@ class PhotoSize(TelegramObject):
         file_size (Optional[int]):
     """
 
+    _id_keys = ('file_id',)
+
     def __init__(self, file_id, width, height, file_size=None, **kwargs):
         # Required
         self.file_id = str(file_id)

--- a/telegram/photosize.py
+++ b/telegram/photosize.py
@@ -48,12 +48,6 @@ class PhotoSize(TelegramObject):
         # Optionals
         self.file_size = file_size
 
-    def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return False
-        return (self.file_id == other.file_id and self.width == other.width
-                and self.height == other.height and self.file_size == other.file_size)
-
     @staticmethod
     def de_json(data, bot):
         """

--- a/telegram/photosize.py
+++ b/telegram/photosize.py
@@ -40,8 +40,6 @@ class PhotoSize(TelegramObject):
         file_size (Optional[int]):
     """
 
-    _id_keys = ('file_id',)
-
     def __init__(self, file_id, width, height, file_size=None, **kwargs):
         # Required
         self.file_id = str(file_id)
@@ -49,6 +47,8 @@ class PhotoSize(TelegramObject):
         self.height = int(height)
         # Optionals
         self.file_size = file_size
+
+        self._id_attrs = (self.file_id,)
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/sticker.py
+++ b/telegram/sticker.py
@@ -44,8 +44,6 @@ class Sticker(TelegramObject):
         file_size (Optional[int]):
     """
 
-    _id_keys = ('file_id',)
-
     def __init__(self, file_id, width, height, thumb=None, emoji=None, file_size=None, **kwargs):
         # Required
         self.file_id = str(file_id)
@@ -55,6 +53,8 @@ class Sticker(TelegramObject):
         self.thumb = thumb
         self.emoji = emoji
         self.file_size = file_size
+
+        self._id_attrs = (self.file_id,)
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/sticker.py
+++ b/telegram/sticker.py
@@ -44,6 +44,8 @@ class Sticker(TelegramObject):
         file_size (Optional[int]):
     """
 
+    _id_keys = ('file_id',)
+
     def __init__(self, file_id, width, height, thumb=None, emoji=None, file_size=None, **kwargs):
         # Required
         self.file_id = str(file_id)

--- a/telegram/update.py
+++ b/telegram/update.py
@@ -52,8 +52,6 @@ class Update(TelegramObject):
 
     """
 
-    _id_keys = ('update_id',)
-
     def __init__(self,
                  update_id,
                  message=None,
@@ -78,6 +76,8 @@ class Update(TelegramObject):
         self._effective_user = None
         self._effective_chat = None
         self._effective_message = None
+
+        self._id_attrs = (self.update_id,)
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/update.py
+++ b/telegram/update.py
@@ -52,6 +52,8 @@ class Update(TelegramObject):
 
     """
 
+    _id_keys = ('update_id',)
+
     def __init__(self,
                  update_id,
                  message=None,

--- a/telegram/user.py
+++ b/telegram/user.py
@@ -44,8 +44,6 @@ class User(TelegramObject):
         bot (Optional[Bot]): The Bot to use for instance methods
     """
 
-    _id_keys = ('id',)
-
     def __init__(self,
                  id,
                  first_name,
@@ -63,6 +61,8 @@ class User(TelegramObject):
         self.username = username
 
         self.bot = bot
+
+        self._id_attrs = (self.id,)
 
     @property
     def name(self):

--- a/telegram/user.py
+++ b/telegram/user.py
@@ -44,6 +44,8 @@ class User(TelegramObject):
         bot (Optional[Bot]): The Bot to use for instance methods
     """
 
+    _id_keys = ('id',)
+
     def __init__(self,
                  id,
                  first_name,

--- a/telegram/venue.py
+++ b/telegram/venue.py
@@ -50,3 +50,11 @@ class Venue(TelegramObject):
         data['location'] = Location.de_json(data.get('location'), bot)
 
         return Venue(**data)
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.location == other.location and self.title == other.title
+        return NotImplemented
+
+    def __hash__(self):
+        return hash((self.__class__, self.location, self.title))

--- a/telegram/venue.py
+++ b/telegram/venue.py
@@ -32,6 +32,8 @@ class Venue(TelegramObject):
         foursquare_id (Optional[str]):
     """
 
+    _id_keys = ('location', 'title')
+
     def __init__(self, location, title, address, foursquare_id=None, **kwargs):
         # Required
         self.location = location
@@ -50,11 +52,3 @@ class Venue(TelegramObject):
         data['location'] = Location.de_json(data.get('location'), bot)
 
         return Venue(**data)
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.location == other.location and self.title == other.title
-        return NotImplemented
-
-    def __hash__(self):
-        return hash((self.__class__, self.location, self.title))

--- a/telegram/venue.py
+++ b/telegram/venue.py
@@ -32,8 +32,6 @@ class Venue(TelegramObject):
         foursquare_id (Optional[str]):
     """
 
-    _id_keys = ('location', 'title')
-
     def __init__(self, location, title, address, foursquare_id=None, **kwargs):
         # Required
         self.location = location
@@ -41,6 +39,8 @@ class Venue(TelegramObject):
         self.address = address
         # Optionals
         self.foursquare_id = foursquare_id
+
+        self._id_attrs = (self.location, self.title)
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/video.py
+++ b/telegram/video.py
@@ -46,8 +46,6 @@ class Video(TelegramObject):
         file_size (Optional[int]):
     """
 
-    _id_keys = ('file_id',)
-
     def __init__(self,
                  file_id,
                  width,
@@ -66,6 +64,8 @@ class Video(TelegramObject):
         self.thumb = thumb
         self.mime_type = mime_type
         self.file_size = file_size
+
+        self._id_attrs = (self.file_id,)
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/video.py
+++ b/telegram/video.py
@@ -46,6 +46,8 @@ class Video(TelegramObject):
         file_size (Optional[int]):
     """
 
+    _id_keys = ('file_id',)
+
     def __init__(self,
                  file_id,
                  width,

--- a/telegram/voice.py
+++ b/telegram/voice.py
@@ -40,8 +40,6 @@ class Voice(TelegramObject):
         file_size (Optional[int]):
     """
 
-    _id_keys = ('file_id',)
-
     def __init__(self, file_id, duration, mime_type=None, file_size=None, **kwargs):
         # Required
         self.file_id = str(file_id)
@@ -49,6 +47,8 @@ class Voice(TelegramObject):
         # Optionals
         self.mime_type = mime_type
         self.file_size = file_size
+
+        self._id_attrs = (self.file_id,)
 
     @staticmethod
     def de_json(data, bot):

--- a/telegram/voice.py
+++ b/telegram/voice.py
@@ -40,6 +40,8 @@ class Voice(TelegramObject):
         file_size (Optional[int]):
     """
 
+    _id_keys = ('file_id',)
+
     def __init__(self, file_id, duration, mime_type=None, file_size=None, **kwargs):
         # Required
         self.file_id = str(file_id)

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -73,3 +73,19 @@ class AnimationTest(BaseTest, unittest.TestCase):
         self.assertEqual(animation['file_name'], self.file_name)
         self.assertEqual(animation['mime_type'], self.mime_type)
         self.assertEqual(animation['file_size'], self.file_size)
+
+    def test_equality(self):
+        a = telegram.Animation(self.animation_file_id)
+        b = telegram.Animation(self.animation_file_id)
+        d = telegram.Animation("")
+        e = telegram.Voice(self.animation_file_id, 0)
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+#
+# A library that provides a Python interface to the Telegram Bot API
+# Copyright (C) 2015-2016
+# Leandro Toledo de Souza <devs@python-telegram-bot.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+"""This module contains an object that represents Tests for Telegram Animation"""
+
+import unittest
+import sys
+
+sys.path.append('.')
+
+import telegram
+from tests.base import BaseTest
+
+
+class AnimationTest(BaseTest, unittest.TestCase):
+    """This object represents Tests for Telegram Animation."""
+
+    def setUp(self):
+        self.animation_file_id = 'CgADBAADFQEAAny4rAUgukhiTv2TWwI'
+        self.thumb = telegram.PhotoSize.de_json({
+            'height': 50,
+            'file_size': 1613,
+            'file_id': 'AAQEABPQUWQZAAT7gZuQAAH0bd93VwACAg',
+            'width': 90
+        }, self._bot)
+        self.file_name = "game.gif.mp4"
+        self.mime_type = "video/mp4"
+        self.file_size = 4008
+
+        self.json_dict = {
+            'file_id': self.animation_file_id,
+            'thumb': self.thumb.to_dict(),
+            'file_name': self.file_name,
+            'mime_type': self.mime_type,
+            'file_size': self.file_size
+        }
+
+    def test_animation_de_json(self):
+        animation = telegram.Animation.de_json(self.json_dict, self._bot)
+
+        self.assertEqual(animation.file_id, self.animation_file_id)
+        self.assertEqual(animation.thumb, self.thumb)
+        self.assertEqual(animation.file_name, self.file_name)
+        self.assertEqual(animation.mime_type, self.mime_type)
+        self.assertEqual(animation.file_size, self.file_size)
+
+    def test_animation_to_json(self):
+        animation = telegram.Animation.de_json(self.json_dict, self._bot)
+
+        self.assertTrue(self.is_json(animation.to_json()))
+
+    def test_animation_to_dict(self):
+        animation = telegram.Animation.de_json(self.json_dict, self._bot)
+
+        self.assertTrue(self.is_dict(animation.to_dict()))
+        self.assertEqual(animation['file_id'], self.animation_file_id)
+        self.assertEqual(animation['thumb'], self.thumb)
+        self.assertEqual(animation['file_name'], self.file_name)
+        self.assertEqual(animation['mime_type'], self.mime_type)
+        self.assertEqual(animation['file_size'], self.file_size)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -268,6 +268,26 @@ class AudioTest(BaseTest, unittest.TestCase):
 
         self.assertNotEqual(message.audio.file_id, None)
 
+    def test_equality(self):
+        a = telegram.Audio(self.audio_file_id, self.duration)
+        b = telegram.Audio(self.audio_file_id, self.duration)
+        c = telegram.Audio(self.audio_file_id, 0)
+        d = telegram.Audio("", self.duration)
+        e = telegram.Voice(self.audio_file_id, self.duration)
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -85,6 +85,26 @@ class ChatTest(BaseTest, unittest.TestCase):
 
         self.assertTrue(result)
 
+    def test_equality(self):
+        a = telegram.Chat(self._id, self.title, self.type)
+        b = telegram.Chat(self._id, self.title, self.type)
+        c = telegram.Chat(self._id, "", "")
+        d = telegram.Chat(0, self.title, self.type)
+        e = telegram.User(self._id, "")
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_chatmember.py
+++ b/tests/test_chatmember.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+#
+# A library that provides a Python interface to the Telegram Bot API
+# Copyright (C) 2015-2016
+# Leandro Toledo de Souza <devs@python-telegram-bot.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+"""This module contains an object that represents Tests for Telegram ChatMember"""
+
+import unittest
+import sys
+
+sys.path.append('.')
+
+import telegram
+from tests.base import BaseTest
+
+
+class ChatMemberTest(BaseTest, unittest.TestCase):
+    """This object represents Tests for Telegram ChatMember."""
+
+    def setUp(self):
+        self.user = {'id': 1, 'first_name': 'User'}
+        self.status = telegram.ChatMember.CREATOR
+
+        self.json_dict = {'user': self.user, 'status': self.status}
+
+    def test_chatmember_de_json(self):
+        chatmember = telegram.ChatMember.de_json(self.json_dict, self._bot)
+
+        self.assertEqual(chatmember.user.to_dict(), self.user)
+        self.assertEqual(chatmember.status, self.status)
+
+    def test_chatmember_to_json(self):
+        chatmember = telegram.ChatMember.de_json(self.json_dict, self._bot)
+
+        self.assertTrue(self.is_json(chatmember.to_json()))
+
+    def test_chatmember_to_dict(self):
+        chatmember = telegram.ChatMember.de_json(self.json_dict, self._bot)
+
+        self.assertTrue(self.is_dict(chatmember.to_dict()))
+        self.assertEqual(chatmember['user'].to_dict(), self.user)
+        self.assertEqual(chatmember['status'], self.status)
+
+    def test_equality(self):
+        a = telegram.ChatMember(telegram.User(1, ""), telegram.ChatMember.ADMINISTRATOR)
+        b = telegram.ChatMember(telegram.User(1, ""), telegram.ChatMember.ADMINISTRATOR)
+        d = telegram.ChatMember(telegram.User(2, ""), telegram.ChatMember.ADMINISTRATOR)
+        d2 = telegram.ChatMember(telegram.User(1, ""), telegram.ChatMember.CREATOR)
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, d2)
+        self.assertNotEqual(hash(a), hash(d2))

--- a/tests/test_choseninlineresult.py
+++ b/tests/test_choseninlineresult.py
@@ -64,6 +64,26 @@ class ChosenInlineResultTest(BaseTest, unittest.TestCase):
         self.assertEqual(result['from'], self.from_user.to_dict())
         self.assertEqual(result['query'], self.query)
 
+    def test_equality(self):
+        a = telegram.ChosenInlineResult(self.result_id, None, "Query", "")
+        b = telegram.ChosenInlineResult(self.result_id, None, "Query", "")
+        c = telegram.ChosenInlineResult(self.result_id, None, "", "")
+        d = telegram.ChosenInlineResult("", None, "Query", "")
+        e = telegram.Voice(self.result_id, 0)
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -67,6 +67,26 @@ class ContactTest(BaseTest, unittest.TestCase):
         self.assertEqual(contact['last_name'], self.last_name)
         self.assertEqual(contact['user_id'], self.user_id)
 
+    def test_equality(self):
+        a = telegram.Contact(self.phone_number, self.first_name)
+        b = telegram.Contact(self.phone_number, self.first_name)
+        c = telegram.Contact(self.phone_number, "")
+        d = telegram.Contact("", self.first_name)
+        e = telegram.Voice("", 0)
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 ''' Commented out, because it would cause "Too Many Requests (429)" errors.
     @flaky(3, 1)

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -178,6 +178,22 @@ class DocumentTest(BaseTest, unittest.TestCase):
 
         self.assertNotEqual(message.document.file_id, '')
 
+    def test_equality(self):
+        a = telegram.Document(self.document_file_id)
+        b = telegram.Document(self.document_file_id)
+        d = telegram.Document("")
+        e = telegram.Voice(self.document_file_id, 0)
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -137,6 +137,26 @@ class FileTest(BaseTest, unittest.TestCase):
 
         self.assertRaises(TypeError, lambda: self._bot.getFile(**json_dict))
 
+    def test_equality(self):
+        a = telegram.File(self.audio_file_id, self._bot)
+        b = telegram.File(self.audio_file_id, self._bot)
+        c = telegram.File(self.audio_file_id, None)
+        d = telegram.File(self.document_file_id, self._bot)
+        e = telegram.Voice(self.audio_file_id, 0)
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -99,36 +99,3 @@ class GameTest(BaseTest, unittest.TestCase):
         self.assertDictEqual(game.parse_text_entities(),
                              {entity: 'http://google.com',
                               entity_2: 'h'})
-
-
-class AnimationTest(BaseTest, unittest.TestCase):
-    """This object represents Tests for Telegram Animatiion."""
-
-    def setUp(self):
-        self.file_id = 'thisisafileid'
-        self.thumb = {'width': 640, 'height': 360, 'file_id': 'Blah', 'file_size': 0}
-        self.file_name = 'File name'
-        self.mime_type = 'something/gif'
-        self.file_size = 42
-
-        self.json_dict = {
-            'file_id': self.file_id,
-            'thumb': self.thumb,
-            'file_name': self.file_name,
-            'mime_type': self.mime_type,
-            'file_size': self.file_size
-        }
-
-    def test_animation_de_json(self):
-        animation = telegram.Animation.de_json(self.json_dict, self._bot)
-
-        self.assertEqual(animation.file_id, self.file_id)
-        self.assertTrue(isinstance(animation.thumb, telegram.PhotoSize))
-        self.assertEqual(animation.file_name, self.file_name)
-        self.assertEqual(animation.mime_type, self.mime_type)
-        self.assertEqual(animation.file_size, self.file_size)
-
-    def test_game_to_json(self):
-        animation = telegram.Animation.de_json(self.json_dict, self._bot)
-
-        self.assertTrue(self.is_json(animation.to_json()))

--- a/tests/test_inlinequery.py
+++ b/tests/test_inlinequery.py
@@ -35,7 +35,7 @@ class InlineQueryTest(BaseTest, unittest.TestCase):
         user = telegram.User(1, 'First name')
         location = telegram.Location(8.8, 53.1)
 
-        self._id = 'id'
+        self._id = 1234
         self.from_user = user
         self.query = 'query text'
         self.offset = 'offset'
@@ -68,6 +68,26 @@ class InlineQueryTest(BaseTest, unittest.TestCase):
 
         self.assertTrue(self.is_dict(inlinequery))
         self.assertDictEqual(inlinequery, self.json_dict)
+
+    def test_equality(self):
+        a = telegram.InlineQuery(self._id, telegram.User(1, ""), "", "")
+        b = telegram.InlineQuery(self._id, telegram.User(1, ""), "", "")
+        c = telegram.InlineQuery(self._id, telegram.User(0, ""), "", "")
+        d = telegram.InlineQuery(0, telegram.User(1, ""), "", "")
+        e = telegram.Update(self._id)
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
 
 
 if __name__ == '__main__':

--- a/tests/test_inlinequeryresultarticle.py
+++ b/tests/test_inlinequeryresultarticle.py
@@ -86,6 +86,26 @@ class InlineQueryResultArticleTest(BaseTest, unittest.TestCase):
         self.assertTrue(self.is_dict(article))
         self.assertDictEqual(self.json_dict, article)
 
+    def test_equality(self):
+        a = telegram.InlineQueryResultArticle(self._id, self.title, self.input_message_content)
+        b = telegram.InlineQueryResultArticle(self._id, self.title, self.input_message_content)
+        c = telegram.InlineQueryResultArticle(self._id, "", self.input_message_content)
+        d = telegram.InlineQueryResultArticle("", self.title, self.input_message_content)
+        e = telegram.InlineQueryResultAudio(self._id, "", "")
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_inlinequeryresultaudio.py
+++ b/tests/test_inlinequeryresultaudio.py
@@ -80,6 +80,26 @@ class InlineQueryResultAudioTest(BaseTest, unittest.TestCase):
         self.assertTrue(self.is_dict(audio))
         self.assertDictEqual(self.json_dict, audio)
 
+    def test_equality(self):
+        a = telegram.InlineQueryResultAudio(self._id, self.audio_url, self.title)
+        b = telegram.InlineQueryResultAudio(self._id, self.title, self.title)
+        c = telegram.InlineQueryResultAudio(self._id, "", self.title)
+        d = telegram.InlineQueryResultAudio("", self.audio_url, self.title)
+        e = telegram.InlineQueryResultArticle(self._id, "", "")
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_inlinequeryresultcachedaudio.py
+++ b/tests/test_inlinequeryresultcachedaudio.py
@@ -72,6 +72,26 @@ class InlineQueryResultCachedAudioTest(BaseTest, unittest.TestCase):
         self.assertTrue(self.is_dict(audio))
         self.assertDictEqual(self.json_dict, audio)
 
+    def test_equality(self):
+        a = telegram.InlineQueryResultCachedAudio(self._id, self.audio_file_id)
+        b = telegram.InlineQueryResultCachedAudio(self._id, self.audio_file_id)
+        c = telegram.InlineQueryResultCachedAudio(self._id, "")
+        d = telegram.InlineQueryResultCachedAudio("", self.audio_file_id)
+        e = telegram.InlineQueryResultCachedVoice(self._id, "", "")
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_inlinequeryresultcacheddocument.py
+++ b/tests/test_inlinequeryresultcacheddocument.py
@@ -78,6 +78,26 @@ class InlineQueryResultCachedDocumentTest(BaseTest, unittest.TestCase):
         self.assertTrue(self.is_dict(document))
         self.assertDictEqual(self.json_dict, document)
 
+    def test_equality(self):
+        a = telegram.InlineQueryResultCachedDocument(self._id, self.title, self.document_file_id)
+        b = telegram.InlineQueryResultCachedDocument(self._id, self.title, self.document_file_id)
+        c = telegram.InlineQueryResultCachedDocument(self._id, self.title, "")
+        d = telegram.InlineQueryResultCachedDocument("", self.title, self.document_file_id)
+        e = telegram.InlineQueryResultCachedVoice(self._id, "", "")
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_inlinequeryresultcachedgif.py
+++ b/tests/test_inlinequeryresultcachedgif.py
@@ -74,6 +74,26 @@ class InlineQueryResultCachedGifTest(BaseTest, unittest.TestCase):
         self.assertTrue(self.is_dict(gif))
         self.assertDictEqual(self.json_dict, gif)
 
+    def test_equality(self):
+        a = telegram.InlineQueryResultCachedGif(self._id, self.gif_file_id)
+        b = telegram.InlineQueryResultCachedGif(self._id, self.gif_file_id)
+        c = telegram.InlineQueryResultCachedGif(self._id, "")
+        d = telegram.InlineQueryResultCachedGif("", self.gif_file_id)
+        e = telegram.InlineQueryResultCachedVoice(self._id, "", "")
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_inlinequeryresultcachedmpeg4gif.py
+++ b/tests/test_inlinequeryresultcachedmpeg4gif.py
@@ -76,6 +76,26 @@ class InlineQueryResultCachedMpeg4GifTest(BaseTest, unittest.TestCase):
         self.assertTrue(self.is_dict(mpeg4))
         self.assertDictEqual(self.json_dict, mpeg4)
 
+    def test_equality(self):
+        a = telegram.InlineQueryResultCachedMpeg4Gif(self._id, self.mpeg4_file_id)
+        b = telegram.InlineQueryResultCachedMpeg4Gif(self._id, self.mpeg4_file_id)
+        c = telegram.InlineQueryResultCachedMpeg4Gif(self._id, "")
+        d = telegram.InlineQueryResultCachedMpeg4Gif("", self.mpeg4_file_id)
+        e = telegram.InlineQueryResultCachedVoice(self._id, "", "")
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_inlinequeryresultcachedphoto.py
+++ b/tests/test_inlinequeryresultcachedphoto.py
@@ -78,6 +78,26 @@ class InlineQueryResultCachedPhotoTest(BaseTest, unittest.TestCase):
         self.assertTrue(self.is_dict(photo))
         self.assertDictEqual(self.json_dict, photo)
 
+    def test_equality(self):
+        a = telegram.InlineQueryResultCachedPhoto(self._id, self.photo_file_id)
+        b = telegram.InlineQueryResultCachedPhoto(self._id, self.photo_file_id)
+        c = telegram.InlineQueryResultCachedPhoto(self._id, "")
+        d = telegram.InlineQueryResultCachedPhoto("", self.photo_file_id)
+        e = telegram.InlineQueryResultCachedVoice(self._id, "", "")
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_inlinequeryresultcachedsticker.py
+++ b/tests/test_inlinequeryresultcachedsticker.py
@@ -70,6 +70,26 @@ class InlineQueryResultCachedStickerTest(BaseTest, unittest.TestCase):
         self.assertTrue(self.is_dict(sticker))
         self.assertDictEqual(self.json_dict, sticker)
 
+    def test_equality(self):
+        a = telegram.InlineQueryResultCachedSticker(self._id, self.sticker_file_id)
+        b = telegram.InlineQueryResultCachedSticker(self._id, self.sticker_file_id)
+        c = telegram.InlineQueryResultCachedSticker(self._id, "")
+        d = telegram.InlineQueryResultCachedSticker("", self.sticker_file_id)
+        e = telegram.InlineQueryResultCachedVoice(self._id, "", "")
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_inlinequeryresultcachedvideo.py
+++ b/tests/test_inlinequeryresultcachedvideo.py
@@ -78,6 +78,26 @@ class InlineQueryResultCachedVideoTest(BaseTest, unittest.TestCase):
         self.assertTrue(self.is_dict(video))
         self.assertDictEqual(self.json_dict, video)
 
+    def test_equality(self):
+        a = telegram.InlineQueryResultCachedVideo(self._id, self.video_file_id, self.title)
+        b = telegram.InlineQueryResultCachedVideo(self._id, self.video_file_id, self.title)
+        c = telegram.InlineQueryResultCachedVideo(self._id, "", self.title)
+        d = telegram.InlineQueryResultCachedVideo("", self.video_file_id, self.title)
+        e = telegram.InlineQueryResultCachedVoice(self._id, "", "")
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_inlinequeryresultcachedvoice.py
+++ b/tests/test_inlinequeryresultcachedvoice.py
@@ -75,6 +75,26 @@ class InlineQueryResultCachedVoiceTest(BaseTest, unittest.TestCase):
         self.assertTrue(self.is_dict(voice))
         self.assertDictEqual(self.json_dict, voice)
 
+    def test_equality(self):
+        a = telegram.InlineQueryResultCachedVoice(self._id, self.voice_file_id, self.title)
+        b = telegram.InlineQueryResultCachedVoice(self._id, self.voice_file_id, self.title)
+        c = telegram.InlineQueryResultCachedVoice(self._id, "", self.title)
+        d = telegram.InlineQueryResultCachedVoice("", self.voice_file_id, self.title)
+        e = telegram.InlineQueryResultCachedVoice(self._id, "", "")
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_inlinequeryresultcachedvoice.py
+++ b/tests/test_inlinequeryresultcachedvoice.py
@@ -80,7 +80,7 @@ class InlineQueryResultCachedVoiceTest(BaseTest, unittest.TestCase):
         b = telegram.InlineQueryResultCachedVoice(self._id, self.voice_file_id, self.title)
         c = telegram.InlineQueryResultCachedVoice(self._id, "", self.title)
         d = telegram.InlineQueryResultCachedVoice("", self.voice_file_id, self.title)
-        e = telegram.InlineQueryResultCachedVoice(self._id, "", "")
+        e = telegram.InlineQueryResultCachedAudio(self._id, "", "")
 
         self.assertEqual(a, b)
         self.assertEqual(hash(a), hash(b))

--- a/tests/test_inlinequeryresultcontact.py
+++ b/tests/test_inlinequeryresultcontact.py
@@ -82,6 +82,26 @@ class InlineQueryResultContactTest(BaseTest, unittest.TestCase):
         self.assertTrue(self.is_dict(contact))
         self.assertDictEqual(self.json_dict, contact)
 
+    def test_equality(self):
+        a = telegram.InlineQueryResultContact(self._id, self.phone_number, self.first_name)
+        b = telegram.InlineQueryResultContact(self._id, self.phone_number, self.first_name)
+        c = telegram.InlineQueryResultContact(self._id, "", self.first_name)
+        d = telegram.InlineQueryResultContact("", self.phone_number, self.first_name)
+        e = telegram.InlineQueryResultArticle(self._id, "", "")
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_inlinequeryresultdocument.py
+++ b/tests/test_inlinequeryresultdocument.py
@@ -88,6 +88,28 @@ class InlineQueryResultDocumentTest(BaseTest, unittest.TestCase):
         self.assertTrue(self.is_dict(document))
         self.assertDictEqual(self.json_dict, document)
 
+    def test_equality(self):
+        a = telegram.InlineQueryResultDocument(self._id, self.document_url, self.title,
+                                               self.mime_type)
+        b = telegram.InlineQueryResultDocument(self._id, self.document_url, self.title,
+                                               self.mime_type)
+        c = telegram.InlineQueryResultDocument(self._id, "", self.title, self.mime_type)
+        d = telegram.InlineQueryResultDocument("", self.document_url, self.title, self.mime_type)
+        e = telegram.InlineQueryResultArticle(self._id, "", "")
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_inlinequeryresultgif.py
+++ b/tests/test_inlinequeryresultgif.py
@@ -83,6 +83,26 @@ class InlineQueryResultGifTest(BaseTest, unittest.TestCase):
         self.assertTrue(self.is_dict(gif))
         self.assertDictEqual(self.json_dict, gif)
 
+    def test_equality(self):
+        a = telegram.InlineQueryResultGif(self._id, self.gif_url, self.thumb_url)
+        b = telegram.InlineQueryResultGif(self._id, self.gif_url, self.thumb_url)
+        c = telegram.InlineQueryResultGif(self._id, "", self.thumb_url)
+        d = telegram.InlineQueryResultGif("", self.gif_url, self.thumb_url)
+        e = telegram.InlineQueryResultArticle(self._id, "", "")
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_inlinequeryresultlocation.py
+++ b/tests/test_inlinequeryresultlocation.py
@@ -34,8 +34,8 @@ class InlineQueryResultLocationTest(BaseTest, unittest.TestCase):
     def setUp(self):
         self._id = 'id'
         self.type = 'location'
-        self.latitude = 'latitude'
-        self.longitude = 'longitude'
+        self.latitude = 0.0
+        self.longitude = 0.0
         self.title = 'title'
         self.thumb_url = 'thumb url'
         self.thumb_width = 10
@@ -81,6 +81,26 @@ class InlineQueryResultLocationTest(BaseTest, unittest.TestCase):
 
         self.assertTrue(self.is_dict(location))
         self.assertDictEqual(self.json_dict, location)
+
+    def test_equality(self):
+        a = telegram.InlineQueryResultLocation(self._id, self.longitude, self.latitude, self.title)
+        b = telegram.InlineQueryResultLocation(self._id, self.longitude, self.latitude, self.title)
+        c = telegram.InlineQueryResultLocation(self._id, 0, self.latitude, self.title)
+        d = telegram.InlineQueryResultLocation("", self.longitude, self.latitude, self.title)
+        e = telegram.InlineQueryResultArticle(self._id, "", "")
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
 
 
 if __name__ == '__main__':

--- a/tests/test_inlinequeryresultmpeg4gif.py
+++ b/tests/test_inlinequeryresultmpeg4gif.py
@@ -83,6 +83,26 @@ class InlineQueryResultMpeg4GifTest(BaseTest, unittest.TestCase):
         self.assertTrue(self.is_dict(mpeg4))
         self.assertDictEqual(self.json_dict, mpeg4)
 
+    def test_equality(self):
+        a = telegram.InlineQueryResultMpeg4Gif(self._id, self.mpeg4_url, self.thumb_url)
+        b = telegram.InlineQueryResultMpeg4Gif(self._id, self.mpeg4_url, self.thumb_url)
+        c = telegram.InlineQueryResultMpeg4Gif(self._id, "", self.thumb_url)
+        d = telegram.InlineQueryResultMpeg4Gif("", self.mpeg4_url, self.thumb_url)
+        e = telegram.InlineQueryResultArticle(self._id, "", "")
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_inlinequeryresultphoto.py
+++ b/tests/test_inlinequeryresultphoto.py
@@ -86,6 +86,26 @@ class InlineQueryResultPhotoTest(BaseTest, unittest.TestCase):
         self.assertTrue(self.is_dict(photo))
         self.assertDictEqual(self.json_dict, photo)
 
+    def test_equality(self):
+        a = telegram.InlineQueryResultPhoto(self._id, self.photo_url, self.thumb_url)
+        b = telegram.InlineQueryResultPhoto(self._id, self.photo_url, self.thumb_url)
+        c = telegram.InlineQueryResultPhoto(self._id, "", self.thumb_url)
+        d = telegram.InlineQueryResultPhoto("", self.photo_url, self.thumb_url)
+        e = telegram.InlineQueryResultArticle(self._id, "", "")
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_inlinequeryresultvenue.py
+++ b/tests/test_inlinequeryresultvenue.py
@@ -88,6 +88,29 @@ class InlineQueryResultVenueTest(BaseTest, unittest.TestCase):
         self.assertTrue(self.is_dict(venue))
         self.assertDictEqual(self.json_dict, venue)
 
+    def test_equality(self):
+        a = telegram.InlineQueryResultVenue(self._id, self.longitude, self.latitude, self.title,
+                                            self._address)
+        b = telegram.InlineQueryResultVenue(self._id, self.longitude, self.latitude, self.title,
+                                            self._address)
+        c = telegram.InlineQueryResultVenue(self._id, "", self.latitude, self.title, self._address)
+        d = telegram.InlineQueryResultVenue("", self.longitude, self.latitude, self.title,
+                                            self._address)
+        e = telegram.InlineQueryResultArticle(self._id, "", "")
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_inlinequeryresultvideo.py
+++ b/tests/test_inlinequeryresultvideo.py
@@ -92,6 +92,30 @@ class InlineQueryResultVideoTest(BaseTest, unittest.TestCase):
         self.assertTrue(self.is_dict(video))
         self.assertDictEqual(self.json_dict, video)
 
+    def test_equality(self):
+        a = telegram.InlineQueryResultVideo(self._id, self.video_url, self.mime_type,
+                                            self.thumb_url, self.title)
+        b = telegram.InlineQueryResultVideo(self._id, self.video_url, self.mime_type,
+                                            self.thumb_url, self.title)
+        c = telegram.InlineQueryResultVideo(self._id, "", self.mime_type, self.thumb_url,
+                                            self.title)
+        d = telegram.InlineQueryResultVideo("", self.video_url, self.mime_type, self.thumb_url,
+                                            self.title)
+        e = telegram.InlineQueryResultArticle(self._id, "", "")
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_inlinequeryresultvoice.py
+++ b/tests/test_inlinequeryresultvoice.py
@@ -77,6 +77,26 @@ class InlineQueryResultVoiceTest(BaseTest, unittest.TestCase):
         self.assertTrue(self.is_dict(voice))
         self.assertDictEqual(self.json_dict, voice)
 
+    def test_equality(self):
+        a = telegram.InlineQueryResultVoice(self._id, self.voice_url, self.title)
+        b = telegram.InlineQueryResultVoice(self._id, self.voice_url, self.title)
+        c = telegram.InlineQueryResultVoice(self._id, "", self.title)
+        d = telegram.InlineQueryResultVoice("", self.voice_url, self.title)
+        e = telegram.InlineQueryResultArticle(self._id, "", "")
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -101,6 +101,22 @@ class LocationTest(BaseTest, unittest.TestCase):
         self.assertEqual(message.location.latitude, self.latitude)
         self.assertEqual(message.location.longitude, self.longitude)
 
+    def test_equality(self):
+        a = telegram.Location(self.longitude, self.latitude)
+        b = telegram.Location(self.longitude, self.latitude)
+        c = telegram.Location(self.longitude, 0)
+        d = telegram.Location(0, self.latitude)
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -104,15 +104,11 @@ class LocationTest(BaseTest, unittest.TestCase):
     def test_equality(self):
         a = telegram.Location(self.longitude, self.latitude)
         b = telegram.Location(self.longitude, self.latitude)
-        c = telegram.Location(self.longitude, 0)
         d = telegram.Location(0, self.latitude)
 
         self.assertEqual(a, b)
         self.assertEqual(hash(a), hash(b))
         self.assertIsNot(a, b)
-
-        self.assertEqual(a, c)
-        self.assertEqual(hash(a), hash(c))
 
         self.assertNotEqual(a, d)
         self.assertNotEqual(hash(a), hash(d))

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -99,8 +99,7 @@ class MessageTest(BaseTest, unittest.TestCase):
                               entity_2: 'h'})
 
     def test_text_html(self):
-        test_html_string = 'Test for <b>bold</b>, <i>italic</i>, <code>code</code>, ' \
-                           '<a href="http://github.com/">links</a> and <pre>pre</pre>.'
+        test_html_string = 'Test for <b>bold</b>, <i>italic</i>, <code>code</code>, ' '<a href="http://github.com/">links</a> and <pre>pre</pre>.'
         text_html = self.test_message.text_html
         self.assertEquals(test_html_string, text_html)
 
@@ -155,6 +154,27 @@ class MessageTest(BaseTest, unittest.TestCase):
         with self.assertRaisesRegexp(telegram.TelegramError, "can't be deleted"):
             # NOTE: This behaviour can be changed in future. See `tests/test_bot.py` for more info
             message.reply_to_message.delete()
+
+    def test_equality(self):
+        _id = 1
+        a = telegram.Message(_id, telegram.User(1, ""), None, None)
+        b = telegram.Message(_id, telegram.User(1, ""), None, None)
+        c = telegram.Message(_id, telegram.User(0, ""), None, None)
+        d = telegram.Message(0, telegram.User(1, ""), None, None)
+        e = telegram.Update(_id)
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
 
 
 if __name__ == '__main__':

--- a/tests/test_photo.py
+++ b/tests/test_photo.py
@@ -209,6 +209,26 @@ class PhotoTest(BaseTest, unittest.TestCase):
 
         self.assertNotEqual(message.photo[0].file_id, '')
 
+    def test_equality(self):
+        a = telegram.PhotoSize(self.photo_file_id, self.width, self.height)
+        b = telegram.PhotoSize(self.photo_file_id, self.width, self.height)
+        c = telegram.PhotoSize(self.photo_file_id, 0, 0)
+        d = telegram.PhotoSize("", self.width, self.height)
+        e = telegram.Sticker(self.photo_file_id, self.width, self.height)
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_sticker.py
+++ b/tests/test_sticker.py
@@ -147,6 +147,26 @@ class StickerTest(BaseTest, unittest.TestCase):
 
         self.assertNotEqual(message.sticker.file_id, '')
 
+    def test_equality(self):
+        a = telegram.Sticker(self.sticker_file_id, self.width, self.height)
+        b = telegram.Sticker(self.sticker_file_id, self.width, self.height)
+        c = telegram.Sticker(self.sticker_file_id, 0, 0)
+        d = telegram.Sticker("", self.width, self.height)
+        e = telegram.PhotoSize(self.sticker_file_id, self.width, self.height)
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -91,6 +91,26 @@ class UpdateTest(BaseTest, unittest.TestCase):
         message = update.effective_message
         self.assertEqual(update.message.text, message.text)
 
+    def test_equality(self):
+        a = telegram.Update(self.update_id, message=self.message)
+        b = telegram.Update(self.update_id, message=self.message)
+        c = telegram.Update(self.update_id)
+        d = telegram.Update(0, message=self.message)
+        e = telegram.User(self.update_id, "")
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -111,6 +111,26 @@ class UserTest(BaseTest, unittest.TestCase):
 
         self.assertNotEquals(result, None)
 
+    def test_equality(self):
+        a = telegram.User(self._id, self.first_name, self.last_name)
+        b = telegram.User(self._id, self.first_name, self.last_name)
+        c = telegram.User(self._id, self.first_name)
+        d = telegram.User(0, self.first_name, self.last_name)
+        e = telegram.Update(self._id)
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_venue.py
+++ b/tests/test_venue.py
@@ -74,6 +74,26 @@ class VenueTest(BaseTest, unittest.TestCase):
         self.assertAlmostEqual(message.venue.location.latitude, self.location.latitude, 2)
         self.assertAlmostEqual(message.venue.location.longitude, self.location.longitude, 2)
 
+    def test_equality(self):
+        a = telegram.Venue(telegram.Location(0, 0), "Title", "Address")
+        b = telegram.Venue(telegram.Location(0, 0), "Title", "Address")
+        c = telegram.Venue(telegram.Location(0, 0), "Title", "Not Address")
+        d = telegram.Venue(telegram.Location(0, 1), "Title", "Address")
+        d2 = telegram.Venue(telegram.Location(0, 0), "Not Title", "Address")
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, d2)
+        self.assertNotEqual(hash(a), hash(d2))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -270,6 +270,26 @@ class VideoTest(BaseTest, unittest.TestCase):
 
         self.assertNotEqual(message.video.file_id, None)
 
+    def test_equality(self):
+        a = telegram.Video(self.video_file_id, self.width, self.height, self.duration)
+        b = telegram.Video(self.video_file_id, self.width, self.height, self.duration)
+        c = telegram.Video(self.video_file_id, 0, 0, 0)
+        d = telegram.Video("", self.width, self.height, self.duration)
+        e = telegram.Voice(self.video_file_id, self.duration)
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_voice.py
+++ b/tests/test_voice.py
@@ -240,6 +240,26 @@ class VoiceTest(BaseTest, unittest.TestCase):
 
         self.assertNotEqual(message.voice.file_id, '')
 
+    def test_equality(self):
+        a = telegram.Voice(self.voice_file_id, self.duration)
+        b = telegram.Voice(self.voice_file_id, self.duration)
+        c = telegram.Voice(self.voice_file_id, 0)
+        d = telegram.Voice("", self.duration)
+        e = telegram.Audio(self.voice_file_id, self.duration)
+
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        self.assertIsNot(a, b)
+
+        self.assertEqual(a, c)
+        self.assertEqual(hash(a), hash(c))
+
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(hash(a), hash(d))
+
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(hash(a), hash(e))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #587 by adding `__eq__` and `__hash__` methods to the base `TelegramObject` class to make them work with the `==` operator.
This makes the following classes behave correctly:

- Animation
- Audio
- Bot
- CallbackQuery
- Chat
- ChosenInlineResult
- Contact
- Document
- File
- Game
- InlineQuery
- InlineQueryResult*
- Message
- PhotoSize (already had a `__eq__` implementation, is it still needed?)
- Sticker
- Update
- Video
- Voice

There's still a few classes that still don't work since they don't have an id. Many of them I don't think needs handling of this (like InlineKeyboard, I don't think anyone ever needs to compare that), but the following we should maybe try to find a solution to. For now I just wanted to get the basics working, to get your opinion on weather this is the way we wanna do it.

- ChatMember
- Game
- GameHighScore
- Location
- MessageEntity
- Venue
- WebhookInfo?

We might also wanna have a look at the `ext` classes to see if any of them need `__eq__` too. 
Still lacking tests. Should I test all of them in their respective test_CLASSNAME or should I add a new test_equality.py test?