### PR TITLE
Update data.py to be compatible with example

### DIFF
--- a/telegram/passport/data.py
+++ b/telegram/passport/data.py
@@ -39,7 +39,7 @@ class PersonalDetails(TelegramObject):
     """
 
     def __init__(self, first_name, last_name, birth_date, gender, country_code,
-                 residence_country_code, first_name_native, last_name_native, middle_name=None,
+                 residence_country_code, first_name_native=None, last_name_native=None, middle_name=None,
                  middle_name_native=None, bot=None, **kwargs):
         # Required
         self.first_name = first_name

--- a/telegram/passport/data.py
+++ b/telegram/passport/data.py
@@ -39,7 +39,8 @@ class PersonalDetails(TelegramObject):
     """
 
     def __init__(self, first_name, last_name, birth_date, gender, country_code,
-                 residence_country_code, first_name_native=None, last_name_native=None, middle_name=None,
+                 residence_country_code, first_name_native=None,
+                 last_name_native=None, middle_name=None,
                  middle_name_native=None, bot=None, **kwargs):
         # Required
         self.first_name = first_name


### PR DESCRIPTION
for now, if you process personal_info with example code, then you got an error if there is no set option to get native fist and last name.

setting default value will allow to process personal_info without native name/surname transation