### PR TITLE
Simple support for nesting ConversationHandlers

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -63,6 +63,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Shelomentsev D <https://github.com/shelomentsevd>`_
 - `Simon Schürrle <https://github.com/SitiSchu>`_
 - `sooyhwang <https://github.com/sooyhwang>`_
+- `syntx <https://github.com/syntx>`_
 - `thodnev <https://github.com/thodnev>`_
 - `Trainer Jono <https://github.com/Tr-Jono>`_
 - `Valentijn <https://github.com/Faalentijn>`_

--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -318,10 +318,11 @@ class ConversationHandler(Handler):
                 context=self.current_conversation
             )
 
-        self.update_state(new_state, self.current_conversation)
-
         if isinstance(self.map_to_parent, dict) and new_state in self.map_to_parent:
+            self.update_state(self.END, self.current_conversation)
             return self.map_to_parent.get(new_state)
+        else:
+            self.update_state(new_state, self.current_conversation)
 
     def update_state(self, new_state, key):
         if new_state == self.END:

--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -113,6 +113,9 @@ class ConversationHandler(Handler):
         conversation_timeout (:obj:`float`|:obj:`datetime.timedelta`, optional): When this handler
             is inactive more than this timeout (in seconds), it will be automatically ended. If
             this value is 0 or None (default), there will be no timeout.
+        map_to_parent (Dict[:obj:`object`, :obj:`object`], optional): A :obj:`dict` that can be
+            used to instruct a nested conversationhandler to transition into a mapped state on
+            its parent conversationhandler in place of a specified nested state.
 
     Raises:
         ValueError
@@ -131,7 +134,8 @@ class ConversationHandler(Handler):
                  per_chat=True,
                  per_user=True,
                  per_message=False,
-                 conversation_timeout=None):
+                 conversation_timeout=None,
+                 map_to_parent=None):
 
         self.entry_points = entry_points
         self.states = states
@@ -144,6 +148,7 @@ class ConversationHandler(Handler):
         self.per_chat = per_chat
         self.per_message = per_message
         self.conversation_timeout = conversation_timeout
+        self.map_to_parent = map_to_parent
 
         self.timeout_jobs = dict()
         self.conversations = dict()
@@ -314,6 +319,9 @@ class ConversationHandler(Handler):
             )
 
         self.update_state(new_state, self.current_conversation)
+
+        if isinstance(self.map_to_parent, dict) and new_state in self.map_to_parent:
+            return self.map_to_parent.get(new_state)
 
     def update_state(self, new_state, key):
         if new_state == self.END:


### PR DESCRIPTION
Allowed **ConversationHandler** to possibly return a value from its **handle_update** method

Useful for allowing **ConversationHandler** to be nested in another **ConversationHandler** (see #405).

This solution was inspired by [transitions](https://github.com/pytransitions/transitions) library's [implementation of Hierarchical State Machines (HSM)](https://github.com/pytransitions/transitions#reuse-of-previously-created-hsms) (see the 'remap' keyword).

With this change it's now possible to return arbitrary state names in the nested **ConversationHandler** as long as the state name is mapped to an external **ConversationHandler** state (e.g. you can have your callback functions return SUCCESS, FAILURE, CANCELED etc. as you wish. You can also map ConversationHandler.END on one or both ends).