### PR TITLE
Add a caption_entity filter for filtering caption entities

### DIFF
--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -532,7 +532,7 @@ class Filters(object):
             self.name = 'Filters.entity({})'.format(self.entity_type)
 
         def filter(self, message):
-            return any([entity.type == self.entity_type for entity in message.entities])
+            return any(entity.type == self.entity_type for entity in message.entities)
 
     class caption_entity(BaseFilter):
         """
@@ -553,7 +553,7 @@ class Filters(object):
             self.name = 'Filters.caption_entity({})'.format(self.entity_type)
 
         def filter(self, message):
-            return any([entity.type == self.entity_type for entity in message.caption_entities])
+            return any(entity.type == self.entity_type for entity in message.caption_entities)
 
     class _Private(BaseFilter):
         name = 'Filters.private'

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -534,6 +534,27 @@ class Filters(object):
         def filter(self, message):
             return any([entity.type == self.entity_type for entity in message.entities])
 
+    class caption_entity(BaseFilter):
+        """
+        Filters media messages to only allow those which have a :class:`telegram.MessageEntity`
+        where their `type` matches `entity_type`.
+
+        Examples:
+            Example ``MessageHandler(Filters.caption_entity("hashtag"), callback_method)``
+
+        Args:
+            entity_type: Caption Entity type to check for. All types can be found as constants
+                in :class:`telegram.MessageEntity`.
+
+        """
+
+        def __init__(self, entity_type):
+            self.entity_type = entity_type
+            self.name = 'Filters.caption_entity({})'.format(self.entity_type)
+
+        def filter(self, message):
+            return any([entity.type == self.entity_type for entity in message.caption_entities])
+
     class _Private(BaseFilter):
         name = 'Filters.private'
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -305,6 +305,21 @@ class TestFilters(object):
         second = MessageEntity.de_json(second, None)
         message.entities = [message_entity, second]
         assert Filters.entity(message_entity.type)(message)
+        assert not Filters.caption_entity(message_entity.type)(message)
+
+    def test_caption_entities_filter(self, message, message_entity):
+        message.caption_entities = [message_entity]
+        assert Filters.caption_entity(message_entity.type)(message)
+
+        message.caption_entities = []
+        assert not Filters.caption_entity(MessageEntity.MENTION)(message)
+
+        second = message_entity.to_dict()
+        second['type'] = 'bold'
+        second = MessageEntity.de_json(second, None)
+        message.caption_entities = [message_entity, second]
+        assert Filters.caption_entity(message_entity.type)(message)
+        assert not Filters.entity(message_entity.type)(message)
 
     def test_private_filter(self, message):
         assert Filters.private(message)


### PR DESCRIPTION
Currently, the Filters.entity filter only checks message.entities.
This PR adds Filters.caption_entities to check message.caption_entities.