### PR TITLE
MessageQueue: fixed args dispatching in decorator

### DIFF
--- a/telegram/ext/messagequeue.py
+++ b/telegram/ext/messagequeue.py
@@ -323,7 +323,7 @@ def queuedmessage(method):
         queued = kwargs.pop('queued', self._is_messages_queued_default)
         isgroup = kwargs.pop('isgroup', False)
         if queued:
-            prom = promise.Promise(method, args, kwargs)
+            prom = promise.Promise(method, (self, ) + args, kwargs)
             return self._msg_queue(prom, isgroup)
         return method(self, *args, **kwargs)
 


### PR DESCRIPTION
The devil is in detail, it didn't work because I forgot to add self to args tuple during dispatching.

Finally it's alive and breathing. See the screenshot (reply time of messages). I also add a simple example, which demonstrates MessageQueue usage.

Again, for now its only 90% of work done and MQ is already usable. But the next step is its proper native incorporation into Bot class without all these dirty decorator tricks.
Also seems that we need to dedicate at least one wiki page on how MQ works and how to use it.

The next week I plan to dedicate myself working on it.
![times](https://user-images.githubusercontent.com/16870636/27772845-fe77da80-5f72-11e7-8694-c32d457a5796.png)

[test_example.py](https://github.com/python-telegram-bot/python-telegram-bot/files/1118019/test_example.py.txt)

