### PR TITLE
add utils.helpers to docs

### DIFF
--- a/docs/source/telegram.rst
+++ b/docs/source/telegram.rst
@@ -3,6 +3,7 @@ telegram package
 
 .. toctree::
 
+   telegram.utils.helpers
    telegram.ext
    telegram.audio
    telegram.bot

--- a/docs/source/telegram.utils.helpers.rst
+++ b/docs/source/telegram.utils.helpers.rst
@@ -1,0 +1,6 @@
+telegram.utils.helpers Module
+=============================
+
+.. automodule:: telegram.utils.helpers
+    :members:
+    :show-inheritance:


### PR DESCRIPTION
I noticed the utils.helpers module was not added to the docs.
Since it contains some handy helper methods I thought it would be good to be able to link to them.