### PR TITLE
improve CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
       - master
   schedule:
     - cron: 7 3 * * *
+  push:
+    branches: 
+      - master
 
 jobs:
   pytest:
@@ -87,6 +90,7 @@ jobs:
         run: |
           pytest -v tests/test_official.py
           exit $?
+        continue-on-error: True
         env:
           TEST_OFFICIAL: "true"
         shell: bash --noprofile --norc {0}


### PR DESCRIPTION
closes #1700

Okay, to explain what happens: Official test always looks like its work, even though it fails (see https://github.community/t5/GitHub-Actions/continue-on-error-allow-failure-UI-indication/td-p/37033)

~I haven't tested the push event, but it should work.~
Edit: Tested, works.