### PR TITLE
Bot API 3.3

### DIFF
--- a/telegram/chat.py
+++ b/telegram/chat.py
@@ -19,7 +19,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represents a Telegram Chat."""
 
-from telegram import TelegramObject, ChatPhoto
+from telegram import TelegramObject, ChatPhoto, Message
 
 
 class Chat(TelegramObject):
@@ -37,6 +37,8 @@ class Chat(TelegramObject):
         photo (:class:`telegram.ChatPhoto`): Optional. Chat photo.
         description (:obj:`str`): Optional. Description, for supergroups and channel chats.
         invite_link (:obj:`str`): Optional. Chat invite link, for supergroups and channel chats.
+        pinned_message (:class:`telegram.Message`): Optional. Pinned message, for supergroups.
+            Returned only in getChat.
 
     Args:
         id (:obj:`int`): Unique identifier for this chat. This number may be greater than 32 bits
@@ -57,6 +59,8 @@ class Chat(TelegramObject):
             Returned only in get_chat.
         invite_link (:obj:`str`, optional): Chat invite link, for supergroups and channel chats.
             Returned only in get_chat.
+        pinned_message (:class:`telegram.Message`, optional): Pinned message, for supergroups.
+            Returned only in getChat.
         bot (:class:`telegram.Bot`, optional): The Bot to use for instance methods.
         **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
@@ -83,6 +87,7 @@ class Chat(TelegramObject):
                  photo=None,
                  description=None,
                  invite_link=None,
+                 pinned_message=None,
                  **kwargs):
         # Required
         self.id = int(id)
@@ -96,6 +101,7 @@ class Chat(TelegramObject):
         self.photo = photo
         self.description = description
         self.invite_link = invite_link
+        self.pinned_message = pinned_message
 
         self.bot = bot
         self._id_attrs = (self.id,)
@@ -106,6 +112,7 @@ class Chat(TelegramObject):
             return None
 
         data['photo'] = ChatPhoto.de_json(data.get('photo'), bot)
+        data['pinned_message'] = Message.de_json(data.get('pinned_message'), bot)
 
         return cls(bot=bot, **data)
 

--- a/telegram/chat.py
+++ b/telegram/chat.py
@@ -19,7 +19,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represents a Telegram Chat."""
 
-from telegram import TelegramObject, ChatPhoto, Message
+from telegram import TelegramObject, ChatPhoto
 
 
 class Chat(TelegramObject):
@@ -38,7 +38,7 @@ class Chat(TelegramObject):
         description (:obj:`str`): Optional. Description, for supergroups and channel chats.
         invite_link (:obj:`str`): Optional. Chat invite link, for supergroups and channel chats.
         pinned_message (:class:`telegram.Message`): Optional. Pinned message, for supergroups.
-            Returned only in getChat.
+            Returned only in get_chat.
 
     Args:
         id (:obj:`int`): Unique identifier for this chat. This number may be greater than 32 bits
@@ -60,7 +60,7 @@ class Chat(TelegramObject):
         invite_link (:obj:`str`, optional): Chat invite link, for supergroups and channel chats.
             Returned only in get_chat.
         pinned_message (:class:`telegram.Message`, optional): Pinned message, for supergroups.
-            Returned only in getChat.
+            Returned only in get_chat.
         bot (:class:`telegram.Bot`, optional): The Bot to use for instance methods.
         **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
@@ -112,6 +112,7 @@ class Chat(TelegramObject):
             return None
 
         data['photo'] = ChatPhoto.de_json(data.get('photo'), bot)
+        from telegram import Message
         data['pinned_message'] = Message.de_json(data.get('pinned_message'), bot)
 
         return cls(bot=bot, **data)

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -86,6 +86,10 @@ class Message(TelegramObject):
         invoice (:class:`telegram.Invoice`): Optional. Information about the invoice.
         successful_payment (:class:`telegram.SuccessfulPayment`): Optional. Information about the
             payment.
+        forward_signature (:obj:`str`): Optional. Signature of the post author for messages
+            forwarded from channels.
+        author_signature (:obj:`str`): Optional. Signature of the post author for messages
+            in channels.
         bot (:class:`telegram.Bot`): Optional. The Bot to use for instance methods.
 
     Deprecated: 6.0
@@ -172,6 +176,10 @@ class Message(TelegramObject):
             information about the invoice.
         successful_payment (:class:`telegram.SuccessfulPayment`, optional): Message is a service
             message about a successful payment, information about the payment.
+        forward_signature (:obj:`str`, optional): Signature of the post author for messages
+            forwarded from channels.
+        author_signature (:obj:`str`, optional): Signature of the post author for messages
+            in channels.
     """
     _effective_attachment = _UNDEFINED
 
@@ -214,6 +222,8 @@ class Message(TelegramObject):
                  pinned_message=None,
                  invoice=None,
                  successful_payment=None,
+                 forward_signature=None,
+                 author_signature=None,
                  bot=None,
                  **kwargs):
         # Required
@@ -256,6 +266,8 @@ class Message(TelegramObject):
         self.forward_from_message_id = forward_from_message_id
         self.invoice = invoice
         self.successful_payment = successful_payment
+        self.forward_signature = forward_signature
+        self.author_signature = author_signature
 
         self.bot = bot
 

--- a/telegram/user.py
+++ b/telegram/user.py
@@ -20,6 +20,9 @@
 """This module contains an object that represents a Telegram User."""
 
 from telegram import TelegramObject
+from telegram.utils.helpers import mention_markdown as util_mention_markdown
+from telegram.utils.helpers import mention_html as util_mention_html
+
 
 
 class User(TelegramObject):
@@ -109,3 +112,29 @@ class User(TelegramObject):
             users.append(cls.de_json(user, bot))
 
         return users
+
+    def mention_markdown(self, name=None):
+        """
+        Args:
+            name (:obj:`str`): If provided, will overwrite the user's name.
+
+        Returns:
+            :obj:`str`: The inline mention for the user as markdown.
+        """
+        if not name:
+            return util_mention_markdown(self.id, self.name)
+        else:
+            return util_mention_markdown(self.id, name)
+
+    def mention_html(self, name=None):
+        """
+        Args:
+            name (:obj:`str`): If provided, will overwrite the user's name.
+
+        Returns:
+            :obj:`str`: The inline mention for the user as HTML.
+        """
+        if not name:
+            return util_mention_html(self.name, self.id)
+        else:
+            return util_mention_html(name, self.id)

--- a/telegram/user.py
+++ b/telegram/user.py
@@ -28,6 +28,7 @@ class User(TelegramObject):
 
     Attributes:
         id (:obj:`int`): Unique identifier for this user or bot.
+        is_bot (:obj:`bool`): True, if this user is a bot
         first_name (:obj:`str`): User's or bot's first name.
         last_name (:obj:`str`): Optional. User's or bot's last name.
         username (:obj:`str`): Optional. User's or bot's last name.
@@ -36,6 +37,7 @@ class User(TelegramObject):
 
     Args:
         id (:obj:`int`): Unique identifier for this user or bot.
+        is_bot (:obj:`bool`): True, if this user is a bot
         first_name (:obj:`str`): User's or bot's first name.
         last_name (:obj:`str`, optional): User's or bot's last name.
         username (:obj:`str`, optional): User's or bot's username.
@@ -45,6 +47,7 @@ class User(TelegramObject):
 
     def __init__(self,
                  id,
+                 is_bot,
                  first_name,
                  last_name=None,
                  username=None,
@@ -53,6 +56,7 @@ class User(TelegramObject):
                  **kwargs):
         # Required
         self.id = int(id)
+        self.is_bot = is_bot
         self.first_name = first_name
         # Optionals
         self.last_name = last_name

--- a/telegram/user.py
+++ b/telegram/user.py
@@ -50,8 +50,8 @@ class User(TelegramObject):
 
     def __init__(self,
                  id,
-                 is_bot,
                  first_name,
+                 is_bot,
                  last_name=None,
                  username=None,
                  language_code=None,
@@ -59,8 +59,8 @@ class User(TelegramObject):
                  **kwargs):
         # Required
         self.id = int(id)
-        self.is_bot = is_bot
         self.first_name = first_name
+        self.is_bot = is_bot
         # Optionals
         self.last_name = last_name
         self.username = username

--- a/telegram/user.py
+++ b/telegram/user.py
@@ -134,6 +134,6 @@ class User(TelegramObject):
             :obj:`str`: The inline mention for the user as HTML.
         """
         if not name:
-            return util_mention_html(self.name, self.id)
+            return util_mention_html(self.id, self.name)
         else:
-            return util_mention_html(name, self.id)
+            return util_mention_html(self.id, name)

--- a/telegram/user.py
+++ b/telegram/user.py
@@ -24,7 +24,6 @@ from telegram.utils.helpers import mention_markdown as util_mention_markdown
 from telegram.utils.helpers import mention_html as util_mention_html
 
 
-
 class User(TelegramObject):
     """
     This object represents a Telegram user or bot.

--- a/telegram/utils/helpers.py
+++ b/telegram/utils/helpers.py
@@ -20,7 +20,6 @@
 
 import re
 from datetime import datetime
-from telegram import User, Message
 
 try:
     from html import escape as escape_html  # noqa: F401
@@ -75,43 +74,27 @@ def from_timestamp(unixtime):
     return datetime.fromtimestamp(unixtime)
 
 
-def mention(user, html=False, name=None):
+def mention_html(user_id, name):
     """
     Args:
-        user (:obj:`int` | :class:`telegram.User` | :class:`telegram.Message`)
-            The user's id, or User object, or a Message from the user which you want to mention.
-        html (:obj:`bool`) Default output as markdown, pass True to use HTML.
-        name (:obj:`str`) The name the mention is showing. Required when id is provided in user.
-            Optional if User or Message is provided and will overwrite the name in user.
+        user_id (:obj:`int`) The user's id which you want to mention.
+        name (:obj:`str`) The name the mention is showing.
 
     Returns:
-        str:
+        :obj:`str`: The inline mention for the user as html.
     """
-    if not user:
-        return None
+    if isinstance(user_id, int):
+        return '<a href="tg://user?id={}">{}</a>'.format(user_id, escape_html(name))
 
-    if isinstance(user, Message):
-        user = Message.from_user
 
-    if isinstance(user, int) and name:
-        if html:
-            return '<a href="tg://user?id={}">{}</a>'.format(user, escape_html(name))
-        else:
-            return "[{}](tg://user?id={}".format(escape_markdown(name), user)
+def mention_markdown(user_id, name):
+    """
+    Args:
+        user_id (:obj:`int`) The user's id which you want to mention.
+        name (:obj:`str`) The name the mention is showing.
 
-    elif isinstance(user, User):
-        if not name:
-            if user.last_name:
-                fullname = '{} {}'.format(user.first_name, user.last_name)
-            else:
-                fullname = user.first_name
-
-            if html:
-                return '<a href="tg://user?id={}">{}</a>'.format(user.id, escape_html(fullname))
-            else:
-                return "[{}](tg://user?id={}".format(escape_markdown(fullname), user.id)
-        else:
-            if html:
-                return '<a href="tg://user?id={}">{}</a>'.format(user.id, escape_html(name))
-            else:
-                return "[{}](tg://user?id={}".format(escape_markdown(name), user.id)
+    Returns:
+        :obj:`str`: The inline mention for the user as markdown.
+    """
+    if isinstance(user_id, int):
+        return '[{}](tg://user?id={})'.format(escape_markdown(name), user_id)

--- a/telegram/utils/helpers.py
+++ b/telegram/utils/helpers.py
@@ -20,6 +20,7 @@
 
 import re
 from datetime import datetime
+from telegram import User, Message
 
 try:
     from html import escape as escape_html  # noqa: F401
@@ -72,3 +73,45 @@ def from_timestamp(unixtime):
         return None
 
     return datetime.fromtimestamp(unixtime)
+
+
+def mention(user, html=False, name=None):
+    """
+    Args:
+        user (:obj:`int` | :class:`telegram.User` | :class:`telegram.Message`)
+            The user's id, or User object, or a Message from the user which you want to mention.
+        html (:obj:`bool`) Default output as markdown, pass True to use HTML.
+        name (:obj:`str`) The name the mention is showing. Required when id is provided in user.
+            Optional if User or Message is provided and will overwrite the name in user.
+
+    Returns:
+        str:
+    """
+    if not user:
+        return None
+
+    if isinstance(user, Message):
+        user = Message.from_user
+
+    if isinstance(user, int) and name:
+        if html:
+            return '<a href="tg://user?id={}">{}</a>'.format(user, escape_html(name))
+        else:
+            return "[{}](tg://user?id={}".format(escape_markdown(name), user)
+
+    elif isinstance(user, User):
+        if not name:
+            if user.last_name:
+                fullname = '{} {}'.format(user.first_name, user.last_name)
+            else:
+                fullname = user.first_name
+
+            if html:
+                return '<a href="tg://user?id={}">{}</a>'.format(user.id, escape_html(fullname))
+            else:
+                return "[{}](tg://user?id={}".format(escape_markdown(fullname), user.id)
+        else:
+            if html:
+                return '<a href="tg://user?id={}">{}</a>'.format(user.id, escape_html(name))
+            else:
+                return "[{}](tg://user?id={}".format(escape_markdown(name), user.id)

--- a/tests/test_callbackquery.py
+++ b/tests/test_callbackquery.py
@@ -39,9 +39,9 @@ def callback_query(bot, request):
 
 class TestCallbackQuery(object):
     id = 'id'
-    from_user = User(1, 'test_user')
+    from_user = User(1, 'test_user', False)
     chat_instance = 'chat_instance'
-    message = Message(3, User(5, 'bot'), None, Chat(4, 'private'))
+    message = Message(3, User(5, 'bot', False), None, Chat(4, 'private'))
     data = 'data'
     inline_message_id = 'inline_message_id'
     game_short_name = 'the_game'

--- a/tests/test_callbackqueryhandler.py
+++ b/tests/test_callbackqueryhandler.py
@@ -22,17 +22,17 @@ from telegram import (Update, CallbackQuery, Bot, Message, User, Chat, InlineQue
                       ChosenInlineResult, ShippingQuery, PreCheckoutQuery)
 from telegram.ext import CallbackQueryHandler
 
-message = Message(1, User(1, ''), None, Chat(1, ''), text='Text')
+message = Message(1, User(1, '', False), None, Chat(1, ''), text='Text')
 
 params = [
     {'message': message},
     {'edited_message': message},
     {'channel_post': message},
     {'edited_channel_post': message},
-    {'inline_query': InlineQuery(1, User(1, ''), '', '')},
-    {'chosen_inline_result': ChosenInlineResult('id', User(1, ''), '')},
-    {'shipping_query': ShippingQuery('id', User(1, ''), '', None)},
-    {'pre_checkout_query': PreCheckoutQuery('id', User(1, ''), '', 0, '')}
+    {'inline_query': InlineQuery(1, User(1, '', False), '', '')},
+    {'chosen_inline_result': ChosenInlineResult('id', User(1, '', False), '')},
+    {'shipping_query': ShippingQuery('id', User(1, '', False), '', None)},
+    {'pre_checkout_query': PreCheckoutQuery('id', User(1, '', False), '', 0, '')}
 ]
 
 ids = ('message', 'edited_message', 'channel_post',

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -122,7 +122,7 @@ class TestChat(object):
         b = Chat(self.id, self.title, self.type)
         c = Chat(self.id, '', '')
         d = Chat(0, self.title, self.type)
-        e = User(self.id, '')
+        e = User(self.id, '', False)
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_chatmember.py
+++ b/tests/test_chatmember.py
@@ -26,7 +26,7 @@ from telegram.utils.helpers import to_timestamp
 
 @pytest.fixture(scope='class')
 def user():
-    return User(1, 'First name')
+    return User(1, 'First name', False)
 
 
 @pytest.fixture(scope='class')
@@ -89,10 +89,10 @@ class TestChatMember(object):
         assert chat_member['status'] == chat_member.status
 
     def test_equality(self):
-        a = ChatMember(User(1, ''), ChatMember.ADMINISTRATOR)
-        b = ChatMember(User(1, ''), ChatMember.ADMINISTRATOR)
-        d = ChatMember(User(2, ''), ChatMember.ADMINISTRATOR)
-        d2 = ChatMember(User(1, ''), ChatMember.CREATOR)
+        a = ChatMember(User(1, '', False), ChatMember.ADMINISTRATOR)
+        b = ChatMember(User(1, '', False), ChatMember.ADMINISTRATOR)
+        d = ChatMember(User(2, '', False), ChatMember.ADMINISTRATOR)
+        d2 = ChatMember(User(1, '', False), ChatMember.CREATOR)
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_choseninlineresult.py
+++ b/tests/test_choseninlineresult.py
@@ -24,7 +24,7 @@ from telegram import User, ChosenInlineResult, Location, Voice
 
 @pytest.fixture(scope='class')
 def user():
-    return User(1, 'First name')
+    return User(1, 'First name', False)
 
 
 @pytest.fixture(scope='class')

--- a/tests/test_choseninlineresulthandler.py
+++ b/tests/test_choseninlineresulthandler.py
@@ -23,18 +23,18 @@ from telegram import (Update, Chat, Bot, ChosenInlineResult, User, Message, Call
                       InlineQuery, ShippingQuery, PreCheckoutQuery)
 from telegram.ext import ChosenInlineResultHandler
 
-message = Message(1, User(1, ''), None, Chat(1, ''), text='Text')
+message = Message(1, User(1, '', False), None, Chat(1, ''), text='Text')
 
 params = [
     {'message': message},
     {'edited_message': message},
-    {'callback_query': CallbackQuery(1, User(1, ''), 'chat', message=message)},
+    {'callback_query': CallbackQuery(1, User(1, '', False), 'chat', message=message)},
     {'channel_post': message},
     {'edited_channel_post': message},
-    {'inline_query': InlineQuery(1, User(1, ''), '', '')},
-    {'shipping_query': ShippingQuery('id', User(1, ''), '', None)},
-    {'pre_checkout_query': PreCheckoutQuery('id', User(1, ''), '', 0, '')},
-    {'callback_query': CallbackQuery(1, User(1, ''), 'chat')}
+    {'inline_query': InlineQuery(1, User(1, '', False), '', '')},
+    {'shipping_query': ShippingQuery('id', User(1, '', False), '', None)},
+    {'pre_checkout_query': PreCheckoutQuery('id', User(1, '', False), '', 0, '')},
+    {'callback_query': CallbackQuery(1, User(1, '', False), 'chat')}
 ]
 
 ids = ('message', 'edited_message', 'callback_query', 'channel_post',
@@ -50,7 +50,7 @@ def false_update(request):
 @pytest.fixture(scope='class')
 def chosen_inline_result():
     return Update(1, chosen_inline_result=ChosenInlineResult('result_id',
-                                                             User(1, 'test_user'),
+                                                             User(1, 'test_user', False),
                                                              'query'))
 
 

--- a/tests/test_commandhandler.py
+++ b/tests/test_commandhandler.py
@@ -23,17 +23,17 @@ from telegram import (Message, Update, Chat, Bot, User, CallbackQuery, InlineQue
                       ChosenInlineResult, ShippingQuery, PreCheckoutQuery)
 from telegram.ext import CommandHandler, Filters
 
-message = Message(1, User(1, ''), None, Chat(1, ''), text='test')
+message = Message(1, User(1, '', False), None, Chat(1, ''), text='test')
 
 params = [
-    {'callback_query': CallbackQuery(1, User(1, ''), 'chat', message=message)},
+    {'callback_query': CallbackQuery(1, User(1, '', False), 'chat', message=message)},
     {'channel_post': message},
     {'edited_channel_post': message},
-    {'inline_query': InlineQuery(1, User(1, ''), '', '')},
-    {'chosen_inline_result': ChosenInlineResult('id', User(1, ''), '')},
-    {'shipping_query': ShippingQuery('id', User(1, ''), '', None)},
-    {'pre_checkout_query': PreCheckoutQuery('id', User(1, ''), '', 0, '')},
-    {'callback_query': CallbackQuery(1, User(1, ''), 'chat')}
+    {'inline_query': InlineQuery(1, User(1, '', False), '', '')},
+    {'chosen_inline_result': ChosenInlineResult('id', User(1, '', False), '')},
+    {'shipping_query': ShippingQuery('id', User(1, '', False), '', None)},
+    {'pre_checkout_query': PreCheckoutQuery('id', User(1, '', False), '', 0, '')},
+    {'callback_query': CallbackQuery(1, User(1, '', False), 'chat')}
 ]
 
 ids = ('callback_query', 'channel_post', 'edited_channel_post', 'inline_query',

--- a/tests/test_conversationhandler.py
+++ b/tests/test_conversationhandler.py
@@ -26,12 +26,12 @@ from telegram.ext import (ConversationHandler, CommandHandler, CallbackQueryHand
 
 @pytest.fixture(scope='class')
 def user1():
-    return User(first_name='Misses Test', id=123)
+    return User(first_name='Misses Test', id=123, is_bot=False)
 
 
 @pytest.fixture(scope='class')
 def user2():
-    return User(first_name='Mister Test', id=124)
+    return User(first_name='Mister Test', id=124, is_bot=False)
 
 
 class TestConversationHandler(object):

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -35,7 +35,7 @@ def dp2(bot):
 
 
 class TestDispatcher(object):
-    message_update = Update(1, message=Message(1, User(1, ''), None, Chat(1, ''), text='Text'))
+    message_update = Update(1, message=Message(1, User(1, '', False), None, Chat(1, ''), text='Text'))
     received = None
     count = 0
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -26,7 +26,7 @@ from telegram.ext import Filters, BaseFilter
 
 @pytest.fixture(scope='function')
 def message():
-    return Message(0, User(0, 'Testuser'), datetime.datetime.now(), Chat(0, 'private'))
+    return Message(0, User(0, 'Testuser', False), datetime.datetime.now(), Chat(0, 'private'))
 
 
 @pytest.fixture(scope='function',
@@ -52,7 +52,7 @@ class TestFilters(object):
         assert Filters.command(message)
 
     def test_filters_reply(self, message):
-        another_message = Message(1, User(1, 'TestOther'), datetime.datetime.now(),
+        another_message = Message(1, User(1, 'TestOther', False), datetime.datetime.now(),
                                   Chat(0, 'private'))
         message.text = 'test'
         assert not Filters.reply(message)

--- a/tests/test_gamehighscore.py
+++ b/tests/test_gamehighscore.py
@@ -31,7 +31,7 @@ def game_highscore():
 
 class TestGameHighScore(object):
     position = 12
-    user = User(2, 'test user')
+    user = User(2, 'test user', False)
     score = 42
 
     def test_de_json(self, bot):

--- a/tests/test_inlinequery.py
+++ b/tests/test_inlinequery.py
@@ -30,7 +30,7 @@ def inline_query(bot):
 
 class TestInlineQuery(object):
     id = 1234
-    from_user = User(1, 'First name')
+    from_user = User(1, 'First name', False)
     query = 'query text'
     offset = 'offset'
     location = Location(8.8, 53.1)
@@ -69,10 +69,10 @@ class TestInlineQuery(object):
         assert inline_query.answer()
 
     def test_equality(self):
-        a = InlineQuery(self.id, User(1, ''), '', '')
-        b = InlineQuery(self.id, User(1, ''), '', '')
-        c = InlineQuery(self.id, User(0, ''), '', '')
-        d = InlineQuery(0, User(1, ''), '', '')
+        a = InlineQuery(self.id, User(1, '', False), '', '')
+        b = InlineQuery(self.id, User(1, '', False), '', '')
+        c = InlineQuery(self.id, User(0, '', False), '', '')
+        d = InlineQuery(0, User(1, '', False), '', '')
         e = Update(self.id)
 
         assert a == b

--- a/tests/test_inlinequeryhandler.py
+++ b/tests/test_inlinequeryhandler.py
@@ -22,18 +22,18 @@ from telegram import (Update, CallbackQuery, Bot, Message, User, Chat, InlineQue
                       ChosenInlineResult, ShippingQuery, PreCheckoutQuery, Location)
 from telegram.ext import InlineQueryHandler
 
-message = Message(1, User(1, ''), None, Chat(1, ''), text='Text')
+message = Message(1, User(1, '', False), None, Chat(1, ''), text='Text')
 
 params = [
     {'message': message},
     {'edited_message': message},
-    {'callback_query': CallbackQuery(1, User(1, ''), 'chat', message=message)},
+    {'callback_query': CallbackQuery(1, User(1, '', False), 'chat', message=message)},
     {'channel_post': message},
     {'edited_channel_post': message},
-    {'chosen_inline_result': ChosenInlineResult('id', User(1, ''), '')},
-    {'shipping_query': ShippingQuery('id', User(1, ''), '', None)},
-    {'pre_checkout_query': PreCheckoutQuery('id', User(1, ''), '', 0, '')},
-    {'callback_query': CallbackQuery(1, User(1, ''), 'chat')}
+    {'chosen_inline_result': ChosenInlineResult('id', User(1, '', False), '')},
+    {'shipping_query': ShippingQuery('id', User(1, '', False), '', None)},
+    {'pre_checkout_query': PreCheckoutQuery('id', User(1, '', False), '', 0, '')},
+    {'callback_query': CallbackQuery(1, User(1, '', False), 'chat')}
 ]
 
 ids = ('message', 'edited_message', 'callback_query', 'channel_post',
@@ -48,7 +48,7 @@ def false_update(request):
 
 @pytest.fixture(scope='function')
 def inline_query(bot):
-    return Update(0, inline_query=InlineQuery('id', User(2, 'test user'),
+    return Update(0, inline_query=InlineQuery('id', User(2, 'test user', False),
                                               'test query', offset='22',
                                               location=Location(latitude=-23.691288,
                                                                 longitude=-46.788279)))

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -74,14 +74,16 @@ def message(bot):
                     {'invoice': Invoice('my invoice', 'invoice', 'start', 'EUR', 243)},
                     {'successful_payment': SuccessfulPayment('EUR', 243, 'payload',
                                                              'charge_id', 'provider_id',
-                                                             order_info={})}
+                                                             order_info={})},
+                    {'forward_signature': 'some_forward_sign'},
+                    {'author_signature': 'some_autohr_sign'}
                 ],
                 ids=['forwarded_user', 'forwarded_channel', 'reply', 'edited', 'text', 'audio',
                      'document', 'game', 'photo', 'sticker', 'video', 'voice', 'video_note',
                      'new_members', 'contact', 'location', 'venue', 'left_member', 'new_title',
                      'new_photo', 'delete_photo', 'group_created', 'supergroup_created',
                      'channel_created', 'migrated_to', 'migrated_from', 'pinned', 'invoice',
-                     'successful_payment'])
+                     'successful_payment', 'forward_signature', 'author_signature'])
 def message_params(bot, request):
     return Message(message_id=TestMessage.id,
                    from_user=TestMessage.from_user,

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -76,7 +76,7 @@ def message(bot):
                                                              'charge_id', 'provider_id',
                                                              order_info={})},
                     {'forward_signature': 'some_forward_sign'},
-                    {'author_signature': 'some_autohr_sign'}
+                    {'author_signature': 'some_author_sign'}
                 ],
                 ids=['forwarded_user', 'forwarded_channel', 'reply', 'edited', 'text', 'audio',
                      'document', 'game', 'photo', 'sticker', 'video', 'voice', 'video_note',

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -33,7 +33,7 @@ def message(bot):
 
 @pytest.fixture(scope='function',
                 params=[
-                    {'forward_from': User(99, 'forward_user'),
+                    {'forward_from': User(99, 'forward_user', False),
                      'forward_date': datetime.now()},
                     {'forward_from_chat': Chat(-23, 'channel'),
                      'forward_from_message_id': 101,
@@ -56,12 +56,12 @@ def message(bot):
                      'caption': 'video_file'},
                     {'voice': Voice('voice_id', 5)},
                     {'video_note': VideoNote('video_note_id', 20, 12)},
-                    {'new_chat_members': [User(55, 'new_user')]},
+                    {'new_chat_members': [User(55, 'new_user', False)]},
                     {'contact': Contact('phone_numner', 'contact_name')},
                     {'location': Location(-23.691288, 46.788279)},
                     {'venue': Venue(Location(-23.691288, 46.788279),
                                     'some place', 'right here')},
-                    {'left_chat_member': User(33, 'kicked')},
+                    {'left_chat_member': User(33, 'kicked', False)},
                     {'new_chat_title': 'new title'},
                     {'new_chat_photo': [PhotoSize('photo_id', 50, 50)]},
                     {'delete_chat_photo': True},
@@ -93,7 +93,7 @@ def message_params(bot, request):
 
 class TestMessage(object):
     id = 1
-    from_user = User(2, 'testuser')
+    from_user = User(2, 'testuser', False)
     date = datetime.now()
     chat = Chat(3, 'private')
     test_entities = [{'length': 4, 'offset': 10, 'type': 'bold'},
@@ -416,7 +416,7 @@ class TestMessage(object):
         id = 1
         a = Message(id, self.from_user, self.date, self.chat)
         b = Message(id, self.from_user, self.date, self.chat)
-        c = Message(id, User(0, ''), self.date, self.chat)
+        c = Message(id, User(0, '', False), self.date, self.chat)
         d = Message(0, self.from_user, self.date, self.chat)
         e = Update(id)
 

--- a/tests/test_messageentity.py
+++ b/tests/test_messageentity.py
@@ -31,7 +31,7 @@ def message_entity(request):
         url = 't.me'
     user = None
     if type == MessageEntity.TEXT_MENTION:
-        user = User(1, 'test_user')
+        user = User(1, 'test_user', False)
     return MessageEntity(type, 1, 3, url=url, user=user)
 
 

--- a/tests/test_messagehandler.py
+++ b/tests/test_messagehandler.py
@@ -23,15 +23,15 @@ from telegram import (Message, Update, Chat, Bot, User, CallbackQuery, InlineQue
                       ChosenInlineResult, ShippingQuery, PreCheckoutQuery)
 from telegram.ext import Filters, MessageHandler
 
-message = Message(1, User(1, ''), None, Chat(1, ''), text='Text')
+message = Message(1, User(1, '', False), None, Chat(1, ''), text='Text')
 
 params = [
-    {'callback_query': CallbackQuery(1, User(1, ''), 'chat', message=message)},
-    {'inline_query': InlineQuery(1, User(1, ''), '', '')},
-    {'chosen_inline_result': ChosenInlineResult('id', User(1, ''), '')},
-    {'shipping_query': ShippingQuery('id', User(1, ''), '', None)},
-    {'pre_checkout_query': PreCheckoutQuery('id', User(1, ''), '', 0, '')},
-    {'callback_query': CallbackQuery(1, User(1, ''), 'chat')}
+    {'callback_query': CallbackQuery(1, User(1, '', False), 'chat', message=message)},
+    {'inline_query': InlineQuery(1, User(1, '', False), '', '')},
+    {'chosen_inline_result': ChosenInlineResult('id', User(1, '', False), '')},
+    {'shipping_query': ShippingQuery('id', User(1, '', False), '', None)},
+    {'pre_checkout_query': PreCheckoutQuery('id', User(1, '', False), '', 0, '')},
+    {'callback_query': CallbackQuery(1, User(1, '', False), 'chat')}
 ]
 
 ids = ('callback_query', 'inline_query', 'chosen_inline_result',

--- a/tests/test_precheckoutquery.py
+++ b/tests/test_precheckoutquery.py
@@ -40,7 +40,7 @@ class TestPreCheckoutQuery(object):
     shipping_option_id = 'shipping_option_id'
     currency = 'EUR'
     total_amount = 100
-    from_user = User(0, '')
+    from_user = User(0, '', False)
     order_info = OrderInfo()
 
     def test_de_json(self, bot):

--- a/tests/test_precheckoutqueryhandler.py
+++ b/tests/test_precheckoutqueryhandler.py
@@ -23,18 +23,18 @@ from telegram import (Update, Chat, Bot, ChosenInlineResult, User, Message, Call
                       InlineQuery, ShippingQuery, PreCheckoutQuery)
 from telegram.ext import PreCheckoutQueryHandler
 
-message = Message(1, User(1, ''), None, Chat(1, ''), text='Text')
+message = Message(1, User(1, '', False), None, Chat(1, ''), text='Text')
 
 params = [
     {'message': message},
     {'edited_message': message},
-    {'callback_query': CallbackQuery(1, User(1, ''), 'chat', message=message)},
+    {'callback_query': CallbackQuery(1, User(1, '', False), 'chat', message=message)},
     {'channel_post': message},
     {'edited_channel_post': message},
-    {'inline_query': InlineQuery(1, User(1, ''), '', '')},
-    {'chosen_inline_result': ChosenInlineResult('id', User(1, ''), '')},
-    {'shipping_query': ShippingQuery('id', User(1, ''), '', None)},
-    {'callback_query': CallbackQuery(1, User(1, ''), 'chat')}
+    {'inline_query': InlineQuery(1, User(1, '', False), '', '')},
+    {'chosen_inline_result': ChosenInlineResult('id', User(1, '', False), '')},
+    {'shipping_query': ShippingQuery('id', User(1, '', False), '', None)},
+    {'callback_query': CallbackQuery(1, User(1, '', False), 'chat')}
 ]
 
 ids = ('message', 'edited_message', 'callback_query', 'channel_post',
@@ -49,7 +49,7 @@ def false_update(request):
 
 @pytest.fixture(scope='class')
 def pre_checkout_query():
-    return Update(1, pre_checkout_query=PreCheckoutQuery('id', User(1, 'test user'), 'EUR', 223,
+    return Update(1, pre_checkout_query=PreCheckoutQuery('id', User(1, 'test user', False), 'EUR', 223,
                                                          'invoice_payload'))
 
 

--- a/tests/test_regexhandler.py
+++ b/tests/test_regexhandler.py
@@ -23,15 +23,15 @@ from telegram import (Message, Update, Chat, Bot, User, CallbackQuery, InlineQue
                       ChosenInlineResult, ShippingQuery, PreCheckoutQuery)
 from telegram.ext import RegexHandler
 
-message = Message(1, User(1, ''), None, Chat(1, ''), text='Text')
+message = Message(1, User(1, '', False), None, Chat(1, ''), text='Text')
 
 params = [
-    {'callback_query': CallbackQuery(1, User(1, ''), 'chat', message=message)},
-    {'inline_query': InlineQuery(1, User(1, ''), '', '')},
-    {'chosen_inline_result': ChosenInlineResult('id', User(1, ''), '')},
-    {'shipping_query': ShippingQuery('id', User(1, ''), '', None)},
-    {'pre_checkout_query': PreCheckoutQuery('id', User(1, ''), '', 0, '')},
-    {'callback_query': CallbackQuery(1, User(1, ''), 'chat')}
+    {'callback_query': CallbackQuery(1, User(1, '', False), 'chat', message=message)},
+    {'inline_query': InlineQuery(1, User(1, '', False), '', '')},
+    {'chosen_inline_result': ChosenInlineResult('id', User(1, '', False), '')},
+    {'shipping_query': ShippingQuery('id', User(1, '', False), '', None)},
+    {'pre_checkout_query': PreCheckoutQuery('id', User(1, '', False), '', 0, '')},
+    {'callback_query': CallbackQuery(1, User(1, '', False), 'chat')}
 ]
 
 ids = ('callback_query', 'inline_query', 'chosen_inline_result',

--- a/tests/test_shippingquery.py
+++ b/tests/test_shippingquery.py
@@ -34,7 +34,7 @@ def shipping_query(bot):
 class TestShippingQuery(object):
     id = 5
     invoice_payload = 'invoice_payload'
-    from_user = User(0, '')
+    from_user = User(0, '', False)
     shipping_address = ShippingAddress('GB', '', 'London', '12 Grimmauld Place', '', 'WC1')
 
     def test_de_json(self, bot):

--- a/tests/test_shippingqueryhandler.py
+++ b/tests/test_shippingqueryhandler.py
@@ -23,18 +23,18 @@ from telegram import (Update, Chat, Bot, ChosenInlineResult, User, Message, Call
                       InlineQuery, ShippingQuery, PreCheckoutQuery, ShippingAddress)
 from telegram.ext import ShippingQueryHandler
 
-message = Message(1, User(1, ''), None, Chat(1, ''), text='Text')
+message = Message(1, User(1, '', False), None, Chat(1, ''), text='Text')
 
 params = [
     {'message': message},
     {'edited_message': message},
-    {'callback_query': CallbackQuery(1, User(1, ''), 'chat', message=message)},
+    {'callback_query': CallbackQuery(1, User(1, '', False), 'chat', message=message)},
     {'channel_post': message},
     {'edited_channel_post': message},
-    {'inline_query': InlineQuery(1, User(1, ''), '', '')},
-    {'chosen_inline_result': ChosenInlineResult('id', User(1, ''), '')},
-    {'pre_checkout_query': PreCheckoutQuery('id', User(1, ''), '', 0, '')},
-    {'callback_query': CallbackQuery(1, User(1, ''), 'chat')}
+    {'inline_query': InlineQuery(1, User(1, '', False), '', '')},
+    {'chosen_inline_result': ChosenInlineResult('id', User(1, '', False), '')},
+    {'pre_checkout_query': PreCheckoutQuery('id', User(1, '', False), '', 0, '')},
+    {'callback_query': CallbackQuery(1, User(1, '', False), 'chat')}
 ]
 
 ids = ('message', 'edited_message', 'callback_query', 'channel_post',
@@ -49,7 +49,7 @@ def false_update(request):
 
 @pytest.fixture(scope='class')
 def shiping_query():
-    return Update(1, shipping_query=ShippingQuery(42, User(1, 'test user'), 'invoice_payload',
+    return Update(1, shipping_query=ShippingQuery(42, User(1, 'test user', False), 'invoice_payload',
                                                   ShippingAddress('EN', 'my_state', 'my_city',
                                                                   'steer_1', '', 'post_code')))
 

--- a/tests/test_stringcommandhandler.py
+++ b/tests/test_stringcommandhandler.py
@@ -22,19 +22,19 @@ from telegram import (Bot, Update, Message, User, Chat, CallbackQuery, InlineQue
                       ChosenInlineResult, ShippingQuery, PreCheckoutQuery)
 from telegram.ext import StringCommandHandler
 
-message = Message(1, User(1, ''), None, Chat(1, ''), text='Text')
+message = Message(1, User(1, '', False), None, Chat(1, ''), text='Text')
 
 params = [
     {'message': message},
     {'edited_message': message},
-    {'callback_query': CallbackQuery(1, User(1, ''), 'chat', message=message)},
+    {'callback_query': CallbackQuery(1, User(1, '', False), 'chat', message=message)},
     {'channel_post': message},
     {'edited_channel_post': message},
-    {'inline_query': InlineQuery(1, User(1, ''), '', '')},
-    {'chosen_inline_result': ChosenInlineResult('id', User(1, ''), '')},
-    {'shipping_query': ShippingQuery('id', User(1, ''), '', None)},
-    {'pre_checkout_query': PreCheckoutQuery('id', User(1, ''), '', 0, '')},
-    {'callback_query': CallbackQuery(1, User(1, ''), 'chat')}
+    {'inline_query': InlineQuery(1, User(1, '', False), '', '')},
+    {'chosen_inline_result': ChosenInlineResult('id', User(1, '', False), '')},
+    {'shipping_query': ShippingQuery('id', User(1, '', False), '', None)},
+    {'pre_checkout_query': PreCheckoutQuery('id', User(1, '', False), '', 0, '')},
+    {'callback_query': CallbackQuery(1, User(1, '', False), 'chat')}
 ]
 
 ids = ('message', 'edited_message', 'callback_query', 'channel_post',

--- a/tests/test_stringregexhandler.py
+++ b/tests/test_stringregexhandler.py
@@ -22,19 +22,19 @@ from telegram import (Bot, Update, Message, User, Chat, CallbackQuery, InlineQue
                       ChosenInlineResult, ShippingQuery, PreCheckoutQuery)
 from telegram.ext import StringRegexHandler
 
-message = Message(1, User(1, ''), None, Chat(1, ''), text='Text')
+message = Message(1, User(1, '', False), None, Chat(1, ''), text='Text')
 
 params = [
     {'message': message},
     {'edited_message': message},
-    {'callback_query': CallbackQuery(1, User(1, ''), 'chat', message=message)},
+    {'callback_query': CallbackQuery(1, User(1, '', False), 'chat', message=message)},
     {'channel_post': message},
     {'edited_channel_post': message},
-    {'inline_query': InlineQuery(1, User(1, ''), '', '')},
-    {'chosen_inline_result': ChosenInlineResult('id', User(1, ''), '')},
-    {'shipping_query': ShippingQuery('id', User(1, ''), '', None)},
-    {'pre_checkout_query': PreCheckoutQuery('id', User(1, ''), '', 0, '')},
-    {'callback_query': CallbackQuery(1, User(1, ''), 'chat')}
+    {'inline_query': InlineQuery(1, User(1, '', False), '', '')},
+    {'chosen_inline_result': ChosenInlineResult('id', User(1, '', False), '')},
+    {'shipping_query': ShippingQuery('id', User(1, '', False), '', None)},
+    {'pre_checkout_query': PreCheckoutQuery('id', User(1, '', False), '', 0, '')},
+    {'callback_query': CallbackQuery(1, User(1, '', False), 'chat')}
 ]
 
 ids = ('message', 'edited_message', 'callback_query', 'channel_post',

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -22,19 +22,19 @@ import pytest
 from telegram import (Message, User, Update, Chat, CallbackQuery, InlineQuery,
                       ChosenInlineResult, ShippingQuery, PreCheckoutQuery)
 
-message = Message(1, User(1, ''), None, Chat(1, ''), text='Text')
+message = Message(1, User(1, '', False), None, Chat(1, ''), text='Text')
 
 params = [
     {'message': message},
     {'edited_message': message},
-    {'callback_query': CallbackQuery(1, User(1, ''), 'chat', message=message)},
+    {'callback_query': CallbackQuery(1, User(1, '', False), 'chat', message=message)},
     {'channel_post': message},
     {'edited_channel_post': message},
-    {'inline_query': InlineQuery(1, User(1, ''), '', '')},
-    {'chosen_inline_result': ChosenInlineResult('id', User(1, ''), '')},
-    {'shipping_query': ShippingQuery('id', User(1, ''), '', None)},
-    {'pre_checkout_query': PreCheckoutQuery('id', User(1, ''), '', 0, '')},
-    {'callback_query': CallbackQuery(1, User(1, ''), 'chat')}
+    {'inline_query': InlineQuery(1, User(1, '', False), '', '')},
+    {'chosen_inline_result': ChosenInlineResult('id', User(1, '', False), '')},
+    {'shipping_query': ShippingQuery('id', User(1, '', False), '', None)},
+    {'pre_checkout_query': PreCheckoutQuery('id', User(1, '', False), '', 0, '')},
+    {'callback_query': CallbackQuery(1, User(1, '', False), 'chat')}
 ]
 
 all_types = ('message', 'edited_message', 'callback_query', 'channel_post',
@@ -122,7 +122,7 @@ class TestUpdate(object):
         b = Update(self.update_id, message=message)
         c = Update(self.update_id)
         d = Update(0, message=message)
-        e = User(self.update_id, '')
+        e = User(self.update_id, '', False)
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -103,7 +103,7 @@ class TestUpdater(object):
 
         try:
             # Now, we send an update to the server via urlopen
-            update = Update(1, message=Message(1, User(1, ''), None, Chat(1, ''), text='Webhook'))
+            update = Update(1, message=Message(1, User(1, '', False), None, Chat(1, ''), text='Webhook'))
             self._send_webhook_msg(ip, port, update.to_json(), 'TOKEN')
             sleep(.2)
             assert q.get(False) == update
@@ -136,7 +136,7 @@ class TestUpdater(object):
         sleep(.2)
 
         # Now, we send an update to the server via urlopen
-        update = Update(1, message=Message(1, User(1, ''), None, Chat(1, ''), text='Webhook 2'))
+        update = Update(1, message=Message(1, User(1, '', False), None, Chat(1, ''), text='Webhook 2'))
         self._send_webhook_msg(ip, port, update.to_json())
         sleep(.2)
         assert q.get(False) == update

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -35,7 +35,7 @@ def json_dict():
 
 @pytest.fixture(scope='function')
 def user(bot):
-    return User(TestUser.id, TestUser.is_bot, TestUser.first_name, last_name=TestUser.last_name,
+    return User(TestUser.id, TestUser.first_name, TestUser.is_bot, last_name=TestUser.last_name,
                 username=TestUser.username, language_code=TestUser.language_code, bot=bot)
 
 
@@ -99,10 +99,10 @@ class TestUser(object):
         assert user.get_profile_photos()
 
     def test_equality(self):
-        a = User(self.id, self.first_name, self.last_name)
-        b = User(self.id, self.first_name, self.last_name)
-        c = User(self.id, self.first_name)
-        d = User(0, self.first_name, self.last_name)
+        a = User(self.id, self.first_name, self.is_bot, self.last_name)
+        b = User(self.id, self.first_name, self.is_bot, self.last_name)
+        c = User(self.id, self.first_name, self.is_bot)
+        d = User(0, self.first_name, self.is_bot, self.last_name)
         e = Update(self.id)
 
         assert a == b

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -25,6 +25,7 @@ from telegram import User, Update
 def json_dict():
     return {
         'id': TestUser.id,
+        'is_bot': TestUser.is_bot,
         'first_name': TestUser.first_name,
         'last_name': TestUser.last_name,
         'username': TestUser.username,
@@ -34,12 +35,13 @@ def json_dict():
 
 @pytest.fixture(scope='function')
 def user(bot):
-    return User(TestUser.id, TestUser.first_name, last_name=TestUser.last_name,
+    return User(TestUser.id, TestUser.is_bot, TestUser.first_name, last_name=TestUser.last_name,
                 username=TestUser.username, language_code=TestUser.language_code, bot=bot)
 
 
 class TestUser(object):
     id = 1
+    is_bot = True
     first_name = 'first_name'
     last_name = 'last_name'
     username = 'username'
@@ -49,6 +51,7 @@ class TestUser(object):
         user = User.de_json(json_dict, bot)
 
         assert user.id == self.id
+        assert user.is_bot == self.is_bot
         assert user.first_name == self.first_name
         assert user.last_name == self.last_name
         assert user.username == self.username
@@ -60,6 +63,7 @@ class TestUser(object):
         user = User.de_json(json_dict, bot)
 
         assert user.id == self.id
+        assert user.is_bot == self.is_bot
         assert user.first_name == self.first_name
         assert user.last_name == self.last_name
         assert user.username is None
@@ -72,6 +76,7 @@ class TestUser(object):
         user = User.de_json(json_dict, bot)
 
         assert user.id == self.id
+        assert user.is_bot == self.is_bot
         assert user.first_name == self.first_name
         assert user.last_name is None
         assert user.username is None


### PR DESCRIPTION
Bot API 3.3
https://core.telegram.org/bots/api#august-23-2017

- added `forward_signature` and `author-signature` to `Message`
- added `is_bot` to `User`
- added `pinned_message` to `Chat`

- added `mention()` to `telegram.utils.helpers` for easy generation of inline text mentions with (id/User/Message) input


edit: i have no idea why it cannot import `Message`...