### PR TITLE
remove unnecessary to_dict()

### DIFF
--- a/telegram/base.py
+++ b/telegram/base.py
@@ -70,6 +70,8 @@ class TelegramObject(object):
                 else:
                     data[key] = value
 
+        if data.get('from_user'):
+            data['from'] = data.pop('from_user', None)
         return data
 
     def __eq__(self, other):

--- a/telegram/callbackquery.py
+++ b/telegram/callbackquery.py
@@ -173,8 +173,7 @@ class CallbackQuery(TelegramObject):
 
         or::
 
-            bot.edit_message_reply_markup(
-            inline_message_id=update.callback_query.inline_message_id,
+            bot.edit_message_reply_markup(inline_message_id=update.callback_query.inline_message_id,
                                        *args, **kwargs)
 
         Returns:

--- a/telegram/callbackquery.py
+++ b/telegram/callbackquery.py
@@ -105,13 +105,6 @@ class CallbackQuery(TelegramObject):
 
         return cls(bot=bot, **data)
 
-    def to_dict(self):
-        data = super(CallbackQuery, self).to_dict()
-
-        # Required
-        data['from'] = data.pop('from_user', None)
-        return data
-
     def answer(self, *args, **kwargs):
         """Shortcut for::
 
@@ -180,7 +173,8 @@ class CallbackQuery(TelegramObject):
 
         or::
 
-            bot.edit_message_reply_markup(inline_message_id=update.callback_query.inline_message_id,
+            bot.edit_message_reply_markup(
+            inline_message_id=update.callback_query.inline_message_id,
                                        *args, **kwargs)
 
         Returns:

--- a/telegram/choseninlineresult.py
+++ b/telegram/choseninlineresult.py
@@ -79,11 +79,3 @@ class ChosenInlineResult(TelegramObject):
         data['location'] = Location.de_json(data.get('location'), bot)
 
         return cls(**data)
-
-    def to_dict(self):
-        data = super(ChosenInlineResult, self).to_dict()
-
-        # Required
-        data['from'] = data.pop('from_user', None)
-
-        return data

--- a/telegram/inline/inlinequery.py
+++ b/telegram/inline/inlinequery.py
@@ -75,14 +75,6 @@ class InlineQuery(TelegramObject):
 
         return cls(bot=bot, **data)
 
-    def to_dict(self):
-        data = super(InlineQuery, self).to_dict()
-
-        # Required
-        data['from'] = data.pop('from_user', None)
-
-        return data
-
     def answer(self, *args, **kwargs):
         """Shortcut for::
 

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -358,7 +358,6 @@ class Message(TelegramObject):
         data = super(Message, self).to_dict()
 
         # Required
-        data['from'] = data.pop('from_user', None)
         data['date'] = to_timestamp(self.date)
         # Optionals
         if self.forward_date:

--- a/telegram/payment/precheckoutquery.py
+++ b/telegram/payment/precheckoutquery.py
@@ -89,13 +89,6 @@ class PreCheckoutQuery(TelegramObject):
 
         return cls(**data)
 
-    def to_dict(self):
-        data = super(PreCheckoutQuery, self).to_dict()
-
-        data['from'] = data.pop('from_user', None)
-
-        return data
-
     def answer(self, *args, **kwargs):
         """Shortcut for::
 

--- a/telegram/payment/shippingquery.py
+++ b/telegram/payment/shippingquery.py
@@ -66,13 +66,6 @@ class ShippingQuery(TelegramObject):
 
         return cls(**data)
 
-    def to_dict(self):
-        data = super(ShippingQuery, self).to_dict()
-
-        data['from'] = data.pop('from_user', None)
-
-        return data
-
     def answer(self, *args, **kwargs):
         """Shortcut for::
 


### PR DESCRIPTION
We have some objects that have exactly the same to_dict() method, only specifying that `from_user` should be `from` in the `data`-dict. I refractored this logic to `TelegramObject` and removed those to_dicts() from the code.