### PR TITLE
Update Filters, CommandHandler and MessageHandler

### DIFF
--- a/telegram/ext/__init__.py
+++ b/telegram/ext/__init__.py
@@ -25,10 +25,10 @@ from .jobqueue import JobQueue, Job
 from .updater import Updater
 from .callbackqueryhandler import CallbackQueryHandler
 from .choseninlineresulthandler import ChosenInlineResultHandler
-from .commandhandler import CommandHandler, PrefixHandler
 from .inlinequeryhandler import InlineQueryHandler
 from .filters import BaseFilter, Filters
 from .messagehandler import MessageHandler
+from .commandhandler import CommandHandler, PrefixHandler
 from .regexhandler import RegexHandler
 from .stringcommandhandler import StringCommandHandler
 from .stringregexhandler import StringRegexHandler

--- a/telegram/ext/__init__.py
+++ b/telegram/ext/__init__.py
@@ -27,8 +27,8 @@ from .callbackqueryhandler import CallbackQueryHandler
 from .choseninlineresulthandler import ChosenInlineResultHandler
 from .commandhandler import CommandHandler, PrefixHandler
 from .inlinequeryhandler import InlineQueryHandler
-from .messagehandler import MessageHandler
 from .filters import BaseFilter, Filters
+from .messagehandler import MessageHandler
 from .regexhandler import RegexHandler
 from .stringcommandhandler import StringCommandHandler
 from .stringregexhandler import StringRegexHandler

--- a/telegram/ext/commandhandler.py
+++ b/telegram/ext/commandhandler.py
@@ -38,7 +38,7 @@ class CommandHandler(Handler):
     which is the text following the command split on single or consecutive whitespace characters.
 
     By default the handler listens to messages as well as edited messages. To change this behavior
-    use ``~Filters.update_type.edited_message``.
+    use ``~Filters.updates.edited_message`` in the filter argument.
 
     Attributes:
         command (:obj:`str` | List[:obj:`str`]): The command or list of commands this handler
@@ -88,7 +88,7 @@ class CommandHandler(Handler):
         allow_edited (:obj:`bool`, optional): Determines whether the handler should also accept
             edited messages. Default is ``False``.
             DEPRECATED: Edited is allowed by default. To change this behavior use
-            ``~Filters.update_type.edited_message``.
+            ``~Filters.updates.edited_message``.
         pass_args (:obj:`bool`, optional): Determines whether the handler should be passed the
             arguments passed to the command as a keyword argument called ``args``. It will contain
             a list of strings, which is the text following the command split on single or
@@ -141,16 +141,16 @@ class CommandHandler(Handler):
                 raise ValueError('Command is not a valid bot command')
 
         if filters:
-            self.filters = Filters.update_type.messages & filters
+            self.filters = Filters.updates.messages & filters
         else:
-            self.filters = Filters.update_type.messages
+            self.filters = Filters.updates.messages
 
         if allow_edited is not None:
             warnings.warn('allow_edited is deprecated. See https://git.io/vp113 for more info',
                           TelegramDeprecationWarning,
                           stacklevel=2)
             if not allow_edited:
-                self.filters &= ~Filters.update_type.edited_message
+                self.filters &= ~Filters.updates.edited_message
         self.pass_args = pass_args
 
     def check_update(self, update):
@@ -216,7 +216,7 @@ class PrefixHandler(CommandHandler):
             '#test', '!help' and '#help'.
 
     By default the handler listens to messages as well as edited messages. To change this behavior
-    use ``~Filters.update_type.edited_message``.
+    use ``~Filters.updates.edited_message``.
 
     Attributes:
         prefix (:obj:`str` | List[:obj:`str`]): The prefix(es) that will precede :attr:`command`.

--- a/telegram/ext/commandhandler.py
+++ b/telegram/ext/commandhandler.py
@@ -160,7 +160,7 @@ class CommandHandler(Handler):
                         command[1].lower() == message.bot.username.lower()):
                     return None
 
-                if self.filters is None or self.filters(message):
+                if self.filters is None or self.filters(update):
                     return args
 
     def collect_optional_args(self, dispatcher, update=None, check_result=None):
@@ -315,5 +315,5 @@ class PrefixHandler(CommandHandler):
             text_list = message.text.split()
             if text_list[0].lower() not in self.command:
                 return None
-            if self.filters is None or self.filters(message):
+            if self.filters is None or self.filters(update):
                 return text_list[1:]

--- a/telegram/ext/commandhandler.py
+++ b/telegram/ext/commandhandler.py
@@ -18,8 +18,12 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains the CommandHandler and PrefixHandler classes."""
 import re
+import warnings
 
 from future.utils import string_types
+
+from telegram.ext import Filters
+from telegram.utils.deprecate import TelegramDeprecationWarning
 
 from telegram import Update, MessageEntity
 from .handler import Handler
@@ -32,6 +36,9 @@ class CommandHandler(Handler):
     bot's name and/or some additional text. The handler will add a ``list`` to the
     :class:`CallbackContext` named :attr:`CallbackContext.args`. It will contain a list of strings,
     which is the text following the command split on single or consecutive whitespace characters.
+
+    By default the handler listens to messages as well as edited messages. To change this behavior
+    use ``~Filters.update_type.edited_message``.
 
     Attributes:
         command (:obj:`str` | List[:obj:`str`]): The command or list of commands this handler
@@ -80,6 +87,8 @@ class CommandHandler(Handler):
             operators (& for and, | for or, ~ for not).
         allow_edited (:obj:`bool`, optional): Determines whether the handler should also accept
             edited messages. Default is ``False``.
+            DEPRECATED: Edited is allowed by default. To change this behavior use
+            ``~Filters.update_type.edited_message``.
         pass_args (:obj:`bool`, optional): Determines whether the handler should be passed the
             arguments passed to the command as a keyword argument called ``args``. It will contain
             a list of strings, which is the text following the command split on single or
@@ -110,7 +119,7 @@ class CommandHandler(Handler):
                  command,
                  callback,
                  filters=None,
-                 allow_edited=False,
+                 allow_edited=None,
                  pass_args=False,
                  pass_update_queue=False,
                  pass_job_queue=False,
@@ -131,8 +140,17 @@ class CommandHandler(Handler):
             if not re.match(r'^[\da-z_]{1,32}$', comm):
                 raise ValueError('Command is not a valid bot command')
 
-        self.filters = filters
-        self.allow_edited = allow_edited
+        if filters:
+            self.filters = Filters.update_type.messages & filters
+        else:
+            self.filters = Filters.update_type.messages
+
+        if allow_edited is not None:
+            warnings.warn('allow_edited is deprecated. See https://git.io/vp113 for more info',
+                          TelegramDeprecationWarning,
+                          stacklevel=2)
+            if not allow_edited:
+                self.filters &= ~Filters.update_type.edited_message
         self.pass_args = pass_args
 
     def check_update(self, update):
@@ -145,8 +163,7 @@ class CommandHandler(Handler):
             :obj:`bool`
 
         """
-        if (isinstance(update, Update) and
-                (update.message or update.edited_message and self.allow_edited)):
+        if (isinstance(update, Update) and update.effective_message):
             message = update.effective_message
 
             if (message.entities and message.entities[0].type == MessageEntity.BOT_COMMAND and
@@ -160,7 +177,7 @@ class CommandHandler(Handler):
                         command[1].lower() == message.bot.username.lower()):
                     return None
 
-                if self.filters is None or self.filters(update):
+                if self.filters(update):
                     return args
 
     def collect_optional_args(self, dispatcher, update=None, check_result=None):
@@ -198,6 +215,9 @@ class PrefixHandler(CommandHandler):
             PrefixHandler(['!', '#'], ['test', 'help`], callback) will respond to '!test',
             '#test', '!help' and '#help'.
 
+    By default the handler listens to messages as well as edited messages. To change this behavior
+    use ``~Filters.update_type.edited_message``.
+
     Attributes:
         prefix (:obj:`str` | List[:obj:`str`]): The prefix(es) that will precede :attr:`command`.
         command (:obj:`str` | List[:obj:`str`]): The command or list of commands this handler
@@ -205,8 +225,6 @@ class PrefixHandler(CommandHandler):
         callback (:obj:`callable`): The callback function for this handler.
         filters (:class:`telegram.ext.BaseFilter`): Optional. Only allow updates with these
             Filters.
-        allow_edited (:obj:`bool`): Determines Whether the handler should also accept
-            edited messages.
         pass_args (:obj:`bool`): Determines whether the handler should be passed
             ``args``.
         pass_update_queue (:obj:`bool`): Determines whether ``update_queue`` will be
@@ -243,8 +261,6 @@ class PrefixHandler(CommandHandler):
             :class:`telegram.ext.filters.BaseFilter`. Standard filters can be found in
             :class:`telegram.ext.filters.Filters`. Filters can be combined using bitwise
             operators (& for and, | for or, ~ for not).
-        allow_edited (:obj:`bool`, optional): Determines whether the handler should also accept
-            edited messages. Default is ``False``.
         pass_args (:obj:`bool`, optional): Determines whether the handler should be passed the
             arguments passed to the command as a keyword argument called ``args``. It will contain
             a list of strings, which is the text following the command split on single or
@@ -274,7 +290,6 @@ class PrefixHandler(CommandHandler):
                  command,
                  callback,
                  filters=None,
-                 allow_edited=False,
                  pass_args=False,
                  pass_update_queue=False,
                  pass_job_queue=False,
@@ -282,7 +297,7 @@ class PrefixHandler(CommandHandler):
                  pass_chat_data=False):
 
         super(PrefixHandler, self).__init__(
-            'nocommand', callback, filters=filters, allow_edited=allow_edited, pass_args=pass_args,
+            'nocommand', callback, filters=filters, allow_edited=None, pass_args=pass_args,
             pass_update_queue=pass_update_queue,
             pass_job_queue=pass_job_queue,
             pass_user_data=pass_user_data,
@@ -308,12 +323,11 @@ class PrefixHandler(CommandHandler):
             :obj:`bool`
 
         """
-        if (isinstance(update, Update) and
-                (update.message or update.edited_message and self.allow_edited)):
+        if (isinstance(update, Update) and update.effective_message):
             message = update.effective_message
 
             text_list = message.text.split()
             if text_list[0].lower() not in self.command:
                 return None
-            if self.filters is None or self.filters(update):
+            if self.filters(update):
                 return text_list[1:]

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -767,12 +767,12 @@ class Filters(object):
         def filter(self, update):
             return self.messages(update) or self.channel_posts(update)
 
-    update_type = _UpdateType()
+    updates = _UpdateType()
     """Subset for filtering the type of update.
 
     Examples:
-        Use these filters like: ``Filters.update_type.message`` or
-        ``Filters.update_type.channel_posts``etc. Or use just ``Filters.update_type`` for all
+        Use these filters like: ``Filters.updates.message`` or
+        ``Filters.updates.channel_posts``etc. Or use just ``Filters.updates`` for all
         types.
 
     Attributes:

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -60,9 +60,13 @@ class BaseFilter(object):
     """
 
     name = None
+    update_filter = False
 
-    def __call__(self, message):
-        return self.filter(message)
+    def __call__(self, update):
+        if self.update_filter:
+            return self.filter(update)
+        else:
+            return self.filter(update.effective_message)
 
     def __and__(self, other):
         return MergedFilter(self, and_filter=other)
@@ -100,12 +104,13 @@ class InvertedFilter(BaseFilter):
         f: The filter to invert.
 
     """
+    update_filter = True
 
     def __init__(self, f):
         self.f = f
 
-    def filter(self, message):
-        return not self.f(message)
+    def filter(self, update):
+        return not self.f(update)
 
     def __repr__(self):
         return "<inverted {}>".format(self.f)
@@ -120,17 +125,18 @@ class MergedFilter(BaseFilter):
         or_filter: Optional filter to "or" with base_filter. Mutually exclusive with and_filter.
 
     """
+    update_filter = True
 
     def __init__(self, base_filter, and_filter=None, or_filter=None):
         self.base_filter = base_filter
         self.and_filter = and_filter
         self.or_filter = or_filter
 
-    def filter(self, message):
+    def filter(self, update):
         if self.and_filter:
-            return self.base_filter(message) and self.and_filter(message)
+            return self.base_filter(update) and self.and_filter(update)
         elif self.or_filter:
-            return self.base_filter(message) or self.or_filter(message)
+            return self.base_filter(update) or self.or_filter(update)
 
     def __repr__(self):
         return "<{} {} {}>".format(self.base_filter, "and" if self.and_filter else "or",
@@ -159,6 +165,7 @@ class Filters(object):
         name = 'Filters.text'
 
         def filter(self, message):
+            print('text_filter_filter {}'.format(repr(self)))
             return bool(message.text and not message.text.startswith('/'))
 
     text = _Text()
@@ -380,6 +387,7 @@ class Filters(object):
             ``Filters.status_update`` for all status update messages.
 
         """
+        update_filter = True
 
         class _NewChatMembers(BaseFilter):
             name = 'Filters.status_update.new_chat_members'

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -19,8 +19,10 @@
 """This module contains the Filters for use with the MessageHandler class."""
 
 import re
-from telegram import Chat
+
 from future.utils import string_types
+
+from telegram import Chat
 
 
 class BaseFilter(object):
@@ -56,7 +58,8 @@ class BaseFilter(object):
 
     Attributes:
         name (:obj:`str`): Name for this filter. Defaults to the type of filter.
-
+        update_filter (:obj:`bool`): whether this filter should work on update. If ``False`` it
+            will run the filter on :attr:`update.effective_message``. Default is ``False``.
     """
 
     name = None
@@ -709,3 +712,77 @@ class Filters(object):
         def filter(self, message):
             return message.from_user.language_code and any(
                 [message.from_user.language_code.startswith(x) for x in self.lang])
+
+    class _UpdateType(BaseFilter):
+        update_filter = True
+
+        class _Message(BaseFilter):
+            update_filter = True
+
+            def filter(self, update):
+                return update.message is not None
+
+        message = _Message()
+
+        class _EditedMessage(BaseFilter):
+            update_filter = True
+
+            def filter(self, update):
+                return update.edited_message is not None
+
+        edited_message = _EditedMessage()
+
+        class _Messages(BaseFilter):
+            update_filter = True
+
+            def filter(self, update):
+                return update.message is not None or update.edited_message is not None
+
+        messages = _Messages()
+
+        class _ChannelPost(BaseFilter):
+            update_filter = True
+
+            def filter(self, update):
+                return update.channel_post is not None
+
+        channel_post = _ChannelPost()
+
+        class _EditedChannelPost(BaseFilter):
+            update_filter = True
+
+            def filter(self, update):
+                return update.edited_channel_post is not None
+
+        edited_channel_post = _EditedChannelPost()
+
+        class _ChannelPosts(BaseFilter):
+            update_filter = True
+
+            def filter(self, update):
+                return update.channel_post is not None or update.edited_channel_post is not None
+
+        channel_posts = _ChannelPosts()
+
+        def filter(self, update):
+            return self.messages(update) or self.channel_posts(update)
+
+    update_type = _UpdateType()
+    """Subset for filtering the type of update.
+
+    Examples:
+        Use these filters like: ``Filters.update_type.message`` or
+        ``Filters.update_type.channel_posts``etc. Or use just ``Filters.update_type`` for all
+        types.
+
+    Attributes:
+        message (:obj:`Filter`): Updates with :attr:`telegram.Update.message`
+        edited_message (:obj:`Filter`): Updates with :attr:`telegram.Update.edited_message`
+        messages (:obj:`Filter`): Updates with either :attr:`telegram.Update.message` or
+            :attr:`telegram.Update.edited_message`
+        channel_post (:obj:`Filter`): Updates with :attr:`telegram.Update.channel_post`
+        edited_channel_post (:obj:`Filter`): Updates with
+            :attr:`telegram.Update.edited_channel_post`
+        channel_posts (:obj:`Filter`): Updates with either :attr:`telegram.Update.channel_post` or
+            :attr:`telegram.Update.edited_channel_post`
+    """

--- a/telegram/ext/messagehandler.py
+++ b/telegram/ext/messagehandler.py
@@ -166,7 +166,4 @@ class MessageHandler(Handler):
 
         """
         if isinstance(update, Update) and update.effective_message:
-            if not self.filters:
-                return True
-            else:
-                return self.filters(update)
+            return self.filters(update)

--- a/telegram/ext/messagehandler.py
+++ b/telegram/ext/messagehandler.py
@@ -148,4 +148,4 @@ class MessageHandler(Handler):
             if not self.filters:
                 return True
             else:
-                return self.filters(update.effective_message)
+                return self.filters(update)

--- a/telegram/ext/messagehandler.py
+++ b/telegram/ext/messagehandler.py
@@ -20,7 +20,10 @@
 """This module contains the MessageHandler class."""
 import warnings
 
+from telegram.utils.deprecate import TelegramDeprecationWarning
+
 from telegram import Update
+from telegram.ext import Filters
 from .handler import Handler
 
 
@@ -40,13 +43,11 @@ class MessageHandler(Handler):
         pass_chat_data (:obj:`bool`): Determines whether ``chat_data`` will be passed to
             the callback function.
         message_updates (:obj:`bool`): Should "normal" message updates be handled?
-            Default is ``True``.
+            Default is ``None``.
         channel_post_updates (:obj:`bool`): Should channel posts updates be handled?
-            Default is ``True``.
+            Default is ``None``.
         edited_updates (:obj:`bool`): Should "edited" message updates be handled?
-            Default is ``False``.
-        allow_edited (:obj:`bool`): If the handler should also accept edited messages.
-            Default is ``False`` - Deprecated. use edited_updates instead.
+            Default is ``None``.
 
     Note:
         :attr:`pass_user_data` and :attr:`pass_chat_data` determine whether a ``dict`` you
@@ -61,7 +62,9 @@ class MessageHandler(Handler):
         filters (:class:`telegram.ext.BaseFilter`, optional): A filter inheriting from
             :class:`telegram.ext.filters.BaseFilter`. Standard filters can be found in
             :class:`telegram.ext.filters.Filters`. Filters can be combined using bitwise
-            operators (& for and, | for or, ~ for not).
+            operators (& for and, | for or, ~ for not). Default is
+            ``Filters.update_type``. If you don't want or need any of those
+            pass ``~Filters.update_type.*``
         callback (:obj:`callable`): The callback function for this handler. Will be called when
             :attr:`check_update` has determined that an update should be processed by this handler.
             Callback signature for context based API:
@@ -87,13 +90,14 @@ class MessageHandler(Handler):
             ``chat_data`` will be passed to the callback function. Default is ``False``.
             DEPRECATED: Please switch to context based callbacks.
         message_updates (:obj:`bool`, optional): Should "normal" message updates be handled?
-            Default is ``True``.
+            Default is ``None``.
+            DEPRECATED: Please switch to filters for update filtering.
         channel_post_updates (:obj:`bool`, optional): Should channel posts updates be handled?
-            Default is ``True``.
+            Default is ``None``.
+            DEPRECATED: Please switch to filters for update filtering.
         edited_updates (:obj:`bool`, optional): Should "edited" message updates be handled? Default
-            is ``False``.
-        allow_edited (:obj:`bool`, optional): If the handler should also accept edited messages.
-            Default is ``False`` - Deprecated. use edited_updates instead.
+            is ``None``.
+            DEPRECATED: Please switch to filters for update filtering.
 
     Raises:
         ValueError
@@ -103,20 +107,13 @@ class MessageHandler(Handler):
     def __init__(self,
                  filters,
                  callback,
-                 allow_edited=False,
                  pass_update_queue=False,
                  pass_job_queue=False,
                  pass_user_data=False,
                  pass_chat_data=False,
-                 message_updates=True,
-                 channel_post_updates=True,
-                 edited_updates=False):
-        if not message_updates and not channel_post_updates and not edited_updates:
-            raise ValueError(
-                'message_updates, channel_post_updates and edited_updates are all False')
-        if allow_edited:
-            warnings.warn('allow_edited is getting deprecated, please use edited_updates instead')
-            edited_updates = allow_edited
+                 message_updates=None,
+                 channel_post_updates=None,
+                 edited_updates=None):
 
         super(MessageHandler, self).__init__(
             callback,
@@ -124,15 +121,39 @@ class MessageHandler(Handler):
             pass_job_queue=pass_job_queue,
             pass_user_data=pass_user_data,
             pass_chat_data=pass_chat_data)
+        if message_updates is False and channel_post_updates is False and edited_updates is False:
+            raise ValueError(
+                'message_updates, channel_post_updates and edited_updates are all False')
         self.filters = filters
-        self.message_updates = message_updates
-        self.channel_post_updates = channel_post_updates
-        self.edited_updates = edited_updates
+        if self.filters is not None:
+            self.filters &= Filters.update_type
+        else:
+            self.filters = Filters.update_type
+        if message_updates is not None:
+            warnings.warn('message_updates is deprecated. See https://git.io/vp113 for more info',
+                          TelegramDeprecationWarning,
+                          stacklevel=2)
+            if message_updates is False:
+                self.filters &= ~Filters.update_type.message
 
-    def _is_allowed_update(self, update):
-        return any([self.message_updates and update.message,
-                    self.edited_updates and (update.edited_message or update.edited_channel_post),
-                    self.channel_post_updates and update.channel_post])
+        if channel_post_updates is not None:
+            warnings.warn('channel_post_updates is deprecated. See https://git.io/vp113 '
+                          'for more info',
+                          TelegramDeprecationWarning,
+                          stacklevel=2)
+            if channel_post_updates is False:
+                self.filters &= ~Filters.update_type.channel_post
+
+        if edited_updates is not None:
+            warnings.warn('edited_updates is deprecated. See https://git.io/vp113 for more info',
+                          TelegramDeprecationWarning,
+                          stacklevel=2)
+            if edited_updates:
+                self.filters |= (Filters.update_type.edited_message |
+                                 Filters.update_type.edited_channel_post)
+            if edited_updates is False:
+                self.filters &= ~(Filters.update_type.edited_message |
+                                  Filters.update_type.edited_channel_post)
 
     def check_update(self, update):
         """Determines whether an update should be passed to this handlers :attr:`callback`.
@@ -144,7 +165,7 @@ class MessageHandler(Handler):
             :obj:`bool`
 
         """
-        if isinstance(update, Update) and self._is_allowed_update(update):
+        if isinstance(update, Update) and update.effective_message:
             if not self.filters:
                 return True
             else:

--- a/telegram/ext/messagehandler.py
+++ b/telegram/ext/messagehandler.py
@@ -63,8 +63,8 @@ class MessageHandler(Handler):
             :class:`telegram.ext.filters.BaseFilter`. Standard filters can be found in
             :class:`telegram.ext.filters.Filters`. Filters can be combined using bitwise
             operators (& for and, | for or, ~ for not). Default is
-            ``Filters.update_type``. If you don't want or need any of those
-            pass ``~Filters.update_type.*``
+            ``Filters.updates``. If you don't want or need any of those
+            pass ``~Filters.updates.*`` in the filter argument.
         callback (:obj:`callable`): The callback function for this handler. Will be called when
             :attr:`check_update` has determined that an update should be processed by this handler.
             Callback signature for context based API:
@@ -126,15 +126,15 @@ class MessageHandler(Handler):
                 'message_updates, channel_post_updates and edited_updates are all False')
         self.filters = filters
         if self.filters is not None:
-            self.filters &= Filters.update_type
+            self.filters &= Filters.updates
         else:
-            self.filters = Filters.update_type
+            self.filters = Filters.updates
         if message_updates is not None:
             warnings.warn('message_updates is deprecated. See https://git.io/vp113 for more info',
                           TelegramDeprecationWarning,
                           stacklevel=2)
             if message_updates is False:
-                self.filters &= ~Filters.update_type.message
+                self.filters &= ~Filters.updates.message
 
         if channel_post_updates is not None:
             warnings.warn('channel_post_updates is deprecated. See https://git.io/vp113 '
@@ -142,18 +142,15 @@ class MessageHandler(Handler):
                           TelegramDeprecationWarning,
                           stacklevel=2)
             if channel_post_updates is False:
-                self.filters &= ~Filters.update_type.channel_post
+                self.filters &= ~Filters.updates.channel_post
 
         if edited_updates is not None:
             warnings.warn('edited_updates is deprecated. See https://git.io/vp113 for more info',
                           TelegramDeprecationWarning,
                           stacklevel=2)
-            if edited_updates:
-                self.filters |= (Filters.update_type.edited_message |
-                                 Filters.update_type.edited_channel_post)
             if edited_updates is False:
-                self.filters &= ~(Filters.update_type.edited_message |
-                                  Filters.update_type.edited_channel_post)
+                self.filters &= ~(Filters.updates.edited_message |
+                                  Filters.updates.edited_channel_post)
 
     def check_update(self, update):
         """Determines whether an update should be passed to this handlers :attr:`callback`.

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 import os
+import sys
 import time
 from datetime import datetime
 from platform import python_implementation
@@ -310,6 +311,8 @@ class TestBot(object):
     @flaky(3, 1)
     @pytest.mark.timeout(15)
     @pytest.mark.xfail
+    @pytest.mark.skipif(os.getenv('APPVEYOR') and (sys.version_info < (3, 6)),
+                        reason='only run on 3.6 on appveyor')
     def test_set_webhook_get_webhook_info_and_delete_webhook(self, bot):
         url = 'https://python-telegram-bot.org/test/webhook'
         max_connections = 7

--- a/tests/test_commandhandler.py
+++ b/tests/test_commandhandler.py
@@ -168,7 +168,7 @@ class TestCommandHandler(object):
         assert check is not None and check is not False
 
         handler = CommandHandler('test', self.callback_basic,
-                                 filters=~Filters.update_type.edited_message)
+                                 filters=~Filters.updates.edited_message)
         check = handler.check_update(Update(0, message))
         assert check is not None and check is not False
 
@@ -467,7 +467,7 @@ class TestPrefixHandler(object):
         assert check is not None and check is not False
 
         handler = PrefixHandler(['!', '#', 'mytrig-'], ['help', 'test'], self.callback_basic,
-                                filters=~Filters.update_type.edited_message)
+                                filters=~Filters.updates.edited_message)
         check = handler.check_update(Update(0, prefixmessage))
         assert check is not None and check is not False
 

--- a/tests/test_commandhandler.py
+++ b/tests/test_commandhandler.py
@@ -474,24 +474,6 @@ class TestPrefixHandler(object):
         check = handler.check_update(Update(0, edited_message=prefixmessage))
         assert check is None or check is False
 
-    def test_edited_deprecated(self, prefixmessage):
-        handler = PrefixHandler(['!', '#', 'mytrig-'], ['help', 'test'], self.callback_basic,
-                                allow_edited=False)
-
-        check = handler.check_update(Update(0, prefixmessage))
-        assert check is not None and check is not False
-
-        check = handler.check_update(Update(0, edited_message=prefixmessage))
-        assert check is None or check is False
-
-        handler = PrefixHandler(['!', '#', 'mytrig-'], ['help', 'test'], self.callback_basic,
-                                allow_edited=True)
-        check = handler.check_update(Update(0, prefixmessage))
-        assert check is not None and check is not False
-
-        check = handler.check_update(Update(0, edited_message=prefixmessage))
-        assert check is not None and check is not False
-
     def test_with_filter(self, prefixmessage):
         handler = PrefixHandler(['!', '#', 'mytrig-'], ['help', 'test'], self.callback_basic,
                                 filters=Filters.group)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -20,14 +20,15 @@ import datetime
 
 import pytest
 
-from telegram import Message, User, Chat, MessageEntity, Document
+from telegram import Message, User, Chat, MessageEntity, Document, Update
 from telegram.ext import Filters, BaseFilter
 import re
 
 
 @pytest.fixture(scope='function')
-def message():
-    return Message(0, User(0, 'Testuser', False), datetime.datetime.now(), Chat(0, 'private'))
+def update():
+    return Update(0, Message(0, User(0, 'Testuser', False), datetime.datetime.now(),
+                             Chat(0, 'private')))
 
 
 @pytest.fixture(scope='function',
@@ -37,306 +38,307 @@ def message_entity(request):
 
 
 class TestFilters(object):
-    def test_filters_all(self, message):
-        assert Filters.all(message)
+    def test_filters_all(self, update):
+        assert Filters.all(update)
 
-    def test_filters_text(self, message):
-        message.text = 'test'
-        assert Filters.text(message)
-        message.text = '/test'
-        assert not Filters.text(message)
+    def test_filters_text(self, update):
+        update.message.text = 'test'
+        assert Filters.text(update)
+        update.message.text = '/test'
+        assert not Filters.text(update)
 
-    def test_filters_command(self, message):
-        message.text = 'test'
-        assert not Filters.command(message)
-        message.text = '/test'
-        assert Filters.command(message)
+    def test_filters_command(self, update):
+        update.message.text = 'test'
+        assert not Filters.command(update)
+        update.message.text = '/test'
+        assert Filters.command(update)
 
-    def test_filters_regex(self, message):
-        message.text = '/start deep-linked param'
-        assert Filters.regex(r'deep-linked param')(message)
-        message.text = '/help'
-        assert Filters.regex(r'help')(message)
-        message.text = '/help'
-        assert Filters.regex('help')(message)
+    def test_filters_regex(self, update):
+        update.message.text = '/start deep-linked param'
+        assert Filters.regex(r'deep-linked param')(update)
+        update.message.text = '/help'
+        assert Filters.regex(r'help')(update)
+        update.message.text = '/help'
+        assert Filters.regex('help')(update)
 
-        message.text = 'test'
-        assert not Filters.regex(r'fail')(message)
-        assert Filters.regex(r'test')(message)
-        assert Filters.regex(re.compile(r'test'))(message)
+        update.message.text = 'test'
+        assert not Filters.regex(r'fail')(update)
+        assert Filters.regex(r'test')(update)
+        assert Filters.regex(re.compile(r'test'))(update)
 
-        message.text = 'i love python'
-        assert Filters.regex(r'.\b[lo]{2}ve python')(message)
+        update.message.text = 'i love python'
+        assert Filters.regex(r'.\b[lo]{2}ve python')(update)
 
-    def test_filters_reply(self, message):
+    def test_filters_reply(self, update):
         another_message = Message(1, User(1, 'TestOther', False), datetime.datetime.now(),
                                   Chat(0, 'private'))
-        message.text = 'test'
-        assert not Filters.reply(message)
-        message.reply_to_message = another_message
-        assert Filters.reply(message)
+        update.message.text = 'test'
+        assert not Filters.reply(update)
+        update.message.reply_to_message = another_message
+        assert Filters.reply(update)
 
-    def test_filters_audio(self, message):
-        assert not Filters.audio(message)
-        message.audio = 'test'
-        assert Filters.audio(message)
+    def test_filters_audio(self, update):
+        assert not Filters.audio(update)
+        update.message.audio = 'test'
+        assert Filters.audio(update)
 
-    def test_filters_document(self, message):
-        assert not Filters.document(message)
-        message.document = 'test'
-        assert Filters.document(message)
+    def test_filters_document(self, update):
+        assert not Filters.document(update)
+        update.message.document = 'test'
+        assert Filters.document(update)
 
-    def test_filters_document_type(self, message):
-        message.document = Document("file_id", mime_type="application/vnd.android.package-archive")
-        assert Filters.document.apk(message)
-        assert Filters.document.application(message)
-        assert not Filters.document.doc(message)
-        assert not Filters.document.audio(message)
+    def test_filters_document_type(self, update):
+        update.message.document = Document("file_id",
+                                           mime_type="application/vnd.android.package-archive")
+        assert Filters.document.apk(update)
+        assert Filters.document.application(update)
+        assert not Filters.document.doc(update)
+        assert not Filters.document.audio(update)
 
-        message.document.mime_type = "application/msword"
-        assert Filters.document.doc(message)
-        assert Filters.document.application(message)
-        assert not Filters.document.docx(message)
-        assert not Filters.document.audio(message)
+        update.message.document.mime_type = "application/msword"
+        assert Filters.document.doc(update)
+        assert Filters.document.application(update)
+        assert not Filters.document.docx(update)
+        assert not Filters.document.audio(update)
 
-        message.document.mime_type = "application/vnd.openxmlformats-" \
-                                     "officedocument.wordprocessingml.document"
-        assert Filters.document.docx(message)
-        assert Filters.document.application(message)
-        assert not Filters.document.exe(message)
-        assert not Filters.document.audio(message)
+        update.message.document.mime_type = "application/vnd.openxmlformats-officedocument." \
+                                            "wordprocessingml.document"
+        assert Filters.document.docx(update)
+        assert Filters.document.application(update)
+        assert not Filters.document.exe(update)
+        assert not Filters.document.audio(update)
 
-        message.document.mime_type = "application/x-ms-dos-executable"
-        assert Filters.document.exe(message)
-        assert Filters.document.application(message)
-        assert not Filters.document.docx(message)
-        assert not Filters.document.audio(message)
+        update.message.document.mime_type = "application/x-ms-dos-executable"
+        assert Filters.document.exe(update)
+        assert Filters.document.application(update)
+        assert not Filters.document.docx(update)
+        assert not Filters.document.audio(update)
 
-        message.document.mime_type = "video/mp4"
-        assert Filters.document.gif(message)
-        assert Filters.document.video(message)
-        assert not Filters.document.jpg(message)
-        assert not Filters.document.text(message)
+        update.message.document.mime_type = "video/mp4"
+        assert Filters.document.gif(update)
+        assert Filters.document.video(update)
+        assert not Filters.document.jpg(update)
+        assert not Filters.document.text(update)
 
-        message.document.mime_type = "image/jpeg"
-        assert Filters.document.jpg(message)
-        assert Filters.document.image(message)
-        assert not Filters.document.mp3(message)
-        assert not Filters.document.video(message)
+        update.message.document.mime_type = "image/jpeg"
+        assert Filters.document.jpg(update)
+        assert Filters.document.image(update)
+        assert not Filters.document.mp3(update)
+        assert not Filters.document.video(update)
 
-        message.document.mime_type = "audio/mpeg"
-        assert Filters.document.mp3(message)
-        assert Filters.document.audio(message)
-        assert not Filters.document.pdf(message)
-        assert not Filters.document.image(message)
+        update.message.document.mime_type = "audio/mpeg"
+        assert Filters.document.mp3(update)
+        assert Filters.document.audio(update)
+        assert not Filters.document.pdf(update)
+        assert not Filters.document.image(update)
 
-        message.document.mime_type = "application/pdf"
-        assert Filters.document.pdf(message)
-        assert Filters.document.application(message)
-        assert not Filters.document.py(message)
-        assert not Filters.document.audio(message)
+        update.message.document.mime_type = "application/pdf"
+        assert Filters.document.pdf(update)
+        assert Filters.document.application(update)
+        assert not Filters.document.py(update)
+        assert not Filters.document.audio(update)
 
-        message.document.mime_type = "text/x-python"
-        assert Filters.document.py(message)
-        assert Filters.document.text(message)
-        assert not Filters.document.svg(message)
-        assert not Filters.document.application(message)
+        update.message.document.mime_type = "text/x-python"
+        assert Filters.document.py(update)
+        assert Filters.document.text(update)
+        assert not Filters.document.svg(update)
+        assert not Filters.document.application(update)
 
-        message.document.mime_type = "image/svg+xml"
-        assert Filters.document.svg(message)
-        assert Filters.document.image(message)
-        assert not Filters.document.txt(message)
-        assert not Filters.document.video(message)
+        update.message.document.mime_type = "image/svg+xml"
+        assert Filters.document.svg(update)
+        assert Filters.document.image(update)
+        assert not Filters.document.txt(update)
+        assert not Filters.document.video(update)
 
-        message.document.mime_type = "text/plain"
-        assert Filters.document.txt(message)
-        assert Filters.document.text(message)
-        assert not Filters.document.targz(message)
-        assert not Filters.document.application(message)
+        update.message.document.mime_type = "text/plain"
+        assert Filters.document.txt(update)
+        assert Filters.document.text(update)
+        assert not Filters.document.targz(update)
+        assert not Filters.document.application(update)
 
-        message.document.mime_type = "application/x-compressed-tar"
-        assert Filters.document.targz(message)
-        assert Filters.document.application(message)
-        assert not Filters.document.wav(message)
-        assert not Filters.document.audio(message)
+        update.message.document.mime_type = "application/x-compressed-tar"
+        assert Filters.document.targz(update)
+        assert Filters.document.application(update)
+        assert not Filters.document.wav(update)
+        assert not Filters.document.audio(update)
 
-        message.document.mime_type = "audio/x-wav"
-        assert Filters.document.wav(message)
-        assert Filters.document.audio(message)
-        assert not Filters.document.xml(message)
-        assert not Filters.document.image(message)
+        update.message.document.mime_type = "audio/x-wav"
+        assert Filters.document.wav(update)
+        assert Filters.document.audio(update)
+        assert not Filters.document.xml(update)
+        assert not Filters.document.image(update)
 
-        message.document.mime_type = "application/xml"
-        assert Filters.document.xml(message)
-        assert Filters.document.application(message)
-        assert not Filters.document.zip(message)
-        assert not Filters.document.audio(message)
+        update.message.document.mime_type = "application/xml"
+        assert Filters.document.xml(update)
+        assert Filters.document.application(update)
+        assert not Filters.document.zip(update)
+        assert not Filters.document.audio(update)
 
-        message.document.mime_type = "application/zip"
-        assert Filters.document.zip(message)
-        assert Filters.document.application(message)
-        assert not Filters.document.apk(message)
-        assert not Filters.document.audio(message)
+        update.message.document.mime_type = "application/zip"
+        assert Filters.document.zip(update)
+        assert Filters.document.application(update)
+        assert not Filters.document.apk(update)
+        assert not Filters.document.audio(update)
 
-        message.document.mime_type = "image/x-rgb"
-        assert not Filters.document.category("application/")(message)
-        assert not Filters.document.mime_type("application/x-sh")(message)
-        message.document.mime_type = "application/x-sh"
-        assert Filters.document.category("application/")(message)
-        assert Filters.document.mime_type("application/x-sh")(message)
+        update.message.document.mime_type = "image/x-rgb"
+        assert not Filters.document.category("application/")(update)
+        assert not Filters.document.mime_type("application/x-sh")(update)
+        update.message.document.mime_type = "application/x-sh"
+        assert Filters.document.category("application/")(update)
+        assert Filters.document.mime_type("application/x-sh")(update)
 
-    def test_filters_photo(self, message):
-        assert not Filters.photo(message)
-        message.photo = 'test'
-        assert Filters.photo(message)
+    def test_filters_photo(self, update):
+        assert not Filters.photo(update)
+        update.message.photo = 'test'
+        assert Filters.photo(update)
 
-    def test_filters_sticker(self, message):
-        assert not Filters.sticker(message)
-        message.sticker = 'test'
-        assert Filters.sticker(message)
+    def test_filters_sticker(self, update):
+        assert not Filters.sticker(update)
+        update.message.sticker = 'test'
+        assert Filters.sticker(update)
 
-    def test_filters_video(self, message):
-        assert not Filters.video(message)
-        message.video = 'test'
-        assert Filters.video(message)
+    def test_filters_video(self, update):
+        assert not Filters.video(update)
+        update.message.video = 'test'
+        assert Filters.video(update)
 
-    def test_filters_voice(self, message):
-        assert not Filters.voice(message)
-        message.voice = 'test'
-        assert Filters.voice(message)
+    def test_filters_voice(self, update):
+        assert not Filters.voice(update)
+        update.message.voice = 'test'
+        assert Filters.voice(update)
 
-    def test_filters_video_note(self, message):
-        assert not Filters.video_note(message)
-        message.video_note = 'test'
-        assert Filters.video_note(message)
+    def test_filters_video_note(self, update):
+        assert not Filters.video_note(update)
+        update.message.video_note = 'test'
+        assert Filters.video_note(update)
 
-    def test_filters_contact(self, message):
-        assert not Filters.contact(message)
-        message.contact = 'test'
-        assert Filters.contact(message)
+    def test_filters_contact(self, update):
+        assert not Filters.contact(update)
+        update.message.contact = 'test'
+        assert Filters.contact(update)
 
-    def test_filters_location(self, message):
-        assert not Filters.location(message)
-        message.location = 'test'
-        assert Filters.location(message)
+    def test_filters_location(self, update):
+        assert not Filters.location(update)
+        update.message.location = 'test'
+        assert Filters.location(update)
 
-    def test_filters_venue(self, message):
-        assert not Filters.venue(message)
-        message.venue = 'test'
-        assert Filters.venue(message)
+    def test_filters_venue(self, update):
+        assert not Filters.venue(update)
+        update.message.venue = 'test'
+        assert Filters.venue(update)
 
-    def test_filters_status_update(self, message):
-        assert not Filters.status_update(message)
+    def test_filters_status_update(self, update):
+        assert not Filters.status_update(update)
 
-        message.new_chat_members = ['test']
-        assert Filters.status_update(message)
-        assert Filters.status_update.new_chat_members(message)
-        message.new_chat_members = None
+        update.message.new_chat_members = ['test']
+        assert Filters.status_update(update)
+        assert Filters.status_update.new_chat_members(update)
+        update.message.new_chat_members = None
 
-        message.left_chat_member = 'test'
-        assert Filters.status_update(message)
-        assert Filters.status_update.left_chat_member(message)
-        message.left_chat_member = None
+        update.message.left_chat_member = 'test'
+        assert Filters.status_update(update)
+        assert Filters.status_update.left_chat_member(update)
+        update.message.left_chat_member = None
 
-        message.new_chat_title = 'test'
-        assert Filters.status_update(message)
-        assert Filters.status_update.new_chat_title(message)
-        message.new_chat_title = ''
+        update.message.new_chat_title = 'test'
+        assert Filters.status_update(update)
+        assert Filters.status_update.new_chat_title(update)
+        update.message.new_chat_title = ''
 
-        message.new_chat_photo = 'test'
-        assert Filters.status_update(message)
-        assert Filters.status_update.new_chat_photo(message)
-        message.new_chat_photo = None
+        update.message.new_chat_photo = 'test'
+        assert Filters.status_update(update)
+        assert Filters.status_update.new_chat_photo(update)
+        update.message.new_chat_photo = None
 
-        message.delete_chat_photo = True
-        assert Filters.status_update(message)
-        assert Filters.status_update.delete_chat_photo(message)
-        message.delete_chat_photo = False
+        update.message.delete_chat_photo = True
+        assert Filters.status_update(update)
+        assert Filters.status_update.delete_chat_photo(update)
+        update.message.delete_chat_photo = False
 
-        message.group_chat_created = True
-        assert Filters.status_update(message)
-        assert Filters.status_update.chat_created(message)
-        message.group_chat_created = False
+        update.message.group_chat_created = True
+        assert Filters.status_update(update)
+        assert Filters.status_update.chat_created(update)
+        update.message.group_chat_created = False
 
-        message.supergroup_chat_created = True
-        assert Filters.status_update(message)
-        assert Filters.status_update.chat_created(message)
-        message.supergroup_chat_created = False
+        update.message.supergroup_chat_created = True
+        assert Filters.status_update(update)
+        assert Filters.status_update.chat_created(update)
+        update.message.supergroup_chat_created = False
 
-        message.channel_chat_created = True
-        assert Filters.status_update(message)
-        assert Filters.status_update.chat_created(message)
-        message.channel_chat_created = False
+        update.message.channel_chat_created = True
+        assert Filters.status_update(update)
+        assert Filters.status_update.chat_created(update)
+        update.message.channel_chat_created = False
 
-        message.migrate_to_chat_id = 100
-        assert Filters.status_update(message)
-        assert Filters.status_update.migrate(message)
-        message.migrate_to_chat_id = 0
+        update.message.migrate_to_chat_id = 100
+        assert Filters.status_update(update)
+        assert Filters.status_update.migrate(update)
+        update.message.migrate_to_chat_id = 0
 
-        message.migrate_from_chat_id = 100
-        assert Filters.status_update(message)
-        assert Filters.status_update.migrate(message)
-        message.migrate_from_chat_id = 0
+        update.message.migrate_from_chat_id = 100
+        assert Filters.status_update(update)
+        assert Filters.status_update.migrate(update)
+        update.message.migrate_from_chat_id = 0
 
-        message.pinned_message = 'test'
-        assert Filters.status_update(message)
-        assert Filters.status_update.pinned_message(message)
-        message.pinned_message = None
+        update.message.pinned_message = 'test'
+        assert Filters.status_update(update)
+        assert Filters.status_update.pinned_message(update)
+        update.message.pinned_message = None
 
-        message.connected_website = 'http://example.com/'
-        assert Filters.status_update(message)
-        assert Filters.status_update.connected_website(message)
-        message.connected_website = None
+        update.message.connected_website = 'http://example.com/'
+        assert Filters.status_update(update)
+        assert Filters.status_update.connected_website(update)
+        update.message.connected_website = None
 
-    def test_filters_forwarded(self, message):
-        assert not Filters.forwarded(message)
-        message.forward_date = 'test'
-        assert Filters.forwarded(message)
+    def test_filters_forwarded(self, update):
+        assert not Filters.forwarded(update)
+        update.message.forward_date = datetime.datetime.now()
+        assert Filters.forwarded(update)
 
-    def test_filters_game(self, message):
-        assert not Filters.game(message)
-        message.game = 'test'
-        assert Filters.game(message)
+    def test_filters_game(self, update):
+        assert not Filters.game(update)
+        update.message.game = 'test'
+        assert Filters.game(update)
 
-    def test_entities_filter(self, message, message_entity):
-        message.entities = [message_entity]
-        assert Filters.entity(message_entity.type)(message)
+    def test_entities_filter(self, update, message_entity):
+        update.message.entities = [message_entity]
+        assert Filters.entity(message_entity.type)(update)
 
-        message.entities = []
-        assert not Filters.entity(MessageEntity.MENTION)(message)
-
-        second = message_entity.to_dict()
-        second['type'] = 'bold'
-        second = MessageEntity.de_json(second, None)
-        message.entities = [message_entity, second]
-        assert Filters.entity(message_entity.type)(message)
-        assert not Filters.caption_entity(message_entity.type)(message)
-
-    def test_caption_entities_filter(self, message, message_entity):
-        message.caption_entities = [message_entity]
-        assert Filters.caption_entity(message_entity.type)(message)
-
-        message.caption_entities = []
-        assert not Filters.caption_entity(MessageEntity.MENTION)(message)
+        update.message.entities = []
+        assert not Filters.entity(MessageEntity.MENTION)(update)
 
         second = message_entity.to_dict()
         second['type'] = 'bold'
         second = MessageEntity.de_json(second, None)
-        message.caption_entities = [message_entity, second]
-        assert Filters.caption_entity(message_entity.type)(message)
-        assert not Filters.entity(message_entity.type)(message)
+        update.message.entities = [message_entity, second]
+        assert Filters.entity(message_entity.type)(update)
+        assert not Filters.caption_entity(message_entity.type)(update)
 
-    def test_private_filter(self, message):
-        assert Filters.private(message)
-        message.chat.type = 'group'
-        assert not Filters.private(message)
+    def test_caption_entities_filter(self, update, message_entity):
+        update.message.caption_entities = [message_entity]
+        assert Filters.caption_entity(message_entity.type)(update)
 
-    def test_group_filter(self, message):
-        assert not Filters.group(message)
-        message.chat.type = 'group'
-        assert Filters.group(message)
-        message.chat.type = 'supergroup'
-        assert Filters.group(message)
+        update.message.caption_entities = []
+        assert not Filters.caption_entity(MessageEntity.MENTION)(update)
+
+        second = message_entity.to_dict()
+        second['type'] = 'bold'
+        second = MessageEntity.de_json(second, None)
+        update.message.caption_entities = [message_entity, second]
+        assert Filters.caption_entity(message_entity.type)(update)
+        assert not Filters.entity(message_entity.type)(update)
+
+    def test_private_filter(self, update):
+        assert Filters.private(update)
+        update.message.chat.type = 'group'
+        assert not Filters.private(update)
+
+    def test_group_filter(self, update):
+        assert not Filters.group(update)
+        update.message.chat.type = 'group'
+        assert Filters.group(update)
+        update.message.chat.type = 'supergroup'
+        assert Filters.group(update)
 
     def test_filters_user(self):
         with pytest.raises(ValueError, match='user_id or username'):
@@ -344,22 +346,22 @@ class TestFilters(object):
         with pytest.raises(ValueError, match='user_id or username'):
             Filters.user()
 
-    def test_filters_user_id(self, message):
-        assert not Filters.user(user_id=1)(message)
-        message.from_user.id = 1
-        assert Filters.user(user_id=1)(message)
-        message.from_user.id = 2
-        assert Filters.user(user_id=[1, 2])(message)
-        assert not Filters.user(user_id=[3, 4])(message)
+    def test_filters_user_id(self, update):
+        assert not Filters.user(user_id=1)(update)
+        update.message.from_user.id = 1
+        assert Filters.user(user_id=1)(update)
+        update.message.from_user.id = 2
+        assert Filters.user(user_id=[1, 2])(update)
+        assert not Filters.user(user_id=[3, 4])(update)
 
-    def test_filters_username(self, message):
-        assert not Filters.user(username='user')(message)
-        assert not Filters.user(username='Testuser')(message)
-        message.from_user.username = 'user'
-        assert Filters.user(username='@user')(message)
-        assert Filters.user(username='user')(message)
-        assert Filters.user(username=['user1', 'user', 'user2'])(message)
-        assert not Filters.user(username=['@username', '@user_2'])(message)
+    def test_filters_username(self, update):
+        assert not Filters.user(username='user')(update)
+        assert not Filters.user(username='Testuser')(update)
+        update.message.from_user.username = 'user'
+        assert Filters.user(username='@user')(update)
+        assert Filters.user(username='user')(update)
+        assert Filters.user(username=['user1', 'user', 'user2'])(update)
+        assert not Filters.user(username=['@username', '@user_2'])(update)
 
     def test_filters_chat(self):
         with pytest.raises(ValueError, match='chat_id or username'):
@@ -367,126 +369,126 @@ class TestFilters(object):
         with pytest.raises(ValueError, match='chat_id or username'):
             Filters.chat()
 
-    def test_filters_chat_id(self, message):
-        assert not Filters.chat(chat_id=-1)(message)
-        message.chat.id = -1
-        assert Filters.chat(chat_id=-1)(message)
-        message.chat.id = -2
-        assert Filters.chat(chat_id=[-1, -2])(message)
-        assert not Filters.chat(chat_id=[-3, -4])(message)
+    def test_filters_chat_id(self, update):
+        assert not Filters.chat(chat_id=-1)(update)
+        update.message.chat.id = -1
+        assert Filters.chat(chat_id=-1)(update)
+        update.message.chat.id = -2
+        assert Filters.chat(chat_id=[-1, -2])(update)
+        assert not Filters.chat(chat_id=[-3, -4])(update)
 
-    def test_filters_chat_username(self, message):
-        assert not Filters.chat(username='chat')(message)
-        message.chat.username = 'chat'
-        assert Filters.chat(username='@chat')(message)
-        assert Filters.chat(username='chat')(message)
-        assert Filters.chat(username=['chat1', 'chat', 'chat2'])(message)
-        assert not Filters.chat(username=['@chat1', 'chat_2'])(message)
+    def test_filters_chat_username(self, update):
+        assert not Filters.chat(username='chat')(update)
+        update.message.chat.username = 'chat'
+        assert Filters.chat(username='@chat')(update)
+        assert Filters.chat(username='chat')(update)
+        assert Filters.chat(username=['chat1', 'chat', 'chat2'])(update)
+        assert not Filters.chat(username=['@chat1', 'chat_2'])(update)
 
-    def test_filters_invoice(self, message):
-        assert not Filters.invoice(message)
-        message.invoice = 'test'
-        assert Filters.invoice(message)
+    def test_filters_invoice(self, update):
+        assert not Filters.invoice(update)
+        update.message.invoice = 'test'
+        assert Filters.invoice(update)
 
-    def test_filters_successful_payment(self, message):
-        assert not Filters.successful_payment(message)
-        message.successful_payment = 'test'
-        assert Filters.successful_payment(message)
+    def test_filters_successful_payment(self, update):
+        assert not Filters.successful_payment(update)
+        update.message.successful_payment = 'test'
+        assert Filters.successful_payment(update)
 
-    def test_language_filter_single(self, message):
-        message.from_user.language_code = 'en_US'
-        assert (Filters.language('en_US'))(message)
-        assert (Filters.language('en'))(message)
-        assert not (Filters.language('en_GB'))(message)
-        assert not (Filters.language('da'))(message)
-        message.from_user.language_code = 'da'
-        assert not (Filters.language('en_US'))(message)
-        assert not (Filters.language('en'))(message)
-        assert not (Filters.language('en_GB'))(message)
-        assert (Filters.language('da'))(message)
+    def test_language_filter_single(self, update):
+        update.message.from_user.language_code = 'en_US'
+        assert (Filters.language('en_US'))(update)
+        assert (Filters.language('en'))(update)
+        assert not (Filters.language('en_GB'))(update)
+        assert not (Filters.language('da'))(update)
+        update.message.from_user.language_code = 'da'
+        assert not (Filters.language('en_US'))(update)
+        assert not (Filters.language('en'))(update)
+        assert not (Filters.language('en_GB'))(update)
+        assert (Filters.language('da'))(update)
 
-    def test_language_filter_multiple(self, message):
+    def test_language_filter_multiple(self, update):
         f = Filters.language(['en_US', 'da'])
-        message.from_user.language_code = 'en_US'
-        assert f(message)
-        message.from_user.language_code = 'en_GB'
-        assert not f(message)
-        message.from_user.language_code = 'da'
-        assert f(message)
+        update.message.from_user.language_code = 'en_US'
+        assert f(update)
+        update.message.from_user.language_code = 'en_GB'
+        assert not f(update)
+        update.message.from_user.language_code = 'da'
+        assert f(update)
 
-    def test_and_filters(self, message):
-        message.text = 'test'
-        message.forward_date = True
-        assert (Filters.text & Filters.forwarded)(message)
-        message.text = '/test'
-        assert not (Filters.text & Filters.forwarded)(message)
-        message.text = 'test'
-        message.forward_date = None
-        assert not (Filters.text & Filters.forwarded)(message)
+    def test_and_filters(self, update):
+        update.message.text = 'test'
+        update.message.forward_date = datetime.datetime.now()
+        assert (Filters.text & Filters.forwarded)(update)
+        update.message.text = '/test'
+        assert not (Filters.text & Filters.forwarded)(update)
+        update.message.text = 'test'
+        update.message.forward_date = None
+        assert not (Filters.text & Filters.forwarded)(update)
 
-        message.text = 'test'
-        message.forward_date = True
-        assert (Filters.text & Filters.forwarded & Filters.private)(message)
+        update.message.text = 'test'
+        update.message.forward_date = datetime.datetime.now()
+        assert (Filters.text & Filters.forwarded & Filters.private)(update)
 
-    def test_or_filters(self, message):
-        message.text = 'test'
-        assert (Filters.text | Filters.status_update)(message)
-        message.group_chat_created = True
-        assert (Filters.text | Filters.status_update)(message)
-        message.text = None
-        assert (Filters.text | Filters.status_update)(message)
-        message.group_chat_created = False
-        assert not (Filters.text | Filters.status_update)(message)
+    def test_or_filters(self, update):
+        update.message.text = 'test'
+        assert (Filters.text | Filters.status_update)(update)
+        update.message.group_chat_created = True
+        assert (Filters.text | Filters.status_update)(update)
+        update.message.text = None
+        assert (Filters.text | Filters.status_update)(update)
+        update.message.group_chat_created = False
+        assert not (Filters.text | Filters.status_update)(update)
 
-    def test_and_or_filters(self, message):
-        message.text = 'test'
-        message.forward_date = True
-        assert (Filters.text & (Filters.forwarded | Filters.status_update))(message)
-        message.forward_date = False
-        assert not (Filters.text & (Filters.forwarded | Filters.status_update))(message)
-        message.pinned_message = True
-        assert (Filters.text & (Filters.forwarded | Filters.status_update)(message))
+    def test_and_or_filters(self, update):
+        update.message.text = 'test'
+        update.message.forward_date = datetime.datetime.now()
+        assert (Filters.text & (Filters.forwarded | Filters.status_update))(update)
+        update.message.forward_date = False
+        assert not (Filters.text & (Filters.forwarded | Filters.status_update))(update)
+        update.message.pinned_message = True
+        assert (Filters.text & (Filters.forwarded | Filters.status_update)(update))
 
         assert str((Filters.text & (Filters.forwarded | Filters.entity(
             MessageEntity.MENTION)))) == '<Filters.text and <Filters.forwarded or ' \
                                          'Filters.entity(mention)>>'
 
-    def test_inverted_filters(self, message):
-        message.text = '/test'
-        assert Filters.command(message)
-        assert not (~Filters.command)(message)
-        message.text = 'test'
-        assert not Filters.command(message)
-        assert (~Filters.command)(message)
+    def test_inverted_filters(self, update):
+        update.message.text = '/test'
+        assert Filters.command(update)
+        assert not (~Filters.command)(update)
+        update.message.text = 'test'
+        assert not Filters.command(update)
+        assert (~Filters.command)(update)
 
-    def test_inverted_and_filters(self, message):
-        message.text = '/test'
-        message.forward_date = 1
-        assert (Filters.forwarded & Filters.command)(message)
-        assert not (~Filters.forwarded & Filters.command)(message)
-        assert not (Filters.forwarded & ~Filters.command)(message)
-        assert not (~(Filters.forwarded & Filters.command))(message)
-        message.forward_date = None
-        assert not (Filters.forwarded & Filters.command)(message)
-        assert (~Filters.forwarded & Filters.command)(message)
-        assert not (Filters.forwarded & ~Filters.command)(message)
-        assert (~(Filters.forwarded & Filters.command))(message)
-        message.text = 'test'
-        assert not (Filters.forwarded & Filters.command)(message)
-        assert not (~Filters.forwarded & Filters.command)(message)
-        assert not (Filters.forwarded & ~Filters.command)(message)
-        assert (~(Filters.forwarded & Filters.command))(message)
+    def test_inverted_and_filters(self, update):
+        update.message.text = '/test'
+        update.message.forward_date = 1
+        assert (Filters.forwarded & Filters.command)(update)
+        assert not (~Filters.forwarded & Filters.command)(update)
+        assert not (Filters.forwarded & ~Filters.command)(update)
+        assert not (~(Filters.forwarded & Filters.command))(update)
+        update.message.forward_date = None
+        assert not (Filters.forwarded & Filters.command)(update)
+        assert (~Filters.forwarded & Filters.command)(update)
+        assert not (Filters.forwarded & ~Filters.command)(update)
+        assert (~(Filters.forwarded & Filters.command))(update)
+        update.message.text = 'test'
+        assert not (Filters.forwarded & Filters.command)(update)
+        assert not (~Filters.forwarded & Filters.command)(update)
+        assert not (Filters.forwarded & ~Filters.command)(update)
+        assert (~(Filters.forwarded & Filters.command))(update)
 
-    def test_faulty_custom_filter(self, message):
+    def test_faulty_custom_filter(self, update):
         class _CustomFilter(BaseFilter):
             pass
 
         custom = _CustomFilter()
 
         with pytest.raises(NotImplementedError):
-            (custom & Filters.text)(message)
+            (custom & Filters.text)(update)
 
-    def test_custom_unnamed_filter(self, message):
+    def test_custom_unnamed_filter(self, update):
         class Unnamed(BaseFilter):
             def filter(self, mes):
                 return True

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -497,40 +497,40 @@ class TestFilters(object):
         assert str(unnamed) == Unnamed.__name__
 
     def test_update_type_message(self, update):
-        assert Filters.update_type.message(update)
-        assert not Filters.update_type.edited_message(update)
-        assert Filters.update_type.messages(update)
-        assert not Filters.update_type.channel_post(update)
-        assert not Filters.update_type.edited_channel_post(update)
-        assert not Filters.update_type.channel_posts(update)
-        assert Filters.update_type(update)
+        assert Filters.updates.message(update)
+        assert not Filters.updates.edited_message(update)
+        assert Filters.updates.messages(update)
+        assert not Filters.updates.channel_post(update)
+        assert not Filters.updates.edited_channel_post(update)
+        assert not Filters.updates.channel_posts(update)
+        assert Filters.updates(update)
 
     def test_update_type_edited_message(self, update):
         update.edited_message, update.message = update.message, update.edited_message
-        assert not Filters.update_type.message(update)
-        assert Filters.update_type.edited_message(update)
-        assert Filters.update_type.messages(update)
-        assert not Filters.update_type.channel_post(update)
-        assert not Filters.update_type.edited_channel_post(update)
-        assert not Filters.update_type.channel_posts(update)
-        assert Filters.update_type(update)
+        assert not Filters.updates.message(update)
+        assert Filters.updates.edited_message(update)
+        assert Filters.updates.messages(update)
+        assert not Filters.updates.channel_post(update)
+        assert not Filters.updates.edited_channel_post(update)
+        assert not Filters.updates.channel_posts(update)
+        assert Filters.updates(update)
 
     def test_update_type_channel_post(self, update):
         update.channel_post, update.message = update.message, update.edited_message
-        assert not Filters.update_type.message(update)
-        assert not Filters.update_type.edited_message(update)
-        assert not Filters.update_type.messages(update)
-        assert Filters.update_type.channel_post(update)
-        assert not Filters.update_type.edited_channel_post(update)
-        assert Filters.update_type.channel_posts(update)
-        assert Filters.update_type(update)
+        assert not Filters.updates.message(update)
+        assert not Filters.updates.edited_message(update)
+        assert not Filters.updates.messages(update)
+        assert Filters.updates.channel_post(update)
+        assert not Filters.updates.edited_channel_post(update)
+        assert Filters.updates.channel_posts(update)
+        assert Filters.updates(update)
 
     def test_update_type_edited_channel_post(self, update):
         update.edited_channel_post, update.message = update.message, update.edited_message
-        assert not Filters.update_type.message(update)
-        assert not Filters.update_type.edited_message(update)
-        assert not Filters.update_type.messages(update)
-        assert not Filters.update_type.channel_post(update)
-        assert Filters.update_type.edited_channel_post(update)
-        assert Filters.update_type.channel_posts(update)
-        assert Filters.update_type(update)
+        assert not Filters.updates.message(update)
+        assert not Filters.updates.edited_message(update)
+        assert not Filters.updates.messages(update)
+        assert not Filters.updates.channel_post(update)
+        assert Filters.updates.edited_channel_post(update)
+        assert Filters.updates.channel_posts(update)
+        assert Filters.updates(update)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -495,3 +495,42 @@ class TestFilters(object):
 
         unnamed = Unnamed()
         assert str(unnamed) == Unnamed.__name__
+
+    def test_update_type_message(self, update):
+        assert Filters.update_type.message(update)
+        assert not Filters.update_type.edited_message(update)
+        assert Filters.update_type.messages(update)
+        assert not Filters.update_type.channel_post(update)
+        assert not Filters.update_type.edited_channel_post(update)
+        assert not Filters.update_type.channel_posts(update)
+        assert Filters.update_type(update)
+
+    def test_update_type_edited_message(self, update):
+        update.edited_message, update.message = update.message, update.edited_message
+        assert not Filters.update_type.message(update)
+        assert Filters.update_type.edited_message(update)
+        assert Filters.update_type.messages(update)
+        assert not Filters.update_type.channel_post(update)
+        assert not Filters.update_type.edited_channel_post(update)
+        assert not Filters.update_type.channel_posts(update)
+        assert Filters.update_type(update)
+
+    def test_update_type_channel_post(self, update):
+        update.channel_post, update.message = update.message, update.edited_message
+        assert not Filters.update_type.message(update)
+        assert not Filters.update_type.edited_message(update)
+        assert not Filters.update_type.messages(update)
+        assert Filters.update_type.channel_post(update)
+        assert not Filters.update_type.edited_channel_post(update)
+        assert Filters.update_type.channel_posts(update)
+        assert Filters.update_type(update)
+
+    def test_update_type_edited_channel_post(self, update):
+        update.edited_channel_post, update.message = update.message, update.edited_message
+        assert not Filters.update_type.message(update)
+        assert not Filters.update_type.edited_message(update)
+        assert not Filters.update_type.messages(update)
+        assert not Filters.update_type.channel_post(update)
+        assert Filters.update_type.edited_channel_post(update)
+        assert Filters.update_type.channel_posts(update)
+        assert Filters.update_type(update)

--- a/tests/test_messagehandler.py
+++ b/tests/test_messagehandler.py
@@ -142,12 +142,12 @@ class TestMessageHandler(object):
                            channel_post_updates=False, edited_updates=False)
 
     def test_with_filter(self, message):
-        handler = MessageHandler(Filters.command, self.callback_basic)
+        handler = MessageHandler(Filters.group, self.callback_basic)
 
-        message.text = '/test'
+        message.chat.type = 'group'
         assert handler.check_update(Update(0, message))
 
-        message.text = 'test'
+        message.chat.type = 'private'
         assert not handler.check_update(Update(0, message))
 
     def test_specific_filters(self, message):

--- a/tests/test_messagehandler.py
+++ b/tests/test_messagehandler.py
@@ -151,9 +151,9 @@ class TestMessageHandler(object):
         assert not handler.check_update(Update(0, message))
 
     def test_specific_filters(self, message):
-        f = (~Filters.update_type.messages &
-             ~Filters.update_type.channel_post &
-             Filters.update_type.edited_channel_post)
+        f = (~Filters.updates.messages &
+             ~Filters.updates.channel_post &
+             Filters.updates.edited_channel_post)
         handler = MessageHandler(f, self.callback_basic)
 
         assert not handler.check_update(Update(0, edited_message=message))


### PR DESCRIPTION
* update_filter attribute on filters
* add update_type filter
* Messagehandler rework
  - remove allow_edited (deprecated for a while)
  - set deprecated defaults to None
  - Raise deprecation warning when they're used
  - add sensible defaults for filters.
  - rework tests
* Commandhandler rework
  - deprecate allow_edited
  - Raise deprecation warning when used
  - default to allowing edited