### PR TITLE
loosen codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,3 +3,17 @@ languages:
 exclude_paths:
 - "telegram/emoji.py"
 - "tests/*"
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - python:
+    checks:
+      Similar code:
+        enabled: false
+
+  radon:
+    enabled: true
+    config:
+      threshold: "C"


### PR DESCRIPTION
Codeclimate's defaults are pretty strict. Our complexity is High for objects and bot methods so I decreased the RADON-setting to be a bit more forgiving.
Secondly I removed the warning for `similar` code leaving only `duplicate` code.