### PR TITLE
Fix Message.text_*

### DIFF
--- a/telegram/message.py
+++ b/telegram/message.py
@@ -673,6 +673,8 @@ class Message(TelegramObject):
 
             if entity.type == MessageEntity.TEXT_LINK:
                 insert = '<a href="{}">{}</a>'.format(entity.url, text)
+            elif entity.type == MessageEntity.URL:
+                insert = '<a href="{0}">{0}</a>'.format(text)
             elif entity.type == MessageEntity.BOLD:
                 insert = '<b>' + text + '</b>'
             elif entity.type == MessageEntity.ITALIC:
@@ -723,6 +725,8 @@ class Message(TelegramObject):
 
             if entity.type == MessageEntity.TEXT_LINK:
                 insert = '[{}]({})'.format(text, entity.url)
+            elif entity.type == MessageEntity.URL:
+                insert = '[{0}]({0})'.format(text)
             elif entity.type == MessageEntity.BOLD:
                 insert = '*' + text + '*'
             elif entity.type == MessageEntity.ITALIC:


### PR DESCRIPTION
Didn't work with URL type MessageEntities
(when you type a url in a tg client and tg converts it to a link for you)