### PR TITLE
Support all_members_are_administrators only by kwargs

### DIFF
--- a/telegram/chat.py
+++ b/telegram/chat.py
@@ -90,7 +90,6 @@ class Chat(TelegramObject):
                  username=None,
                  first_name=None,
                  last_name=None,
-                 all_members_are_administrators=None,
                  bot=None,
                  photo=None,
                  description=None,
@@ -108,7 +107,8 @@ class Chat(TelegramObject):
         self.username = username
         self.first_name = first_name
         self.last_name = last_name
-        self.all_members_are_administrators = all_members_are_administrators
+        # TODO: Remove (also from tests), when Telegram drops this completely
+        self.all_members_are_administrators = kwargs.get('all_members_are_administrators')
         self.photo = photo
         self.description = description
         self.invite_link = invite_link

--- a/tests/test_official.py
+++ b/tests/test_official.py
@@ -120,8 +120,6 @@ def check_object(h4):
         ignored |= {'credentials'}
     elif name == 'PassportElementError':
         ignored |= {'message', 'type', 'source'}
-    elif name == 'Chat':
-        ignored |= {'all_members_are_administrators'}
 
     assert (sig.parameters.keys() ^ checked) - ignored == set()
 


### PR DESCRIPTION
As discussed offline, this removes `all_members_are_administrators` from `Chat` s parameters. I didn't remove it from `test_chat` since Telegram still returns it, so I guess we should still test it.