### PR TITLE
Fix #695 by checking if a user exists

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -32,6 +32,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Jacob Bom <https://github.com/bomjacob>`_
 - `JASON0916 <https://github.com/JASON0916>`_
 - `jeffffc <https://github.com/jeffffc>`_
+- `Jelle Besseling <https://github.com/pingiun>`_
 - `jh0ker <https://github.com/jh0ker>`_
 - `John Yong <https://github.com/whipermr5>`_
 - `jossalgon <https://github.com/jossalgon>`_

--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -160,7 +160,7 @@ class ConversationHandler(Handler):
         if self.per_chat:
             key.append(chat.id)
 
-        if self.per_user:
+        if self.per_user and user is not None:
             key.append(user.id)
 
         if self.per_message:

--- a/tests/test_conversationhandler.py
+++ b/tests/test_conversationhandler.py
@@ -330,6 +330,12 @@ class ConversationHandlerTest(BaseTest, unittest.TestCase):
         update = Update(0, callback_query=cbq)
         handler.check_update(update)
 
+    def test_channelMessageWithoutChat(self):
+        handler = ConversationHandler(entry_points=[CommandHandler('start', self.start_end)], states={}, fallbacks=[])
+        message = Message(0, None, None, Chat(0, Chat.CHANNEL, "Misses Test"))
+        update = Update(0, message=message)
+        handler.check_update(update)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Check if a user exists for the update because it can't be used
otherwise in a conversationhandler.

Added a test to detect #695 

Fixes #695 

This PR doesn't fix #637 even though it was requested in 695 because making from_user optional would make it a keyword argument, which would break compatibility.