### PR TITLE
Fix Job Class Missing from the docs

### DIFF
--- a/docs/source/telegram.ext.job.rst
+++ b/docs/source/telegram.ext.job.rst
@@ -1,0 +1,6 @@
+telegram.ext.Job
+=====================
+
+.. autoclass:: telegram.ext.Job
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.ext.rst
+++ b/docs/source/telegram.ext.rst
@@ -6,6 +6,7 @@ telegram.ext package
     telegram.ext.updater
     telegram.ext.dispatcher
     telegram.ext.filters
+    telegram.ext.job
     telegram.ext.jobqueue
     telegram.ext.messagequeue
     telegram.ext.delayqueue

--- a/telegram/ext/jobqueue.py
+++ b/telegram/ext/jobqueue.py
@@ -373,7 +373,7 @@ class Job(object):
         name (:obj:`str`, optional): The name of the new job. Defaults to ``callback.__name__``.
         days (Tuple[:obj:`int`], optional): Defines on which days of the week the job should run.
             Defaults to ``Days.EVERY_DAY``
-        job_queue (class:`telegram.ext.JobQueue`, optional): The ``JobQueue`` this job belongs to.
+        job_queue (:class::`telegram.ext.JobQueue`, optional): The ``JobQueue`` this job belongs to.
             Only optional for backward compatibility with ``JobQueue.put()``.
 
     """

--- a/telegram/ext/jobqueue.py
+++ b/telegram/ext/jobqueue.py
@@ -373,7 +373,7 @@ class Job(object):
         name (:obj:`str`, optional): The name of the new job. Defaults to ``callback.__name__``.
         days (Tuple[:obj:`int`], optional): Defines on which days of the week the job should run.
             Defaults to ``Days.EVERY_DAY``
-        job_queue (:class::`telegram.ext.JobQueue`, optional): The ``JobQueue`` this job belongs to.
+        job_queue (:class:`telegram.ext.JobQueue`, optional): The ``JobQueue`` this job belongs to.
             Only optional for backward compatibility with ``JobQueue.put()``.
 
     """


### PR DESCRIPTION
Fix `Job` Class missing from the docs
and fix the docstring at `Job` class that failed to link `JobQueue`
preview at: http://ptb.readthedocs.io/en/docs-fix4/

duplicated with #843, closing it