### PR TITLE
answer callbackqueries when no handler handled them

### DIFF
--- a/telegram/callbackquery.py
+++ b/telegram/callbackquery.py
@@ -29,6 +29,9 @@ class CallbackQuery(TelegramObject):
     :attr:`message` will be present. If the button was attached to a message sent via the bot (in
     inline mode), the field :attr:`inline_message_id` will be present.
 
+    If there is a not handled CallbackQuery update, the library answers it silently, which
+    prevents clients from showing an error message.
+
     Note:
         * In Python `from` is a reserved word, use `from_user` instead.
         * Exactly one of the fields :attr:`data` or :attr:`game_short_name` will be present.

--- a/telegram/ext/dispatcher.py
+++ b/telegram/ext/dispatcher.py
@@ -68,7 +68,9 @@ class DispatcherHandlerStop(Exception):
 
 
 class Dispatcher(object):
-    """This class dispatches all kinds of updates to its registered handlers.
+    """This class dispatches all kinds of updates to its registered handlers. If there is a not
+    handled CallbackQuery update, the library answers it silently, which prevents clients from
+    showing an error message.
 
     Attributes:
         bot (:class:`telegram.Bot`): The bot object that should be passed to the handlers.
@@ -361,7 +363,7 @@ class Dispatcher(object):
             return
 
         context = None
-        skip = False
+        is_update_handled = False
 
         for group in self.groups:
             try:
@@ -372,7 +374,7 @@ class Dispatcher(object):
                             context = CallbackContext.from_update(update, self)
                         handler.handle_update(update, self, check, context)
                         persist_update(update)
-                        skip = True
+                        is_update_handled = True
                         break
 
             # Stop processing with any other handler.
@@ -394,7 +396,7 @@ class Dispatcher(object):
                                           'uncaught error was raised while handling the error '
                                           'with an error_handler')
 
-        if not skip and update.callback_query:
+        if not is_update_handled and update.callback_query:
             # this means the update wasn't handled so far, and we can simply answer the query for
             # the user
             update.callback_query.answer()

--- a/telegram/ext/dispatcher.py
+++ b/telegram/ext/dispatcher.py
@@ -361,6 +361,7 @@ class Dispatcher(object):
             return
 
         context = None
+        skip = False
 
         for group in self.groups:
             try:
@@ -371,6 +372,7 @@ class Dispatcher(object):
                             context = CallbackContext.from_update(update, self)
                         handler.handle_update(update, self, check, context)
                         persist_update(update)
+                        skip = True
                         break
 
             # Stop processing with any other handler.
@@ -391,6 +393,11 @@ class Dispatcher(object):
                     self.logger.exception('An error was raised while processing the update and an '
                                           'uncaught error was raised while handling the error '
                                           'with an error_handler')
+
+        if not skip and update.callback_query:
+            # this means the update wasn't handled so far, and we can simply answer the query for
+            # the user
+            update.callback_query.answer()
 
     def add_handler(self, handler, group=DEFAULT_GROUP):
         """Register a handler.

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -237,21 +237,21 @@ class TestDispatcher(object):
         assert self.count == 3
 
     def test_callbackquery_answered_when_no_handler(self, dp, bot, monkeypatch):
-        update = Update(1, callback_query=CallbackQuery(1, User(1, "pool", False), 1, bot=bot))
-        wuhu = []
+        update = Update(1, callback_query=CallbackQuery(1, User(1, "Test", False), 1, bot=bot))
+        passed = []
 
         def test(*args, **kwargs):
-            wuhu.append(1)
+            passed.append(1)
 
         def test_2(update, context):
-            wuhu.append(2)
+            passed.append(2)
 
         monkeypatch.setattr('telegram.Bot.answerCallbackQuery', test)
 
         dp.process_update(update)
         dp.add_handler(CallbackQueryHandler(test_2))
         dp.process_update(update)
-        assert wuhu == [1, 2]
+        assert passed == [1, 2]
 
     def test_add_handler_errors(self, dp):
         handler = 'not a handler'


### PR DESCRIPTION
This closes #1364. I could turn the skip argument in one for the dispatcher, so user could disable this feature. I dont see any harm this could do though, so I didnt make it an option.

If the query is somehow answered, this call is just ignored by telegram. If it doesnt, this just enhances the user experience while not changing anything for the developer.