### PR TITLE
Refactor msg_in

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -26,7 +26,6 @@ The following wonderful people contributed directly or indirectly to this projec
 - `d-qoi <https://github.com/d-qoi>`_
 - `daimajia <https://github.com/daimajia>`_
 - `Daniel Reed <https://github.com/nmlorg>`_
-- `Dmitry Grigoryev <https://github.com/icecom-dg>`_
 - `Ehsan Online <https://github.com/ehsanonline>`_
 - `Eli Gao <https://github.com/eligao>`_
 - `Emilio Molinari <https://github.com/xates>`_

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -909,39 +909,6 @@ officedocument.wordprocessingml.document")``-
             return message.from_user.language_code and any(
                 [message.from_user.language_code.startswith(x) for x in self.lang])
 
-    class msg_in(BaseFilter):
-        """Filters messages to only allow those whose text/caption appears in a given list.
-
-        Examples:
-            A simple usecase is to allow only messages that were send by a custom
-            :class:`telegram.ReplyKeyboardMarkup`::
-
-                buttons = ['Start', 'Settings', 'Back']
-                markup = ReplyKeyboardMarkup.from_column(buttons)
-                ...
-                MessageHandler(Filters.msg_in(buttons), callback_method)
-
-        Args:
-            list_ (List[:obj:`str`]): Which messages to allow through. Only exact matches
-                are allowed.
-            caption (:obj:`bool`): Optional. Whether the caption should be used instead of text.
-                Default is ``False``.
-
-        """
-
-        def __init__(self, list_, caption=False):
-            self.list_ = list_
-            self.caption = caption
-            self.name = 'Filters.msg_in({!r}, caption={!r})'.format(self.list_, self.caption)
-
-        def filter(self, message):
-            if self.caption:
-                txt = message.caption
-            else:
-                txt = message.text
-
-            return txt in self.list_
-
     class _UpdateType(BaseFilter):
         update_filter = True
 

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -311,7 +311,7 @@ class Filters(object):
     allow those whose caption is appearing in the given iterable.
 
     Examples:
-        ``MessageHandler(Filters.user(1234), callback_method)``
+        ``MessageHandler(Filters.caption, callback_method)``
 
     Args:
         update (Iterable[:obj:`str`], optional): Which captions to allow. Only exact matches

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -264,8 +264,11 @@ class Filters(object):
     whose text is appearing in the given iterable.
 
     Examples:
-        A simple usecase is to allow only messages that were send by a custom
-        :class:`telegram.ReplyKeyboardMarkup`::
+        To allow any text message, simply use
+        ``MessageHandler(Filters.text, callback_method)``.
+
+        A simple usecase for passing an iterable is to allow only messages that were send by a
+        custom :class:`telegram.ReplyKeyboardMarkup`::
 
             buttons = ['Start', 'Settings', 'Back']
             markup = ReplyKeyboardMarkup.from_column(buttons)
@@ -306,6 +309,9 @@ class Filters(object):
     caption = _Caption()
     """Messages with a caption. If an iterable of strings is passed, it filters messages to only
     allow those whose caption is appearing in the given iterable.
+
+    Examples:
+        ``MessageHandler(Filters.user(1234), callback_method)``
 
     Args:
         update (Iterable[:obj:`str`], optional): Which captions to allow. Only exact matches

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -604,16 +604,6 @@ class TestFilters(object):
         update.message.from_user.language_code = 'da'
         assert f(update)
 
-    def test_msg_in_filter(self, update):
-        update.message.text = 'test'
-        update.message.caption = 'caption'
-
-        assert Filters.msg_in(['test'])(update)
-        assert Filters.msg_in(['caption'], caption=True)(update)
-
-        assert not Filters.msg_in(['test'], caption=True)(update)
-        assert not Filters.msg_in(['caption'])(update)
-
     def test_and_filters(self, update):
         update.message.text = 'test'
         update.message.forward_date = datetime.datetime.utcnow()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -43,9 +43,25 @@ class TestFilters(object):
 
     def test_filters_text(self, update):
         update.message.text = 'test'
-        assert Filters.text(update)
+        assert (Filters.text)(update)
         update.message.text = '/test'
-        assert not Filters.text(update)
+        assert not (Filters.text)(update)
+
+    def test_filters_text_iterable(self, update):
+        update.message.text = 'test'
+        assert Filters.text({'test', 'test1'})(update)
+        assert not Filters.text(['test1', 'test2'])(update)
+
+    def test_filters_caption(self, update):
+        update.message.caption = 'test'
+        assert (Filters.caption)(update)
+        update.message.caption = None
+        assert not (Filters.caption)(update)
+
+    def test_filters_caption_iterable(self, update):
+        update.message.caption = 'test'
+        assert Filters.caption({'test', 'test1'})(update)
+        assert not Filters.caption(['test1', 'test2'])(update)
 
     def test_filters_command(self, update):
         update.message.text = 'test'


### PR DESCRIPTION
As discussed offline, this refactors the `Filters.msg_in` filter to work as `__call__` of `Filters.text`, thus closing #1625 
I encountered two (and a half) obstacles:

* `BaseFilter`s `__call__` is used to perform the update checks, i.e. it executes `filter()`. To allow for `Filters.text({'foo', 'bar'})` anyway, `Filters.text`s `__call__` now checks, if the argument is of type `Update`. If it's not, it returns an instance of a subclass that works like the former `msg_in`. An alternative way would be to do something like

    ```
    def __call__(self, update=None, iterable=None):
        if update:
            self.filter(update)
        else:
            return _TextIterable(iterable)
    ```

    However calling `Filters.text(iterable={'foo', 'bar'})` seemed neither convenient nor intuitive for me. Also, usually you won't have to call `Filter.text(update)` manually anyway …
* To recreate the caption filter functionality, I needed to add the base class `Filters.caption` that allows only messages that have a caption. Including caption filtering into `Filters.text` like

    ```
    Filters.text({'foo', 'bar'}, caption=True)
    ```

    didn't seem very natural to me …
    If you feel like `Filters.caption` is unneeded, we can just remove it. The main usecase for this PR is `Filters.text(buttons)` anyway …

* I wasn't very original in naming the subclasses (`_TextIterable` and `_CaptionIterable`). If you have a better naming idea, please tell :)