### PR TITLE
fixing message.link

### DIFF
--- a/telegram/message.py
+++ b/telegram/message.py
@@ -339,8 +339,8 @@ class Message(TelegramObject):
     @property
     def link(self):
         """:obj:`str`: Convenience property. If the chat of the message is not
-        a private chat, returns a t.me link of the message."""
-        if self.chat.type != Chat.PRIVATE:
+        a private chat or normal group, returns a t.me link of the message."""
+        if self.chat.type not in [Chat.PRIVATE, Chat.GROUP]:
             if self.chat.username:
                 to_link = self.chat.username
             else:

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -344,13 +344,8 @@ class Message(TelegramObject):
             if self.chat.username:
                 to_link = self.chat.username
             else:
-                if self.chat.type != Chat.GROUP:
-                    # Get rid of leading -100 for supergroups
-                    id_to_link = str(self.chat.id)[4:]
-                else:
-                    # Get rid of leading minus for regular groups
-                    id_to_link = str(self.chat.id)[1:]
-                to_link = "c/{}".format(id_to_link)
+                # Get rid of leading -100 for supergroups
+                to_link = "c/{}".format(str(self.chat.id)[4:])
             return "https://t.me/{}/{}".format(to_link, self.message_id)
         return None
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -311,8 +311,7 @@ class TestMessage(object):
                                                            message.message_id)
 
     @pytest.mark.parametrize('type, id', argvalues=[
-        (Chat.CHANNEL, -1003), (Chat.SUPERGROUP, -1003), (Chat.GROUP, -3)
-    ])
+        (Chat.CHANNEL, -1003), (Chat.SUPERGROUP, -1003)])
     def test_link_with_id(self, message, type, id):
         message.chat.username = None
         message.chat.id = id
@@ -327,6 +326,8 @@ class TestMessage(object):
         message.chat.type = Chat.PRIVATE
         message.chat.id = id
         message.chat.username = username
+        assert message.link is None
+        message.chat.type = Chat.GROUP
         assert message.link is None
 
     def test_effective_attachment(self, message_params):


### PR DESCRIPTION
the good eyes of @Bibo-Joshi saw that message.link was wrongfully generated for private groups. This PR fixes that as well as expanding tests for this case 