### PR TITLE
test: Fix 'test_idle' test

### DIFF
--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -334,9 +334,16 @@ class TestUpdater(object):
         with caplog.at_level(logging.INFO):
             updater.idle()
 
-        rec = caplog.records[-1]
-        assert rec.msg.startswith('Received signal {}'.format(signal.SIGTERM))
-        assert rec.levelname == 'INFO'
+        rec1, rec2 = caplog.records[-1], caplog.records[-2]
+
+        def test1(rec):
+            return rec.msg.startswith('Received signal {}'.format(signal.SIGTERM))
+
+        def test2(rec):
+            return rec.levelname == 'INFO'
+
+        assert test1(rec1) or test1(rec2)
+        assert test2(rec1) or test2(rec2)
 
         # If we get this far, idle() ran through
         sleep(.5)


### PR DESCRIPTION
This test annoyingly caused some Travis CI checks to appear as failed, when the changes are unrelated to that test. The cause was the fact that the last message logged isn't the 'Received signal 15' message, but the 'Error while getting Updates: Conflict: terminated by setWebhook request'.