### PR TITLE
Fixed typo in helper.py enocde_conversations_to_json

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -67,6 +67,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Pieter Schutz <https://github.com/eldinnie>`_
 - `Poolitzer <https://github.com/Poolitzer>`_
 - `Rahiel Kasim <https://github.com/rahiel>`_
+- `Rizlas <https://github.com/rizlas>`_
 - `Sahil Sharma <https://github.com/sahilsharma811>`_
 - `Sascha <https://github.com/saschalalala>`_
 - `Shelomentsev D <https://github.com/shelomentsevd>`_

--- a/telegram/ext/dictpersistence.py
+++ b/telegram/ext/dictpersistence.py
@@ -20,7 +20,7 @@
 from copy import deepcopy
 
 from telegram.utils.helpers import decode_user_chat_data_from_json,\
-    decode_conversations_from_json, enocde_conversations_to_json
+    decode_conversations_from_json, encode_conversations_to_json
 
 try:
     import ujson as json
@@ -119,7 +119,7 @@ class DictPersistence(BasePersistence):
         if self._conversations_json:
             return self._conversations_json
         else:
-            return enocde_conversations_to_json(self.conversations)
+            return encode_conversations_to_json(self.conversations)
 
     def get_user_data(self):
         """Returns the user_data created from the ``user_data_json`` or an empty defaultdict.

--- a/telegram/utils/helpers.py
+++ b/telegram/utils/helpers.py
@@ -300,7 +300,7 @@ def create_deep_linked_url(bot_username, payload=None, group=False):
     )
 
 
-def enocde_conversations_to_json(conversations):
+def encode_conversations_to_json(conversations):
     """Helper method to encode a conversations dict (that uses tuples as keys) to a
     JSON-serializable way. Use :attr:`_decode_conversations_from_json` to decode.
 

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 import signal
 
-from telegram.utils.helpers import enocde_conversations_to_json
+from telegram.utils.helpers import encode_conversations_to_json
 
 try:
     import ujson as json
@@ -774,7 +774,7 @@ class TestDictPersistence(object):
         dict_persistence.update_conversation('name3', (1, 2), 3)
         assert dict_persistence.conversations == conversations_two
         assert dict_persistence.conversations_json != conversations_json
-        assert dict_persistence.conversations_json == enocde_conversations_to_json(
+        assert dict_persistence.conversations_json == encode_conversations_to_json(
             conversations_two)
 
     def test_with_handler(self, bot, update):


### PR DESCRIPTION
Fixed typo in helper.py `enocde_conversations_to_json` function.
Closes #1660 

Files modified:

```
	modified:   AUTHORS.rst
	modified:   telegram/ext/dictpersistence.py
	modified:   telegram/utils/helpers.py
	modified:   tests/test_persistence.py
```
