### PR TITLE
dropping 2.7, 3.3, 3.4 support from setup.py and README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ Introduction
 
 This library provides a pure Python interface for the
 `Telegram Bot API <https://core.telegram.org/bots/api>`_.
-It's compatible with Python versions 2.7, 3.3+ and `PyPy <http://pypy.org/>`_.
+It's compatible with Python versions 3.5+ and `PyPy <http://pypy.org/>`_.
 
 In addition to the pure API implementation, this library features a number of high-level classes to
 make the development of bots easy and straightforward. These classes are contained in the

--- a/setup.py
+++ b/setup.py
@@ -50,10 +50,7 @@ with codecs.open('README.rst', 'r', 'utf-8') as fd:
               'Topic :: Communications :: Chat',
               'Topic :: Internet',
               'Programming Language :: Python',
-              'Programming Language :: Python :: 2',
-              'Programming Language :: Python :: 2.7',
               'Programming Language :: Python :: 3',
-              'Programming Language :: Python :: 3.4',
               'Programming Language :: Python :: 3.5',
               'Programming Language :: Python :: 3.6',
               'Programming Language :: Python :: 3.7'


### PR DESCRIPTION
This closes #1720

removes versions from public endpoints in order to reduce confusion about supported versions of this library
