### PR TITLE
Support for tz-aware datetime.datetime objects

### DIFF
--- a/telegram/ext/jobqueue.py
+++ b/telegram/ext/jobqueue.py
@@ -36,6 +36,22 @@ class Days(object):
     EVERY_DAY = tuple(range(7))
 
 
+class UTC(datetime.tzinfo):
+    """UTC"""
+
+    ZERO = datetime.timedelta(0)
+    HOUR = datetime.timedelta(hours=1)
+
+    def utcoffset(self, dt):
+        return ZERO
+
+    def tzname(self, dt):
+        return "UTC"
+
+    def dst(self, dt):
+        return ZERO
+
+
 class JobQueue(object):
     """This class allows you to periodically perform tasks with the bot.
 
@@ -77,7 +93,10 @@ class JobQueue(object):
                 raise ValueError('next_t is None')
 
         if isinstance(next_t, datetime.datetime):
-            next_t = (next_t - datetime.datetime.now()).total_seconds()
+            if next_t.tzinfo == None:
+                next_t = (next_t - datetime.datetime.now()).total_seconds()
+            else:
+                next_t = (next_t.astimezone(UTC()).replace(tzinfo=None) - datetime.datetime.utcnow()).total_seconds()
 
         elif isinstance(next_t, datetime.time):
             next_datetime = datetime.datetime.combine(datetime.date.today(), next_t)


### PR DESCRIPTION
## Original issue ##
Issue: #1409 
version: 12.0.0b1

## Changes ##
The `._put()` method can now accept utc_offset-aware/timezone-aware `datetime.datetime` objects. This helps bots to be hosted on a server with any timezone without complications.

To convert datetimes to UTC, a "UTC" subclass of the `datetime.tzinfo` class was added, and used in `._put()`.

## Other options considered ##
- Changing all the `.now()` comparisons in `._put()` to `.utcnow()`. This was not chosen, since it would cause a major compatibility issue. Bots would have to be rewritten to pass in UTC datetimes, instead of local (computer time) datetimes, into the jobqueue.run_once and other methods. This would likely be unwanted behaivour.