### PR TITLE
Add poll messages support to filters

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -26,6 +26,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `d-qoi <https://github.com/d-qoi>`_
 - `daimajia <https://github.com/daimajia>`_
 - `Daniel Reed <https://github.com/nmlorg>`_
+- `Eana Hufwe <https://github.com/blueset>`_
 - `Ehsan Online <https://github.com/ehsanonline>`_
 - `Eli Gao <https://github.com/eligao>`_
 - `Emilio Molinari <https://github.com/xates>`_

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -956,6 +956,15 @@ officedocument.wordprocessingml.document")``-
     passport_data = _PassportData()
     """Messages that contain a :class:`telegram.PassportData`"""
 
+    class _Poll(BaseFilter):
+        name = 'Filters.poll'
+
+        def filter(self, message):
+            return bool(message.poll)
+
+    poll = _Poll()
+    """Messages that contain a :class:`telegram.Poll`."""
+
     class language(BaseFilter):
         """Filters messages to only allow those which are from users with a certain language code.
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -599,6 +599,11 @@ class TestFilters(object):
         update.message.passport_data = 'test'
         assert Filters.passport_data(update)
 
+    def test_filters_poll(self, update):
+        assert not Filters.poll(update)
+        update.message.poll = 'test'
+        assert Filters.poll(update)
+
     def test_language_filter_single(self, update):
         update.message.from_user.language_code = 'en_US'
         assert (Filters.language('en_US'))(update)


### PR DESCRIPTION
This PR fixes #1672 

It adds poll message support to filters (`telegram.ext.filters.Filters.poll`). Both filter code and tests are updated accordingly.