### PR TITLE
updating pre-commit config file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
 -   repo: git://github.com/python-telegram-bot/mirrors-yapf
-    sha: 5769e088ef6e0a0d1eb63bd6d0c1fe9f3606d6c8
+    rev: 5769e088ef6e0a0d1eb63bd6d0c1fe9f3606d6c8
     hooks:
     -   id: yapf
         files: ^(telegram|tests)/.*\.py$
         args:
         - --diff
--   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: 0b70e285e369bcb24b57b74929490ea7be9c4b19
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.1
     hooks:
     -   id: flake8
 -   repo: git://github.com/pre-commit/mirrors-pylint
-    sha: 9d8dcbc2b86c796275680f239c1e90dcd50bd398
+    rev: 9d8dcbc2b86c796275680f239c1e90dcd50bd398
     hooks:
     -   id: pylint
         files: ^telegram/.*\.py$


### PR DESCRIPTION
as discussed in the chat

I changed sha to rev (which is the way to go) and also changed the deprecated url from flake8 to the official one. I picked 3.7.1 because thats the version we took from the old collection