### PR TITLE
#936 Reply media group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.pytest_cache
 nosetests.xml
 coverage.xml
 *,cover

--- a/.pytest_cache/v/cache/lastfailed
+++ b/.pytest_cache/v/cache/lastfailed
@@ -1,0 +1,3 @@
+{
+  "tests/test_official.py::test_official[sendInvoice]": true
+}

--- a/.pytest_cache/v/cache/lastfailed
+++ b/.pytest_cache/v/cache/lastfailed
@@ -1,3 +1,0 @@
-{
-  "tests/test_official.py::test_official[sendInvoice]": true
-}

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -51,6 +51,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `njittam <https://github.com/njittam>`_
 - `Noam Meltzer <https://github.com/tsnoam>`_
 - `Oleg Shlyazhko <https://github.com/ollmer>`_
+- `Oleg Sushchenko <https://github.com/feuillemorte>`_
 - `overquota <https://github.com/overquota>`_
 - `Patrick Hofmann <https://github.com/PH89>`_
 - `Pieter Schutz <https://github.com/eldinnie>`_

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -432,16 +432,10 @@ class Message(TelegramObject):
             bot.reply_media_group(update.message.chat_id, *args, **kwargs)
 
         Keyword Args:
-            chat_id (:obj:`int` | :obj:`str`): Unique identifier for the target chat or username
-                of the target channel (in the format @channelusername).
-            media (List[:class:`telegram.InputMedia`]): An array describing photos and videos to be
-                sent, must include 2-10 items.
-            disable_notification (:obj:`bool`, optional): Sends the message silently. Users will
-                receive a notification with no sound.
-            reply_to_message_id (:obj:`int`, optional): If the message is a reply, ID of the
-                original message.
-            timeout (:obj:`int` | :obj:`float`, optional): Send file timeout (default: 20 seconds).
-            **kwargs (:obj:`dict`): Arbitrary keyword arguments.
+            quote (:obj:`bool`, optional): If set to ``True``, the media group is sent as an
+                actual reply to this message. If ``reply_to_message_id`` is passed in ``kwargs``,
+                this parameter will be ignored. Default: ``True`` in group chats and ``False`` in
+                private chats.
 
         Returns:
             List[:class:`telegram.Message`]: An array of the sent Messages.

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -426,6 +426,32 @@ class Message(TelegramObject):
         self._quote(kwargs)
         return self.bot.send_message(self.chat_id, *args, **kwargs)
 
+    def reply_media_group(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.reply_media_group(update.message.chat_id, *args, **kwargs)
+
+        Keyword Args:
+            chat_id (:obj:`int` | :obj:`str`): Unique identifier for the target chat or username
+                of the target channel (in the format @channelusername).
+            media (List[:class:`telegram.InputMedia`]): An array describing photos and videos to be
+                sent, must include 2-10 items.
+            disable_notification (:obj:`bool`, optional): Sends the message silently. Users will
+                receive a notification with no sound.
+            reply_to_message_id (:obj:`int`, optional): If the message is a reply, ID of the
+                original message.
+            timeout (:obj:`int` | :obj:`float`, optional): Send file timeout (default: 20 seconds).
+            **kwargs (:obj:`dict`): Arbitrary keyword arguments.
+
+        Returns:
+            List[:class:`telegram.Message`]: An array of the sent Messages.
+
+        Raises:
+            :class:`telegram.TelegramError`
+        """
+        self._quote(kwargs)
+        return self.bot.send_media_group(self.chat_id, *args, **kwargs)
+
     def reply_photo(self, *args, **kwargs):
         """Shortcut for::
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -241,6 +241,20 @@ class TestMessage(object):
         assert message.reply_text('test', quote=True)
         assert message.reply_text('test', reply_to_message_id=message.message_id, quote=True)
 
+    def test_reply_media_group(self, monkeypatch, message):
+        def test(*args, **kwargs):
+            id = args[1] == message.chat_id
+            media = kwargs['media'] == 'reply_media_group'
+            if kwargs.get('reply_to_message_id'):
+                reply = kwargs['reply_to_message_id'] == message.message_id
+            else:
+                reply = True
+            return id and media and reply
+
+        monkeypatch.setattr('telegram.Bot.send_media_group', test)
+        assert message.reply_media_group(media='reply_media_group')
+        assert message.reply_media_group(media='reply_media_group', quote=True)
+
     def test_reply_photo(self, monkeypatch, message):
         def test(*args, **kwargs):
             id = args[1] == message.chat_id


### PR DESCRIPTION
Fixes #936 

Added reply_media_group() function in Message class.

How to tests:

create handler, insert code:
```
update.message.reply_media_group([InputMediaPhoto('https://telegram.org/img/t_logo.png'),
                                      InputMediaPhoto('https://telegram.org/img/t_logo.png')],
                                     quote=True)
```
use handler in telegram client

![image](https://user-images.githubusercontent.com/9434344/35696790-769ffe74-0799-11e8-9f80-44f9393d972e.png)
