### PR TITLE
increase update_id by 1 to skip bad server response

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -42,6 +42,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `JASON0916 <https://github.com/JASON0916>`_
 - `jeffffc <https://github.com/jeffffc>`_
 - `Jelle Besseling <https://github.com/pingiun>`_
+- `Jerry Xiao <https://github.com/isjerryxiao>`_
 - `jh0ker <https://github.com/jh0ker>`_
 - `jlmadurga <https://github.com/jlmadurga>`_
 - `John Yong <https://github.com/whipermr5>`_

--- a/telegram/ext/updater.py
+++ b/telegram/ext/updater.py
@@ -288,9 +288,14 @@ class Updater(object):
         self.logger.debug('Bootstrap done')
 
         def polling_action_cb():
-            updates = self.bot.get_updates(
-                self.last_update_id, timeout=timeout, read_latency=read_latency,
-                allowed_updates=allowed_updates)
+            try:
+                updates = self.bot.get_updates(
+                    self.last_update_id, timeout=timeout, read_latency=read_latency,
+                    allowed_updates=allowed_updates)
+            except TelegramError as te:
+                self.logger.warning('Trying to skip a malformed update which caused %s', te)
+                updates = list()
+                self.last_update_id += 1
 
             if updates:
                 if not self.running:

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -28,7 +28,7 @@ def test_parse_illegal_callback_data():
     Clients can send arbitrary bytes in callback data.
     Make sure the correct error is raised in this case.
     """
-    server_response = b'{"invalid utf-8": "\x80"}'
+    server_response = b'{"ok":true, "result": [{"invalid utf-8": "\x80\x9c"}]}'
 
     with pytest.raises(TelegramError, match='Server response could not be decoded using UTF-8'):
         Request._parse(server_response)


### PR DESCRIPTION
A possible fix for #1609.  
We actually should not ignore unicode decode error or json decode error in order to make it work, my solution is to increase last_update_id by 1 until that bad update is skipped.  
This may cause the bot to **lose some of its updates**, which is a little bit of a problem. However this is way better than **looping and throwing exceptions endlessly**.