### PR TITLE
Add `last` keyword argument to `run_repeating`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -63,6 +63,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Oleg Sushchenko <https://github.com/feuillemorte>`_
 - `Or Bin <https://github.com/OrBin>`_
 - `overquota <https://github.com/overquota>`_
+- `Paolo Lammens <https://github.com/plammens>`_
 - `Patrick Hofmann <https://github.com/PH89>`_
 - `Paul Larsen <https://github.com/PaulSonOfLars>`_
 - `Pieter Schutz <https://github.com/eldinnie>`_

--- a/tests/test_jobqueue.py
+++ b/tests/test_jobqueue.py
@@ -126,6 +126,13 @@ class TestJobQueue(object):
         sleep(0.001)
         assert self.result == 1
 
+    def test_run_repeating_last(self, job_queue):
+        job_queue.run_repeating(self.job_run_once, 0.05, last=0.1)
+        sleep(0.12)
+        assert self.result == 2
+        sleep(0.1)
+        assert self.result == 2
+
     def test_multiple(self, job_queue):
         job_queue.run_once(self.job_run_once, 0.01)
         job_queue.run_once(self.job_run_once, 0.02)


### PR DESCRIPTION
See #1345 ([reopened on `master` instead of `V12`](https://github.com/python-telegram-bot/python-telegram-bot/pull/1345#issuecomment-526491062)):

> Added a `last` keyword argument to the `run_repeating` method of job queues that takes in a time specifier (in the same formats supported by `first`). It specifies the last time the job should be run. Currently, checking if the job should be run or not involves a certain "delay buffer" (so that if `last` is an exact multiple of `interval`, the internal delays don't mess up the intended behaviour), but it's a temporary solution. Also, I've made some minor refactorings.
>
> Tests run correctly from my side. I've added one test for the new feature, but maybe a few more would be in place. The docs haven't been updated yet.

Closes #1333.