### PR TITLE
Fix and enhance PicklePersistence: deepcopy

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -19,6 +19,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Anton Tagunov <https://github.com/anton-tagunov>`_
 - `Avanatiker <https://github.com/Avanatiker>`_
 - `Balduro <https://github.com/Balduro>`_
+- `Bibo-Joshi <https://github.com/Bibo-Joshi`_
 - `bimmlerd <https://github.com/bimmlerd>`_
 - `d-qoi <https://github.com/d-qoi>`_
 - `daimajia <https://github.com/daimajia>`_

--- a/telegram/ext/basepersistence.py
+++ b/telegram/ext/basepersistence.py
@@ -33,6 +33,12 @@ class BasePersistence(object):
       must overwrite :meth:`get_conversations` and :meth:`update_conversation`.
     * :meth:`flush` will be called when the bot is shutdown.
 
+    Note:
+        It may be benifitial to check if data has changed, before persisting it. Therefore
+        :meth:`get_chat_data`, :meth:`get_user_data` and :meth:`get_conversations` should *not*
+        return the data stored in the instance of your persistence class but rather a deep copy
+        of it.
+
     Attributes:
         store_user_data (:obj:`bool`): Optional, Whether user_data should be saved by this
             persistence class.

--- a/telegram/ext/dictpersistence.py
+++ b/telegram/ext/dictpersistence.py
@@ -169,7 +169,7 @@ class DictPersistence(BasePersistence):
         if self.on_update:
             return deepcopy(self.conversations.get(name, {}))
         else:
-            return (self.conversations.get(name, {}))
+            return self.conversations.get(name, {})
 
     def update_conversation(self, name, key, new_state):
         """Will update the conversations for the given handler.

--- a/telegram/ext/picklepersistence.py
+++ b/telegram/ext/picklepersistence.py
@@ -56,7 +56,7 @@ class PicklePersistence(BasePersistence):
         on_flush (:obj:`bool`, optional): When ``True`` will only save to file when :meth:`flush`
             is called and keep data in memory until that happens. When False will store data on any
             transaction. Default is ``False``.
-        on_update (:obj:`bool`): Optional. When ``True`` will only save to file, if data has
+        on_update (:obj:`bool`, optional): When ``True`` will only save to file, if data has
             changed. When ``False`` will save to file on every update. Default is ``False``.
     """
 
@@ -131,7 +131,7 @@ class PicklePersistence(BasePersistence):
         if self.on_update:
             return deepcopy(self.user_data)
         else:
-            return self.user_data.copy()
+            return self.user_data
 
     def get_chat_data(self):
         """Returns the chat_data from the pickle file if it exsists or an empty defaultdict.
@@ -154,7 +154,7 @@ class PicklePersistence(BasePersistence):
         if self.on_update:
             return deepcopy(self.chat_data)
         else:
-            return self.chat_data.copy()
+            return self.chat_data
 
     def get_conversations(self, name):
         """Returns the conversations from the pickle file if it exsists or an empty defaultdict.
@@ -178,7 +178,7 @@ class PicklePersistence(BasePersistence):
         if self.on_update:
             return deepcopy(self.conversations.get(name, {}))
         else:
-            return (self.conversations.get(name, {})).copy()
+            return (self.conversations.get(name, {}))
 
     def update_conversation(self, name, key, new_state):
         """Will update the conversations for the given handler and depending on :attr:`on_flush`
@@ -192,7 +192,9 @@ class PicklePersistence(BasePersistence):
         if self.on_update:
             if self.conversations.setdefault(name, {}).get(key) == new_state:
                 return
-        self.conversations[name][key] = new_state
+            self.conversations[name][key] = deepcopy(new_state)
+        else:
+            self.conversations[name][key] = new_state
         if not self.on_flush:
             if not self.single_file:
                 filename = "{}_conversations".format(self.filename)

--- a/telegram/ext/picklepersistence.py
+++ b/telegram/ext/picklepersistence.py
@@ -178,7 +178,7 @@ class PicklePersistence(BasePersistence):
         if self.on_update:
             return deepcopy(self.conversations.get(name, {}))
         else:
-            return (self.conversations.get(name, {}))
+            return self.conversations.get(name, {})
 
     def update_conversation(self, name, key, new_state):
         """Will update the conversations for the given handler and depending on :attr:`on_flush`

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -223,7 +223,8 @@ def pickle_persistence():
                              store_user_data=True,
                              store_chat_data=True,
                              singe_file=False,
-                             on_flush=False)
+                             on_flush=False,
+                             on_update=True)
 
 
 @pytest.fixture(scope='function')
@@ -598,7 +599,7 @@ def conversations_json(conversations):
 
 class TestDictPersistence(object):
     def test_no_json_given(self):
-        dict_persistence = DictPersistence()
+        dict_persistence = DictPersistence(on_update=True)
         assert dict_persistence.get_user_data() == defaultdict(dict)
         assert dict_persistence.get_chat_data() == defaultdict(dict)
         assert dict_persistence.get_conversations('noname') == {}
@@ -608,27 +609,28 @@ class TestDictPersistence(object):
         bad_chat_data = 'thisisnojson99900()))('
         bad_conversations = 'thisisnojson99900()))('
         with pytest.raises(TypeError, match='user_data'):
-            DictPersistence(user_data_json=bad_user_data)
+            DictPersistence(user_data_json=bad_user_data, on_update=True)
         with pytest.raises(TypeError, match='chat_data'):
-            DictPersistence(chat_data_json=bad_chat_data)
+            DictPersistence(chat_data_json=bad_chat_data, on_update=True)
         with pytest.raises(TypeError, match='conversations'):
-            DictPersistence(conversations_json=bad_conversations)
+            DictPersistence(conversations_json=bad_conversations, on_update=True)
 
     def test_invalid_json_string_given(self, pickle_persistence, bad_pickle_files):
         bad_user_data = '["this", "is", "json"]'
         bad_chat_data = '["this", "is", "json"]'
         bad_conversations = '["this", "is", "json"]'
         with pytest.raises(TypeError, match='user_data'):
-            DictPersistence(user_data_json=bad_user_data)
+            DictPersistence(user_data_json=bad_user_data, on_update=True)
         with pytest.raises(TypeError, match='chat_data'):
-            DictPersistence(chat_data_json=bad_chat_data)
+            DictPersistence(chat_data_json=bad_chat_data, on_update=True)
         with pytest.raises(TypeError, match='conversations'):
-            DictPersistence(conversations_json=bad_conversations)
+            DictPersistence(conversations_json=bad_conversations, on_update=True)
 
     def test_good_json_input(self, user_data_json, chat_data_json, conversations_json):
         dict_persistence = DictPersistence(user_data_json=user_data_json,
                                            chat_data_json=chat_data_json,
-                                           conversations_json=conversations_json)
+                                           conversations_json=conversations_json,
+                                           on_update=True)
         user_data = dict_persistence.get_user_data()
         assert isinstance(user_data, defaultdict)
         assert user_data[12345]['test1'] == 'test2'
@@ -658,7 +660,8 @@ class TestDictPersistence(object):
                           conversations, conversations_json):
         dict_persistence = DictPersistence(user_data_json=user_data_json,
                                            chat_data_json=chat_data_json,
-                                           conversations_json=conversations_json)
+                                           conversations_json=conversations_json,
+                                           on_update=True)
         assert dict_persistence.user_data == user_data
         assert dict_persistence.chat_data == chat_data
         assert dict_persistence.conversations == conversations
@@ -666,7 +669,8 @@ class TestDictPersistence(object):
     def test_json_outputs(self, user_data_json, chat_data_json, conversations_json):
         dict_persistence = DictPersistence(user_data_json=user_data_json,
                                            chat_data_json=chat_data_json,
-                                           conversations_json=conversations_json)
+                                           conversations_json=conversations_json,
+                                           on_update=True)
         assert dict_persistence.user_data_json == user_data_json
         assert dict_persistence.chat_data_json == chat_data_json
         assert dict_persistence.conversations_json == conversations_json
@@ -675,7 +679,8 @@ class TestDictPersistence(object):
                           conversations, conversations_json):
         dict_persistence = DictPersistence(user_data_json=user_data_json,
                                            chat_data_json=chat_data_json,
-                                           conversations_json=conversations_json)
+                                           conversations_json=conversations_json,
+                                           on_update=True)
         user_data_two = user_data.copy()
         user_data_two.update({4: {5: 6}})
         dict_persistence.update_user_data(4, {5: 6})
@@ -699,7 +704,7 @@ class TestDictPersistence(object):
             conversations_two)
 
     def test_with_handler(self, bot, update):
-        dict_persistence = DictPersistence()
+        dict_persistence = DictPersistence(on_update=True)
         u = Updater(bot=bot, persistence=dict_persistence)
         dp = u.dispatcher
 
@@ -727,7 +732,8 @@ class TestDictPersistence(object):
         chat_data = dict_persistence.chat_data_json
         del (dict_persistence)
         dict_persistence_2 = DictPersistence(user_data_json=user_data,
-                                             chat_data_json=chat_data)
+                                             chat_data_json=chat_data,
+                                             on_update=True)
 
         u = Updater(bot=bot, persistence=dict_persistence_2)
         dp = u.dispatcher
@@ -735,7 +741,8 @@ class TestDictPersistence(object):
         dp.process_update(update)
 
     def test_with_conversationHandler(self, dp, update, conversations_json):
-        dict_persistence = DictPersistence(conversations_json=conversations_json)
+        dict_persistence = DictPersistence(conversations_json=conversations_json,
+                                           on_update=True)
         dp.persistence = dict_persistence
         NEXT, NEXT2 = range(2)
 


### PR DESCRIPTION
As reported in [#1297](https://github.com/python-telegram-bot/python-telegram-bot/issues/1297), the use of shallow copies in `PicklePersistence` leads to data not being persisted. Same holds for `DictPersistence` A fix would be the use of `copy.deepcopy`, which however may become time consuming for large data sets.

I therefore implemented an additional argument `on_update` for `Pickle/DictPersistence` that let's you choose wether to check for updates before dumping or not.
If `on_update = False`, checking is obmitted and one can skip time consuming deepcopies (i.e. just pass the actual data). If `on_update = True`, deepcopies are used.