### PR TITLE
Add a prefix to worker thread

### DIFF
--- a/telegram/ext/dispatcher.py
+++ b/telegram/ext/dispatcher.py
@@ -166,7 +166,8 @@ class Dispatcher(object):
         base_name = '{}_'.format(base_name) if base_name else ''
 
         for i in range(workers):
-            thread = Thread(target=self._pooled, name='{}{}'.format(base_name, i))
+            thread = Thread(target=self._pooled, name='Bot:{}:worker:{}{}'.format(self.bot.id,
+                                                                                  base_name, i))
             self.__async_threads.add(thread)
             thread.start()
 
@@ -208,6 +209,13 @@ class Dispatcher(object):
                 self.logger.warning(
                     'DispatcherHandlerStop is not supported with async functions; func: %s',
                     promise.pooled_function.__name__)
+
+    # This method purely exsists for testing purposes.
+    def _get_thread_names(self):
+        if self.__async_threads:
+            return (x.name for x in self.__async_threads)
+        else:
+            return None
 
     def run_async(self, func, *args, **kwargs):
         """Queue a function (with given args/kwargs) to be run asynchronously.

--- a/telegram/ext/dispatcher.py
+++ b/telegram/ext/dispatcher.py
@@ -210,13 +210,6 @@ class Dispatcher(object):
                     'DispatcherHandlerStop is not supported with async functions; func: %s',
                     promise.pooled_function.__name__)
 
-    # This method purely exsists for testing purposes.
-    def _get_thread_names(self):
-        if self.__async_threads:
-            return (x.name for x in self.__async_threads)
-        else:
-            return None
-
     def run_async(self, func, *args, **kwargs):
         """Queue a function (with given args/kwargs) to be run asynchronously.
 

--- a/telegram/ext/jobqueue.py
+++ b/telegram/ext/jobqueue.py
@@ -277,7 +277,8 @@ class JobQueue(object):
         if not self._running:
             self._running = True
             self.__start_lock.release()
-            self.__thread = Thread(target=self._main_loop, name="job_queue")
+            self.__thread = Thread(target=self._main_loop,
+                                   name="Bot:{}:job_queue".format(self._dispatcher.bot.id))
             self.__thread.start()
             self.logger.debug('%s thread started', self.__class__.__name__)
         else:

--- a/telegram/ext/updater.py
+++ b/telegram/ext/updater.py
@@ -157,7 +157,8 @@ class Updater(object):
         self.__threads = []
 
     def _init_thread(self, target, name, *args, **kwargs):
-        thr = Thread(target=self._thread_wrapper, name=name, args=(target,) + args, kwargs=kwargs)
+        thr = Thread(target=self._thread_wrapper, name="Bot:{}:{}".format(self.bot.id, name),
+                     args=(target,) + args, kwargs=kwargs)
         thr.start()
         self.__threads.append(thr)
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -384,6 +384,11 @@ class TestDispatcher(object):
         sleep(.1)
         assert self.received == 'Unauthorized.'
 
+    def test_sensible_worker_thread_names(self, dp2):
+        thread_names = [name for name in dp2._get_thread_names()]
+        for thread_name in thread_names:
+            assert thread_name.startswith("Bot:{}:worker:".format(dp2.bot.id))
+
     @pytest.mark.skipif(sys.version_info < (3, 0), reason='pytest fails this for no reason')
     def test_non_context_deprecation(self, dp):
         with pytest.warns(TelegramDeprecationWarning):

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -385,7 +385,8 @@ class TestDispatcher(object):
         assert self.received == 'Unauthorized.'
 
     def test_sensible_worker_thread_names(self, dp2):
-        thread_names = [name for name in dp2._get_thread_names()]
+        thread_names = [thread.name for thread in getattr(dp2, '_Dispatcher__async_threads')]
+        print(thread_names)
         for thread_name in thread_names:
             assert thread_name.startswith("Bot:{}:worker:".format(dp2.bot.id))
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -111,8 +111,10 @@ class TestUpdater(object):
         # NOTE: Checking Updater.running is problematic because it is not set to False when there's
         #       an unhandled exception.
         # TODO: We should have a way to poll Updater status and decide if it's running or not.
-        assert any('unhandled exception in updater' in rec.getMessage() for rec in
-                   caplog.get_records('call'))
+        import pprint
+        pprint.pprint([rec.getMessage() for rec in caplog.get_records('call')])
+        assert any('unhandled exception in Bot:{}:updater'.format(updater.bot.id) in
+                   rec.getMessage() for rec in caplog.get_records('call'))
 
     @pytest.mark.parametrize(('error',),
                              argvalues=[(RetryAfter(0.01),),


### PR DESCRIPTION
This adds a prefix of `Bot:<id>:worker:` to the name of the worker threads.
Fixes #1332