### PR TITLE
Allow persistence with non telegram.Update updates

### DIFF
--- a/telegram/ext/dispatcher.py
+++ b/telegram/ext/dispatcher.py
@@ -30,7 +30,7 @@ from queue import Queue, Empty
 
 from future.builtins import range
 
-from telegram import TelegramError
+from telegram import TelegramError, Update
 from telegram.ext.handler import Handler
 from telegram.utils.promise import Promise
 from telegram.ext import BasePersistence
@@ -299,7 +299,7 @@ class Dispatcher(object):
             try:
                 for handler in (x for x in self.handlers[group] if x.check_update(update)):
                     handler.handle_update(update, self)
-                    if self.persistence:
+                    if self.persistence and isinstance(update, Update):
                         if self.persistence.store_chat_data and update.effective_chat.id:
                             chat_id = update.effective_chat.id
                             try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,6 +96,7 @@ def dp(_dp):
         _dp.update_queue.get(False)
     _dp.chat_data = defaultdict(dict)
     _dp.user_data = defaultdict(dict)
+    _dp.persistence = None
     _dp.handlers = {}
     _dp.groups = []
     _dp.error_handlers = []

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -31,7 +31,7 @@ import pytest
 
 from telegram import Update, Message, User, Chat
 from telegram.ext import BasePersistence, Updater, ConversationHandler, MessageHandler, Filters, \
-    PicklePersistence, CommandHandler, DictPersistence
+    PicklePersistence, CommandHandler, DictPersistence, TypeHandler
 
 
 @pytest.fixture(scope="function")
@@ -200,6 +200,21 @@ class TestBasePersistence(object):
 
         assert dp.user_data[54321][1] == 'test7'
         assert dp.chat_data[-987654][2] == 'test8'
+
+    def test_persistence_dispatcher_arbitrary_update_types(self, dp, base_persistence, caplog):
+        # Updates used with TypeHandler doesn't necessarily have the proper attributes for
+        # persistence, makes sure it works anyways
+
+        dp.persistence = base_persistence
+
+        class MyUpdate(object):
+            pass
+
+        dp.add_handler(TypeHandler(MyUpdate, lambda *_: None))
+
+        with caplog.at_level(logging.ERROR):
+            dp.process_update(MyUpdate())
+        assert 'An uncaught error was raised while processing the update' not in caplog.text
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
Update types used with TypeHandler, doesn't necessarily have a `effective_chat` and `effective_user`. Therefore we need to make sure that it's an instance of telegram.Update before assuming those attributes exist.

I'm unsure how to test... any suggestions?