### PR TITLE
README: show AppVeyor logo in badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ We have made you a wrapper you can't refuse
    :target: https://travis-ci.org/python-telegram-bot/python-telegram-bot
    :alt: Travis CI Status
 
-.. image:: https://img.shields.io/appveyor/ci/Eldinnie/python-telegram-bot/master.svg
+.. image:: https://img.shields.io/appveyor/ci/Eldinnie/python-telegram-bot/master.svg?logo=appveyor
    :target: https://ci.appveyor.com/project/Eldinnie/python-telegram-bot
    :alt: AppVeyor CI Status
 


### PR DESCRIPTION
Currently the Travis and AppVeyor badges look identically. This adds the AppVeyor logo to its badge, which was [very recently](https://github.com/badges/shields/pull/1092) removed as default.