### PR TITLE
Cannot handle timeout by callback in ConversationHandler #1136

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -68,6 +68,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Trainer Jono <https://github.com/Tr-Jono>`_
 - `Valentijn <https://github.com/Faalentijn>`_
 - `voider1 <https://github.com/voider1>`_
+- `Vorobjev Simon <https://github.com/simonvorobjev>`_
 - `Wagner Macedo <https://github.com/wagnerluis1982>`_
 - `wjt <https://github.com/wjt>`_
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,6 @@ flaky
 yapf
 pre-commit
 beautifulsoup4
-pytest
+pytest>=3.8.1
 pytest-timeout
 wheel

--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -55,8 +55,8 @@ class ConversationHandler(Handler):
     To change the state of conversation, the callback function of a handler must return the new
     state after responding to the user. If it does not return anything (returning ``None`` by
     default), the state will not change. To end the conversation, the callback function must
-    return :attr:`END` or ``-1``. To handle the conversation timeout, use must add handler
-    for :attr:`TIMEOUT` or ``-2``.
+    return :attr:`END` or ``-1``. To handle the conversation timeout, use handler
+    :attr:`TIMEOUT` or ``-2``.
 
     Attributes:
         entry_points (List[:class:`telegram.ext.Handler`]): A list of ``Handler`` objects that can

--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -336,8 +336,9 @@ class ConversationHandler(Handler):
     def _trigger_timeout(self, bot, job):
         self.logger.debug('conversation timeout was triggered!')
         del self.timeout_jobs[job.context['current_conversation']]
-        handlers = self.states.get(self.TIMEOUT)
-        for candidate in (handlers or []):
+        handlers = self.states.get(self.TIMEOUT, [])
+        for candidate in handlers:
             handler = candidate
-            handler.handle_update(job.context['update'], job.context['dispatcher'])
+            if handler.check_update(job.context['update']):
+                handler.handle_update(job.context['update'], job.context['dispatcher'])
         self.update_state(self.END, job.context['current_conversation'])

--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -331,10 +331,8 @@ class ConversationHandler(Handler):
         if self.conversation_timeout and new_state != self.END:
             self.timeout_jobs[conversation_key] = dispatcher.job_queue.run_once(
                 self._trigger_timeout, self.conversation_timeout,
-                context={'current_conversation': self.current_conversation,
-                         'update': update,
-                         'dispatcher': dispatcher}
-              )
+                context={'current_conversation': conversation_key, 'update': update,
+                         'dispatcher': dispatcher})
 
         self.update_state(new_state, conversation_key)
 
@@ -363,6 +361,7 @@ class ConversationHandler(Handler):
         del self.timeout_jobs[job.context['current_conversation']]
         handlers = self.states.get(self.TIMEOUT, [])
         for handler in handlers:
-            if handler.check_update(job.context['update']):
-                handler.handle_update(job.context['update'], job.context['dispatcher'])
+            check = handler.check_update(job.context['update'])
+            if check is not None and check is not False:
+                handler.handle_update(job.context['update'], job.context['dispatcher'], check)
         self.update_state(self.END, job.context['current_conversation'])

--- a/telegram/ext/dispatcher.py
+++ b/telegram/ext/dispatcher.py
@@ -322,16 +322,18 @@ class Dispatcher(object):
                     if check is not None and check is not False:
                         handler.handle_update(update, self, check)
                         if self.persistence:
-                            if self.persistence.store_chat_data and update.effective_chat.id:
+                            if self.persistence.store_chat_data and update.effective_chat:
                                 chat_id = update.effective_chat.id
                                 try:
-                                    self.persistence.update_chat_data(chat_id, self.chat_data[chat_id])
+                                    self.persistence.update_chat_data(chat_id,
+                                                                      self.chat_data[chat_id])
                                 except Exception:
                                     self.logger.exception('Saving chat data raised an error')
-                            if self.persistence.store_user_data and update.effective_user.id:
+                            if self.persistence.store_user_data and update.effective_user:
                                 user_id = update.effective_user.id
                                 try:
-                                    self.persistence.update_user_data(user_id, self.user_data[user_id])
+                                    self.persistence.update_user_data(user_id,
+                                                                      self.user_data[user_id])
                                 except Exception:
                                     self.logger.exception('Saving user data raised an error')
                         break

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,7 @@ def dp(_dp):
     _dp.__async_queue = Queue()
     _dp.__async_threads = set()
     _dp.persistence = None
+    _dp.use_context = False
     if _dp._Dispatcher__singleton_semaphore.acquire(blocking=0):
         Dispatcher._set_singleton(_dp)
     yield _dp

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,6 +104,7 @@ def dp(_dp):
     _dp.__exception_event = Event()
     _dp.__async_queue = Queue()
     _dp.__async_threads = set()
+    _dp.persistence = None
     if _dp._Dispatcher__singleton_semaphore.acquire(blocking=0):
         Dispatcher._set_singleton(_dp)
     yield _dp

--- a/tests/test_conversationhandler.py
+++ b/tests/test_conversationhandler.py
@@ -23,7 +23,8 @@ import pytest
 
 from telegram import (CallbackQuery, Chat, ChosenInlineResult, InlineQuery, Message,
                       PreCheckoutQuery, ShippingQuery, Update, User)
-from telegram.ext import (ConversationHandler, CommandHandler, CallbackQueryHandler)
+from telegram.ext import (ConversationHandler, CommandHandler, CallbackQueryHandler,
+                          MessageHandler)
 
 
 @pytest.fixture(scope='class')
@@ -64,7 +65,7 @@ class TestConversationHandler(object):
                 CommandHandler('drinkMore', self.drink)
             ],
             ConversationHandler.TIMEOUT: [
-                CommandHandler('Nothing', self.passout)
+                MessageHandler(None, self.passout)
             ]
         }
         self.fallbacks = [CommandHandler('eat', self.start)]


### PR DESCRIPTION
https://github.com/python-telegram-bot/python-telegram-bot/issues/1136

Met same issue, if conversation ended by timeout, we cannot handle it and make some finalization like clearing data, stopping threads etc. Now we can add handler for ConversationHandler.END, for example:

```python
conv_handler = ConversationHandler(
        entry_points=[CommandHandler('find', begin)],
        states={
            PRODUCT_CHOOSE: [MessageHandler(Filters.text,
                                           product_reply,
                                           pass_user_data=True),
                            ],
            ConversationHandler.END: [MessageHandler(Filters.text,
                                         conversation_timeout,
                                         pass_user_data=True),
                            ]
        }
```