### PR TITLE
Update ChatMember class to Bot API 4.5

### DIFF
--- a/telegram/chatmember.py
+++ b/telegram/chatmember.py
@@ -28,6 +28,7 @@ class ChatMember(TelegramObject):
     Attributes:
         user (:class:`telegram.User`): Information about the user.
         status (:obj:`str`): The member's status in the chat.
+        custom_title (:obj:`str`): Optionl. Custom title for owner and administrators.
         until_date (:class:`datetime.datetime`): Optional. Date when restrictions will be lifted
             for this user.
         can_be_edited (:obj:`bool`): Optional. If the bot is allowed to edit administrator
@@ -62,6 +63,7 @@ class ChatMember(TelegramObject):
         user (:class:`telegram.User`): Information about the user.
         status (:obj:`str`): The member's status in the chat. Can be 'creator', 'administrator',
             'member', 'restricted', 'left' or 'kicked'.
+        custom_title (:obj:`str`, optional): Owner and administrators only. Custom title for this user.
         until_date (:class:`datetime.datetime`, optional): Restricted and kicked only. Date when
             restrictions will be lifted for this user.
         can_be_edited (:obj:`bool`, optional): Administrators only. True, if the bot is allowed to
@@ -112,7 +114,7 @@ class ChatMember(TelegramObject):
     RESTRICTED = 'restricted'
     """:obj:`str`: 'restricted'"""
 
-    def __init__(self, user, status, until_date=None, can_be_edited=None,
+    def __init__(self, user, status, custom_title=None, until_date=None, can_be_edited=None,
                  can_change_info=None, can_post_messages=None, can_edit_messages=None,
                  can_delete_messages=None, can_invite_users=None,
                  can_restrict_members=None, can_pin_messages=None,
@@ -122,6 +124,7 @@ class ChatMember(TelegramObject):
         # Required
         self.user = user
         self.status = status
+        self.custom_title = custom_title
         self.until_date = until_date
         self.can_be_edited = can_be_edited
         self.can_change_info = can_change_info


### PR DESCRIPTION
Update due to new API attribute `custom_title` from [API 4.5](https://core.telegram.org/bots/api#december-31-2019)