### PR TITLE
CommandHandler faster check

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -65,6 +65,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `thodnev <https://github.com/thodnev>`_
 - `Valentijn <https://github.com/Faalentijn>`_
 - `voider1 <https://github.com/voider1>`_
+- `Wagner Macedo <https://github.com/wagnerluis1982>`_
 - `wjt <https://github.com/wjt>`_
 
 Please add yourself here alphabetically when you submit your first pull request.

--- a/telegram/ext/commandhandler.py
+++ b/telegram/ext/commandhandler.py
@@ -140,6 +140,10 @@ class CommandHandler(Handler):
                     command.append(
                         message.bot.username)  # in case the command was sent without a username
 
+                    if not (command[0].lower() in self.command
+                            and command[1].lower() == message.bot.username.lower()):
+                        return False
+
                     if self.filters is None:
                         res = True
                     elif isinstance(self.filters, list):
@@ -147,8 +151,7 @@ class CommandHandler(Handler):
                     else:
                         res = self.filters(message)
 
-                    return res and (command[0].lower() in self.command
-                                    and command[1].lower() == message.bot.username.lower())
+                    return res
 
         return False
 

--- a/tests/test_commandhandler.py
+++ b/tests/test_commandhandler.py
@@ -246,3 +246,23 @@ class TestCommandHandler(object):
     def test_other_update_types(self, false_update):
         handler = CommandHandler('test', self.callback_basic)
         assert not handler.check_update(false_update)
+
+    def test_filters_for_wrong_command(self, message):
+        """Filters should not be executed if the command does not match the handler"""
+
+        class TestFilter(BaseFilter):
+            def __init__(self):
+                self.tested = False
+
+            def filter(self, message):
+                self.tested = True
+
+        test_filter = TestFilter()
+
+        handler = CommandHandler('foo', self.callback_basic, filters=test_filter)
+        message.text = '/bar'
+
+        handler.check_update(Update(0, message=message))
+
+        assert not test_filter.tested
+

--- a/tests/test_commandhandler.py
+++ b/tests/test_commandhandler.py
@@ -265,4 +265,3 @@ class TestCommandHandler(object):
         handler.check_update(Update(0, message=message))
 
         assert not test_filter.tested
-

--- a/tests/test_commandhandler.py
+++ b/tests/test_commandhandler.py
@@ -21,7 +21,7 @@ import pytest
 
 from telegram import (Message, Update, Chat, Bot, User, CallbackQuery, InlineQuery,
                       ChosenInlineResult, ShippingQuery, PreCheckoutQuery)
-from telegram.ext import CommandHandler, Filters
+from telegram.ext import CommandHandler, Filters, BaseFilter
 
 message = Message(1, User(1, '', False), None, Chat(1, ''), text='test')
 


### PR DESCRIPTION
Make the filters applied to a command to execute only if the command name matches. This solves the problem described in #1073  