### PR TITLE
Fix to_dict method

### DIFF
--- a/telegram/base.py
+++ b/telegram/base.py
@@ -65,7 +65,8 @@ class TelegramObject(object):
                        '_credentials',
                        '_decrypted_credentials',
                        '_decrypted_data',
-                       '_decrypted_secret'):
+                       '_decrypted_secret',
+                       '_effective_attachment'):
                 continue
 
             value = self.__dict__[key]


### PR DESCRIPTION
Add `_effective_attachment` to black-list of `to_dict` method