### PR TITLE
Fix None check in JobQueue._put()

### DIFF
--- a/telegram/ext/jobqueue.py
+++ b/telegram/ext/jobqueue.py
@@ -95,7 +95,8 @@ class JobQueue(object):
 
         """
         # get time at which to run:
-        time_spec = time_spec or job.interval
+        if time_spec is None:
+            time_spec = job.interval
         if time_spec is None:
             raise ValueError("no time specification given for scheduling non-repeating job")
         next_t = to_float_timestamp(time_spec, reference_timestamp=previous_t)

--- a/tests/test_jobqueue.py
+++ b/tests/test_jobqueue.py
@@ -119,6 +119,11 @@ class TestJobQueue(object):
         sleep(0.07)
         assert self.result == 1
 
+    def test_run_repeating_first_immediate(self, job_queue):
+        job_queue.run_repeating(self.job_run_once, 0.1, first=0)
+        sleep(0.05)
+        assert self.result == 1
+
     def test_run_repeating_first_timezone(self, job_queue, timezone):
         """Test correct scheduling of job when passing a timezone-aware datetime as ``first``"""
         first = (dtm.datetime.utcnow() + timezone.utcoffset(None)).replace(tzinfo=timezone)


### PR DESCRIPTION
Closes #1701 
Problem was that `time_spec = time_spec or job.interval` would evalute `time_spec = 0` as `False`. Added a test case for that.