### PR TITLE
filter accepts a Message by default, not an Update

### DIFF
--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -103,15 +103,13 @@ class BaseFilter(object):
             self.name = self.__class__.__name__
         return self.name
 
-    def filter(self, update):
+    def filter(self, message):
         """This method must be overwritten.
 
-        Note:
-            If :attr:`update_filter` is false then the first argument is `message` and of
-            type :class:`telegram.Message`.
-
         Args:
-            update (:class:`telegram.Update`): The update that is tested.
+            message (:class:`telegram.Message`): The message that is tested. If
+            :attr:`update_filter` is True update is `update` of type
+            :class:`telegram.Update`.
 
         Returns:
             :obj:`dict` or :obj:`bool`

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -108,7 +108,7 @@ class BaseFilter(object):
 
         Args:
             message (:class:`telegram.Message`): The message that is tested. If
-            :attr:`update_filter` is True update is `update` of type
+            :attr:`update_filter` is True, message is an instance of
             :class:`telegram.Update`.
 
         Returns:


### PR DESCRIPTION
The method `BaseFilter.filter()` accepts a `Message` by default. Only if
class attribute `update_filter` is set to `True` the method accepts an
`Update`.

This pull request provides a commit that emphasizes this behaviour, because one can misunderstand it.

Closes: #1595