### PR TITLE
Remove DispatcherHandlerContinue + more unitests for dispatcher

### DIFF
--- a/telegram/ext/__init__.py
+++ b/telegram/ext/__init__.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """Extensions over the Telegram Bot API to facilitate bot making"""
 
-from .dispatcher import Dispatcher, DispatcherHandlerContinue, DispatcherHandlerStop, run_async
+from .dispatcher import Dispatcher, DispatcherHandlerStop, run_async
 from .jobqueue import JobQueue, Job
 from .updater import Updater
 from .callbackqueryhandler import CallbackQueryHandler
@@ -43,4 +43,4 @@ __all__ = ('Dispatcher', 'JobQueue', 'Job', 'Updater', 'CallbackQueryHandler',
            'MessageHandler', 'BaseFilter', 'Filters', 'RegexHandler', 'StringCommandHandler',
            'StringRegexHandler', 'TypeHandler', 'ConversationHandler',
            'PreCheckoutQueryHandler', 'ShippingQueryHandler', 'MessageQueue', 'DelayQueue',
-           'DispatcherHandlerContinue', 'DispatcherHandlerStop', 'run_async')
+           'DispatcherHandlerStop', 'run_async')

--- a/telegram/ext/dispatcher.py
+++ b/telegram/ext/dispatcher.py
@@ -301,7 +301,7 @@ class Dispatcher(object):
         A handler must be an instance of a subclass of :class:`telegram.ext.Handler`. All handlers
         are organized in groups with a numeric value. The default group is 0. All groups will be
         evaluated for handling an update, but only 0 or 1 handler per group will be used. If
-        :class:`telegram.DispatcherHandlerStop` is raised from one of the handler, no further
+        :class:`telegram.DispatcherHandlerStop` is raised from one of the handlers, no further
         handlers (regardless of the group) will be called.
 
         The priority/order of handlers is determined as follows:

--- a/telegram/ext/dispatcher.py
+++ b/telegram/ext/dispatcher.py
@@ -55,25 +55,8 @@ def run_async(func):
     return async_func
 
 
-class DispatcherHandlerFlow(Exception):
-    """
-    Dispatcher update processing manipulation exceptions are base on this class.
-    """
-    pass
-
-
-class DispatcherHandlerContinue(DispatcherHandlerFlow):
-    """
-    If check Handler's check_updated returned true, but execution of handler raised this,
-    then handlers checking will continue.
-    """
-    pass
-
-
-class DispatcherHandlerStop(DispatcherHandlerFlow):
-    """
-    Raise this in handler to prevent execution any other handlers (even in different group).
-    """
+class DispatcherHandlerStop(Exception):
+    """Raise this in handler to prevent execution any other handler (even in different group)."""
     pass
 
 
@@ -178,9 +161,10 @@ class Dispatcher(object):
                 break
 
             promise.run()
-            if isinstance(promise.exception, DispatcherHandlerFlow):
-                self.logger.warning('DispatcherHandlerFlow is not supported with async '
-                                    'functions; func: %s', promise.pooled_function.__name__)
+            if isinstance(promise.exception, DispatcherHandlerStop):
+                self.logger.warning(
+                    'DispatcherHandlerStop is not supported with async functions; func: %s',
+                    promise.pooled_function.__name__)
 
     def run_async(self, func, *args, **kwargs):
         """
@@ -284,63 +268,54 @@ class Dispatcher(object):
             return
         for group in self.groups:
             try:
-                for handler in self.handlers[group]:
-                    try:
-                        if handler.check_update(update):
-                            try:
-                                handler.handle_update(update, self)
-                            except DispatcherHandlerContinue:
-                                continue
-                            break
-                    except DispatcherHandlerFlow:
-                        raise
-                    except TelegramError as te:
-                        self.logger.warning('A TelegramError was raised while processing the '
-                                            'Update.')
+                for handler in (x for x in self.handlers[group] if x.check_update(update)):
+                    handler.handle_update(update, self)
+                    break
 
-                        try:
-                            self.dispatch_error(update, te)
-                        except Exception:
-                            self.logger.exception('An uncaught error was raised while '
-                                                  'handling the error')
-                        finally:
-                            break
-
-                    # Errors should not stop the thread
-                    except Exception:
-                        self.logger.exception('An uncaught error was raised while '
-                                              'processing the update')
-                        break
+            # Stop processing with any other handler.
             except DispatcherHandlerStop:
+                self.logger.debug('Stopping further handlers due to DispatcherHandlerStop')
                 break
 
-    def add_handler(self, handler, group=DEFAULT_GROUP):
-        """
-        Register a handler.
+            # Dispatch any error.
+            except TelegramError as te:
+                self.logger.warning('A TelegramError was raised while processing the Update')
 
-        TL;DR: Order and priority counts. 0 or 1 handlers per group will be
-        used.
+                try:
+                    self.dispatch_error(update, te)
+                except DispatcherHandlerStop:
+                    self.logger.debug('Error handler stopped further handlers')
+                    break
+                except Exception:
+                    self.logger.exception('An uncaught error was raised while handling the error')
+
+            # Errors should not stop the thread.
+            except Exception:
+                self.logger.exception('An uncaught error was raised while processing the update')
+
+    def add_handler(self, handler, group=DEFAULT_GROUP):
+        """Register a handler.
+
+        TL;DR: Order and priority counts. 0 or 1 handlers per group will be used.
 
         A handler must be an instance of a subclass of :class:`telegram.ext.Handler`. All handlers
         are organized in groups with a numeric value. The default group is 0. All groups will be
-        evaluated for handling an update, but only 0 or 1 handler per group will be used,
-        except situations when :class:`telegram.DispatcherHandlerContinue` or
-        :class:`telegram.DispatcherHandlerStop` were raised.
+        evaluated for handling an update, but only 0 or 1 handler per group will be used. If
+        :class:`telegram.DispatcherHandlerStop` is raised from one of the handler, no further
+        handlers (regardless of the group) will be called.
 
         The priority/order of handlers is determined as follows:
 
           * Priority of the group (lower group number == higher priority)
-          * The first handler in a group which should handle an update will be
-            used. Other handlers from the group will not be used. The order in
-            which handlers were added to the group defines the priority.
-          * If :class:`telegram.DispatcherHandlerContinue` was raised, then next handler in the
-            same group will be called.
-          * If :class:`telegram.DispatcherHandlerStop` was raised, then zero handlers (even
-            from other groups) will called.
+          * The first handler in a group which should handle an update (see
+            :method:`telegram.ext.Handler.check_update`) will be used. Other handlers from the
+            group will not be used. The order in which handlers were added to the group defines the
+            priority.
 
         Args:
             handler (:class:`telegram.ext.Handler`): A Handler instance.
             group (:obj:`int`, optional): The group identifier. Default is 0.
+
         """
 
         if not isinstance(handler, Handler):


### PR DESCRIPTION
The idea was nice, but it really complicated things for us and for the
user.
If a user wants to run more than one handler on an update, he can put
the handlers in different groups or he can have a single handler.
If a user wants to have multiple handlers in the same group which only
one of them should run on the update, he should use check_update().

Since we haven't released this code yet, there's no problem with
backward compatability.