### PR TITLE
Remove pytest-catchlog from requirements.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,4 @@ yapf
 pre-commit
 beautifulsoup4
 pytest
-pytest-catchlog
 pytest-timeout


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3002987/39541871-4b150a48-4e47-11e8-9db0-b1f150610fcd.png)
Getting real tired of seeing the above in logs :P