### PR TITLE
Clean up else clause on conversation handler check_update for loop #1236

### DIFF
--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -247,7 +247,9 @@ class ConversationHandler(Handler):
             self.logger.debug('waiting for promise...')
 
             old_state, new_state = state
-            if new_state.done.wait(timeout=self.run_async_timeout):
+            promise_completed = new_state.done.wait(timeout=self.run_async_timeout)
+
+            if promise_completed:
                 try:
                     res = new_state.result(timeout=0)
                     res = res if res is not None else old_state

--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -266,9 +266,7 @@ class ConversationHandler(Handler):
                         self.current_handler = candidate
 
                         return True
-
-                else:
-                    return False
+                return False
 
         self.logger.debug('selecting conversation %s with state %s' % (str(key), str(state)))
 


### PR DESCRIPTION
As per issue #1236, this PR replaces the `else` clause on the `for` loop with a default return `False` statement. The unit tests for this class continue to pass. I ran *pytest* against the whole project and found 2 errors when running locally on my MacBook with Python3.6, but at first glance they appear to be unrelated.

I also moved a conditional into a named local variable that to me made the purpose of the block of code that I was changing more explicit.