### PR TITLE
Improved CommandHandler

### DIFF
--- a/telegram/ext/commandhandler.py
+++ b/telegram/ext/commandhandler.py
@@ -30,7 +30,7 @@ class CommandHandler(Handler):
     name and/or some additional text.
 
     Args:
-        commands (str|list): The name of the command or list of commands this handler should
+        command (str|list): The name of the command or list of command this handler should
             listen for.
         callback (function): A function that takes ``bot, update`` as
             positional arguments. It will be called when the ``check_update``
@@ -65,7 +65,7 @@ class CommandHandler(Handler):
     """
 
     def __init__(self,
-                 commands,
+                 command,
                  callback,
                  filters=None,
                  allow_edited=False,
@@ -80,10 +80,10 @@ class CommandHandler(Handler):
             pass_job_queue=pass_job_queue,
             pass_user_data=pass_user_data,
             pass_chat_data=pass_chat_data)
-        if isinstance(commands, str):
-            self.commands = [commands]
+        if isinstance(command, str):
+            self.command = [command]
         else:
-            self.commands = commands
+            self.command = command
         self.filters = filters
         self.allow_edited = allow_edited
         self.pass_args = pass_args
@@ -112,7 +112,7 @@ class CommandHandler(Handler):
                 else:
                     res = self.filters(message)
 
-                return res and (message.text.startswith('/') and command[0] in self.commands
+                return res and (message.text.startswith('/') and command[0] in self.command
                                 and command[1].lower() == message.bot.username.lower())
             else:
                 return False

--- a/telegram/ext/commandhandler.py
+++ b/telegram/ext/commandhandler.py
@@ -30,7 +30,8 @@ class CommandHandler(Handler):
     name and/or some additional text.
 
     Args:
-        command (str): The name of the command this handler should listen for.
+        commands (str|list): The name of the command or list of commands this handler should
+            listen for.
         callback (function): A function that takes ``bot, update`` as
             positional arguments. It will be called when the ``check_update``
             has determined that an update should be processed by this handler.
@@ -64,7 +65,7 @@ class CommandHandler(Handler):
     """
 
     def __init__(self,
-                 command,
+                 commands,
                  callback,
                  filters=None,
                  allow_edited=False,
@@ -79,7 +80,10 @@ class CommandHandler(Handler):
             pass_job_queue=pass_job_queue,
             pass_user_data=pass_user_data,
             pass_chat_data=pass_chat_data)
-        self.command = command
+        if isinstance(commands, str):
+            self.commands = [commands]
+        else:
+            self.commands = commands
         self.filters = filters
         self.allow_edited = allow_edited
         self.pass_args = pass_args
@@ -108,7 +112,7 @@ class CommandHandler(Handler):
                 else:
                     res = self.filters(message)
 
-                return res and (message.text.startswith('/') and command[0] == self.command
+                return res and (message.text.startswith('/') and command[0] in self.commands
                                 and command[1].lower() == message.bot.username.lower())
             else:
                 return False

--- a/telegram/ext/commandhandler.py
+++ b/telegram/ext/commandhandler.py
@@ -80,7 +80,12 @@ class CommandHandler(Handler):
             pass_job_queue=pass_job_queue,
             pass_user_data=pass_user_data,
             pass_chat_data=pass_chat_data)
-        if isinstance(command, str):
+        try:
+            _str = basestring  # Python 2
+        except NameError:
+            _str = str  # Python 3
+
+        if isinstance(command, _str):
             self.command = [command]
         else:
             self.command = command

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -300,6 +300,29 @@ class UpdaterTest(BaseTest, unittest.TestCase):
         sleep(.1)
         self.assertTrue(None is self.received_message)
 
+    def test_CommandHandler_commandList(self):
+        self._setup_updater('', messages=0)
+        handler = CommandHandler(['foo', 'bar', 'spameggs'], self.telegramHandlerTest)
+        self.updater.dispatcher.add_handler(handler)
+        bot = self.updater.bot
+        user = User(0, 'TestUser')
+        queue = self.updater.start_polling(0.01)
+
+        message = Message(0, user, 0, None, text='/foo', bot=bot)
+        queue.put(Update(0, message=message))
+        sleep(.1)
+        self.assertEqual(self.received_message, '/foo')
+
+        message.text = '/bar'
+        queue.put(Update(1, message=message))
+        sleep(.1)
+        self.assertEqual(self.received_message, '/bar')
+
+        message.text = '/spameggs'
+        queue.put(Update(2, message=message))
+        sleep(.1)
+        self.assertEqual(self.received_message, '/spameggs')
+
     def test_addRemoveStringRegexHandler(self):
         self._setup_updater('', messages=0)
         d = self.updater.dispatcher

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -323,6 +323,12 @@ class UpdaterTest(BaseTest, unittest.TestCase):
         sleep(.1)
         self.assertEqual(self.received_message, '/spameggs')
 
+        self.reset()
+        message.text = '/not_in_list'
+        queue.put(Update(3, message=message))
+        sleep(.1)
+        self.assertTrue(self.received_message is None)
+
     def test_addRemoveStringRegexHandler(self):
         self._setup_updater('', messages=0)
         d = self.updater.dispatcher


### PR DESCRIPTION
Now you can pass list of commands instead of one command
It will be useful when you define some aliases for command or if commands (such as `/start` and `/help`) has the same behaviour