### PR TITLE
Make MessageEntity objects comparable

### DIFF
--- a/telegram/messageentity.py
+++ b/telegram/messageentity.py
@@ -55,6 +55,8 @@ class MessageEntity(TelegramObject):
         self.url = url
         self.user = user
 
+        self._id_attrs = (self.type, self.offset, self.length)
+
     @classmethod
     def de_json(cls, data, bot):
         data = super(MessageEntity, cls).de_json(data, bot)

--- a/telegram/messageentity.py
+++ b/telegram/messageentity.py
@@ -55,7 +55,7 @@ class MessageEntity(TelegramObject):
         self.url = url
         self.user = user
 
-        self._id_attrs = (self.type, self.offset, self.length, self.url, self.user)
+        self._id_attrs = (self.type, self.offset, self.length)
 
     @classmethod
     def de_json(cls, data, bot):

--- a/telegram/messageentity.py
+++ b/telegram/messageentity.py
@@ -55,7 +55,7 @@ class MessageEntity(TelegramObject):
         self.url = url
         self.user = user
 
-        self._id_attrs = (self.type, self.offset, self.length)
+        self._id_attrs = (self.type, self.offset, self.length, self.url, self.user)
 
     @classmethod
     def de_json(cls, data, bot):

--- a/tests/test_messageentity.py
+++ b/tests/test_messageentity.py
@@ -64,3 +64,19 @@ class TestMessageEntity(object):
             assert entity_dict['url'] == message_entity.url
         if message_entity.user:
             assert entity_dict['user'] == message_entity.user.to_dict()
+
+    def test_equality(self):
+        a = MessageEntity(MessageEntity.BOLD, 2, 3)
+        b = MessageEntity(MessageEntity.BOLD, 2, 3)
+        c = MessageEntity(MessageEntity.CODE, 2, 3)
+        d = MessageEntity(MessageEntity.CODE, 5, 6)
+
+        assert a == b
+        assert hash(a) == hash(b)
+        assert a is not b
+
+        assert a != c
+        assert hash(a) != hash(c)
+
+        assert a != d
+        assert hash(a) != hash(d)


### PR DESCRIPTION
Right now comparison of `MessageEntity` object fails, e.g.
```
MessageEntity('bold', 2, 4) == MessageEntity('code', 5, 10)
```
yields `True`.

To make `MessageEntity` objects comparable, I used `TelegramObject`s attribute `_id_attr`. Also, I added a `test_equality` to `test_messageentity`.
