### PR TITLE
Allow filenames without dots in them when sending files

### DIFF
--- a/telegram/files/inputfile.py
+++ b/telegram/files/inputfile.py
@@ -70,7 +70,7 @@ class InputFile(object):
                     self.filename)[0] or DEFAULT_MIME_TYPE
             else:
                 self.mimetype = DEFAULT_MIME_TYPE
-        if not self.filename or '.' not in self.filename:
+        if not self.filename:
             self.filename = self.mimetype.replace('/', '.')
 
     @property

--- a/tests/test_inputfile.py
+++ b/tests/test_inputfile.py
@@ -63,3 +63,26 @@ class TestInputFile(object):
         assert (InputFile(BytesIO(b'blah'), filename='tg.notaproperext').mimetype ==
                 'application/octet-stream')
         assert InputFile(BytesIO(b'blah')).mimetype == 'application/octet-stream'
+
+    def test_filenames(self):
+        assert InputFile(open('tests/data/telegram.jpg', 'rb')).filename == 'telegram.jpg'
+        assert InputFile(open('tests/data/telegram.jpg', 'rb'), filename='blah').filename == 'blah'
+        assert InputFile(open('tests/data/telegram.jpg', 'rb'), filename='blah.jpg').filename == 'blah.jpg'
+        assert InputFile(open('tests/data/telegram', 'rb')).filename == 'telegram'
+        assert InputFile(open('tests/data/telegram', 'rb'), filename='blah').filename == 'blah'
+        assert InputFile(open('tests/data/telegram', 'rb'), filename='blah.jpg').filename == 'blah.jpg'
+
+        class MockedFileobject(object):
+            # A open(?, 'rb') without a .name
+            def __init__(self, f):
+                self.f = open(f, 'rb')
+
+            def read(self):
+                return self.f.read()
+
+        assert InputFile(MockedFileobject('tests/data/telegram.jpg')).filename == 'image.jpeg'
+        assert InputFile(MockedFileobject('tests/data/telegram.jpg'), filename='blah').filename == 'blah'
+        assert InputFile(MockedFileobject('tests/data/telegram.jpg'), filename='blah.jpg').filename == 'blah.jpg'
+        assert InputFile(MockedFileobject('tests/data/telegram')).filename == 'application.octet-stream'
+        assert InputFile(MockedFileobject('tests/data/telegram'), filename='blah').filename == 'blah'
+        assert InputFile(MockedFileobject('tests/data/telegram'), filename='blah.jpg').filename == 'blah.jpg'

--- a/tests/test_inputfile.py
+++ b/tests/test_inputfile.py
@@ -66,11 +66,15 @@ class TestInputFile(object):
 
     def test_filenames(self):
         assert InputFile(open('tests/data/telegram.jpg', 'rb')).filename == 'telegram.jpg'
-        assert InputFile(open('tests/data/telegram.jpg', 'rb'), filename='blah').filename == 'blah'
-        assert InputFile(open('tests/data/telegram.jpg', 'rb'), filename='blah.jpg').filename == 'blah.jpg'
+        assert InputFile(open('tests/data/telegram.jpg', 'rb'),
+                         filename='blah').filename == 'blah'
+        assert InputFile(open('tests/data/telegram.jpg', 'rb'),
+                         filename='blah.jpg').filename == 'blah.jpg'
         assert InputFile(open('tests/data/telegram', 'rb')).filename == 'telegram'
-        assert InputFile(open('tests/data/telegram', 'rb'), filename='blah').filename == 'blah'
-        assert InputFile(open('tests/data/telegram', 'rb'), filename='blah.jpg').filename == 'blah.jpg'
+        assert InputFile(open('tests/data/telegram', 'rb'),
+                         filename='blah').filename == 'blah'
+        assert InputFile(open('tests/data/telegram', 'rb'),
+                         filename='blah.jpg').filename == 'blah.jpg'
 
         class MockedFileobject(object):
             # A open(?, 'rb') without a .name
@@ -81,8 +85,12 @@ class TestInputFile(object):
                 return self.f.read()
 
         assert InputFile(MockedFileobject('tests/data/telegram.jpg')).filename == 'image.jpeg'
-        assert InputFile(MockedFileobject('tests/data/telegram.jpg'), filename='blah').filename == 'blah'
-        assert InputFile(MockedFileobject('tests/data/telegram.jpg'), filename='blah.jpg').filename == 'blah.jpg'
-        assert InputFile(MockedFileobject('tests/data/telegram')).filename == 'application.octet-stream'
-        assert InputFile(MockedFileobject('tests/data/telegram'), filename='blah').filename == 'blah'
-        assert InputFile(MockedFileobject('tests/data/telegram'), filename='blah.jpg').filename == 'blah.jpg'
+        assert InputFile(MockedFileobject('tests/data/telegram.jpg'),
+                         filename='blah').filename == 'blah'
+        assert InputFile(MockedFileobject('tests/data/telegram.jpg'),
+                         filename='blah.jpg').filename == 'blah.jpg'
+        assert InputFile(MockedFileobject('tests/data/telegram')).filename == 'application.octet-stream' # flake8: noqa
+        assert InputFile(MockedFileobject('tests/data/telegram'),
+                         filename='blah').filename == 'blah'
+        assert InputFile(MockedFileobject('tests/data/telegram'),
+                         filename='blah.jpg').filename == 'blah.jpg'


### PR DESCRIPTION
Fixes #1227 