### PR TITLE
correct_option_id validated with None

### DIFF
--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -3435,7 +3435,7 @@ class Bot(TelegramObject):
             data['type'] = type
         if allows_multiple_answers:
             data['allows_multiple_answers'] = allows_multiple_answers
-        if correct_option_id:
+        if correct_option_id is not None:
             data['correct_option_id'] = correct_option_id
         if is_closed:
             data['is_closed'] = is_closed


### PR DESCRIPTION
when trying to send a poll with correct option id 0 it was failing. Now None check is done so that even when 0 is passed it is assigned.