### PR TITLE
Add two arguments to send_invoice

### DIFF
--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -2202,6 +2202,8 @@ class Bot(TelegramObject):
                      reply_to_message_id=None,
                      reply_markup=None,
                      provider_data=None,
+                     send_phone_number_to_provider=None,
+                     send_email_to_provider=None,
                      timeout=None,
                      **kwargs):
         """Use this method to send invoices.
@@ -2236,6 +2238,10 @@ class Bot(TelegramObject):
                 complete the order.
             need_shipping_address (:obj:`bool`, optional): Pass True, if you require the user's
                 shipping address to complete the order.
+            send_phone_number_to_provider (:obj:`bool`, optional): Pass True, if user's phone
+                number should be sent to provider.
+            send_email_to_provider (:obj:`bool`, optional): Pass True, if user's email address
+                should be sent to provider.
             is_flexible (:obj:`bool`, optional): Pass True, if the final price depends on the
                 shipping method.
             disable_notification (:obj:`bool`, optional): Sends the message silently. Users will
@@ -2292,6 +2298,10 @@ class Bot(TelegramObject):
             data['need_shipping_address'] = need_shipping_address
         if is_flexible is not None:
             data['is_flexible'] = is_flexible
+        if send_phone_number_to_provider is not None:
+            data['send_phone_number_to_provider'] = send_email_to_provider
+        if send_email_to_provider is not None:
+            data['send_email_to_provider'] = send_email_to_provider
 
         return url, data
 

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -100,6 +100,8 @@ class TestInvoice(object):
             need_phone_number=True,
             need_email=True,
             need_shipping_address=True,
+            send_phone_number_to_provider=True,
+            send_email_to_provider=True,
             is_flexible=True)
 
         assert message.invoice.currency == self.currency


### PR DESCRIPTION
Telegram silently added `send_phone_number_to_provider` and `send_email_to_provider` to the send_invoice method.