### PR TITLE
More instance methods

### DIFF
--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -1305,7 +1305,7 @@ class Bot(TelegramObject):
         return UserProfilePhotos.de_json(result, self)
 
     @log
-    def get_file(self, file_or_file_id, timeout=None, **kwargs):
+    def get_file(self, file_id, timeout=None, **kwargs):
         """
         Use this method to get basic info about a file and prepare it for downloading. For the
         moment, bots can download files of up to 20MB in size. The file can then be downloaded
@@ -1314,10 +1314,10 @@ class Bot(TelegramObject):
         calling get_file again.
 
         Args:
-            file_or_file_id (:obj:`str` | :class:`telegram.Audio` | :class:`telegram.Document` | \
-                             :class:`telegram.PhotoSize` | :class:`telegram.Sticker` |           \
-                             :class:`telegram.Video` | :class:`telegram.VideoNote` |             \
-                             :class:`telegram.Voice`):
+            file_id (:obj:`str` | :class:`telegram.Audio` | :class:`telegram.Document` |          \
+                     :class:`telegram.PhotoSize` | :class:`telegram.Sticker` |                    \
+                     :class:`telegram.Video` | :class:`telegram.VideoNote` |                      \
+                     :class:`telegram.Voice`):
                 Either the file identifier or an object that has a file_id attribute
                 to get file information about.
             timeout (:obj:`int` | :obj:`float`, optional): If this value is specified, use it as
@@ -1335,11 +1335,11 @@ class Bot(TelegramObject):
         url = '{0}/getFile'.format(self.base_url)
 
         try:
-            file_or_file_id = file_or_file_id.file_id
+            file_id = file_id.file_id
         except AttributeError:
             pass
 
-        data = {'file_id': file_or_file_id}
+        data = {'file_id': file_id}
         data.update(kwargs)
 
         result = self._request.post(url, data, timeout=timeout)

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -1312,7 +1312,7 @@ class Bot(TelegramObject):
         moment, bots can download files of up to 20MB in size. The file can then be downloaded
         with :attr:`telegram.File.download`. It is guaranteed that the link will be
         valid for at least 1 hour. When the link expires, a new one can be requested by
-        calling getFile again.
+        calling get_file again.
 
         Args:
             file_or_file_id (:obj:`str` | :class:`telegram.Audio` | :class:`telegram.Document` | :class:`telegram.PhotoSize` | :class:`telegram.Sticker` | :class:`telegram.Video` | :class:`telegram.VideoNote` | :class:`telegram.Voice`):

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # pylint: disable=E0611,E0213,E1102,C0103,E1101,W0613,R0913,R0904
+# flake8: noqa E501
 #
 # A library that provides a Python interface to the Telegram Bot API
 # Copyright (C) 2015-2017
@@ -1305,7 +1306,7 @@ class Bot(TelegramObject):
         return UserProfilePhotos.de_json(result, self)
 
     @log
-    def get_file(self, file_id, timeout=None, **kwargs):
+    def get_file(self, file_or_file_id, timeout=None, **kwargs):
         """
         Use this method to get basic info about a file and prepare it for downloading. For the
         moment, bots can download files of up to 20MB in size. The file can then be downloaded
@@ -1314,7 +1315,9 @@ class Bot(TelegramObject):
         calling getFile again.
 
         Args:
-            file_id (:obj:`str`): File identifier to get info about.
+            file_or_file_id (:obj:`str` | :class:`telegram.Audio` | :class:`telegram.Document` | :class:`telegram.PhotoSize` | :class:`telegram.Sticker` | :class:`telegram.Video` | :class:`telegram.VideoNote` | :class:`telegram.Voice`):
+                Either the file identifier or an object that has a file_id attribute
+                to get file information about.
             timeout (:obj:`int` | :obj:`float`, optional): If this value is specified, use it as
                 the read timeout from the server (instead of the one specified during creation of
                 the connection pool).
@@ -1329,7 +1332,12 @@ class Bot(TelegramObject):
         """
         url = '{0}/getFile'.format(self.base_url)
 
-        data = {'file_id': file_id}
+        try:
+            file_or_file_id = file_or_file_id.file_id
+        except AttributeError:
+            pass
+
+        data = {'file_id': file_or_file_id}
         data.update(kwargs)
 
         result = self._request.post(url, data, timeout=timeout)

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # pylint: disable=E0611,E0213,E1102,C0103,E1101,W0613,R0913,R0904
-# flake8: noqa E501
 #
 # A library that provides a Python interface to the Telegram Bot API
 # Copyright (C) 2015-2017
@@ -1315,7 +1314,10 @@ class Bot(TelegramObject):
         calling get_file again.
 
         Args:
-            file_or_file_id (:obj:`str` | :class:`telegram.Audio` | :class:`telegram.Document` | :class:`telegram.PhotoSize` | :class:`telegram.Sticker` | :class:`telegram.Video` | :class:`telegram.VideoNote` | :class:`telegram.Voice`):
+            file_or_file_id (:obj:`str` | :class:`telegram.Audio` | :class:`telegram.Document` | \
+                             :class:`telegram.PhotoSize` | :class:`telegram.Sticker` |           \
+                             :class:`telegram.Video` | :class:`telegram.VideoNote` |             \
+                             :class:`telegram.Voice`):
                 Either the file identifier or an object that has a file_id attribute
                 to get file information about.
             timeout (:obj:`int` | :obj:`float`, optional): If this value is specified, use it as

--- a/telegram/chat.py
+++ b/telegram/chat.py
@@ -212,3 +212,107 @@ class Chat(TelegramObject):
 
         """
         return self.bot.unban_chat_member(self.id, *args, **kwargs)
+
+    def send_message(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_message(Chat.chat_id, *args, **kwargs)
+
+        Where Chat is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.send_message(chat_id=self.id, *args, **kwargs)
+
+    def send_photo(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_photo(Chat.chat_id, *args, **kwargs)
+
+        Where Chat is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.send_photo(chat_id=self.id, *args, **kwargs)
+
+    def send_audio(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_audio(Chat.chat_id, *args, **kwargs)
+
+        Where Chat is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.send_audio(chat_id=self.id, *args, **kwargs)
+
+    def send_document(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_document(Chat.chat_id, *args, **kwargs)
+
+        Where Chat is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.send_document(chat_id=self.id, *args, **kwargs)
+
+    def send_sticker(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_sticker(Chat.chat_id, *args, **kwargs)
+
+        Where Chat is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.send_sticker(chat_id=self.id, *args, **kwargs)
+
+    def send_video(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_video(Chat.chat_id, *args, **kwargs)
+
+        Where Chat is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.send_video(chat_id=self.id, *args, **kwargs)
+
+    def send_video_note(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_video_note(Chat.chat_id, *args, **kwargs)
+
+        Where Chat is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.send_video_note(chat_id=self.id, *args, **kwargs)
+
+    def send_voice(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_voice(Chat.chat_id, *args, **kwargs)
+
+        Where Chat is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.send_voice(chat_id=self.id, *args, **kwargs)

--- a/telegram/chat.py
+++ b/telegram/chat.py
@@ -224,7 +224,7 @@ class Chat(TelegramObject):
             :class:`telegram.Message`: On success, instance representing the message posted.
 
         """
-        return self.send_message(chat_id=self.id, *args, **kwargs)
+        return self.bot.send_message(chat_id=self.id, *args, **kwargs)
 
     def send_photo(self, *args, **kwargs):
         """Shortcut for::
@@ -237,7 +237,7 @@ class Chat(TelegramObject):
             :class:`telegram.Message`: On success, instance representing the message posted.
 
         """
-        return self.send_photo(chat_id=self.id, *args, **kwargs)
+        return self.bot.send_photo(chat_id=self.id, *args, **kwargs)
 
     def send_audio(self, *args, **kwargs):
         """Shortcut for::
@@ -250,7 +250,7 @@ class Chat(TelegramObject):
             :class:`telegram.Message`: On success, instance representing the message posted.
 
         """
-        return self.send_audio(chat_id=self.id, *args, **kwargs)
+        return self.bot.send_audio(chat_id=self.id, *args, **kwargs)
 
     def send_document(self, *args, **kwargs):
         """Shortcut for::
@@ -263,7 +263,7 @@ class Chat(TelegramObject):
             :class:`telegram.Message`: On success, instance representing the message posted.
 
         """
-        return self.send_document(chat_id=self.id, *args, **kwargs)
+        return self.bot.send_document(chat_id=self.id, *args, **kwargs)
 
     def send_sticker(self, *args, **kwargs):
         """Shortcut for::
@@ -276,7 +276,7 @@ class Chat(TelegramObject):
             :class:`telegram.Message`: On success, instance representing the message posted.
 
         """
-        return self.send_sticker(chat_id=self.id, *args, **kwargs)
+        return self.bot.send_sticker(chat_id=self.id, *args, **kwargs)
 
     def send_video(self, *args, **kwargs):
         """Shortcut for::
@@ -289,7 +289,7 @@ class Chat(TelegramObject):
             :class:`telegram.Message`: On success, instance representing the message posted.
 
         """
-        return self.send_video(chat_id=self.id, *args, **kwargs)
+        return self.bot.send_video(chat_id=self.id, *args, **kwargs)
 
     def send_video_note(self, *args, **kwargs):
         """Shortcut for::
@@ -302,7 +302,7 @@ class Chat(TelegramObject):
             :class:`telegram.Message`: On success, instance representing the message posted.
 
         """
-        return self.send_video_note(chat_id=self.id, *args, **kwargs)
+        return self.bot.send_video_note(chat_id=self.id, *args, **kwargs)
 
     def send_voice(self, *args, **kwargs):
         """Shortcut for::
@@ -315,4 +315,4 @@ class Chat(TelegramObject):
             :class:`telegram.Message`: On success, instance representing the message posted.
 
         """
-        return self.send_voice(chat_id=self.id, *args, **kwargs)
+        return self.bot.send_voice(chat_id=self.id, *args, **kwargs)

--- a/telegram/files/audio.py
+++ b/telegram/files/audio.py
@@ -32,6 +32,7 @@ class Audio(TelegramObject):
         title (:obj:`str`): Optional. Title of the audio as defined by sender or by audio tags.
         mime_type (:obj:`str`): Optional. MIME type of the file as defined by sender.
         file_size (:obj:`int`): Optional. File size.
+        bot (:class:`telegram.Bot`): Optional. The Bot to use for instance methods.
 
     Args:
         file_id (:obj:`str`): Unique identifier for this file.
@@ -41,6 +42,7 @@ class Audio(TelegramObject):
         title (:obj:`str`, optional): Title of the audio as defined by sender or by audio tags.
         mime_type (:obj:`str`, optional): MIME type of the file as defined by sender.
         file_size (:obj:`int`, optional): File size.
+        bot (:class:`telegram.Bot`, optional): The Bot to use for instance methods.
         **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
     """
@@ -52,6 +54,7 @@ class Audio(TelegramObject):
                  title=None,
                  mime_type=None,
                  file_size=None,
+                 bot=None,
                  **kwargs):
         # Required
         self.file_id = str(file_id)
@@ -61,6 +64,7 @@ class Audio(TelegramObject):
         self.title = title
         self.mime_type = mime_type
         self.file_size = file_size
+        self.bot = bot
 
         self._id_attrs = (self.file_id,)
 
@@ -69,4 +73,27 @@ class Audio(TelegramObject):
         if not data:
             return None
 
-        return cls(**data)
+        return cls(bot=bot, **data)
+
+    def get_file(self, timeout=None, **kwargs):
+        """
+        Use this method to get basic info about the audio file and prepare it for downloading.
+        For the moment, bots can download files of up to 20MB in size. The file can then be
+        downloaded with :attr:`telegram.File.download`. It is guaranteed that the link will be
+        valid for at least 1 hour. When the link expires, a new one can be requested by
+        calling get_file again.
+
+        Args:
+            timeout (:obj:`int` | :obj:`float`, optional): If this value is specified, use it as
+                the read timeout from the server (instead of the one specified during creation of
+                the connection pool).
+            **kwargs (:obj:`dict`): Arbitrary keyword arguments.
+
+        Returns:
+            :class:`telegram.File`
+
+        Raises:
+            :class:`telegram.TelegramError`
+
+        """
+        return self.bot.get_file(self.file_id, timeout=timeout, **kwargs)

--- a/telegram/files/audio.py
+++ b/telegram/files/audio.py
@@ -76,12 +76,7 @@ class Audio(TelegramObject):
         return cls(bot=bot, **data)
 
     def get_file(self, timeout=None, **kwargs):
-        """
-        Use this method to get basic info about the audio file and prepare it for downloading.
-        For the moment, bots can download files of up to 20MB in size. The file can then be
-        downloaded with :attr:`telegram.File.download`. It is guaranteed that the link will be
-        valid for at least 1 hour. When the link expires, a new one can be requested by
-        calling get_file again.
+        """Convenience wrapper over :attr:`telegram.Bot.get_file`
 
         Args:
             timeout (:obj:`int` | :obj:`float`, optional): If this value is specified, use it as

--- a/telegram/files/document.py
+++ b/telegram/files/document.py
@@ -75,12 +75,7 @@ class Document(TelegramObject):
         return cls(**data, bot=bot)
 
     def get_file(self, timeout=None, **kwargs):
-        """
-        Use this method to get basic info about the document and prepare it for downloading. For
-        the moment, bots can download files of up to 20MB in size. The file can then be downloaded
-        with :attr:`telegram.File.download`. It is guaranteed that the link will be
-        valid for at least 1 hour. When the link expires, a new one can be requested by
-        calling get_file again.
+        """Convenience wrapper over :attr:`telegram.Bot.get_file`
 
         Args:
             timeout (:obj:`int` | :obj:`float`, optional): If this value is specified, use it as

--- a/telegram/files/document.py
+++ b/telegram/files/document.py
@@ -30,6 +30,7 @@ class Document(TelegramObject):
         file_name (:obj:`str`): Original filename.
         mime_type (:obj:`str`): Optional. MIME type of the file.
         file_size (:obj:`int`): Optional. File size.
+        bot (:class:`telegram.Bot`): Optional. The Bot to use for instance methods.
 
     Args:
         file_id (:obj:`str`): Unique file identifier
@@ -37,6 +38,7 @@ class Document(TelegramObject):
         file_name (:obj:`str`, optional): Original filename as defined by sender.
         mime_type (:obj:`str`, optional): MIME type of the file as defined by sender.
         file_size (:obj:`int`, optional): File size.
+        bot (:class:`telegram.Bot`, optional): The Bot to use for instance methods.
         **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
     """
@@ -48,6 +50,7 @@ class Document(TelegramObject):
                  file_name=None,
                  mime_type=None,
                  file_size=None,
+                 bot=None,
                  **kwargs):
         # Required
         self.file_id = str(file_id)
@@ -56,6 +59,7 @@ class Document(TelegramObject):
         self.file_name = file_name
         self.mime_type = mime_type
         self.file_size = file_size
+        self.bot = bot
 
         self._id_attrs = (self.file_id,)
 
@@ -68,4 +72,27 @@ class Document(TelegramObject):
 
         data['thumb'] = PhotoSize.de_json(data.get('thumb'), bot)
 
-        return cls(**data)
+        return cls(**data, bot=bot)
+
+    def get_file(self, timeout=None, **kwargs):
+        """
+        Use this method to get basic info about the document and prepare it for downloading. For
+        the moment, bots can download files of up to 20MB in size. The file can then be downloaded
+        with :attr:`telegram.File.download`. It is guaranteed that the link will be
+        valid for at least 1 hour. When the link expires, a new one can be requested by
+        calling get_file again.
+
+        Args:
+            timeout (:obj:`int` | :obj:`float`, optional): If this value is specified, use it as
+                the read timeout from the server (instead of the one specified during creation of
+                the connection pool).
+            **kwargs (:obj:`dict`): Arbitrary keyword arguments.
+
+        Returns:
+            :class:`telegram.File`
+
+        Raises:
+            :class:`telegram.TelegramError`
+
+        """
+        return self.bot.get_file(self.file_id, timeout=timeout, **kwargs)

--- a/telegram/files/photosize.py
+++ b/telegram/files/photosize.py
@@ -29,23 +29,26 @@ class PhotoSize(TelegramObject):
         width (:obj:`int`): Photo width.
         height (:obj:`int`): Photo height.
         file_size (:obj:`int`): Optional. File size.
+        bot (:class:`telegram.Bot`): Optional. The Bot to use for instance methods.
 
     Args:
         file_id (:obj:`str`): Unique identifier for this file.
         width (:obj:`int`): Photo width.
         height (:obj:`int`): Photo height.
         file_size (:obj:`int`, optional): File size.
+        bot (:class:`telegram.Bot`, optional): The Bot to use for instance methods.
         **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
     """
 
-    def __init__(self, file_id, width, height, file_size=None, **kwargs):
+    def __init__(self, file_id, width, height, file_size=None, bot=None, **kwargs):
         # Required
         self.file_id = str(file_id)
         self.width = int(width)
         self.height = int(height)
         # Optionals
         self.file_size = file_size
+        self.bot = bot
 
         self._id_attrs = (self.file_id,)
 
@@ -54,7 +57,7 @@ class PhotoSize(TelegramObject):
         if not data:
             return None
 
-        return cls(**data)
+        return cls(bot=bot, **data)
 
     @classmethod
     def de_list(cls, data, bot):
@@ -66,3 +69,26 @@ class PhotoSize(TelegramObject):
             photos.append(cls.de_json(photo, bot))
 
         return photos
+
+    def get_file(self, timeout=None, **kwargs):
+        """
+        Use this method to get basic info about the photo (only one size) and prepare it for
+        downloading. For the moment, bots can download files of up to 20MB in size. The file can
+        then be downloaded with :attr:`telegram.File.download`. It is guaranteed that the link
+        will be valid for at least 1 hour. When the link expires, a new one can be requested by
+        calling get_file again.
+
+        Args:
+            timeout (:obj:`int` | :obj:`float`, optional): If this value is specified, use it as
+                the read timeout from the server (instead of the one specified during creation of
+                the connection pool).
+            **kwargs (:obj:`dict`): Arbitrary keyword arguments.
+
+        Returns:
+            :class:`telegram.File`
+
+        Raises:
+            :class:`telegram.TelegramError`
+
+        """
+        return self.bot.get_file(self.file_id, timeout=timeout, **kwargs)

--- a/telegram/files/photosize.py
+++ b/telegram/files/photosize.py
@@ -71,12 +71,7 @@ class PhotoSize(TelegramObject):
         return photos
 
     def get_file(self, timeout=None, **kwargs):
-        """
-        Use this method to get basic info about the photo (only one size) and prepare it for
-        downloading. For the moment, bots can download files of up to 20MB in size. The file can
-        then be downloaded with :attr:`telegram.File.download`. It is guaranteed that the link
-        will be valid for at least 1 hour. When the link expires, a new one can be requested by
-        calling get_file again.
+        """Convenience wrapper over :attr:`telegram.Bot.get_file`
 
         Args:
             timeout (:obj:`int` | :obj:`float`, optional): If this value is specified, use it as

--- a/telegram/files/sticker.py
+++ b/telegram/files/sticker.py
@@ -35,6 +35,7 @@ class Sticker(TelegramObject):
         mask_position (:class:`telegram.MaskPosition`): Optional. For mask stickers, the position
             where the mask should be placed.
         file_size (:obj:`int`): Optional. File size.
+        bot (:class:`telegram.Bot`): Optional. The Bot to use for instance methods.
 
     Args:
         file_id (:obj:`str`): Unique identifier for this file.
@@ -48,7 +49,8 @@ class Sticker(TelegramObject):
         mask_position (:class:`telegram.MaskPosition`, optional): For mask stickers, the
             position where the mask should be placed.
         file_size (:obj:`int`, optional): File size.
-        **kwargs (obj:`dict`): Arbitrary keyword arguments.
+        **kwargs (obj:`dict`): Arbitrary keyword arguments.7
+        bot (:class:`telegram.Bot`, optional): The Bot to use for instance methods.
 
     """
 
@@ -61,6 +63,7 @@ class Sticker(TelegramObject):
                  file_size=None,
                  set_name=None,
                  mask_position=None,
+                 bot=None,
                  **kwargs):
         # Required
         self.file_id = str(file_id)
@@ -72,6 +75,7 @@ class Sticker(TelegramObject):
         self.file_size = file_size
         self.set_name = set_name
         self.mask_position = mask_position
+        self.bot = bot
 
         self._id_attrs = (self.file_id,)
 
@@ -85,7 +89,7 @@ class Sticker(TelegramObject):
         data['thumb'] = PhotoSize.de_json(data.get('thumb'), bot)
         data['mask_position'] = MaskPosition.de_json(data.get('mask_position'), bot)
 
-        return cls(**data)
+        return cls(bot=bot, **data)
 
     @classmethod
     def de_list(cls, data, bot):
@@ -93,6 +97,29 @@ class Sticker(TelegramObject):
             return list()
 
         return [cls.de_json(d, bot) for d in data]
+
+    def get_file(self, timeout=None, **kwargs):
+        """
+        Use this method to get basic info about the sticker file and prepare it for downloading.
+        For the moment, bots can download files of up to 20MB in size. The file can then be
+        downloaded with :attr:`telegram.File.download`. It is guaranteed that the link will be
+        valid for at least 1 hour. When the link expires, a new one can be requested by
+        calling get_file again.
+
+        Args:
+            timeout (:obj:`int` | :obj:`float`, optional): If this value is specified, use it as
+                the read timeout from the server (instead of the one specified during creation of
+                the connection pool).
+            **kwargs (:obj:`dict`): Arbitrary keyword arguments.
+
+        Returns:
+            :class:`telegram.File`
+
+        Raises:
+            :class:`telegram.TelegramError`
+
+        """
+        return self.bot.get_file(self.file_id, timeout=timeout, **kwargs)
 
 
 class StickerSet(TelegramObject):

--- a/telegram/files/sticker.py
+++ b/telegram/files/sticker.py
@@ -99,12 +99,7 @@ class Sticker(TelegramObject):
         return [cls.de_json(d, bot) for d in data]
 
     def get_file(self, timeout=None, **kwargs):
-        """
-        Use this method to get basic info about the sticker file and prepare it for downloading.
-        For the moment, bots can download files of up to 20MB in size. The file can then be
-        downloaded with :attr:`telegram.File.download`. It is guaranteed that the link will be
-        valid for at least 1 hour. When the link expires, a new one can be requested by
-        calling get_file again.
+        """Convenience wrapper over :attr:`telegram.Bot.get_file`
 
         Args:
             timeout (:obj:`int` | :obj:`float`, optional): If this value is specified, use it as

--- a/telegram/files/video.py
+++ b/telegram/files/video.py
@@ -82,12 +82,7 @@ class Video(TelegramObject):
         return cls(bot=bot, **data)
 
     def get_file(self, timeout=None, **kwargs):
-        """
-        Use this method to get basic info about the video file and prepare it for downloading.
-        For the moment, bots can download files of up to 20MB in size. The file can then be
-        downloaded with :attr:`telegram.File.download`. It is guaranteed that the link will be
-        valid for at least 1 hour. When the link expires, a new one can be requested by
-        calling get_file again.
+        """Convenience wrapper over :attr:`telegram.Bot.get_file`
 
         Args:
             timeout (:obj:`int` | :obj:`float`, optional): If this value is specified, use it as

--- a/telegram/files/video.py
+++ b/telegram/files/video.py
@@ -32,6 +32,7 @@ class Video(TelegramObject):
         thumb (:class:`telegram.PhotoSize`): Optional. Video thumbnail.
         mime_type (:obj:`str`): Optional. Mime type of a file as defined by sender.
         file_size (:obj:`int`): Optional. File size.
+        bot (:class:`telegram.Bot`): Optional. The Bot to use for instance methods.
 
     Args:
         file_id (:obj:`str`): Unique identifier for this file.
@@ -41,6 +42,7 @@ class Video(TelegramObject):
         thumb (:class:`telegram.PhotoSize`, optional): Video thumbnail.
         mime_type (:obj:`str`, optional): Mime type of a file as defined by sender.
         file_size (:obj:`int`, optional): File size.
+        bot (:class:`telegram.Bot`, optional): The Bot to use for instance methods.
         **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
     """
@@ -53,6 +55,7 @@ class Video(TelegramObject):
                  thumb=None,
                  mime_type=None,
                  file_size=None,
+                 bot=None,
                  **kwargs):
         # Required
         self.file_id = str(file_id)
@@ -63,6 +66,7 @@ class Video(TelegramObject):
         self.thumb = thumb
         self.mime_type = mime_type
         self.file_size = file_size
+        self.bot = bot
 
         self._id_attrs = (self.file_id,)
 
@@ -75,4 +79,27 @@ class Video(TelegramObject):
 
         data['thumb'] = PhotoSize.de_json(data.get('thumb'), bot)
 
-        return cls(**data)
+        return cls(bot=bot, **data)
+
+    def get_file(self, timeout=None, **kwargs):
+        """
+        Use this method to get basic info about the video file and prepare it for downloading.
+        For the moment, bots can download files of up to 20MB in size. The file can then be
+        downloaded with :attr:`telegram.File.download`. It is guaranteed that the link will be
+        valid for at least 1 hour. When the link expires, a new one can be requested by
+        calling get_file again.
+
+        Args:
+            timeout (:obj:`int` | :obj:`float`, optional): If this value is specified, use it as
+                the read timeout from the server (instead of the one specified during creation of
+                the connection pool).
+            **kwargs (:obj:`dict`): Arbitrary keyword arguments.
+
+        Returns:
+            :class:`telegram.File`
+
+        Raises:
+            :class:`telegram.TelegramError`
+
+        """
+        return self.bot.get_file(self.file_id, timeout=timeout, **kwargs)

--- a/telegram/files/videonote.py
+++ b/telegram/files/videonote.py
@@ -30,6 +30,7 @@ class VideoNote(TelegramObject):
         duration (:obj:`int`): Duration of the video in seconds as defined by sender.
         thumb (:class:`telegram.PhotoSize`): Optional. Video thumbnail.
         file_size (:obj:`int`): Optional. File size.
+        bot (:class:`telegram.Bot`): Optional. The Bot to use for instance methods.
 
     Args:
         file_id (:obj:`str`): Unique identifier for this file.
@@ -37,11 +38,12 @@ class VideoNote(TelegramObject):
         duration (:obj:`int`): Duration of the video in seconds as defined by sender.
         thumb (:class:`telegram.PhotoSize`, optional): Video thumbnail.
         file_size (:obj:`int`, optional): File size.
+        bot (:class:`telegram.Bot`, optional): The Bot to use for instance methods.
         **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
     """
 
-    def __init__(self, file_id, length, duration, thumb=None, file_size=None, **kwargs):
+    def __init__(self, file_id, length, duration, thumb=None, file_size=None, bot=None, **kwargs):
         # Required
         self.file_id = str(file_id)
         self.length = int(length)
@@ -49,6 +51,7 @@ class VideoNote(TelegramObject):
         # Optionals
         self.thumb = thumb
         self.file_size = file_size
+        self.bot = bot
 
         self._id_attrs = (self.file_id,)
 
@@ -61,4 +64,27 @@ class VideoNote(TelegramObject):
 
         data['thumb'] = PhotoSize.de_json(data.get('thumb'), bot)
 
-        return cls(**data)
+        return cls(bot=bot, **data)
+
+    def get_file(self, timeout=None, **kwargs):
+        """
+        Use this method to get basic info about the video message file and prepare it for
+        downloading. For the moment, bots can download files of up to 20MB in size. The file can
+        then be downloaded with :attr:`telegram.File.download`. It is guaranteed that the link
+        will be valid for at least 1 hour. When the link expires, a new one can be requested by
+        calling get_file again.
+
+        Args:
+            timeout (:obj:`int` | :obj:`float`, optional): If this value is specified, use it as
+                the read timeout from the server (instead of the one specified during creation of
+                the connection pool).
+            **kwargs (:obj:`dict`): Arbitrary keyword arguments.
+
+        Returns:
+            :class:`telegram.File`
+
+        Raises:
+            :class:`telegram.TelegramError`
+
+        """
+        return self.bot.get_file(self.file_id, timeout=timeout, **kwargs)

--- a/telegram/files/videonote.py
+++ b/telegram/files/videonote.py
@@ -67,12 +67,7 @@ class VideoNote(TelegramObject):
         return cls(bot=bot, **data)
 
     def get_file(self, timeout=None, **kwargs):
-        """
-        Use this method to get basic info about the video message file and prepare it for
-        downloading. For the moment, bots can download files of up to 20MB in size. The file can
-        then be downloaded with :attr:`telegram.File.download`. It is guaranteed that the link
-        will be valid for at least 1 hour. When the link expires, a new one can be requested by
-        calling get_file again.
+        """Convenience wrapper over :attr:`telegram.Bot.get_file`
 
         Args:
             timeout (:obj:`int` | :obj:`float`, optional): If this value is specified, use it as

--- a/telegram/files/voice.py
+++ b/telegram/files/voice.py
@@ -62,12 +62,7 @@ class Voice(TelegramObject):
         return cls(bot=bot, **data)
 
     def get_file(self, timeout=None, **kwargs):
-        """
-        Use this method to get basic info about the sticker file and prepare it for downloading.
-        For the moment, bots can download files of up to 20MB in size. The file can then be
-        downloaded with :attr:`telegram.File.download`. It is guaranteed that the link will be
-        valid for at least 1 hour. When the link expires, a new one can be requested by
-        calling get_file again.
+        """Convenience wrapper over :attr:`telegram.Bot.get_file`
 
         Args:
             timeout (:obj:`int` | :obj:`float`, optional): If this value is specified, use it as

--- a/telegram/files/voice.py
+++ b/telegram/files/voice.py
@@ -29,23 +29,26 @@ class Voice(TelegramObject):
         duration (:obj:`int`): Duration of the audio in seconds as defined by sender.
         mime_type (:obj:`str`): Optional. MIME type of the file as defined by sender.
         file_size (:obj:`int`): Optional. File size.
+        bot (:class:`telegram.Bot`): Optional. The Bot to use for instance methods.
 
     Args:
         file_id (:obj:`str`): Unique identifier for this file.
         duration (:obj:`int`, optional): Duration of the audio in seconds as defined by sender.
         mime_type (:obj:`str`, optional): MIME type of the file as defined by sender.
         file_size (:obj:`int`, optional): File size.
+        bot (:class:`telegram.Bot`, optional): The Bot to use for instance methods.
         **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
     """
 
-    def __init__(self, file_id, duration, mime_type=None, file_size=None, **kwargs):
+    def __init__(self, file_id, duration, mime_type=None, file_size=None, bot=None, **kwargs):
         # Required
         self.file_id = str(file_id)
         self.duration = int(duration)
         # Optionals
         self.mime_type = mime_type
         self.file_size = file_size
+        self.bot = bot
 
         self._id_attrs = (self.file_id,)
 
@@ -56,4 +59,27 @@ class Voice(TelegramObject):
 
         data = super(Voice, cls).de_json(data, bot)
 
-        return cls(**data)
+        return cls(bot=bot, **data)
+
+    def get_file(self, timeout=None, **kwargs):
+        """
+        Use this method to get basic info about the sticker file and prepare it for downloading.
+        For the moment, bots can download files of up to 20MB in size. The file can then be
+        downloaded with :attr:`telegram.File.download`. It is guaranteed that the link will be
+        valid for at least 1 hour. When the link expires, a new one can be requested by
+        calling get_file again.
+
+        Args:
+            timeout (:obj:`int` | :obj:`float`, optional): If this value is specified, use it as
+                the read timeout from the server (instead of the one specified during creation of
+                the connection pool).
+            **kwargs (:obj:`dict`): Arbitrary keyword arguments.
+
+        Returns:
+            :class:`telegram.File`
+
+        Raises:
+            :class:`telegram.TelegramError`
+
+        """
+        return self.bot.get_file(self.file_id, timeout=timeout, **kwargs)

--- a/telegram/user.py
+++ b/telegram/user.py
@@ -20,8 +20,8 @@
 """This module contains an object that represents a Telegram User."""
 
 from telegram import TelegramObject
-from telegram.utils.helpers import mention_markdown as util_mention_markdown
 from telegram.utils.helpers import mention_html as util_mention_html
+from telegram.utils.helpers import mention_markdown as util_mention_markdown
 
 
 class User(TelegramObject):
@@ -146,3 +146,107 @@ class User(TelegramObject):
             return util_mention_html(self.id, self.name)
         else:
             return util_mention_html(self.id, name)
+
+    def send_message(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_message(User.chat_id, *args, **kwargs)
+
+        Where User is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.send_message(chat_id=self.id, *args, **kwargs)
+
+    def send_photo(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_photo(User.chat_id, *args, **kwargs)
+
+        Where User is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.send_photo(chat_id=self.id, *args, **kwargs)
+
+    def send_audio(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_audio(User.chat_id, *args, **kwargs)
+
+        Where User is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.send_audio(chat_id=self.id, *args, **kwargs)
+
+    def send_document(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_document(User.chat_id, *args, **kwargs)
+
+        Where User is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.send_document(chat_id=self.id, *args, **kwargs)
+
+    def send_sticker(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_sticker(User.chat_id, *args, **kwargs)
+
+        Where User is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.send_sticker(chat_id=self.id, *args, **kwargs)
+
+    def send_video(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_video(User.chat_id, *args, **kwargs)
+
+        Where User is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.send_video(chat_id=self.id, *args, **kwargs)
+
+    def send_video_note(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_video_note(User.chat_id, *args, **kwargs)
+
+        Where User is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.send_video_note(chat_id=self.id, *args, **kwargs)
+
+    def send_voice(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_voice(User.chat_id, *args, **kwargs)
+
+        Where User is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.send_voice(chat_id=self.id, *args, **kwargs)

--- a/telegram/user.py
+++ b/telegram/user.py
@@ -158,7 +158,7 @@ class User(TelegramObject):
             :class:`telegram.Message`: On success, instance representing the message posted.
 
         """
-        return self.send_message(chat_id=self.id, *args, **kwargs)
+        return self.bot.send_message(chat_id=self.id, *args, **kwargs)
 
     def send_photo(self, *args, **kwargs):
         """Shortcut for::
@@ -171,7 +171,7 @@ class User(TelegramObject):
             :class:`telegram.Message`: On success, instance representing the message posted.
 
         """
-        return self.send_photo(chat_id=self.id, *args, **kwargs)
+        return self.bot.send_photo(chat_id=self.id, *args, **kwargs)
 
     def send_audio(self, *args, **kwargs):
         """Shortcut for::
@@ -184,7 +184,7 @@ class User(TelegramObject):
             :class:`telegram.Message`: On success, instance representing the message posted.
 
         """
-        return self.send_audio(chat_id=self.id, *args, **kwargs)
+        return self.bot.send_audio(chat_id=self.id, *args, **kwargs)
 
     def send_document(self, *args, **kwargs):
         """Shortcut for::
@@ -197,7 +197,7 @@ class User(TelegramObject):
             :class:`telegram.Message`: On success, instance representing the message posted.
 
         """
-        return self.send_document(chat_id=self.id, *args, **kwargs)
+        return self.bot.send_document(chat_id=self.id, *args, **kwargs)
 
     def send_sticker(self, *args, **kwargs):
         """Shortcut for::
@@ -210,7 +210,7 @@ class User(TelegramObject):
             :class:`telegram.Message`: On success, instance representing the message posted.
 
         """
-        return self.send_sticker(chat_id=self.id, *args, **kwargs)
+        return self.bot.send_sticker(chat_id=self.id, *args, **kwargs)
 
     def send_video(self, *args, **kwargs):
         """Shortcut for::
@@ -223,7 +223,7 @@ class User(TelegramObject):
             :class:`telegram.Message`: On success, instance representing the message posted.
 
         """
-        return self.send_video(chat_id=self.id, *args, **kwargs)
+        return self.bot.send_video(chat_id=self.id, *args, **kwargs)
 
     def send_video_note(self, *args, **kwargs):
         """Shortcut for::
@@ -236,7 +236,7 @@ class User(TelegramObject):
             :class:`telegram.Message`: On success, instance representing the message posted.
 
         """
-        return self.send_video_note(chat_id=self.id, *args, **kwargs)
+        return self.bot.send_video_note(chat_id=self.id, *args, **kwargs)
 
     def send_voice(self, *args, **kwargs):
         """Shortcut for::
@@ -249,4 +249,4 @@ class User(TelegramObject):
             :class:`telegram.Message`: On success, instance representing the message posted.
 
         """
-        return self.send_voice(chat_id=self.id, *args, **kwargs)
+        return self.bot.send_voice(chat_id=self.id, *args, **kwargs)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -165,6 +165,13 @@ class TestAudio(object):
         with pytest.raises(TypeError):
             bot.send_audio(chat_id=chat_id)
 
+    def test_get_file_instance_method(self, monkeypatch, audio):
+        def test(*args, **kwargs):
+            return args[1] == audio.file_id
+
+        monkeypatch.setattr('telegram.Bot.get_file', test)
+        assert audio.get_file()
+
     def test_equality(self, audio):
         a = Audio(audio.file_id, audio.duration)
         b = Audio(audio.file_id, audio.duration)

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -124,6 +124,55 @@ class TestChat(object):
         monkeypatch.setattr('telegram.Bot.unban_chat_member', test)
         assert chat.unban_member(42)
 
+    def test_instance_method_send_message(self, monkeypatch, chat):
+        def test(*args, **kwargs):
+            return kwargs['chat_id'] == chat.id and args[1] == 'test'
+
+        monkeypatch.setattr('telegram.Bot.send_message', test)
+        assert chat.send_message('test')
+
+    def test_instance_method_send_audio(self, monkeypatch, chat):
+        def test(*args, **kwargs):
+            return kwargs['chat_id'] == chat.id and kwargs['audio'] == 'test_audio'
+
+        monkeypatch.setattr('telegram.Bot.send_audio', test)
+        assert chat.send_audio(audio='test_audio')
+
+    def test_instance_method_send_document(self, monkeypatch, chat):
+        def test(*args, **kwargs):
+            return kwargs['chat_id'] == chat.id and kwargs['document'] == 'test_document'
+
+        monkeypatch.setattr('telegram.Bot.send_document', test)
+        assert chat.send_document(document='test_document')
+
+    def test_instance_method_send_sticker(self, monkeypatch, chat):
+        def test(*args, **kwargs):
+            return kwargs['chat_id'] == chat.id and kwargs['sticker'] == 'test_sticker'
+
+        monkeypatch.setattr('telegram.Bot.send_sticker', test)
+        assert chat.send_sticker(sticker='test_sticker')
+
+    def test_instance_method_send_video(self, monkeypatch, chat):
+        def test(*args, **kwargs):
+            return kwargs['chat_id'] == chat.id and kwargs['video'] == 'test_video'
+
+        monkeypatch.setattr('telegram.Bot.send_video', test)
+        assert chat.send_video(video='test_video')
+
+    def test_instance_method_send_video_note(self, monkeypatch, chat):
+        def test(*args, **kwargs):
+            return kwargs['chat_id'] == chat.id and kwargs['video_note'] == 'test_video_note'
+
+        monkeypatch.setattr('telegram.Bot.send_video_note', test)
+        assert chat.send_video_note(video_note='test_video_note')
+
+    def test_instance_method_send_voice(self, monkeypatch, chat):
+        def test(*args, **kwargs):
+            return kwargs['chat_id'] == chat.id and kwargs['voice'] == 'test_voice'
+
+        monkeypatch.setattr('telegram.Bot.send_voice', test)
+        assert chat.send_voice(voice='test_voice')
+
     def test_equality(self):
         a = Chat(self.id, self.title, self.type)
         b = Chat(self.id, self.title, self.type)

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -162,6 +162,13 @@ class TestDocument(object):
         with pytest.raises(TypeError):
             bot.send_document(chat_id=chat_id)
 
+    def test_get_file_instance_method(self, monkeypatch, document):
+        def test(*args, **kwargs):
+            return args[1] == document.file_id
+
+        monkeypatch.setattr('telegram.Bot.get_file', test)
+        assert document.get_file()
+
     def test_equality(self, document):
         a = Document(document.file_id)
         b = Document(document.file_id)

--- a/tests/test_photo.py
+++ b/tests/test_photo.py
@@ -246,6 +246,13 @@ class TestPhoto(object):
         with pytest.raises(TypeError):
             bot.send_photo(chat_id=chat_id)
 
+    def test_get_file_instance_method(self, monkeypatch, photo):
+        def test(*args, **kwargs):
+            return args[1] == photo.file_id
+
+        monkeypatch.setattr('telegram.Bot.get_file', test)
+        assert photo.get_file()
+
     def test_equality(self, photo):
         a = PhotoSize(photo.file_id, self.width, self.height)
         b = PhotoSize(photo.file_id, self.width, self.height)

--- a/tests/test_sticker.py
+++ b/tests/test_sticker.py
@@ -277,6 +277,13 @@ class TestStickerSet(object):
         file_id = sticker_set.stickers[-1].file_id
         assert bot.delete_sticker_from_set(file_id)
 
+    def test_get_file_instance_method(self, monkeypatch, sticker):
+        def test(*args, **kwargs):
+            return args[1] == sticker.file_id
+
+        monkeypatch.setattr('telegram.Bot.get_file', test)
+        assert sticker.get_file()
+
     def test_equality(self):
         a = StickerSet(self.name, self.title, self.contains_masks, self.stickers)
         b = StickerSet(self.name, self.title, self.contains_masks, self.stickers)

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -90,7 +90,7 @@ class TestUser(object):
         assert user.name == 'first_name'
         user.username = self.username
         assert user.name == '@username'
-    
+
     def test_full_name(self, user):
         assert user.full_name == 'first_name last_name'
         user.last_name = None
@@ -102,6 +102,55 @@ class TestUser(object):
 
         monkeypatch.setattr('telegram.Bot.get_user_profile_photos', test)
         assert user.get_profile_photos()
+
+    def test_instance_method_send_message(self, monkeypatch, user):
+        def test(*args, **kwargs):
+            return kwargs['chat_id'] == user.id and args[1] == 'test'
+
+        monkeypatch.setattr('telegram.Bot.send_message', test)
+        assert user.send_message('test')
+
+    def test_instance_method_send_audio(self, monkeypatch, user):
+        def test(*args, **kwargs):
+            return kwargs['chat_id'] == user.id and kwargs['audio'] == 'test_audio'
+
+        monkeypatch.setattr('telegram.Bot.send_audio', test)
+        assert user.send_audio(audio='test_audio')
+
+    def test_instance_method_send_document(self, monkeypatch, user):
+        def test(*args, **kwargs):
+            return kwargs['chat_id'] == user.id and kwargs['document'] == 'test_document'
+
+        monkeypatch.setattr('telegram.Bot.send_document', test)
+        assert user.send_document(document='test_document')
+
+    def test_instance_method_send_sticker(self, monkeypatch, user):
+        def test(*args, **kwargs):
+            return kwargs['chat_id'] == user.id and kwargs['sticker'] == 'test_sticker'
+
+        monkeypatch.setattr('telegram.Bot.send_sticker', test)
+        assert user.send_sticker(sticker='test_sticker')
+
+    def test_instance_method_send_video(self, monkeypatch, user):
+        def test(*args, **kwargs):
+            return kwargs['chat_id'] == user.id and kwargs['video'] == 'test_video'
+
+        monkeypatch.setattr('telegram.Bot.send_video', test)
+        assert user.send_video(video='test_video')
+
+    def test_instance_method_send_video_note(self, monkeypatch, user):
+        def test(*args, **kwargs):
+            return kwargs['chat_id'] == user.id and kwargs['video_note'] == 'test_video_note'
+
+        monkeypatch.setattr('telegram.Bot.send_video_note', test)
+        assert user.send_video_note(video_note='test_video_note')
+
+    def test_instance_method_send_voice(self, monkeypatch, user):
+        def test(*args, **kwargs):
+            return kwargs['chat_id'] == user.id and kwargs['voice'] == 'test_voice'
+
+        monkeypatch.setattr('telegram.Bot.send_voice', test)
+        assert user.send_voice(voice='test_voice')
 
     def test_equality(self):
         a = User(self.id, self.first_name, self.is_bot, self.last_name)

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -183,6 +183,13 @@ class TestVideo(object):
         with pytest.raises(TypeError):
             bot.send_video(chat_id=chat_id)
 
+    def test_get_file_instance_method(self, monkeypatch, video):
+        def test(*args, **kwargs):
+            return args[1] == video.file_id
+
+        monkeypatch.setattr('telegram.Bot.get_file', test)
+        assert video.get_file()
+
     def test_equality(self, video):
         a = Video(video.file_id, self.width, self.height, self.duration)
         b = Video(video.file_id, self.width, self.height, self.duration)

--- a/tests/test_videonote.py
+++ b/tests/test_videonote.py
@@ -146,6 +146,13 @@ class TestVideoNote(object):
         with pytest.raises(TypeError):
             bot.send_video_note(chat_id=chat_id)
 
+    def test_get_file_instance_method(self, monkeypatch, video_note):
+        def test(*args, **kwargs):
+            return args[1] == video_note.file_id
+
+        monkeypatch.setattr('telegram.Bot.get_file', test)
+        assert video_note.get_file()
+
     def test_equality(self, video_note):
         a = VideoNote(video_note.file_id, self.length, self.duration)
         b = VideoNote(video_note.file_id, self.length, self.duration)

--- a/tests/test_voice.py
+++ b/tests/test_voice.py
@@ -150,6 +150,13 @@ class TestVoice(object):
         with pytest.raises(TypeError):
             bot.sendVoice(chat_id)
 
+    def test_get_file_instance_method(self, monkeypatch, voice):
+        def test(*args, **kwargs):
+            return args[1] == voice.file_id
+
+        monkeypatch.setattr('telegram.Bot.get_file', test)
+        assert voice.get_file()
+
     def test_equality(self, voice):
         a = Voice(voice.file_id, self.duration)
         b = Voice(voice.file_id, self.duration)


### PR DESCRIPTION
Fixes #955 
Adds more instance methods, namely:
- Chat.send_\*() and User.send_\*()
*This allows stuff such as:*
```python
def callback(bot, update):
  # send the user a PM
  update.effective_user.send_message("Hi you send stuff")
  update.message.reply_text("Hey {}, check your PM".format(update.effective_user.mention_html()), parse_mode="HTML")
```
- Document.get_file()
_As well as PhotoSize.get_file(), Video.get_file() etc._
_Allows stuff like:_
```python
def callback(bot, update):
    update.message.document.get_file().download()
```


Additionally also does such that
`bot.get_file(update.message.document)`
works instead of
`bot.get_file(update.message.document.file_id)`