### PR TITLE
docs: set minimum Sphinx version to version running at read the docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ sys.path.insert(0, os.path.abspath('../..'))
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '1.5.4'  # fixes issues with autodoc-skip-member and napoleon
+needs_sphinx = '1.5.3'  # fixes issues with autodoc-skip-member and napoleon
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom


### PR DESCRIPTION
As mentioned in #684, the doc builds are [failing](https://readthedocs.org/projects/python-telegram-bot/builds/5592612/) because of the version requirement.