### PR TITLE
Add missing message.text check in PrefixHandler check_update

### DIFF
--- a/telegram/ext/commandhandler.py
+++ b/telegram/ext/commandhandler.py
@@ -332,7 +332,7 @@ class PrefixHandler(CommandHandler):
         if isinstance(update, Update) and update.effective_message:
             message = update.effective_message
 
-            if message.text and len(message.text) > 1:
+            if message.text:
                 text_list = message.text.split()
                 if text_list[0].lower() not in self.command:
                     return None

--- a/telegram/ext/commandhandler.py
+++ b/telegram/ext/commandhandler.py
@@ -332,14 +332,15 @@ class PrefixHandler(CommandHandler):
         if isinstance(update, Update) and update.effective_message:
             message = update.effective_message
 
-            text_list = message.text.split()
-            if text_list[0].lower() not in self.command:
-                return None
-            filter_result = self.filters(update)
-            if filter_result:
-                return text_list[1:], filter_result
-            else:
-                return False
+            if message.text and len(message.text) > 1:
+                text_list = message.text.split()
+                if text_list[0].lower() not in self.command:
+                    return None
+                filter_result = self.filters(update)
+                if filter_result:
+                    return text_list[1:], filter_result
+                else:
+                    return False
 
     def collect_additional_context(self, context, update, dispatcher, check_result):
         context.args = check_result[0]


### PR DESCRIPTION
As reported by users in group chat, sending a non text message makes made PrefixHandler throw an exception.