### PR TITLE
Add note on how to run test_official to contrib guide

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -113,6 +113,14 @@ Here's how to make a one-off code change.
 
         $ pytest -v
 
+     To run ``test_official`` (particularly useful if you made API changes), run
+
+     .. code-block::
+
+        $ export TEST_OFFICIAL=True
+
+     prior to running the tests.
+
    - To actually make the commit (this will trigger tests for yapf, lint and pep8 automatically):
 
      .. code-block:: bash


### PR DESCRIPTION
Thought it would be good to have contributors know how to run `test_official`, because we're currently having issues with how to properly run it again