### PR TITLE
CommandHandler - ignore strings in entities and "/" followed by whitespace

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -53,8 +53,8 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Oleg Shlyazhko <https://github.com/ollmer>`_
 - `Oleg Sushchenko <https://github.com/feuillemorte>`_
 - `overquota <https://github.com/overquota>`_
-- `Paul Larsen <https://github.com/PaulSonOfLars>`_
 - `Patrick Hofmann <https://github.com/PH89>`_
+- `Paul Larsen <https://github.com/PaulSonOfLars>`_
 - `Pieter Schutz <https://github.com/eldinnie>`_
 - `Rahiel Kasim <https://github.com/rahiel>`_
 - `Sascha <https://github.com/saschalalala>`_

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -53,6 +53,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Oleg Shlyazhko <https://github.com/ollmer>`_
 - `Oleg Sushchenko <https://github.com/feuillemorte>`_
 - `overquota <https://github.com/overquota>`_
+- `Paul Larsen <https://github.com/PaulSonOfLars>`_
 - `Patrick Hofmann <https://github.com/PH89>`_
 - `Pieter Schutz <https://github.com/eldinnie>`_
 - `Rahiel Kasim <https://github.com/rahiel>`_

--- a/telegram/ext/commandhandler.py
+++ b/telegram/ext/commandhandler.py
@@ -134,19 +134,24 @@ class CommandHandler(Handler):
             message = update.message or update.edited_message
 
             if message.text and message.text.startswith('/') and len(message.text) > 1:
-                command = message.text[1:].split(None, 1)[0].split('@')
-                command.append(
-                    message.bot.username)  # in case the command was send without a username
+                fst_word = message.text.split(None, 1)[0]
+                if len(fst_word) > 1 and fst_word.startswith('/'):
+                    command = fst_word[1:].split('@')
+                    command.append(
+                        message.bot.username)  # in case the command was sent without a username
 
-                if self.filters is None:
-                    res = True
-                elif isinstance(self.filters, list):
-                    res = any(func(message) for func in self.filters)
+                    if self.filters is None:
+                        res = True
+                    elif isinstance(self.filters, list):
+                        res = any(func(message) for func in self.filters)
+                    else:
+                        res = self.filters(message)
+
+                    return res and (command[0].lower() in self.command
+                                    and command[1].lower() == message.bot.username.lower())
                 else:
-                    res = self.filters(message)
+                    return False
 
-                return res and (command[0].lower() in self.command
-                                and command[1].lower() == message.bot.username.lower())
             else:
                 return False
 

--- a/telegram/ext/commandhandler.py
+++ b/telegram/ext/commandhandler.py
@@ -134,7 +134,7 @@ class CommandHandler(Handler):
             message = update.message or update.edited_message
 
             if message.text and message.text.startswith('/') and len(message.text) > 1:
-                fst_word = message.text.split(None, 1)[0]
+                fst_word = message.text_markdown.split(None, 1)[0]
                 if len(fst_word) > 1 and fst_word.startswith('/'):
                     command = fst_word[1:].split('@')
                     command.append(

--- a/telegram/ext/commandhandler.py
+++ b/telegram/ext/commandhandler.py
@@ -134,9 +134,9 @@ class CommandHandler(Handler):
             message = update.message or update.edited_message
 
             if message.text and message.text.startswith('/') and len(message.text) > 1:
-                fst_word = message.text_markdown.split(None, 1)[0]
-                if len(fst_word) > 1 and fst_word.startswith('/'):
-                    command = fst_word[1:].split('@')
+                first_word = message.text_html.split(None, 1)[0]
+                if len(first_word) > 1 and first_word.startswith('/'):
+                    command = first_word[1:].split('@')
                     command.append(
                         message.bot.username)  # in case the command was sent without a username
 

--- a/telegram/ext/commandhandler.py
+++ b/telegram/ext/commandhandler.py
@@ -149,14 +149,8 @@ class CommandHandler(Handler):
 
                     return res and (command[0].lower() in self.command
                                     and command[1].lower() == message.bot.username.lower())
-                else:
-                    return False
 
-            else:
-                return False
-
-        else:
-            return False
+        return False
 
     def handle_update(self, update, dispatcher):
         """Send the update to the :attr:`callback`.

--- a/tests/test_commandhandler.py
+++ b/tests/test_commandhandler.py
@@ -190,6 +190,9 @@ class TestCommandHandler(object):
         message.text = '/'
         assert not handler.check_update(Update(0, message))
 
+        message.text = '/ test'
+        assert not handler.check_update(Update(0, message))
+
     def test_pass_user_or_chat_data(self, dp, message):
         handler = CommandHandler('test', self.callback_data_1, pass_user_data=True)
         dp.add_handler(handler)


### PR DESCRIPTION
Telegram entities show that `/ test` is not a valid command. However,
PTB accepts this as a valid command due to how the message splitting is
done.

This commit makes sure that any commands are indeed in the format of
`/test`, with no space between `/` and `test`.