### PR TITLE
feat: @send_action(action: ChatAction) decorator

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -47,6 +47,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `macrojames <https://github.com/macrojames>`_
 - `Michael Elovskikh <https://github.com/wronglink>`_
 - `Mischa Krüger <https://github.com/Makman2>`_
+- `Arseny Mitin <https://github.com/mitinarseny>`_
 - `naveenvhegde <https://github.com/naveenvhegde>`_
 - `neurrone <https://github.com/neurrone>`_
 - `njittam <https://github.com/njittam>`_

--- a/telegram/__init__.py
+++ b/telegram/__init__.py
@@ -34,7 +34,8 @@ from .files.contact import Contact
 from .files.location import Location
 from .files.venue import Venue
 from .files.videonote import VideoNote
-from .chataction import ChatAction
+from .chataction import (ChatAction, 
+                         send_action)
 from .userprofilephotos import UserProfilePhotos
 from .keyboardbutton import KeyboardButton
 from .replymarkup import ReplyMarkup
@@ -139,10 +140,10 @@ __all__ = [
     'Video', 'Voice', 'MAX_MESSAGE_LENGTH', 'MAX_CAPTION_LENGTH', 'SUPPORTED_WEBHOOK_PORTS',
     'MAX_FILESIZE_DOWNLOAD', 'MAX_FILESIZE_UPLOAD', 'MAX_MESSAGES_PER_SECOND_PER_CHAT',
     'MAX_MESSAGES_PER_SECOND', 'MAX_MESSAGES_PER_MINUTE_PER_GROUP', 'WebhookInfo', 'Animation',
-    'Game', 'GameHighScore', 'VideoNote', 'LabeledPrice', 'SuccessfulPayment', 'ShippingOption',
-    'ShippingAddress', 'PreCheckoutQuery', 'OrderInfo', 'Invoice', 'ShippingQuery', 'ChatPhoto',
-    'StickerSet', 'MaskPosition', 'CallbackGame', 'InputMedia', 'InputMediaPhoto',
-    'InputMediaVideo', 'PassportElementError', 'PassportElementErrorFile',
+    'Game', 'GameHighScore', 'VideoNote', 'LabeledPrice', 'send_action','SuccessfulPayment', 
+    'ShippingOption', 'ShippingAddress', 'PreCheckoutQuery', 'OrderInfo', 'Invoice', 
+    'ShippingQuery', 'ChatPhoto', 'StickerSet', 'MaskPosition', 'CallbackGame', 'InputMedia',
+    'InputMediaPhoto', 'InputMediaVideo', 'PassportElementError', 'PassportElementErrorFile',
     'PassportElementErrorReverseSide', 'PassportElementErrorFrontSide',
     'PassportElementErrorFiles', 'PassportElementErrorDataField', 'PassportElementErrorFile',
     'Credentials', 'DataCredentials', 'SecureData', 'FileCredentials', 'IdDocumentData',

--- a/telegram/chataction.py
+++ b/telegram/chataction.py
@@ -43,3 +43,19 @@ class ChatAction(object):
     """:obj:`str`: 'upload_video'"""
     UPLOAD_VIDEO_NOTE = 'upload_video_note'
     """:obj:`str`: 'upload_video_note'"""
+
+
+def send_action(action: ChatAction):
+    """ This decorator sends `CharAction` to `update.effective_user` before executing callback.
+    Args:
+        action (:obj: `ChatAction`): action to send.
+    """
+    def decorator(func: callable):
+        @wraps(func)
+        def wrapper(bot: Bot, update: Update, *args, **kwargs):
+            bot.send_chat_action(update.effective_user.id, action)
+            return func(bot, update, *args, **kwargs)
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
Implemented `@send_action` decorator to decorate callback functions of handlers.

Just simply:
```python
from telegram import (Bot, ChatAction, Update)
@send_action(ChatAction.TYPING)
def start_callback(bot: Bot, update: Update):
    update.message.reply_text('Before this message ChatAction.TYPING was sent.')
```