### PR TITLE
Improve regex filter docstring and avoid compiling compiled regex

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -16,6 +16,7 @@ Contributors
 The following wonderful people contributed directly or indirectly to this project:
 
 - `Alateas <https://github.com/alateas>`_
+- `Ambro17 <https://github.com/Ambro17>`_
 - `Anton Tagunov <https://github.com/anton-tagunov>`_
 - `Avanatiker <https://github.com/Avanatiker>`_
 - `Balduro <https://github.com/Balduro>`_

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -173,10 +173,11 @@ class Filters(object):
     command = _Command()
     """:obj:`Filter`: Messages starting with ``/``."""
 
-    class regex(BaseFilter):
+    class _Regex(BaseFilter):
         """
-        Filters updates by searching for an occurence of ``pattern`` in the message text.
+        Filters updates by searching for an occurrence of ``pattern`` in the message text.
         The ``re.search`` function is used to determine whether an update should be filtered.
+
         Refer to the documentation of the ``re`` module for more information.
 
         Note: Does not allow passing groups or a groupdict like the ``RegexHandler`` yet,
@@ -184,14 +185,20 @@ class Filters(object):
         RegexHandler (see https://github.com/python-telegram-bot/python-telegram-bot/issues/835).
 
         Examples:
-            Example ``CommandHandler("start", deep_linked_callback, Filters.regex('parameter'))``
+            Use ``MessageHandler(Filters.regex(r'help'), callback) to capture all messages that
+            contain the word help. You can also use
+            ``MessageHandler(Filters.regex(re.compile(r'help', re.IGNORECASE), callback)
+            if you want your pattern to be case insensitive. This approach is recommended
+            if you need to specify flags on your pattern.
 
         Args:
             pattern (:obj:`str` | :obj:`Pattern`): The regex pattern.
         """
 
         def __init__(self, pattern):
-            self.pattern = re.compile(pattern)
+            if isinstance(pattern, string_types):
+                pattern = re.compile(pattern)
+            self.pattern = pattern
             self.name = 'Filters.regex({})'.format(self.pattern)
 
         # TODO: Once the callback revamp (#1026) is done, the regex filter should be able to pass
@@ -201,6 +208,9 @@ class Filters(object):
             if message.text:
                 return bool(self.pattern.search(message.text))
             return False
+
+    regex = _Regex
+    """:obj:`Filter`: Messages that match the specified pattern."""
 
     class _Reply(BaseFilter):
         name = 'Filters.reply'

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -182,14 +182,16 @@ class Filters(object):
 
         Note: Does not allow passing groups or a groupdict like the ``RegexHandler`` yet,
         but this will probably be implemented in a future update, gradually phasing out the
-        RegexHandler (see https://github.com/python-telegram-bot/python-telegram-bot/issues/835).
+        RegexHandler (See `Github Issue
+        <https://github.com/python-telegram-bot/python-telegram-bot/issues/835/>`_).
 
         Examples:
-            Use ``MessageHandler(Filters.regex(r'help'), callback) to capture all messages that
+            Use ``MessageHandler(Filters.regex(r'help'), callback)`` to capture all messages that
             contain the word help. You can also use
-            ``MessageHandler(Filters.regex(re.compile(r'help', re.IGNORECASE), callback)
-            if you want your pattern to be case insensitive. This approach is recommended
+            ``MessageHandler(Filters.regex(re.compile(r'help', re.IGNORECASE), callback)`` if
+            you want your pattern to be case insensitive. This approach is recommended
             if you need to specify flags on your pattern.
+
 
         Args:
             pattern (:obj:`str` | :obj:`Pattern`): The regex pattern.
@@ -205,11 +207,10 @@ class Filters(object):
         # the matched groups and groupdict to the context object.
 
         def filter(self, message):
+            """:obj:`Filter`: Messages that have an occurrence of ``pattern``."""
             if message.text:
                 return bool(self.pattern.search(message.text))
             return False
-
-    """:obj:`Filter`: Messages that match the specified pattern."""
 
     class _Reply(BaseFilter):
         name = 'Filters.reply'

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -173,7 +173,7 @@ class Filters(object):
     command = _Command()
     """:obj:`Filter`: Messages starting with ``/``."""
 
-    class _Regex(BaseFilter):
+    class regex(BaseFilter):
         """
         Filters updates by searching for an occurrence of ``pattern`` in the message text.
         The ``re.search`` function is used to determine whether an update should be filtered.
@@ -209,7 +209,6 @@ class Filters(object):
                 return bool(self.pattern.search(message.text))
             return False
 
-    regex = _Regex
     """:obj:`Filter`: Messages that match the specified pattern."""
 
     class _Reply(BaseFilter):

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -180,10 +180,11 @@ class Filters(object):
 
         Refer to the documentation of the ``re`` module for more information.
 
-        Note: Does not allow passing groups or a groupdict like the ``RegexHandler`` yet,
-        but this will probably be implemented in a future update, gradually phasing out the
-        RegexHandler (See `Github Issue
-        <https://github.com/python-telegram-bot/python-telegram-bot/issues/835/>`_).
+        Note:
+            Does not allow passing groups or a groupdict like the ``RegexHandler`` yet,
+            but this will probably be implemented in a future update, gradually phasing out the
+            RegexHandler (See `Github Issue
+            <https://github.com/python-telegram-bot/python-telegram-bot/issues/835/>`_).
 
         Examples:
             Use ``MessageHandler(Filters.regex(r'help'), callback)`` to capture all messages that

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -64,6 +64,7 @@ class TestFilters(object):
         assert not Filters.regex(r'fail')(message)
         assert Filters.regex(r'test')(message)
         assert Filters.regex(re.compile(r'test'))(message)
+        assert Filters.regex(re.compile(r'TEST', re.IGNORECASE))(message)
 
         message.text = 'i love python'
         assert Filters.regex(r'.\b[lo]{2}ve python')(message)


### PR DESCRIPTION
This PR improves the docstring of Filters.regex. Changed format to comply with the rest of the file, and specify that pattern can be either a string or a pattern object. Also avoids recompiling regex on regex instantiation.
Add test case and define `Filter` attribute so sphinx can show the proper message instead of the placeholder text 