### PR TITLE
Fix in telegram.Message

### DIFF
--- a/telegram/message.py
+++ b/telegram/message.py
@@ -868,7 +868,7 @@ class Message(TelegramObject):
 
     @staticmethod
     def _parse_html(message_text, entities, urled=False):
-        if not message_text:
+        if message_text is None:
             return None
 
         if not sys.maxunicode == 0xffff:
@@ -965,7 +965,7 @@ class Message(TelegramObject):
 
     @staticmethod
     def _parse_markdown(message_text, entities, urled=False):
-        if not message_text:
+        if message_text is None:
             return None
 
         if not sys.maxunicode == 0xffff:

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -868,6 +868,9 @@ class Message(TelegramObject):
 
     @staticmethod
     def _parse_html(message_text, entities, urled=False):
+        if not message_text:
+            return None
+
         if not sys.maxunicode == 0xffff:
             message_text = message_text.encode('utf-16-le')
 
@@ -962,6 +965,9 @@ class Message(TelegramObject):
 
     @staticmethod
     def _parse_markdown(message_text, entities, urled=False):
+        if not message_text:
+            return None
+
         if not sys.maxunicode == 0xffff:
             message_text = message_text.encode('utf-16-le')
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -176,7 +176,7 @@ class TestMessage(object):
     def test_text_html_empty(self, message):
         message.text = None
         message.caption = "test"
-        assert not message.text_html
+        assert message.text_html is None
 
     def test_text_html_urled(self):
         test_html_string = ('Test for &lt;<b>bold</b>, <i>ita_lic</i>, <code>code</code>, '
@@ -194,7 +194,7 @@ class TestMessage(object):
     def test_text_markdown_empty(self, message):
         message.text = None
         message.caption = "test"
-        assert not message.text_markdown
+        assert message.text_markdown is None
 
     def test_text_markdown_urled(self):
         test_md_string = ('Test for <*bold*, _ita\_lic_, `code`, [links](http://github.com/) and '
@@ -228,7 +228,7 @@ class TestMessage(object):
     def test_caption_html_empty(self, message):
         message.text = "test"
         message.caption = None
-        assert not message.caption_html
+        assert message.caption_html is None
 
     def test_caption_html_urled(self):
         test_html_string = ('Test for &lt;<b>bold</b>, <i>ita_lic</i>, <code>code</code>, '
@@ -246,7 +246,7 @@ class TestMessage(object):
     def test_caption_markdown_empty(self, message):
         message.text = "test"
         message.caption = None
-        assert not message.caption_markdown
+        assert message.caption_markdown is None
 
     def test_caption_markdown_urled(self):
         test_md_string = ('Test for <*bold*, _ita\_lic_, `code`, [links](http://github.com/) and '

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -173,6 +173,11 @@ class TestMessage(object):
         text_html = self.test_message.text_html
         assert text_html == test_html_string
 
+    def test_text_html_empty(self, message):
+        message.text = None
+        message.caption = "test"
+        assert not message.text_html
+
     def test_text_html_urled(self):
         test_html_string = ('Test for &lt;<b>bold</b>, <i>ita_lic</i>, <code>code</code>, '
                             '<a href="http://github.com/">links</a> and <pre>pre</pre>. '
@@ -185,6 +190,11 @@ class TestMessage(object):
                           '```pre```. http://google.com')
         text_markdown = self.test_message.text_markdown
         assert text_markdown == test_md_string
+
+    def test_text_markdown_empty(self, message):
+        message.text = None
+        message.caption = "test"
+        assert not message.text_markdown
 
     def test_text_markdown_urled(self):
         test_md_string = ('Test for <*bold*, _ita\_lic_, `code`, [links](http://github.com/) and '
@@ -215,6 +225,11 @@ class TestMessage(object):
         caption_html = self.test_message.caption_html
         assert caption_html == test_html_string
 
+    def test_caption_html_empty(self, message):
+        message.text = "test"
+        message.caption = None
+        assert not message.caption_html
+
     def test_caption_html_urled(self):
         test_html_string = ('Test for &lt;<b>bold</b>, <i>ita_lic</i>, <code>code</code>, '
                             '<a href="http://github.com/">links</a> and <pre>pre</pre>. '
@@ -227,6 +242,11 @@ class TestMessage(object):
                           '```pre```. http://google.com')
         caption_markdown = self.test_message.caption_markdown
         assert caption_markdown == test_md_string
+
+    def test_caption_markdown_empty(self, message):
+        message.text = "test"
+        message.caption = None
+        assert not message.caption_markdown
 
     def test_caption_markdown_urled(self):
         test_md_string = ('Test for <*bold*, _ita\_lic_, `code`, [links](http://github.com/) and '


### PR DESCRIPTION
The `_parse_(html|markdown)` methods now properly return `None` on an empty `Message.text` or an empty `Message.caption`