### PR TITLE
Add Missing Job Class to docs

### DIFF
--- a/docs/source/telegram.ext.job.rst
+++ b/docs/source/telegram.ext.job.rst
@@ -1,0 +1,3 @@
+.. autoclass:: telegram.ext.Job
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.ext.job.rst
+++ b/docs/source/telegram.ext.job.rst
@@ -1,3 +1,6 @@
+telegram.ext.Job
+=====================
+
 .. autoclass:: telegram.ext.Job
     :members:
     :show-inheritance:

--- a/docs/source/telegram.ext.job.rst
+++ b/docs/source/telegram.ext.job.rst
@@ -1,3 +1,4 @@
 .. autoclass:: telegram.ext.Job
     :members:
     :show-inheritance:
+    :special-members:

--- a/docs/source/telegram.ext.jobqueue.rst
+++ b/docs/source/telegram.ext.jobqueue.rst
@@ -4,3 +4,4 @@ telegram.ext.JobQueue
 .. autoclass:: telegram.ext.JobQueue
     :members:
     :show-inheritance:
+    :special-members:

--- a/docs/source/telegram.ext.rst
+++ b/docs/source/telegram.ext.rst
@@ -6,6 +6,7 @@ telegram.ext package
     telegram.ext.updater
     telegram.ext.dispatcher
     telegram.ext.filters
+    telegram.ext.job
     telegram.ext.jobqueue
     telegram.ext.messagequeue
     telegram.ext.delayqueue


### PR DESCRIPTION
`Job` class was missing from the docs 
preview here: http://ptb.readthedocs.io/en/docs-fix/