### PR TITLE
Fix bug: unable to save jobs with timezone aware dates

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -16,6 +16,7 @@ Contributors
 The following wonderful people contributed directly or indirectly to this project:
 
 - `Alateas <https://github.com/alateas>`_
+- `Ambro17 <https://github.com/Ambro17>`_
 - `Anton Tagunov <https://github.com/anton-tagunov>`_
 - `Avanatiker <https://github.com/Avanatiker>`_
 - `Balduro <https://github.com/Balduro>`_

--- a/telegram/ext/jobqueue.py
+++ b/telegram/ext/jobqueue.py
@@ -62,7 +62,7 @@ class JobQueue(object):
                 raise ValueError('next_t is None')
 
         if isinstance(next_t, datetime.datetime):
-            next_t = (next_t - datetime.datetime.now()).total_seconds()
+            next_t = (next_t - datetime.datetime.now(next_t.tzinfo)).total_seconds()
 
         elif isinstance(next_t, datetime.time):
             next_datetime = datetime.datetime.combine(datetime.date.today(), next_t)

--- a/tests/test_jobqueue.py
+++ b/tests/test_jobqueue.py
@@ -184,6 +184,24 @@ class TestJobQueue(object):
         sleep(0.06)
         assert pytest.approx(self.job_time) == expected_time
 
+    def test_datetime_with_timezone_job_run_once(self, job_queue):
+        # Test that run_once jobs work with timezone aware datetimes.
+        offset = datetime.timedelta(hours=-3)
+        when = datetime.datetime.now(datetime.timezone(offset))
+
+        job_queue.run_once(self.job_run_once, when)
+        sleep(0.01)
+        assert self.result == 1
+
+    def test_datetime_with_timezone_job_run_repeating(self, job_queue):
+        # Test that run_repeating jobs work with timezone aware datetimes.
+        offset = datetime.timedelta(hours=5)
+        now_with_offset = datetime.datetime.now(datetime.timezone(offset))
+
+        job_queue.run_repeating(self.job_run_once, interval=0.01, first=now_with_offset)
+        sleep(0.015)
+        assert self.result == 2
+
     def test_time_unit_dt_time_today(self, job_queue):
         # Testing running at a specific time today
         delta = 0.05


### PR DESCRIPTION
There was a bug when trying to save a job with a timezone aware date. The error was the following:
`TypeError: can't subtract offset-naive and offset-aware datetimes`

This was caused by the line 65 of `telegram/ext/jobqueue.py` that not surprisingly, tried to substract the timezone aware date of the job with `datetime.now()` which is naive as follows.
`next_t = (next_t - datetime.datetime.now(next_t.tzinfo)).total_seconds()`

This PR fixes that and adds tests that pass on the new implementation and fail on the previous one.