### PR TITLE
Handle utf8 decoding errors

### DIFF
--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -151,7 +151,7 @@ class Request(object):
             data = json.loads(decoded_s)
         except UnicodeDecodeError:
             logging.getLogger(__name__).debug(
-                'Logging raw invalid UTF-8 response:\n{}'.format(str(json_data)))
+                'Logging raw invalid UTF-8 response:\n%s', str(json_data))
             raise TelegramError('Server response could not be decoded using UTF-8')
         except ValueError:
             raise TelegramError('Invalid server response')

--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -145,9 +145,14 @@ class Request(object):
             dict: A JSON parsed as Python dict with results - on error this dict will be empty.
 
         """
-        decoded_s = json_data.decode('utf-8')
+
         try:
+            decoded_s = json_data.decode('utf-8')
             data = json.loads(decoded_s)
+        except UnicodeDecodeError:
+            logging.getLogger(__name__).debug(
+                'Logging raw invalid UTF-8 response:\n{}'.format(str(json_data)))
+            raise TelegramError('Server response could not be decoded using UTF-8')
         except ValueError:
             raise TelegramError('Invalid server response')
 

--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -151,7 +151,7 @@ class Request(object):
             data = json.loads(decoded_s)
         except UnicodeDecodeError:
             logging.getLogger(__name__).debug(
-                'Logging raw invalid UTF-8 response:\n%s', str(json_data))
+                'Logging raw invalid UTF-8 response:\n%r', json_data)
             raise TelegramError('Server response could not be decoded using UTF-8')
         except ValueError:
             raise TelegramError('Invalid server response')

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+#
+# A library that provides a Python interface to the Telegram Bot API
+# Copyright (C) 2015-2018
+# Leandro Toledo de Souza <devs@python-telegram-bot.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+
+import pytest
+
+from telegram import TelegramError
+from telegram.utils.request import Request
+
+
+def test_parse_illegal_callback_data():
+    """
+    Clients can send arbitrary bytes in callback data.
+    Make sure the correct error is raised in this case.
+    """
+    server_response = b'{"invalid utf-8": "\x80"}'
+
+    with pytest.raises(TelegramError, match='Server response could not be decoded using UTF-8'):
+        Request._parse(server_response)


### PR DESCRIPTION
As pointed out in #1072, malicious clients can send arbitrary `callback_data` in callback queries, even bytes that can't be decoded using the utf-8 codec. This would bring the whole bot to a halt.