### PR TITLE
Change hard-coded 20. to timeout parameter

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,6 +15,7 @@ Contributors
 
 The following wonderful people contributed directly or indirectly to this project:
 
+- `Alateas <https://github.com/alateas>`_
 - `Avanatiker <https://github.com/Avanatiker>`_
 - `Anton Tagunov <https://github.com/anton-tagunov>`_
 - `Balduro <https://github.com/Balduro>`_

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -443,7 +443,7 @@ class Bot(TelegramObject):
             disable_notification=disable_notification,
             reply_to_message_id=reply_to_message_id,
             reply_markup=reply_markup,
-            timeout=20.,
+            timeout=timeout,
             **kwargs)
 
     @log


### PR DESCRIPTION
Passing timeout parameter to _message_wrapper in send_audio instead of hard-coded 20 seconds