### PR TITLE
Catch json_data decode errors

### DIFF
--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -148,7 +148,7 @@ class Request(object):
         try:
             decoded_s = json_data.decode('utf-8')
             data = json.loads(decoded_s)
-        except ValueError:
+        except (ValueError, UnicodeDecodeError):
             raise TelegramError('Invalid server response')
 
         if not data.get('ok'):  # pragma: no cover

--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -145,8 +145,8 @@ class Request(object):
             dict: A JSON parsed as Python dict with results - on error this dict will be empty.
 
         """
-        decoded_s = json_data.decode('utf-8')
         try:
+            decoded_s = json_data.decode('utf-8')
             data = json.loads(decoded_s)
         except ValueError:
             raise TelegramError('Invalid server response')


### PR DESCRIPTION
Fixes the case where non-utf8 data would cause an exception and halt the dispatcher. See https://t.me/pythontelegrambotgroup/129353 for more info.

Note that the telegram docs at https://core.telegram.org/bots/api#callbackquery warn about this specific case ("Be aware that a bad client can send arbitrary data in this field.").