### PR TITLE
broadcast telegram errors from run_async functions

### DIFF
--- a/telegram/ext/dispatcher.py
+++ b/telegram/ext/dispatcher.py
@@ -188,6 +188,9 @@ class Dispatcher(object):
                 self.logger.warning('DispatcherHandlerFlow is not supported with async '
                                     'functions; func: %s', promise.pooled_function.__name__)
 
+            elif isinstance(promise.exception, TelegramError):
+                self.update_queue.put(promise.exception)
+
     def run_async(self, func, *args, **kwargs):
         """
         Queue a function (with given args/kwargs) to be run asynchronously.


### PR DESCRIPTION
fixes #682 
Not sure if this is really the way to do it, IIRC there were some discussions about this in the dev group. Perhaps @Eldinnie can recall more details?