### PR TITLE
Remove checks for None on assignement for opt args

### DIFF
--- a/telegram/inline/inlinekeyboardbutton.py
+++ b/telegram/inline/inlinekeyboardbutton.py
@@ -86,20 +86,13 @@ class InlineKeyboardButton(TelegramObject):
         self.text = text
 
         # Optionals
-        if url:
-            self.url = url
-        if login_url:
-            self.login_url = login_url
-        if callback_data:
-            self.callback_data = callback_data
-        if switch_inline_query:
-            self.switch_inline_query = switch_inline_query
-        if switch_inline_query_current_chat:
-            self.switch_inline_query_current_chat = switch_inline_query_current_chat
-        if callback_game:
-            self.callback_game = callback_game
-        if pay:
-            self.pay = pay
+        self.url = url
+        self.login_url = login_url
+        self.callback_data = callback_data
+        self.switch_inline_query = switch_inline_query
+        self.switch_inline_query_current_chat = switch_inline_query_current_chat
+        self.callback_game = callback_game
+        self.pay = pay
 
     @classmethod
     def de_json(cls, data, bot):

--- a/telegram/inline/inlinequeryresultarticle.py
+++ b/telegram/inline/inlinequeryresultarticle.py
@@ -77,17 +77,10 @@ class InlineQueryResultArticle(InlineQueryResult):
         self.input_message_content = input_message_content
 
         # Optional
-        if reply_markup:
-            self.reply_markup = reply_markup
-        if url:
-            self.url = url
-        if hide_url:
-            self.hide_url = hide_url
-        if description:
-            self.description = description
-        if thumb_url:
-            self.thumb_url = thumb_url
-        if thumb_width:
-            self.thumb_width = thumb_width
-        if thumb_height:
-            self.thumb_height = thumb_height
+        self.reply_markup = reply_markup
+        self.url = url
+        self.hide_url = hide_url
+        self.description = description
+        self.thumb_url = thumb_url
+        self.thumb_width = thumb_width
+        self.thumb_height = thumb_height

--- a/telegram/inline/inlinequeryresultaudio.py
+++ b/telegram/inline/inlinequeryresultaudio.py
@@ -79,15 +79,9 @@ class InlineQueryResultAudio(InlineQueryResult):
         self.title = title
 
         # Optionals
-        if performer:
-            self.performer = performer
-        if audio_duration:
-            self.audio_duration = audio_duration
-        if caption:
-            self.caption = caption
-        if parse_mode:
-            self.parse_mode = parse_mode
-        if reply_markup:
-            self.reply_markup = reply_markup
-        if input_message_content:
-            self.input_message_content = input_message_content
+        self.performer = performer
+        self.audio_duration = audio_duration
+        self.caption = caption
+        self.parse_mode = parse_mode
+        self.reply_markup = reply_markup
+        self.input_message_content = input_message_content

--- a/telegram/inline/inlinequeryresultcachedaudio.py
+++ b/telegram/inline/inlinequeryresultcachedaudio.py
@@ -68,11 +68,7 @@ class InlineQueryResultCachedAudio(InlineQueryResult):
         self.audio_file_id = audio_file_id
 
         # Optionals
-        if caption:
-            self.caption = caption
-        if parse_mode:
-            self.parse_mode = parse_mode
-        if reply_markup:
-            self.reply_markup = reply_markup
-        if input_message_content:
-            self.input_message_content = input_message_content
+        self.caption = caption
+        self.parse_mode = parse_mode
+        self.reply_markup = reply_markup
+        self.input_message_content = input_message_content

--- a/telegram/inline/inlinequeryresultcacheddocument.py
+++ b/telegram/inline/inlinequeryresultcacheddocument.py
@@ -75,13 +75,8 @@ class InlineQueryResultCachedDocument(InlineQueryResult):
         self.document_file_id = document_file_id
 
         # Optionals
-        if description:
-            self.description = description
-        if caption:
-            self.caption = caption
-        if parse_mode:
-            self.parse_mode = parse_mode
-        if reply_markup:
-            self.reply_markup = reply_markup
-        if input_message_content:
-            self.input_message_content = input_message_content
+        self.description = description
+        self.caption = caption
+        self.parse_mode = parse_mode
+        self.reply_markup = reply_markup
+        self.input_message_content = input_message_content

--- a/telegram/inline/inlinequeryresultcachedgif.py
+++ b/telegram/inline/inlinequeryresultcachedgif.py
@@ -72,13 +72,8 @@ class InlineQueryResultCachedGif(InlineQueryResult):
         self.gif_file_id = gif_file_id
 
         # Optionals
-        if title:
-            self.title = title
-        if caption:
-            self.caption = caption
-        if parse_mode:
-            self.parse_mode = parse_mode
-        if reply_markup:
-            self.reply_markup = reply_markup
-        if input_message_content:
-            self.input_message_content = input_message_content
+        self.title = title
+        self.caption = caption
+        self.parse_mode = parse_mode
+        self.reply_markup = reply_markup
+        self.input_message_content = input_message_content

--- a/telegram/inline/inlinequeryresultcachedmpeg4gif.py
+++ b/telegram/inline/inlinequeryresultcachedmpeg4gif.py
@@ -72,13 +72,8 @@ class InlineQueryResultCachedMpeg4Gif(InlineQueryResult):
         self.mpeg4_file_id = mpeg4_file_id
 
         # Optionals
-        if title:
-            self.title = title
-        if caption:
-            self.caption = caption
-        if parse_mode:
-            self.parse_mode = parse_mode
-        if reply_markup:
-            self.reply_markup = reply_markup
-        if input_message_content:
-            self.input_message_content = input_message_content
+        self.title = title
+        self.caption = caption
+        self.parse_mode = parse_mode
+        self.reply_markup = reply_markup
+        self.input_message_content = input_message_content

--- a/telegram/inline/inlinequeryresultcachedphoto.py
+++ b/telegram/inline/inlinequeryresultcachedphoto.py
@@ -75,15 +75,9 @@ class InlineQueryResultCachedPhoto(InlineQueryResult):
         self.photo_file_id = photo_file_id
 
         # Optionals
-        if title:
-            self.title = title
-        if description:
-            self.description = description
-        if caption:
-            self.caption = caption
-        if parse_mode:
-            self.parse_mode = parse_mode
-        if reply_markup:
-            self.reply_markup = reply_markup
-        if input_message_content:
-            self.input_message_content = input_message_content
+        self.title = title
+        self.description = description
+        self.caption = caption
+        self.parse_mode = parse_mode
+        self.reply_markup = reply_markup
+        self.input_message_content = input_message_content

--- a/telegram/inline/inlinequeryresultcachedsticker.py
+++ b/telegram/inline/inlinequeryresultcachedsticker.py
@@ -58,7 +58,5 @@ class InlineQueryResultCachedSticker(InlineQueryResult):
         self.sticker_file_id = sticker_file_id
 
         # Optionals
-        if reply_markup:
-            self.reply_markup = reply_markup
-        if input_message_content:
-            self.input_message_content = input_message_content
+        self.reply_markup = reply_markup
+        self.input_message_content = input_message_content

--- a/telegram/inline/inlinequeryresultcachedvideo.py
+++ b/telegram/inline/inlinequeryresultcachedvideo.py
@@ -76,13 +76,8 @@ class InlineQueryResultCachedVideo(InlineQueryResult):
         self.title = title
 
         # Optionals
-        if description:
-            self.description = description
-        if caption:
-            self.caption = caption
-        if parse_mode:
-            self.parse_mode = parse_mode
-        if reply_markup:
-            self.reply_markup = reply_markup
-        if input_message_content:
-            self.input_message_content = input_message_content
+        self.description = description
+        self.caption = caption
+        self.parse_mode = parse_mode
+        self.reply_markup = reply_markup
+        self.input_message_content = input_message_content

--- a/telegram/inline/inlinequeryresultcachedvoice.py
+++ b/telegram/inline/inlinequeryresultcachedvoice.py
@@ -72,11 +72,7 @@ class InlineQueryResultCachedVoice(InlineQueryResult):
         self.title = title
 
         # Optionals
-        if caption:
-            self.caption = caption
-        if parse_mode:
-            self.parse_mode = parse_mode
-        if reply_markup:
-            self.reply_markup = reply_markup
-        if input_message_content:
-            self.input_message_content = input_message_content
+        self.caption = caption
+        self.parse_mode = parse_mode
+        self.reply_markup = reply_markup
+        self.input_message_content = input_message_content

--- a/telegram/inline/inlinequeryresultcontact.py
+++ b/telegram/inline/inlinequeryresultcontact.py
@@ -79,17 +79,10 @@ class InlineQueryResultContact(InlineQueryResult):
         self.first_name = first_name
 
         # Optionals
-        if last_name:
-            self.last_name = last_name
-        if vcard:
-            self.vcard = vcard
-        if reply_markup:
-            self.reply_markup = reply_markup
-        if input_message_content:
-            self.input_message_content = input_message_content
-        if thumb_url:
-            self.thumb_url = thumb_url
-        if thumb_width:
-            self.thumb_width = thumb_width
-        if thumb_height:
-            self.thumb_height = thumb_height
+        self.last_name = last_name
+        self.vcard = vcard
+        self.reply_markup = reply_markup
+        self.input_message_content = input_message_content
+        self.thumb_url = thumb_url
+        self.thumb_width = thumb_width
+        self.thumb_height = thumb_height

--- a/telegram/inline/inlinequeryresultdocument.py
+++ b/telegram/inline/inlinequeryresultdocument.py
@@ -91,19 +91,11 @@ class InlineQueryResultDocument(InlineQueryResult):
         self.mime_type = mime_type
 
         # Optionals
-        if caption:
-            self.caption = caption
-        if parse_mode:
-            self.parse_mode = parse_mode
-        if description:
-            self.description = description
-        if reply_markup:
-            self.reply_markup = reply_markup
-        if input_message_content:
-            self.input_message_content = input_message_content
-        if thumb_url:
-            self.thumb_url = thumb_url
-        if thumb_width:
-            self.thumb_width = thumb_width
-        if thumb_height:
-            self.thumb_height = thumb_height
+        self.caption = caption
+        self.parse_mode = parse_mode
+        self.description = description
+        self.reply_markup = reply_markup
+        self.input_message_content = input_message_content
+        self.thumb_url = thumb_url
+        self.thumb_width = thumb_width
+        self.thumb_height = thumb_height

--- a/telegram/inline/inlinequeryresultgame.py
+++ b/telegram/inline/inlinequeryresultgame.py
@@ -46,5 +46,4 @@ class InlineQueryResultGame(InlineQueryResult):
         self.id = id
         self.game_short_name = game_short_name
 
-        if reply_markup:
-            self.reply_markup = reply_markup
+        self.reply_markup = reply_markup

--- a/telegram/inline/inlinequeryresultgif.py
+++ b/telegram/inline/inlinequeryresultgif.py
@@ -85,19 +85,11 @@ class InlineQueryResultGif(InlineQueryResult):
         self.thumb_url = thumb_url
 
         # Optionals
-        if gif_width:
-            self.gif_width = gif_width
-        if gif_height:
-            self.gif_height = gif_height
-        if gif_duration:
-            self.gif_duration = gif_duration
-        if title:
-            self.title = title
-        if caption:
-            self.caption = caption
-        if parse_mode:
-            self.parse_mode = parse_mode
-        if reply_markup:
-            self.reply_markup = reply_markup
-        if input_message_content:
-            self.input_message_content = input_message_content
+        self.gif_width = gif_width
+        self.gif_height = gif_height
+        self.gif_duration = gif_duration
+        self.title = title
+        self.caption = caption
+        self.parse_mode = parse_mode
+        self.reply_markup = reply_markup
+        self.input_message_content = input_message_content

--- a/telegram/inline/inlinequeryresultlocation.py
+++ b/telegram/inline/inlinequeryresultlocation.py
@@ -80,15 +80,9 @@ class InlineQueryResultLocation(InlineQueryResult):
         self.title = title
 
         # Optionals
-        if live_period:
-            self.live_period = live_period
-        if reply_markup:
-            self.reply_markup = reply_markup
-        if input_message_content:
-            self.input_message_content = input_message_content
-        if thumb_url:
-            self.thumb_url = thumb_url
-        if thumb_width:
-            self.thumb_width = thumb_width
-        if thumb_height:
-            self.thumb_height = thumb_height
+        self.live_period = live_period
+        self.reply_markup = reply_markup
+        self.input_message_content = input_message_content
+        self.thumb_url = thumb_url
+        self.thumb_width = thumb_width
+        self.thumb_height = thumb_height

--- a/telegram/inline/inlinequeryresultmpeg4gif.py
+++ b/telegram/inline/inlinequeryresultmpeg4gif.py
@@ -86,19 +86,11 @@ class InlineQueryResultMpeg4Gif(InlineQueryResult):
         self.thumb_url = thumb_url
 
         # Optional
-        if mpeg4_width:
-            self.mpeg4_width = mpeg4_width
-        if mpeg4_height:
-            self.mpeg4_height = mpeg4_height
-        if mpeg4_duration:
-            self.mpeg4_duration = mpeg4_duration
-        if title:
-            self.title = title
-        if caption:
-            self.caption = caption
-        if parse_mode:
-            self.parse_mode = parse_mode
-        if reply_markup:
-            self.reply_markup = reply_markup
-        if input_message_content:
-            self.input_message_content = input_message_content
+        self.mpeg4_width = mpeg4_width
+        self.mpeg4_height = mpeg4_height
+        self.mpeg4_duration = mpeg4_duration
+        self.title = title
+        self.caption = caption
+        self.parse_mode = parse_mode
+        self.reply_markup = reply_markup
+        self.input_message_content = input_message_content

--- a/telegram/inline/inlinequeryresultphoto.py
+++ b/telegram/inline/inlinequeryresultphoto.py
@@ -86,19 +86,11 @@ class InlineQueryResultPhoto(InlineQueryResult):
         self.thumb_url = thumb_url
 
         # Optionals
-        if photo_width:
-            self.photo_width = int(photo_width)
-        if photo_height:
-            self.photo_height = int(photo_height)
-        if title:
-            self.title = title
-        if description:
-            self.description = description
-        if caption:
-            self.caption = caption
-        if parse_mode:
-            self.parse_mode = parse_mode
-        if reply_markup:
-            self.reply_markup = reply_markup
-        if input_message_content:
-            self.input_message_content = input_message_content
+        self.photo_width = int(photo_width)if photo_width is not None else None
+        self.photo_height = int(photo_height) if photo_height is not None else None
+        self.title = title
+        self.description = description
+        self.caption = caption
+        self.parse_mode = parse_mode
+        self.reply_markup = reply_markup
+        self.input_message_content = input_message_content

--- a/telegram/inline/inlinequeryresultvenue.py
+++ b/telegram/inline/inlinequeryresultvenue.py
@@ -90,17 +90,10 @@ class InlineQueryResultVenue(InlineQueryResult):
         self.address = address
 
         # Optional
-        if foursquare_id:
-            self.foursquare_id = foursquare_id
-        if foursquare_type:
-            self.foursquare_type = foursquare_type
-        if reply_markup:
-            self.reply_markup = reply_markup
-        if input_message_content:
-            self.input_message_content = input_message_content
-        if thumb_url:
-            self.thumb_url = thumb_url
-        if thumb_width:
-            self.thumb_width = thumb_width
-        if thumb_height:
-            self.thumb_height = thumb_height
+        self.foursquare_id = foursquare_id
+        self.foursquare_type = foursquare_type
+        self.reply_markup = reply_markup
+        self.input_message_content = input_message_content
+        self.thumb_url = thumb_url
+        self.thumb_width = thumb_width
+        self.thumb_height = thumb_height

--- a/telegram/inline/inlinequeryresultvideo.py
+++ b/telegram/inline/inlinequeryresultvideo.py
@@ -94,19 +94,11 @@ class InlineQueryResultVideo(InlineQueryResult):
         self.title = title
 
         # Optional
-        if caption:
-            self.caption = caption
-        if parse_mode:
-            self.parse_mode = parse_mode
-        if video_width:
-            self.video_width = video_width
-        if video_height:
-            self.video_height = video_height
-        if video_duration:
-            self.video_duration = video_duration
-        if description:
-            self.description = description
-        if reply_markup:
-            self.reply_markup = reply_markup
-        if input_message_content:
-            self.input_message_content = input_message_content
+        self.caption = caption
+        self.parse_mode = parse_mode
+        self.video_width = video_width
+        self.video_height = video_height
+        self.video_duration = video_duration
+        self.description = description
+        self.reply_markup = reply_markup
+        self.input_message_content = input_message_content

--- a/telegram/inline/inlinequeryresultvoice.py
+++ b/telegram/inline/inlinequeryresultvoice.py
@@ -77,13 +77,8 @@ class InlineQueryResultVoice(InlineQueryResult):
         self.title = title
 
         # Optional
-        if voice_duration:
-            self.voice_duration = voice_duration
-        if caption:
-            self.caption = caption
-        if parse_mode:
-            self.parse_mode = parse_mode
-        if reply_markup:
-            self.reply_markup = reply_markup
-        if input_message_content:
-            self.input_message_content = input_message_content
+        self.voice_duration = voice_duration
+        self.caption = caption
+        self.parse_mode = parse_mode
+        self.reply_markup = reply_markup
+        self.input_message_content = input_message_content

--- a/telegram/loginurl.py
+++ b/telegram/loginurl.py
@@ -54,13 +54,11 @@ class LoginUrl(TelegramObject):
     """
 
     def __init__(self, url, forward_text=None, bot_username=None, request_write_access=None):
+        # Required
         self.url = url
-
-        if forward_text:
-            self.forward_text = forward_text
-        if bot_username:
-            self.bot_username = bot_username
-        if request_write_access:
-            self.request_write_access = request_write_access
+        # Optional
+        self.forward_text = forward_text
+        self.bot_username = bot_username
+        self.request_write_access = request_write_access
 
         self._id_attrs = (self.url,)


### PR DESCRIPTION
As pointed out by @jh0ker in the dev-chat, the checks

```
if arg:
    self.arg = arg
```

are not necessary, since `TelegramObject.to_dict()` ignores `None` anyway.

Also Closes #1594 