### PR TITLE
Add `last` kwarg to `run_repeating`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -60,6 +60,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Oleg Sushchenko <https://github.com/feuillemorte>`_
 - `Or Bin <https://github.com/OrBin>`_
 - `overquota <https://github.com/overquota>`_
+- `Paolo Lammens <https://github.com/plammens>`_
 - `Patrick Hofmann <https://github.com/PH89>`_
 - `Paul Larsen <https://github.com/PaulSonOfLars>`_
 - `Pieter Schutz <https://github.com/eldinnie>`_

--- a/telegram/ext/jobqueue.py
+++ b/telegram/ext/jobqueue.py
@@ -508,7 +508,7 @@ class Job(object):
         return False
 
 
-def _to_timestamp(time_, previous_t=None):
+def _to_timestamp(t, previous_t=None):
     # """
     # Converts a given time object (i.e., `datetime.datetime`,
     # `datetime.time`, `datetime.timedelta`, interval from now
@@ -516,22 +516,28 @@ def _to_timestamp(time_, previous_t=None):
     # kwargs like `first` to a uniform format.
     # """
 
-    previous_t = previous_t or time.time()
+    now = time.time()
+    previous_t = previous_t or now
 
-    if time_ is None:
+    if t is None:
         return None
-    elif hasattr(time_, 'timestamp'):
-        return time_.timestamp()
-    elif isinstance(time_, datetime.time):
+
+    if isinstance(t, datetime.timedelta):
+        return previous_t + t.total_seconds()
+
+    if isinstance(t, Number):
+        return previous_t + t
+
+    if isinstance(t, datetime.time):
         date = datetime.date.today()
 
-        if time_ < datetime.datetime.today().time():
+        if t < datetime.datetime.today().time():
             date += datetime.timedelta(days=1)
 
-        return datetime.datetime.combine(date, time_).timestamp()
-    elif isinstance(time_, datetime.timedelta):
-        return previous_t + time_.total_seconds()
-    elif isinstance(time_, Number):
-        return previous_t + time_
-    else:
-        raise TypeError('Unable to convert to timestamp')
+        t = datetime.datetime.combine(date, t)
+
+    if isinstance(t, datetime.datetime):
+        # replacement for datetime.datetime.timestamp() for py2
+        return (t - datetime.datetime.fromtimestamp(now)).total_seconds() + now
+
+    raise TypeError('Unable to convert to timestamp')

--- a/telegram/ext/jobqueue.py
+++ b/telegram/ext/jobqueue.py
@@ -248,7 +248,7 @@ class JobQueue(object):
                 self._set_next_peek(t)
                 break
 
-            delay_buffer = 0.01
+            delay_buffer = 0.01  # tolerance for last
             if job.finish_time is not None and now > job.finish_time + delay_buffer:
                 job.schedule_removal()  # job shouldn't run anymore
             if job.removed:
@@ -462,11 +462,15 @@ class Job(object):
 
     @property
     def finish_time(self):
+        """:obj:`float`: Optional. Time at which the job should stop repeating."""
         return self._finish_time
 
     @finish_time.setter
     def finish_time(self, time_):
-        self._finish_time = time.time() + _to_interval_seconds(time_)
+        if time_ is not None:
+            if not self.repeat:
+                raise ValueError("'finish_time' cannot be set if job doesn't repeat")
+            self._finish_time = time.time() + _to_interval_seconds(time_)
 
     @property
     def days(self):

--- a/tests/test_jobqueue.py
+++ b/tests/test_jobqueue.py
@@ -98,6 +98,13 @@ class TestJobQueue(object):
         sleep(0.07)
         assert self.result == 1
 
+    def test_run_repeating_last(self, job_queue):
+        job_queue.run_repeating(self.job_run_once, 0.05, last=0.1)
+        sleep(0.12)
+        assert self.result == 2
+        sleep(0.1)
+        assert self.result == 2
+
     def test_multiple(self, job_queue):
         job_queue.run_once(self.job_run_once, 0.01)
         job_queue.run_once(self.job_run_once, 0.02)


### PR DESCRIPTION
Added a `last` keyword argument to the `run_repeating` method of job queues that takes in a time specifier (in the same formats supported by `first`). It specifies the last time the job should be run. Currently, checking if the job should be run or not involves a certain "delay buffer" (so that if `last` is an exact multiple of `interval`, the internal delays don't mess up the intended behaviour), but it's a temporary solution. Also, I've made some minor refactorings.

Tests run correctly from my side. I've added one test for the new feature, but maybe a few more would be in place. The docs haven't been updated yet.

Closes #1333.