### PR TITLE
Refactor test_commandhandler.py

### DIFF
--- a/telegram/ext/handler.py
+++ b/telegram/ext/handler.py
@@ -151,14 +151,11 @@ class Handler(object):
             optional_args['update_queue'] = dispatcher.update_queue
         if self.pass_job_queue:
             optional_args['job_queue'] = dispatcher.job_queue
-        if self.pass_user_data or self.pass_chat_data:
-            chat = update.effective_chat
+        if self.pass_user_data:
             user = update.effective_user
-
-            if self.pass_user_data:
-                optional_args['user_data'] = dispatcher.user_data[user.id if user else None]
-
-            if self.pass_chat_data:
-                optional_args['chat_data'] = dispatcher.chat_data[chat.id if chat else None]
+            optional_args['user_data'] = dispatcher.user_data[user.id if user else None]
+        if self.pass_chat_data:
+            chat = update.effective_chat
+            optional_args['chat_data'] = dispatcher.chat_data[chat.id if chat else None]
 
         return optional_args

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,10 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
+import datetime
 import os
 import sys
+import re
 from collections import defaultdict
 from queue import Queue
 from threading import Thread, Event
@@ -25,8 +27,9 @@ from time import sleep
 
 import pytest
 
-from telegram import Bot
-from telegram.ext import Dispatcher, JobQueue, Updater
+from telegram import Bot, Message, User, Chat, MessageEntity, Update, \
+    InlineQuery, CallbackQuery, ShippingQuery, PreCheckoutQuery, ChosenInlineResult
+from telegram.ext import Dispatcher, JobQueue, Updater, BaseFilter
 from tests.bots import get_bot
 
 TRAVIS = os.getenv('TRAVIS', False)
@@ -46,7 +49,7 @@ def bot_info():
 
 @pytest.fixture(scope='session')
 def bot(bot_info):
-    return Bot(bot_info['token'], private_key=PRIVATE_KEY)
+    return make_bot(bot_info)
 
 
 @pytest.fixture(scope='session')
@@ -146,3 +149,107 @@ def pytest_configure(config):
     if sys.version_info >= (3,):
         config.addinivalue_line('filterwarnings', 'ignore::ResourceWarning')
         # TODO: Write so good code that we don't need to ignore ResourceWarnings anymore
+
+
+def make_bot(bot_info):
+    return Bot(bot_info['token'], private_key=PRIVATE_KEY)
+
+
+CMD_PATTERN = re.compile(r'/[\da-z_]{1,32}(?:@\w{1,32})?')
+DATE = datetime.datetime.now()
+
+
+def make_message(text, **kwargs):
+    """
+    Testing utility factory to create a fake ``telegram.Message`` with
+    reasonable defaults for mimicking a real message.
+    :param text: (str) message text
+    :return: a (fake) ``telegram.Message``
+    """
+    return Message(message_id=1,
+                   from_user=kwargs.pop('user', User(id=1, first_name='', is_bot=False)),
+                   date=kwargs.pop('date', DATE),
+                   chat=kwargs.pop('chat', Chat(id=1, type='')),
+                   text=text,
+                   bot=kwargs.pop('bot', make_bot(get_bot())),
+                   **kwargs)
+
+
+def make_command_message(text, **kwargs):
+    """
+    Testing utility factory to create a message containing a single telegram
+    command.
+    Mimics the Telegram API in that it identifies commands within the message
+    and tags the returned ``Message`` object with the appropriate ``MessageEntity``
+    tag (but it does this only for commands).
+
+    :param text: (str) message text containing (or not) the command
+    :return: a (fake) ``telegram.Message`` containing only the command
+    """
+
+    match = re.search(CMD_PATTERN, text)
+    entities = [MessageEntity(type=MessageEntity.BOT_COMMAND,
+                              offset=match.start(0),
+                              length=len(match.group(0)))] if match else []
+
+    return make_message(text, entities=entities, **kwargs)
+
+
+def make_message_update(message, message_factory=make_message, edited=False, **kwargs):
+    """
+    Testing utility factory to create an update from a message, as either a
+    ``telegram.Message`` or a string. In the latter case ``message_factory``
+    is used to convert ``message`` to a ``telegram.Message``.
+    :param message: either a ``telegram.Message`` or a string with the message text
+    :param message_factory: function to convert the message text into a ``telegram.Message``
+    :param edited: whether the message should be stored as ``edited_message`` (vs. ``message``)
+    :return: ``telegram.Update`` with the given message
+    """
+    if not isinstance(message, Message):
+        message = message_factory(message, **kwargs)
+    update_kwargs = {'message' if not edited else 'edited_message': message}
+    return Update(0, **update_kwargs)
+
+
+def make_command_update(message, edited=False, **kwargs):
+    """
+    Testing utility factory to create an update from a message that potentially
+    contains a command. See ``make_command_message`` for more details.
+    :param message: message potentially containing a command
+    :param edited: whether the message should be stored as ``edited_message`` (vs. ``message``)
+    :return: ``telegram.Update`` with the given message
+    """
+    return make_message_update(message, make_command_message, edited, **kwargs)
+
+
+@pytest.fixture(scope='function')
+def mock_filter():
+    class MockFilter(BaseFilter):
+        def __init__(self):
+            self.tested = False
+
+        def filter(self, message):
+            self.tested = True
+
+    return MockFilter()
+
+
+def get_false_update_fixture_decorator_params():
+    message = Message(1, User(1, '', False), DATE, Chat(1, ''), text='test')
+    params = [
+        {'callback_query': CallbackQuery(1, User(1, '', False), 'chat', message=message)},
+        {'channel_post': message},
+        {'edited_channel_post': message},
+        {'inline_query': InlineQuery(1, User(1, '', False), '', '')},
+        {'chosen_inline_result': ChosenInlineResult('id', User(1, '', False), '')},
+        {'shipping_query': ShippingQuery('id', User(1, '', False), '', None)},
+        {'pre_checkout_query': PreCheckoutQuery('id', User(1, '', False), '', 0, '')},
+        {'callback_query': CallbackQuery(1, User(1, '', False), 'chat')}
+    ]
+    ids = tuple(key for kwargs in params for key in kwargs)
+    return {'params': params, 'ids': ids}
+
+
+@pytest.fixture(scope='function', **get_false_update_fixture_decorator_params())
+def false_update(request):
+    return Update(update_id=1, **request.param)


### PR DESCRIPTION
# Summary
  - Improved usage of fixtures
    - Replaced fixtures for directly callable factories where
    multiple mock objects were needed in the same test function
    - Extracted fixtures where possible (in place of literals or
    global constants)
  - Moved some fixtures to ``conftest.py`` to be used by other
    modules
  - Made a common base class for both ``TestCommandHandler`` and
    ``TestPrefixHandler``, extracting common methods, patterns and
    signatures
    - The extracted patterns in test methods have been named with
    leading ``_test``
  - Extracted other repeatedly used test utilities into functions
    (e.g. ``is_match``) and methods (e.g. ``make_default_handler``)

# Rationale

The main goal was to improve maintainability. Here are some of the reasons for each of the changes.

## Replacing fixtures for factory functions

Some test functions requested a fixture and used the same object multiple times, "patching" the object with the necessary changes to make each assertion, which was error-prone and cluttered the code. For example, this is how ``test_basic`` in `TestCommandHandler ` was before:

```python
    def test_basic(self, dp, message):
        handler = CommandHandler('test', self.callback_basic)
        dp.add_handler(handler)

        message.text = '/test'
        dp.process_update(Update(0, message))
        assert self.test_flag

        message.text = '/nottest'
        check = handler.check_update(Update(0, message))
        assert check is None or check is False

        message.text = 'test'
        check = handler.check_update(Update(0, message))
        assert check is None or check is False

        message.text = 'not /test at start'
        check = handler.check_update(Update(0, message))
        assert check is None or check is False

        message.entities = []
        message.text = '/test'
        check = handler.check_update(Update(0, message))
        assert check is None or check is False
```

The single `message` fixture is "reused" by patching the `message.text` field every time. That leads to a broken test, though, since the `message.entities` field isn't being changed appropriately: for example, if the third text was `'atest /test at start'` instead of `not /test at start`, the corresponding assertion would fail (since the entity in `message.entities` still pointed at `message.text[0]`), and that's not the intended behaviour.

Now this test looks like this:

```python
   def test_basic(self, dp, command):
        """Test whether a command handler responds to its command
        and not to others, or badly formatted commands"""
        handler = self.make_default_handler()
        dp.add_handler(handler)

        assert self.response(dp, make_command_update(command))
        assert not is_match(handler, make_command_update(command[1:]))
        assert not is_match(handler, make_command_update('/not{}'.format(command[1:])))
        assert not is_match(handler, make_command_update('not {} at start'.format(command)))
```

Where `command` is a fixture for a command, like `'/test'`, and `make_command_update`is a factory that handles making an accurate `telegram.Message` with the appropiate entity.


## Base class for both test classes

The two test classes, ``TestCommandHandler`` and ``TestPrefixHandler``, were very very similar, so a base class for both with common fixtures, callbacks and other utility methods helped a lot in cleaning the code

## Fixtures in `conftest.py`

Some fixtures were moved to `conftest.py` so that they can be used by other test modules. Grouping test modules into subdirectories with their own `conftest.py` with shared fixtures and utilities would be ideal, but I only worked on `test_commandhandler.py`.

## Other details

### Tests for `pass_*`

I had a hard time understanding why `pass_user_data`, `pass_chat_data`, `pass_job_queue`, and `pass_update_queue` were tested in pairs:

```python
    def test_pass_user_or_chat_data(self, dp, message):
        handler = CommandHandler('test', self.callback_data_1,
                                 pass_user_data=True)
        dp.add_handler(handler)

        message.text = '/test'
        dp.process_update(Update(0, message=message))
        assert self.test_flag

        dp.remove_handler(handler)
        handler = CommandHandler('test', self.callback_data_1,
                                 pass_chat_data=True)
        dp.add_handler(handler)

        self.test_flag = False
        dp.process_update(Update(0, message=message))
        assert self.test_flag

        dp.remove_handler(handler)
        handler = CommandHandler('test', self.callback_data_2,
                                 pass_chat_data=True,
                                 pass_user_data=True)
        dp.add_handler(handler)

        self.test_flag = False
        dp.process_update(Update(0, message=message))
        assert self.test_flag

    def test_pass_job_or_update_queue(self, dp, message):
        handler = CommandHandler('test', self.callback_queue_1,
                                 pass_job_queue=True)
        dp.add_handler(handler)

        message.text = '/test'
        dp.process_update(Update(0, message=message))
        assert self.test_flag

        dp.remove_handler(handler)
        handler = CommandHandler('test', self.callback_queue_1,
                                 pass_update_queue=True)
        dp.add_handler(handler)

        self.test_flag = False
        dp.process_update(Update(0, message=message))
        assert self.test_flag

        dp.remove_handler(handler)
        handler = CommandHandler('test', self.callback_queue_2,
                                 pass_job_queue=True,
                                 pass_update_queue=True)
        dp.add_handler(handler)

        self.test_flag = False
        dp.process_update(Update(0, message=message))
        assert self.test_flag
```

In any case, due to their similarity, I condensed together in a single parametrised test method:

```python
@pytest.mark.parametrize('pass_keyword', BaseTest.PASS_KEYWORDS)
    def test_pass_data(self, dp, command_update, pass_combination, pass_keyword):
        handler = CommandHandler('test', self.make_callback_for(pass_keyword), **pass_combination)
        dp.add_handler(handler)
        assert self.response(dp, command_update) == pass_combination.get(pass_keyword, False)
```

I kept the "testing in pairs" by parametrising the `pass_combination` fixture appropriately:

```python
PASS_KEYWORDS = ('pass_user_data', 'pass_chat_data', 'pass_job_queue', 'pass_update_queue')

@pytest.fixture(scope='module', params=itertools.combinations(PASS_KEYWORDS, 2))
def pass_combination(self, request):
    return {key: True for key in request.param}
```