### PR TITLE
Make sure PP can read files that dont have bot_data

### DIFF
--- a/telegram/ext/picklepersistence.py
+++ b/telegram/ext/picklepersistence.py
@@ -85,9 +85,7 @@ class PicklePersistence(BasePersistence):
                 self.user_data = defaultdict(dict, all['user_data'])
                 self.chat_data = defaultdict(dict, all['chat_data'])
                 # For backwards compatibility with files not containing bot data
-                self.bot_data = all.get('bot_data')
-                if self.bot_data is None:
-                    self.bot_data = {}
+                self.bot_data = all.get('bot_data', {})
                 self.conversations = all['conversations']
         except IOError:
             self.conversations = {}

--- a/telegram/ext/picklepersistence.py
+++ b/telegram/ext/picklepersistence.py
@@ -84,7 +84,10 @@ class PicklePersistence(BasePersistence):
                 all = pickle.load(f)
                 self.user_data = defaultdict(dict, all['user_data'])
                 self.chat_data = defaultdict(dict, all['chat_data'])
-                self.bot_data = all['bot_data']
+                # For backwards compatibility with files not containing bot data
+                self.bot_data = all.get('bot_data')
+                if self.bot_data is None:
+                    self.bot_data = {}
                 self.conversations = all['conversations']
         except IOError:
             self.conversations = {}


### PR DESCRIPTION
This assures that a pickle file that doesn't contain bot_data is read correctly. Tests are added as well.
Not necessary for DictPersistence because it doesn't store anything.

closes #1761 