### PR TITLE
Never install dependencies with sudo

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -25,7 +25,7 @@ Setting things up
 
    .. code-block:: bash
 
-      $ sudo pip install -r requirements.txt -r requirements-dev.txt
+      $ pip install -r requirements.txt -r requirements-dev.txt
 
 
 5. Install pre-commit hooks:


### PR DESCRIPTION
[This is about Ruby](https://github.com/calabash/calabash-ios/wiki/Best-Practice%3A--Never-install-gems-with-sudo) but I think most of it still applies. Countless times I fixed colleagues' systems because they used `sudo`.

We could add instructions for using `virtualenv` on top of this.