### PR TITLE
Add --with-urllib3 option to remove vendored version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@
 
 import codecs
 import os
+import sys
+
 from setuptools import setup, find_packages
 
 
@@ -18,6 +20,13 @@ def requirements():
 
 
 packages = find_packages(exclude=['tests*'])
+requirements = requirements()
+
+# Allow for a package install to not use the vendored urllib3
+if '--with-urllib3' in sys.argv:
+    sys.argv.remove('--with-urllib3')
+    requirements.append('urllib3')
+    packages = [package for package in packages if 'urllib3' not in package]
 
 with codecs.open('README.rst', 'r', 'utf-8') as fd:
     fn = os.path.join('telegram', 'version.py')
@@ -35,7 +44,7 @@ with codecs.open('README.rst', 'r', 'utf-8') as fd:
           description="We have made you a wrapper you can't refuse",
           long_description=fd.read(),
           packages=packages,
-          install_requires=requirements(),
+          install_requires=requirements,
           extras_require={
               'json': 'ujson',
               'socks': 'PySocks'

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,11 @@ packages = find_packages(exclude=['tests*'])
 requirements = requirements()
 
 # Allow for a package install to not use the vendored urllib3
-if '--with-urllib3' in sys.argv:
-    sys.argv.remove('--with-urllib3')
-    requirements.append('urllib3')
-    packages = [package for package in packages if 'urllib3' not in package]
+UPSTREAM_URLLIB3_FLAG = '--with-upstream-urllib3'
+if UPSTREAM_URLLIB3_FLAG in sys.argv:
+    sys.argv.remove(UPSTREAM_URLLIB3_FLAG)
+    requirements.append('urllib3 >= 1.19.1')
+    packages = [x for x in packages if not x.startswith('telegram.vendor.ptb_urllib3')]
 
 with codecs.open('README.rst', 'r', 'utf-8') as fd:
     fn = os.path.join('telegram', 'version.py')

--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -38,9 +38,11 @@ try:
     from telegram.vendor.ptb_urllib3.urllib3.util.timeout import Timeout
     from telegram.vendor.ptb_urllib3.urllib3.fields import RequestField
 except ImportError:  # pragma: no cover
-    warnings.warn("python-telegram-bot wasn't properly installed. Please refer to README.rst on "
-                  "how to properly install.")
-    raise
+    import urllib3
+    import urllib3.contrib.appengine as appengine
+    from urllib3.connection import HTTPConnection
+    from urllib3.util.timeout import Timeout
+    from urllib3.fields import RequestField
 
 from telegram import (InputFile, TelegramError, InputMedia)
 from telegram.error import (Unauthorized, NetworkError, TimedOut, BadRequest, ChatMigrated,

--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -38,11 +38,20 @@ try:
     from telegram.vendor.ptb_urllib3.urllib3.util.timeout import Timeout
     from telegram.vendor.ptb_urllib3.urllib3.fields import RequestField
 except ImportError:  # pragma: no cover
-    import urllib3
-    import urllib3.contrib.appengine as appengine
-    from urllib3.connection import HTTPConnection
-    from urllib3.util.timeout import Timeout
-    from urllib3.fields import RequestField
+    try:
+        import urllib3
+        import urllib3.contrib.appengine as appengine
+        from urllib3.connection import HTTPConnection
+        from urllib3.util.timeout import Timeout
+        from urllib3.fields import RequestField
+        warnings.warn('python-telegram-bot is using upstream urllib3. This is allowed but not '
+                      'supported by python-telegram-bot maintainers.')
+    except ImportError:
+        warnings.warn(
+            "python-telegram-bot wasn't properly installed. Please refer to README.rst on "
+            "how to properly install.")
+        raise
+
 
 from telegram import (InputFile, TelegramError, InputMedia)
 from telegram.error import (Unauthorized, NetworkError, TimedOut, BadRequest, ChatMigrated,


### PR DESCRIPTION
Fixes #1583 

To use this feature, install using:
```bash
python setup.py install --with-urllib3
```