### PR TITLE
temporarily skip tests failing b/c missing api 4.5

### DIFF
--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -109,6 +109,7 @@ class TestAnimation(object):
 
     @flaky(3, 1)
     @pytest.mark.timeout(10)
+    @pytest.mark.skip(reason='Doesnt work without API 4.5')
     def test_resend(self, bot, chat_id, animation):
         message = bot.send_animation(chat_id, animation.file_id)
 

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -119,6 +119,7 @@ class TestAudio(object):
 
     @flaky(3, 1)
     @pytest.mark.timeout(10)
+    @pytest.mark.skip(reason='Doesnt work without API 4.5')
     def test_resend(self, bot, chat_id, audio):
         message = bot.send_audio(chat_id=chat_id, audio=audio.file_id)
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -108,6 +108,7 @@ class TestDocument(object):
 
     @flaky(3, 1)
     @pytest.mark.timeout(10)
+    @pytest.mark.skip(reason='Doesnt work without API 4.5')
     def test_send_resend(self, bot, chat_id, document):
         message = bot.send_document(chat_id=chat_id, document=document.file_id)
 

--- a/tests/test_photo.py
+++ b/tests/test_photo.py
@@ -141,6 +141,7 @@ class TestPhoto(object):
 
     @flaky(3, 1)
     @pytest.mark.timeout(10)
+    @pytest.mark.skip(reason='Doesnt work without API 4.5')
     def test_get_and_download(self, bot, photo):
         new_file = bot.getFile(photo.file_id)
 

--- a/tests/test_sticker.py
+++ b/tests/test_sticker.py
@@ -108,6 +108,7 @@ class TestSticker(object):
 
     @flaky(3, 1)
     @pytest.mark.timeout(10)
+    @pytest.mark.skip(reason='Doesnt work without API 4.5')
     def test_resend(self, bot, chat_id, sticker):
         message = bot.send_sticker(chat_id=chat_id, sticker=sticker.file_id)
 

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -128,6 +128,7 @@ class TestVideo(object):
 
     @flaky(3, 1)
     @pytest.mark.timeout(10)
+    @pytest.mark.skip(reason='Doesnt work without API 4.5')
     def test_resend(self, bot, chat_id, video):
         message = bot.send_video(chat_id, video.file_id)
 

--- a/tests/test_videonote.py
+++ b/tests/test_videonote.py
@@ -96,6 +96,7 @@ class TestVideoNote(object):
 
     @flaky(3, 1)
     @pytest.mark.timeout(10)
+    @pytest.mark.skip(reason='Doesnt work without API 4.5')
     def test_resend(self, bot, chat_id, video_note):
         message = bot.send_video_note(chat_id, video_note.file_id)
 

--- a/tests/test_voice.py
+++ b/tests/test_voice.py
@@ -98,6 +98,7 @@ class TestVoice(object):
 
     @flaky(3, 1)
     @pytest.mark.timeout(10)
+    @pytest.mark.skip(reason='Doesnt work without API 4.5')
     def test_resend(self, bot, chat_id, voice):
         message = bot.sendVoice(chat_id, voice.file_id)
 


### PR DESCRIPTION
as discussed this skips the resend tests. Revert, when #1508 is meged.