### PR TITLE
fix to_dict() for Game

### DIFF
--- a/telegram/games/game.py
+++ b/telegram/games/game.py
@@ -88,7 +88,8 @@ class Game(TelegramObject):
         data = super(Game, self).to_dict()
 
         data['photo'] = [p.to_dict() for p in self.photo]
-        data['text_entities'] = [x.to_dict() for x in self.text_entities]
+        if self.text_entities:
+            data['text_entities'] = [x.to_dict() for x in self.text_entities]
 
         return data
 


### PR DESCRIPTION
`Game.to_dict()` fails if the `optional` parameter `test_entities` has it's default value `None`
This fixes that.