### PR TITLE
Add setChatAdministratorCustomTitle future from Bot API 4.5

### DIFF
--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -2836,6 +2836,39 @@ class Bot(TelegramObject):
         return result
 
     @log
+    def set_administrator_custom_title(self, chat_id, user_id, custom_title, timeout=None, **kwargs):
+        """
+        Use this method to set custom title for owner or administrators. The bot must be an
+        administrator in the supergroup for this to work. Returns True on success.
+
+        Args:
+            chat_id (:obj:`int` | :obj:`str`): Unique identifier for the target chat or username of
+                the target supergroup (in the format `@supergroupusername`).
+            user_id (:obj:`int`): Unique identifier of the target administrator.
+            custom_title (:obj:`str`) New custom title for the administrator. It must be a string
+                with len 0-16 characters, emoji are not allowed.
+            timeout (:obj:`int` | :obj:`float`, optional): If this value is specified, use it as
+                the read timeout from the server (instead of the one specified during creation of
+                the connection pool).
+            **kwargs (:obj:`dict`): Arbitrary keyword arguments
+
+        Returns:
+            :obj:`bool`: Returns True on success.
+
+        Raises:
+            :class:`telegram.TelegramError`
+
+        """
+        url = '{0}/setChatAdministratorCustomTitle'.format(self.base_url)
+
+        data = {'chat_id': chat_id, 'user_id': user_id, 'custom_title': custom_title}
+        data.update(kwargs)
+
+        result = self._request.post(url, data, timeout=timeout)
+
+        return result
+    
+    @log
     def export_chat_invite_link(self, chat_id, timeout=None, **kwargs):
         """
         Use this method to export an invite link to a supergroup or a channel. The bot must be an

--- a/telegram/chat.py
+++ b/telegram/chat.py
@@ -40,6 +40,8 @@ class Chat(TelegramObject):
             Returned only in get_chat.
         permissions (:class:`telegram.ChatPermission`): Optional. Default chat member permissions,
             for groups and supergroups. Returned only in getChat.
+        slow_mode_delay (:obj:`int`): Optional. For supergroups, the minimum allowed delay between 
+            consecutive messages sent by each unpriviledged user. Returned only in getChat.
         sticker_set_name (:obj:`str`): Optional. For supergroups, name of Group sticker set.
         can_set_sticker_set (:obj:`bool`): Optional. ``True``, if the bot can change group the
             sticker set.
@@ -65,6 +67,8 @@ class Chat(TelegramObject):
             Returned only in get_chat.
         permissions (:class:`telegram.ChatPermission`): Optional. Default chat member permissions,
             for groups and supergroups. Returned only in getChat.
+        slow_mode_delay (:obj:`int`, optional): For supergroups, the minimum allowed delay between 
+            consecutive messages sent by each unpriviledged user. Returned only in getChat.
         bot (:class:`telegram.Bot`, optional): The Bot to use for instance methods.
         sticker_set_name (:obj:`str`, optional): For supergroups, name of Group sticker set.
             Returned only in get_chat.
@@ -96,6 +100,7 @@ class Chat(TelegramObject):
                  invite_link=None,
                  pinned_message=None,
                  permissions=None,
+                 slow_mode_delay=None,
                  sticker_set_name=None,
                  can_set_sticker_set=None,
                  **kwargs):
@@ -114,6 +119,7 @@ class Chat(TelegramObject):
         self.invite_link = invite_link
         self.pinned_message = pinned_message
         self.permissions = permissions
+        self.slow_mode_delay = slow_mode_delay
         self.sticker_set_name = sticker_set_name
         self.can_set_sticker_set = can_set_sticker_set
 
@@ -237,6 +243,18 @@ class Chat(TelegramObject):
     """
         return self.bot.set_chat_permissions(self.id, *args, **kwargs)
 
+    
+    def set_administrator_custom_title(self, *args, **kwargs):
+        """Shortcut for::
+
+                bot.set_chat_administrator_custom_title(update.message.chat.id, *args, **kwargs)
+
+        Returns:
+        :obj:`bool`: If the action was sent successfully.
+
+    """
+        return self.bot.set_chat_administrator_custom_title(self.id, *args, **kwargs)
+    
     def send_message(self, *args, **kwargs):
         """Shortcut for::
 


### PR DESCRIPTION
Reason: Telegram Bot API update v. 4.5

Changes:
 - added `custom_title` attribute to the Chat class of chatmember.py;
 - added `set_administrator_custom_title()` method to the Chat class of chatmember.py;
 - added `set_chat_administrator_custom_title()` method to the Bot class of bot.py.