### PR TITLE
Fix for tzinfo issues in JobQueue

### DIFF
--- a/telegram/ext/jobqueue.py
+++ b/telegram/ext/jobqueue.py
@@ -275,7 +275,7 @@ class JobQueue(object):
             if job.enabled:
                 try:
                     current_week_day = datetime.datetime.now(job.tzinfo).date().weekday()
-                    if any(day == current_week_day for day in job.days):
+                    if current_week_day in job.days:
                         self.logger.debug('Running job %s', job.name)
                         job.run(self._dispatcher)
 
@@ -387,7 +387,7 @@ class Job(object):
                  days=Days.EVERY_DAY,
                  name=None,
                  job_queue=None,
-                 tzinfo=_UTC):
+                 tzinfo=None):
 
         self.callback = callback
         self.context = context
@@ -400,7 +400,7 @@ class Job(object):
 
         self._days = None
         self.days = days
-        self.tzinfo = tzinfo
+        self.tzinfo = tzinfo or _UTC
 
         self._job_queue = weakref.proxy(job_queue) if job_queue is not None else None
 

--- a/tests/test_jobqueue.py
+++ b/tests/test_jobqueue.py
@@ -28,7 +28,7 @@ from flaky import flaky
 
 from telegram.ext import JobQueue, Updater, Job, CallbackContext
 from telegram.utils.deprecate import TelegramDeprecationWarning
-from telegram.utils.helpers import _UtcOffsetTimezone
+from telegram.utils.helpers import _UtcOffsetTimezone, _UTC
 
 
 @pytest.fixture(scope='function')
@@ -325,3 +325,14 @@ class TestJobQueue(object):
         sleep(0.03)
 
         assert self.result == 0
+
+    def test_job_default_tzinfo(self, job_queue):
+        """Test that default tzinfo is always set to UTC"""
+        job_1 = job_queue.run_once(self.job_run_once, 0.01)
+        job_2 = job_queue.run_repeating(self.job_run_once, 10)
+        job_3 = job_queue.run_daily(self.job_run_once, time=dtm.time(hour=15))
+
+        jobs = [job_1, job_2, job_3]
+
+        for job in jobs:
+            assert job.tzinfo == _UTC


### PR DESCRIPTION
Closes #1693

Changes:
1. Added optional argument `tzinfo` for `run_once`, `run_repeating`.
2. Made sure `job.tzinfo` will be set as UTC by default and not `None`. 
3. Added test that checks that all methods by default set `job.tzinfo` as UTC.

First I've added `tzinfo` argument to `run_daily` too but it's seems excessive. For example, to make sure that job will be ran every monday and tuesday on  14:00 in desired timezone you'd had to pass timezone twice - as `time.tzinfo` and as `tzinfo`. 
```python
target_tzinfo = dtm.timezone(dtm.timedelta(hours=3))
target_time = dtm.time(hour=14).replace(tzinfo=target_tzinfo)
job_queue.run_daily(
    job_callback,
    time=target_time,
    days=(0, 1),
    tzinfo=target_tzinfo)
```
And I think there is no need to use different timezones for `time.tzinfo` and `tzinfo` because result may be counterintuitive. So, I've removed `tzinfo` from `run_daily`.