### PR TITLE
Filters for Category and file types

### DIFF
--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -224,7 +224,7 @@ class Filters(object):
         video = category('video/')
         text = category('text/')
 
-        class file_type(BaseFilter):
+        class mime_type(BaseFilter):
             """This Filter filters documents by their mime-type attribute
 
             Note:
@@ -234,36 +234,36 @@ class Filters(object):
                     send media with wrong types that don't fit to this handler.
 
             Examples:
-                Filters.documents.file_type('audio/mpeg') filters all audio in mp3 format.
+                Filters.documents.mime_type('audio/mpeg') filters all audio in mp3 format.
             """
 
-            def __init__(self, filetype):
+            def __init__(self, mimetype):
                 """Initialize the category you want to filter
 
                 Args:
                     filetype (str, optional): mime_type of the media you want to filter"""
-                self.filetype = filetype
-                self.name = "Filters.document.file_type('{}')".format(self.filetype)
+                self.mimetype = mimetype
+                self.name = "Filters.document.mime_type('{}')".format(self.mimetype)
 
             def filter(self, message):
                 if message.document:
-                    return message.document.mime_type == self.filetype
+                    return message.document.mime_type == self.mimetype
 
-        apk = file_type('application/vnd.android.package-archive')
-        doc = file_type('application/msword')
-        docx = file_type('application/vnd.openxmlformats-officedocument.wordprocessingml.document')
-        exe = file_type('application/x-ms-dos-executable')
-        gif = file_type('video/mp4')
-        jpg = file_type('image/jpeg')
-        mp3 = file_type('audio/mpeg')
-        pdf = file_type('application/pdf')
-        py = file_type('text/x-python')
-        svg = file_type('image/svg+xml')
-        txt = file_type('text/plain')
-        targz = file_type('application/x-compressed-tar')
-        wav = file_type('audio/x-wav')
-        xml = file_type('application/xml')
-        zip = file_type('application/zip')
+        apk = mime_type('application/vnd.android.package-archive')
+        doc = mime_type('application/msword')
+        docx = mime_type('application/vnd.openxmlformats-officedocument.wordprocessingml.document')
+        exe = mime_type('application/x-ms-dos-executable')
+        gif = mime_type('video/mp4')
+        jpg = mime_type('image/jpeg')
+        mp3 = mime_type('audio/mpeg')
+        pdf = mime_type('application/pdf')
+        py = mime_type('text/x-python')
+        svg = mime_type('image/svg+xml')
+        txt = mime_type('text/plain')
+        targz = mime_type('application/x-compressed-tar')
+        wav = mime_type('audio/x-wav')
+        xml = mime_type('application/xml')
+        zip = mime_type('application/zip')
 
         def filter(self, message):
             return bool(message.document)

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -243,7 +243,7 @@ class Filters(object):
                 Args:
                     filetype (str, optional): mime_type of the media you want to filter"""
                 self.filetype = filetype
-                self.name = 'Filters.document.Filetype(\'{}\')'.format(self.filetype)
+                self.name = 'Filters.document.file_type(\'{}\')'.format(self.filetype)
 
             def filter(self, message):
                 if message.document:

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -212,7 +212,7 @@ class Filters(object):
                 Args:
                     category (str, optional): category of the media you want to filter"""
                 self.category = category
-                self.name = 'Filters.document.category(\'{}\')'.format(self.category)
+                self.name = "Filters.document.category('{}')".format(self.category)
 
             def filter(self, message):
                 if message.document:
@@ -243,7 +243,7 @@ class Filters(object):
                 Args:
                     filetype (str, optional): mime_type of the media you want to filter"""
                 self.filetype = filetype
-                self.name = 'Filters.document.file_type(\'{}\')'.format(self.filetype)
+                self.name = "Filters.document.file_type('{}')".format(self.filetype)
 
             def filter(self, message):
                 if message.document:

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -35,7 +35,7 @@ class BaseFilter(object):
         >>> (Filters.audio | Filters.video)
 
     Not:
-
+:
         >>> ~ Filters.command
 
     Also works with more than two filters:
@@ -350,7 +350,7 @@ class Filters(object):
                 return bool(message.new_chat_members)
 
         new_chat_members = _NewChatMembers()
-        """:obj:`Filter`: Messages that contain :attr:`telegram.Message.new_chat_member`."""
+        """:obj:`Filter`: Messages that contain :attr:`telegram.Message.new_chat_members`."""
 
         class _LeftChatMember(BaseFilter):
             name = 'Filters.status_update.left_chat_member'
@@ -441,7 +441,7 @@ class Filters(object):
     """Subset for messages containing a status update.
 
     Examples:
-        Use these filters like: ``Filters.status_update.new_chat_member`` etc. Or use just
+        Use these filters like: ``Filters.status_update.new_chat_members`` etc. Or use just
         ``Filters.status_update`` for all status update messages.
 
     Attributes:
@@ -457,7 +457,7 @@ class Filters(object):
             :attr:`telegram.Message.migrate_from_chat_id` or
             :attr: `telegram.Message.migrate_from_chat_id`.
         new_chat_members (:obj:`Filter`): Messages that contain
-            :attr:`telegram.Message.new_chat_member`.
+            :attr:`telegram.Message.new_chat_members`.
         new_chat_photo (:obj:`Filter`): Messages that contain
             :attr:`telegram.Message.new_chat_photo`.
         new_chat_title (:obj:`Filter`): Messages that contain

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -192,6 +192,79 @@ class Filters(object):
     class _Document(BaseFilter):
         name = 'Filters.document'
 
+        class category(BaseFilter):
+            """This Filter filters documents by their category in the mime-type attribute
+
+            Note:
+                This Filter only filters by the mime_type of the document,
+                    it doesn't check the validity of the document.
+                The user can manipulate the mime-type of a message and
+                    send media with wrong types that don't fit to this handler.
+
+            Examples:
+                Filters.documents.category('audio/') returnes `True` for all types
+                of audio sent as file, for example 'audio/mpeg' or 'audio/x-wav'
+            """
+
+            def __init__(self, category):
+                """Initialize the category you want to filter
+
+                Args:
+                    category (str, optional): category of the media you want to filter"""
+                self.category = category
+                self.name = 'Filters.document.category(\'{}\')'.format(self.category)
+
+            def filter(self, message):
+                if message.document:
+                    return message.document.mime_type.startswith(self.category)
+
+        application = category('application/')
+        audio = category('audio/')
+        image = category('image/')
+        video = category('video/')
+        text = category('text/')
+
+        class file_type(BaseFilter):
+            """This Filter filters documents by their mime-type attribute
+
+            Note:
+                This Filter only filters by the mime_type of the document,
+                    it doesn't check the validity of document.
+                The user can manipulate the mime-type of a message and
+                    send media with wrong types that don't fit to this handler.
+
+            Examples:
+                Filters.documents.file_type('audio/mpeg') filters all audio in mp3 format.
+            """
+
+            def __init__(self, filetype):
+                """Initialize the category you want to filter
+
+                Args:
+                    filetype (str, optional): mime_type of the media you want to filter"""
+                self.filetype = filetype
+                self.name = 'Filters.document.Filetype(\'{}\')'.format(self.filetype)
+
+            def filter(self, message):
+                if message.document:
+                    return message.document.mime_type == self.filetype
+
+        apk = file_type('application/vnd.android.package-archive')
+        doc = file_type('application/msword')
+        docx = file_type('application/vnd.openxmlformats-officedocument.wordprocessingml.document')
+        exe = file_type('application/x-ms-dos-executable')
+        gif = file_type('video/mp4')
+        jpg = file_type('image/jpeg')
+        mp3 = file_type('audio/mpeg')
+        pdf = file_type('application/pdf')
+        py = file_type('text/x-python')
+        svg = file_type('image/svg+xml')
+        txt = file_type('text/plain')
+        targz = file_type('application/x-compressed-tar')
+        wav = file_type('audio/x-wav')
+        xml = file_type('application/xml')
+        zip = file_type('application/zip')
+
         def filter(self, message):
             return bool(message.document)
 
@@ -277,7 +350,7 @@ class Filters(object):
                 return bool(message.new_chat_members)
 
         new_chat_members = _NewChatMembers()
-        """:obj:`Filter`: Messages that contain :attr:`telegram.Message.new_chat_members`."""
+        """:obj:`Filter`: Messages that contain :attr:`telegram.Message.new_chat_member`."""
 
         class _LeftChatMember(BaseFilter):
             name = 'Filters.status_update.left_chat_member'
@@ -368,7 +441,7 @@ class Filters(object):
     """Subset for messages containing a status update.
 
     Examples:
-        Use these filters like: ``Filters.status_update.new_chat_members`` etc. Or use just
+        Use these filters like: ``Filters.status_update.new_chat_member`` etc. Or use just
         ``Filters.status_update`` for all status update messages.
 
     Attributes:
@@ -384,7 +457,7 @@ class Filters(object):
             :attr:`telegram.Message.migrate_from_chat_id` or
             :attr: `telegram.Message.migrate_from_chat_id`.
         new_chat_members (:obj:`Filter`): Messages that contain
-            :attr:`telegram.Message.new_chat_members`.
+            :attr:`telegram.Message.new_chat_member`.
         new_chat_photo (:obj:`Filter`): Messages that contain
             :attr:`telegram.Message.new_chat_photo`.
         new_chat_title (:obj:`Filter`): Messages that contain

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -35,7 +35,7 @@ class BaseFilter(object):
         >>> (Filters.audio | Filters.video)
 
     Not:
-:
+
         >>> ~ Filters.command
 
     Also works with more than two filters:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -20,7 +20,7 @@ import datetime
 
 import pytest
 
-from telegram import Message, User, Chat, MessageEntity
+from telegram import Message, User, Chat, MessageEntity, Document
 from telegram.ext import Filters, BaseFilter
 
 
@@ -69,15 +69,104 @@ class TestFilters(object):
         message.document = 'test'
         assert Filters.document(message)
 
-    def test_filters_document_category(self, message):
-        assert not Filters.document.application(message)
-        message.document.mime_type = 'application/pdf'
-        assert Filters.document(message)
+    def test_filters_document_type(self, message):
+        message.document = Document("file_id", mime_type="application/vnd.android.package-archive")
+        assert Filters.document.apk(message)
+        assert Filters.document.application(message)
+        assert not Filters.document.doc(message)
+        assert not Filters.document.audio(message)
 
-    def test_filters_document_file_type(self, message):
-        assert not Filters.document.gif(message)
-        message.document.mime_type = 'video/mp4'
+        message.document.mime_type = "application/msword"
+        assert Filters.document.doc(message)
+        assert Filters.document.application(message)
+        assert not Filters.document.docx(message)
+        assert not Filters.document.audio(message)
+
+        message.document.mime_type = "application/vnd.openxmlformats-" \
+                                     "officedocument.wordprocessingml.document"
+        assert Filters.document.docx(message)
+        assert Filters.document.application(message)
+        assert not Filters.document.exe(message)
+        assert not Filters.document.audio(message)
+
+        message.document.mime_type = "application/x-ms-dos-executable"
+        assert Filters.document.exe(message)
+        assert Filters.document.application(message)
+        assert not Filters.document.docx(message)
+        assert not Filters.document.audio(message)
+
+        message.document.mime_type = "video/mp4"
         assert Filters.document.gif(message)
+        assert Filters.document.video(message)
+        assert not Filters.document.jpg(message)
+        assert not Filters.document.text(message)
+
+        message.document.mime_type = "image/jpeg"
+        assert Filters.document.jpg(message)
+        assert Filters.document.image(message)
+        assert not Filters.document.mp3(message)
+        assert not Filters.document.video(message)
+
+        message.document.mime_type = "audio/mpeg"
+        assert Filters.document.mp3(message)
+        assert Filters.document.audio(message)
+        assert not Filters.document.pdf(message)
+        assert not Filters.document.image(message)
+
+        message.document.mime_type = "application/pdf"
+        assert Filters.document.pdf(message)
+        assert Filters.document.application(message)
+        assert not Filters.document.py(message)
+        assert not Filters.document.audio(message)
+
+        message.document.mime_type = "text/x-python"
+        assert Filters.document.py(message)
+        assert Filters.document.text(message)
+        assert not Filters.document.svg(message)
+        assert not Filters.document.application(message)
+
+        message.document.mime_type = "image/svg+xml"
+        assert Filters.document.svg(message)
+        assert Filters.document.image(message)
+        assert not Filters.document.txt(message)
+        assert not Filters.document.video(message)
+
+        message.document.mime_type = "text/plain"
+        assert Filters.document.txt(message)
+        assert Filters.document.text(message)
+        assert not Filters.document.targz(message)
+        assert not Filters.document.application(message)
+
+        message.document.mime_type = "application/x-compressed-tar"
+        assert Filters.document.targz(message)
+        assert Filters.document.application(message)
+        assert not Filters.document.wav(message)
+        assert not Filters.document.audio(message)
+
+        message.document.mime_type = "audio/x-wav"
+        assert Filters.document.wav(message)
+        assert Filters.document.audio(message)
+        assert not Filters.document.xml(message)
+        assert not Filters.document.image(message)
+
+        message.document.mime_type = "application/xml"
+        assert Filters.document.xml(message)
+        assert Filters.document.application(message)
+        assert not Filters.document.zip(message)
+        assert not Filters.document.audio(message)
+
+        message.document.mime_type = "application/zip"
+        assert Filters.document.zip(message)
+        assert Filters.document.application(message)
+        assert not Filters.document.apk(message)
+        assert not Filters.document.audio(message)
+
+        message.document.mime_type = "image/x-rgb"
+        assert not Filters.document.category("application/")(message)
+        assert not Filters.document.file_type("application/x-sh")(message)
+        message.document.mime_type = "application/x-sh"
+        assert Filters.document.category("application/")(message)
+        assert Filters.document.file_type("application/x-sh")(message)
 
     def test_filters_photo(self, message):
         assert not Filters.photo(message)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -163,10 +163,10 @@ class TestFilters(object):
 
         message.document.mime_type = "image/x-rgb"
         assert not Filters.document.category("application/")(message)
-        assert not Filters.document.file_type("application/x-sh")(message)
+        assert not Filters.document.mime_type("application/x-sh")(message)
         message.document.mime_type = "application/x-sh"
         assert Filters.document.category("application/")(message)
-        assert Filters.document.file_type("application/x-sh")(message)
+        assert Filters.document.mime_type("application/x-sh")(message)
 
     def test_filters_photo(self, message):
         assert not Filters.photo(message)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -69,6 +69,16 @@ class TestFilters(object):
         message.document = 'test'
         assert Filters.document(message)
 
+    def test_filters_document_category(self, message):
+        assert not Filters.document.application(message)
+        message.document.mime_type = 'application/pdf'
+        assert Filters.document(message)
+
+    def test_filters_document_file_type(self, message):
+        assert not Filters.document.gif(message)
+        message.document.mime_type = 'video/mp4'
+        assert Filters.document.gif(message)
+
     def test_filters_photo(self, message):
         assert not Filters.photo(message)
         message.photo = 'test'


### PR DESCRIPTION
Basically PR #889 , without the file_size Filter.

Filters for file Category and Mime Type, based on the mime_type of the file.

            Note:
                This Filter only filters by the mime_type of the document,
                    it doesn't check the validity of document.
                The user can manipulate the mime-type of a message and
                    send media with wrong types that don't fit to this handler.

Here is my fixed version of my previous PR. I'm not sure how detailed the tests have to be.