### PR TITLE
Changed User.chat_id to User.id in docstrings of User.send_* methods in user.py

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -64,6 +64,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Simon Schürrle <https://github.com/SitiSchu>`_
 - `sooyhwang <https://github.com/sooyhwang>`_
 - `thodnev <https://github.com/thodnev>`_
+- `Trainer Jono <https://github.com/Tr-Jono>`_
 - `Valentijn <https://github.com/Faalentijn>`_
 - `voider1 <https://github.com/voider1>`_
 - `Wagner Macedo <https://github.com/wagnerluis1982>`_

--- a/telegram/user.py
+++ b/telegram/user.py
@@ -150,7 +150,7 @@ class User(TelegramObject):
     def send_message(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_message(User.chat_id, *args, **kwargs)
+            bot.send_message(User.id, *args, **kwargs)
 
         Where User is the current instance.
 
@@ -163,7 +163,7 @@ class User(TelegramObject):
     def send_photo(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_photo(User.chat_id, *args, **kwargs)
+            bot.send_photo(User.id, *args, **kwargs)
 
         Where User is the current instance.
 
@@ -176,7 +176,7 @@ class User(TelegramObject):
     def send_audio(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_audio(User.chat_id, *args, **kwargs)
+            bot.send_audio(User.id, *args, **kwargs)
 
         Where User is the current instance.
 
@@ -189,7 +189,7 @@ class User(TelegramObject):
     def send_document(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_document(User.chat_id, *args, **kwargs)
+            bot.send_document(User.id, *args, **kwargs)
 
         Where User is the current instance.
 
@@ -202,7 +202,7 @@ class User(TelegramObject):
     def send_sticker(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_sticker(User.chat_id, *args, **kwargs)
+            bot.send_sticker(User.id, *args, **kwargs)
 
         Where User is the current instance.
 
@@ -215,7 +215,7 @@ class User(TelegramObject):
     def send_video(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_video(User.chat_id, *args, **kwargs)
+            bot.send_video(User.id, *args, **kwargs)
 
         Where User is the current instance.
 
@@ -228,7 +228,7 @@ class User(TelegramObject):
     def send_video_note(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_video_note(User.chat_id, *args, **kwargs)
+            bot.send_video_note(User.id, *args, **kwargs)
 
         Where User is the current instance.
 
@@ -241,7 +241,7 @@ class User(TelegramObject):
     def send_voice(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_voice(User.chat_id, *args, **kwargs)
+            bot.send_voice(User.id, *args, **kwargs)
 
         Where User is the current instance.
 


### PR DESCRIPTION
Since the `User.send_*` methods' docstrings show that they are shortcuts for `bot.send_*(User.chat_id, *args, **kwargs)` methods (as below) in `user.py`, I replaced `User.chat_id` with `User.id` in the docstrings in these methods, because `User` does not have the attribute `chat_id` and I believe it has been confused as `id`.

Original docstrings of User.send_* methods in `user.py`:
>     def send_*(self, *args, **kwargs):
>         """Shortcut for::
>             bot.send_*(User.chat_id, *args, **kwargs)
>         Where User is the current instance.
>         ...
>         """