### PR TITLE
fix tests for pycharm windows

### DIFF
--- a/tests/test_precheckoutquery.py
+++ b/tests/test_precheckoutquery.py
@@ -32,7 +32,7 @@ class PreCheckoutQueryTest(BaseTest, unittest.TestCase):
     """This object represents Tests for Telegram PreCheckoutQuery."""
 
     def setUp(self):
-        self.id = 5
+        self._id = 5
         self.invoice_payload = 'invoice_payload'
         self.shipping_option_id = 'shipping_option_id'
         self.currency = 'EUR'
@@ -41,7 +41,7 @@ class PreCheckoutQueryTest(BaseTest, unittest.TestCase):
         self.order_info = telegram.OrderInfo()
 
         self.json_dict = {
-            'id': self.id,
+            'id': self._id,
             'invoice_payload': self.invoice_payload,
             'shipping_option_id': self.shipping_option_id,
             'currency': self.currency,
@@ -53,7 +53,7 @@ class PreCheckoutQueryTest(BaseTest, unittest.TestCase):
     def test_precheckoutquery_de_json(self):
         precheckoutquery = telegram.PreCheckoutQuery.de_json(self.json_dict, self._bot)
 
-        self.assertEqual(precheckoutquery.id, self.id)
+        self.assertEqual(precheckoutquery.id, self._id)
         self.assertEqual(precheckoutquery.invoice_payload, self.invoice_payload)
         self.assertEqual(precheckoutquery.shipping_option_id, self.shipping_option_id)
         self.assertEqual(precheckoutquery.currency, self.currency)
@@ -72,14 +72,14 @@ class PreCheckoutQueryTest(BaseTest, unittest.TestCase):
         self.assertDictEqual(self.json_dict, precheckoutquery)
 
     def test_equality(self):
-        a = telegram.PreCheckoutQuery(self.id, self.from_user, self.currency, self.total_amount,
+        a = telegram.PreCheckoutQuery(self._id, self.from_user, self.currency, self.total_amount,
                                       self.invoice_payload)
-        b = telegram.PreCheckoutQuery(self.id, self.from_user, self.currency, self.total_amount,
+        b = telegram.PreCheckoutQuery(self._id, self.from_user, self.currency, self.total_amount,
                                       self.invoice_payload)
-        c = telegram.PreCheckoutQuery(self.id, None, '', 0, '')
+        c = telegram.PreCheckoutQuery(self._id, None, '', 0, '')
         d = telegram.PreCheckoutQuery(0, self.from_user, self.currency, self.total_amount,
                                       self.invoice_payload)
-        e = telegram.Update(self.id)
+        e = telegram.Update(self._id)
 
         self.assertEqual(a, b)
         self.assertEqual(hash(a), hash(b))

--- a/tests/test_shippingoption.py
+++ b/tests/test_shippingoption.py
@@ -32,7 +32,7 @@ class ShippingOptionTest(BaseTest, unittest.TestCase):
     """This object represents Tests for Telegram ShippingOption."""
 
     def setUp(self):
-        self.id = 'id'
+        self._id = 'id'
         self.title = 'title'
         self.prices = [
             telegram.LabeledPrice('Fish Container', 100),
@@ -40,7 +40,7 @@ class ShippingOptionTest(BaseTest, unittest.TestCase):
         ]
 
         self.json_dict = {
-            'id': self.id,
+            'id': self._id,
             'title': self.title,
             'prices': [x.to_dict() for x in self.prices]
         }
@@ -48,7 +48,7 @@ class ShippingOptionTest(BaseTest, unittest.TestCase):
     def test_shippingoption_de_json(self):
         shippingoption = telegram.ShippingOption.de_json(self.json_dict, self._bot)
 
-        self.assertEqual(shippingoption.id, self.id)
+        self.assertEqual(shippingoption.id, self._id)
         self.assertEqual(shippingoption.title, self.title)
         self.assertEqual(shippingoption.prices, self.prices)
 
@@ -64,11 +64,11 @@ class ShippingOptionTest(BaseTest, unittest.TestCase):
         self.assertDictEqual(self.json_dict, shippingoption)
 
     def test_equality(self):
-        a = telegram.ShippingOption(self.id, self.title, self.prices)
-        b = telegram.ShippingOption(self.id, self.title, self.prices)
-        c = telegram.ShippingOption(self.id, '', [])
+        a = telegram.ShippingOption(self._id, self.title, self.prices)
+        b = telegram.ShippingOption(self._id, self.title, self.prices)
+        c = telegram.ShippingOption(self._id, '', [])
         d = telegram.ShippingOption(0, self.title, self.prices)
-        e = telegram.Voice(self.id, 0)
+        e = telegram.Voice(self._id, 0)
 
         self.assertEqual(a, b)
         self.assertEqual(hash(a), hash(b))

--- a/tests/test_shippingquery.py
+++ b/tests/test_shippingquery.py
@@ -32,14 +32,14 @@ class ShippingQueryTest(BaseTest, unittest.TestCase):
     """This object represents Tests for Telegram ShippingQuery."""
 
     def setUp(self):
-        self.id = 5
+        self._id = 5
         self.invoice_payload = 'invoice_payload'
         self.from_user = telegram.User(0, '')
         self.shipping_address = telegram.ShippingAddress('GB', '', 'London', '12 Grimmauld Place',
                                                          '', 'WC1')
 
         self.json_dict = {
-            'id': self.id,
+            'id': self._id,
             'invoice_payload': self.invoice_payload,
             'from': self.from_user.to_dict(),
             'shipping_address': self.shipping_address.to_dict()
@@ -48,7 +48,7 @@ class ShippingQueryTest(BaseTest, unittest.TestCase):
     def test_shippingquery_de_json(self):
         shippingquery = telegram.ShippingQuery.de_json(self.json_dict, self._bot)
 
-        self.assertEqual(shippingquery.id, self.id)
+        self.assertEqual(shippingquery.id, self._id)
         self.assertEqual(shippingquery.invoice_payload, self.invoice_payload)
         self.assertEqual(shippingquery.from_user, self.from_user)
         self.assertEqual(shippingquery.shipping_address, self.shipping_address)
@@ -65,13 +65,13 @@ class ShippingQueryTest(BaseTest, unittest.TestCase):
         self.assertDictEqual(self.json_dict, shippingquery)
 
     def test_equality(self):
-        a = telegram.ShippingQuery(self.id, self.from_user, self.invoice_payload,
+        a = telegram.ShippingQuery(self._id, self.from_user, self.invoice_payload,
                                    self.shipping_address)
-        b = telegram.ShippingQuery(self.id, self.from_user, self.invoice_payload,
+        b = telegram.ShippingQuery(self._id, self.from_user, self.invoice_payload,
                                    self.shipping_address)
-        c = telegram.ShippingQuery(self.id, None, '', None)
+        c = telegram.ShippingQuery(self._id, None, '', None)
         d = telegram.ShippingQuery(0, self.from_user, self.invoice_payload, self.shipping_address)
-        e = telegram.Update(self.id)
+        e = telegram.Update(self._id)
 
         self.assertEqual(a, b)
         self.assertEqual(hash(a), hash(b))


### PR DESCRIPTION
Refractored self.id in new tests to self._id (as I did before) so testrunner in pycharm can run under Windows.