### PR TITLE
Use context.error for v12 context-based error callbacks

### DIFF
--- a/examples/conversationbot2.py
+++ b/examples/conversationbot2.py
@@ -102,7 +102,7 @@ def done(update, context):
 
 def error(update, context):
     """Log Errors caused by Updates."""
-    logger.warning('Update "%s" caused error "%s"', update, error)
+    logger.warning('Update "%s" caused error "%s"', update, context.error)
 
 
 def main():

--- a/examples/persistentconversationbot.py
+++ b/examples/persistentconversationbot.py
@@ -113,7 +113,7 @@ def done(update, context):
 
 def error(update, context):
     """Log Errors caused by Updates."""
-    logger.warning('Update "%s" caused error "%s"', update, error)
+    logger.warning('Update "%s" caused error "%s"', update, context.error)
 
 
 def main():


### PR DESCRIPTION
Some of the examples are using context-based callbacks, but the error callbacks are not updated. This PR fixes these.