### PR TITLE
Allow edited as seperate input

### DIFF
--- a/telegram/ext/messagehandler.py
+++ b/telegram/ext/messagehandler.py
@@ -75,6 +75,7 @@ class MessageHandler(Handler):
                 'message_updates, channel_post_updates and edited_updates are all False')
         if allow_edited:
             warnings.warn('allow_edited is getting deprecated, please use edited_updates instead')
+            edited_updates = allow_edited
 
         super(MessageHandler, self).__init__(
             callback,
@@ -83,7 +84,6 @@ class MessageHandler(Handler):
             pass_user_data=pass_user_data,
             pass_chat_data=pass_chat_data)
         self.filters = filters
-        self.allow_edited = allow_edited
         self.message_updates = message_updates
         self.channel_post_updates = channel_post_updates
         self.edited_updates = edited_updates
@@ -97,7 +97,6 @@ class MessageHandler(Handler):
 
     def _is_allowed_update(self, update):
         return any([(self.message_updates and update.message),
-                    (self.allow_edited and update.edited_message),
                     (self.edited_updates and update.edited_message),
                     (self.channel_post_updates and update.channel_post)])
 

--- a/telegram/ext/messagehandler.py
+++ b/telegram/ext/messagehandler.py
@@ -37,8 +37,6 @@ class MessageHandler(Handler):
         callback (function): A function that takes ``bot, update`` as
             positional arguments. It will be called when the ``check_update``
             has determined that an update should be processed by this handler.
-        allow_edited (Optional[bool]): If the handler should also accept edited messages.
-            Default is ``False``
         pass_update_queue (optional[bool]): If the handler should be passed the
             update queue as a keyword argument called ``update_queue``. It can
             be used to insert updates. Default is ``False``
@@ -52,8 +50,12 @@ class MessageHandler(Handler):
             For each update in the same chat, it will be the same ``dict``. Default is ``False``.
         message_updates (Optional[bool]): Should "normal" message updates be handled? Default is
             ``True``.
+        allow_edited (Optional[bool]): If the handler should also accept edited messages.
+            Default is ``False`` - Depricated. use edited updates instead.
         channel_post_updates (Optional[bool]): Should channel posts updates be handled? Default is
             ``True``.
+        edited_updates (Optional[bool]): Should "edited" message updates be handled? Default is
+            ``False``.
 
     """
 
@@ -66,9 +68,14 @@ class MessageHandler(Handler):
                  pass_user_data=False,
                  pass_chat_data=False,
                  message_updates=True,
-                 channel_post_updates=True):
-        if not message_updates and not channel_post_updates:
-            raise ValueError('Both message_updates & channel_post_updates are False')
+                 channel_post_updates=True,
+                 edited_updates=False):
+        if not message_updates and not channel_post_updates and not edited_updates:
+            raise ValueError(
+                'message_updates, channel_post_updates and edited_updates are all False')
+        if allow_edited:
+            warnings.warn('allow_edited is getting deprecated, please use edited_updates instead',
+                          DeprecationWarning)
 
         super(MessageHandler, self).__init__(
             callback,
@@ -80,6 +87,7 @@ class MessageHandler(Handler):
         self.allow_edited = allow_edited
         self.message_updates = message_updates
         self.channel_post_updates = channel_post_updates
+        self.edited_updates = edited_updates
 
         # We put this up here instead of with the rest of checking code
         # in check_update since we don't wanna spam a ton
@@ -88,17 +96,14 @@ class MessageHandler(Handler):
                           'deprecated, please use bitwise operators (& and |) '
                           'instead. More info: https://git.io/vPTbc.')
 
-    def _is_allowed_message(self, update):
-        return (self.message_updates
-                and (update.message or (update.edited_message and self.allow_edited)))
-
-    def _is_allowed_channel_post(self, update):
-        return (self.channel_post_updates
-                and (update.channel_post or (update.edited_channel_post and self.allow_edited)))
+    def _is_allowed_update(self, update):
+        return any([
+            self.message_updates, update.message, (update.edited_message and self.allow_edited),
+            self.edited_updates
+        ])
 
     def check_update(self, update):
-        if (isinstance(update, Update)
-                and (self._is_allowed_message(update) or self._is_allowed_channel_post(update))):
+        if isinstance(update, Update) and self._is_allowed_update(update):
 
             if not self.filters:
                 res = True

--- a/telegram/ext/messagehandler.py
+++ b/telegram/ext/messagehandler.py
@@ -74,8 +74,7 @@ class MessageHandler(Handler):
             raise ValueError(
                 'message_updates, channel_post_updates and edited_updates are all False')
         if allow_edited:
-            warnings.warn('allow_edited is getting deprecated, please use edited_updates instead',
-                          DeprecationWarning)
+            warnings.warn('allow_edited is getting deprecated, please use edited_updates instead')
 
         super(MessageHandler, self).__init__(
             callback,

--- a/telegram/ext/messagehandler.py
+++ b/telegram/ext/messagehandler.py
@@ -51,7 +51,7 @@ class MessageHandler(Handler):
         message_updates (Optional[bool]): Should "normal" message updates be handled? Default is
             ``True``.
         allow_edited (Optional[bool]): If the handler should also accept edited messages.
-            Default is ``False`` - Depricated. use edited updates instead.
+            Default is ``False`` - Deprecated. use edited updates instead.
         channel_post_updates (Optional[bool]): Should channel posts updates be handled? Default is
             ``True``.
         edited_updates (Optional[bool]): Should "edited" message updates be handled? Default is
@@ -97,10 +97,10 @@ class MessageHandler(Handler):
                           'instead. More info: https://git.io/vPTbc.')
 
     def _is_allowed_update(self, update):
-        return any([
-            self.message_updates, update.message, (update.edited_message and self.allow_edited),
-            self.edited_updates
-        ])
+        return any([(self.message_updates and update.message),
+                    (self.allow_edited and update.edited_message),
+                    (self.edited_updates and update.edited_message),
+                    (self.channel_post_updates and update.channel_post)])
 
     def check_update(self, update):
         if isinstance(update, Update) and self._is_allowed_update(update):

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -108,7 +108,7 @@ class UpdaterTest(BaseTest, unittest.TestCase):
         self.message_count += 1
 
     def telegramHandlerEditedTest(self, bot, update):
-        self.received_message = update.edited_message.text
+        self.received_message = update.effective_message.text
         self.message_count += 1
 
     def telegramInlineHandlerTest(self, bot, update):
@@ -188,21 +188,32 @@ class UpdaterTest(BaseTest, unittest.TestCase):
         self._setup_updater('Test', edited=True)
         d = self.updater.dispatcher
         from telegram.ext import Filters
-        handler = MessageHandler(Filters.text, self.telegramHandlerEditedTest, allow_edited=True)
+        handler = MessageHandler(Filters.text, self.telegramHandlerEditedTest, edited_updates=True)
         d.add_handler(handler)
         self.updater.start_polling(0.01)
         sleep(.1)
         self.assertEqual(self.received_message, 'Test')
 
-        # Remove handler
-        d.remove_handler(handler)
-        handler = MessageHandler(Filters.text, self.telegramHandlerEditedTest, allow_edited=False)
-        d.add_handler(handler)
         self.reset()
-
+        d.remove_handler(handler)
+        handler = MessageHandler(
+            Filters.text,
+            self.telegramHandlerEditedTest,
+            edited_updates=False,
+            message_updates=False)
+        d.add_handler(handler)
         self.updater.bot.send_messages = 1
         sleep(.1)
         self.assertTrue(None is self.received_message)
+
+        with self.assertWarns(DeprecationWarning):
+            handler = MessageHandler(
+                Filters.text, self.telegramHandlerEditedTest, allow_edited=True)
+        d.add_handler(handler)
+        self.reset()
+        self.updater.bot.send_messages = 1
+        sleep(.1)
+        self.assertEqual(self.received_message, 'Test')
 
     def test_addTelegramMessageHandlerMultipleMessages(self):
         self._setup_updater('Multiple', 100)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -206,9 +206,7 @@ class UpdaterTest(BaseTest, unittest.TestCase):
         sleep(.1)
         self.assertTrue(None is self.received_message)
 
-        with self.assertWarns(DeprecationWarning):
-            handler = MessageHandler(
-                Filters.text, self.telegramHandlerEditedTest, allow_edited=True)
+        handler = MessageHandler(Filters.text, self.telegramHandlerEditedTest, allow_edited=True)
         d.add_handler(handler)
         self.reset()
         self.updater.bot.send_messages = 1


### PR DESCRIPTION
In short made it possible to tune messagehandler more to your wishes. and choose exactly what updates to receive. messages, edited_message or channel_post or a combination.

- Added the edited_updates argument to MessageHandler
- Added DeprecationWarning when using allow_edited
- replaced _is_allowed_message and _is_allowed_channel_post with _is_allowed_update
- Modified tests to reflect new way

fixes #607 