### PR TITLE
Fix Filters.regex failing on non-text message

### DIFF
--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -198,7 +198,9 @@ class Filters(object):
         # the matched groups and groupdict to the context object.
 
         def filter(self, message):
-            return bool(self.pattern.search(message.text))
+            if message.text:
+                return bool(self.pattern.search(message.text))
+            return False
 
     class _Reply(BaseFilter):
         name = 'Filters.reply'

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -68,6 +68,9 @@ class TestFilters(object):
         message.text = 'i love python'
         assert Filters.regex(r'.\b[lo]{2}ve python')(message)
 
+        message.text = None
+        assert not Filters.regex(r'fail')(message)
+
     def test_filters_reply(self, message):
         another_message = Message(1, User(1, 'TestOther', False), datetime.datetime.now(),
                                   Chat(0, 'private'))


### PR DESCRIPTION
Fix #1115 and improve `test_filters_regex`