### PR TITLE
Fix the default value of "timeout" argument to match documentation

### DIFF
--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -545,7 +545,7 @@ class Bot(TelegramObject):
                      disable_notification=False,
                      reply_to_message_id=None,
                      reply_markup=None,
-                     timeout=None,
+                     timeout=20,
                      **kwargs):
         """Use this method to send .webp stickers.
 


### PR DESCRIPTION
It is said "20 seconds" is the default value, but in fact, it is None.