### PR TITLE
Use UTC in from_timestamp

### DIFF
--- a/telegram/utils/helpers.py
+++ b/telegram/utils/helpers.py
@@ -87,7 +87,7 @@ def from_timestamp(unixtime):
     if not unixtime:
         return None
 
-    return datetime.fromtimestamp(unixtime)
+    return datetime.utcfromtimestamp(unixtime)
 
 
 def mention_html(user_id, name):


### PR DESCRIPTION
Closes #1362 

By the discussion in #1409 and #1451 I had the impression that timezone aware `datetime` objects are to avoided and hence I used `utcfromtimestamp` instead of `fromtimestamp(unixtime, tz=timezone.utc)`. If this was the false conclusion, please let me know.