### PR TITLE
Roles

### DIFF
--- a/docs/source/telegram.ext.chatadminsrole.rst
+++ b/docs/source/telegram.ext.chatadminsrole.rst
@@ -1,0 +1,6 @@
+telegram.ext.ChatAdminsRole
+===========================
+
+.. autoclass:: telegram.ext.ChatAdminsRole
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.ext.chatcreatorrole.rst
+++ b/docs/source/telegram.ext.chatcreatorrole.rst
@@ -1,0 +1,6 @@
+telegram.ext.ChatCreatorRole
+============================
+
+.. autoclass:: telegram.ext.ChatCreatorRole
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.ext.role.rst
+++ b/docs/source/telegram.ext.role.rst
@@ -1,0 +1,6 @@
+telegram.ext.Role
+=================
+
+.. autoclass:: telegram.ext.Role
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.ext.roles.rst
+++ b/docs/source/telegram.ext.roles.rst
@@ -1,0 +1,6 @@
+telegram.ext.Roles
+==================
+
+.. autoclass:: telegram.ext.Roles
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.ext.rst
+++ b/docs/source/telegram.ext.rst
@@ -13,6 +13,8 @@ telegram.ext package
     telegram.ext.delayqueue
     telegram.ext.callbackcontext
     telegram.ext.defaults
+    telegram.ext.role
+    telegram.ext.roles
 
 Handlers
 --------

--- a/docs/source/telegram.ext.rst
+++ b/docs/source/telegram.ext.rst
@@ -46,3 +46,13 @@ Persistence
     telegram.ext.basepersistence
     telegram.ext.picklepersistence
     telegram.ext.dictpersistence
+
+Authentication
+--------------
+
+.. toctree::
+
+    telegram.ext.role
+    telegram.ext.roles
+    telegram.ext.chatadminsrole
+    telegram.ext.chatcreatorrole

--- a/telegram/ext/__init__.py
+++ b/telegram/ext/__init__.py
@@ -44,7 +44,7 @@ from .messagequeue import DelayQueue
 from .pollanswerhandler import PollAnswerHandler
 from .pollhandler import PollHandler
 from .defaults import Defaults
-from .roles import Role, Roles
+from .roles import Role, Roles, ChatAdminsRole, ChatCreatorRole
 
 __all__ = ('Dispatcher', 'JobQueue', 'Job', 'Updater', 'CallbackQueryHandler',
            'ChosenInlineResultHandler', 'CommandHandler', 'Handler', 'InlineQueryHandler',
@@ -53,4 +53,4 @@ __all__ = ('Dispatcher', 'JobQueue', 'Job', 'Updater', 'CallbackQueryHandler',
            'PreCheckoutQueryHandler', 'ShippingQueryHandler', 'MessageQueue', 'DelayQueue',
            'DispatcherHandlerStop', 'run_async', 'CallbackContext', 'BasePersistence',
            'PicklePersistence', 'DictPersistence', 'PrefixHandler', 'PollAnswerHandler',
-           'PollHandler', 'Defaults', 'Role', 'Roles')
+           'PollHandler', 'Defaults', 'Role', 'Roles', 'ChatAdminsRole', 'ChatCreatorRole')

--- a/telegram/ext/__init__.py
+++ b/telegram/ext/__init__.py
@@ -44,6 +44,7 @@ from .messagequeue import DelayQueue
 from .pollanswerhandler import PollAnswerHandler
 from .pollhandler import PollHandler
 from .defaults import Defaults
+from .roles import Role, Roles
 
 __all__ = ('Dispatcher', 'JobQueue', 'Job', 'Updater', 'CallbackQueryHandler',
            'ChosenInlineResultHandler', 'CommandHandler', 'Handler', 'InlineQueryHandler',
@@ -52,4 +53,4 @@ __all__ = ('Dispatcher', 'JobQueue', 'Job', 'Updater', 'CallbackQueryHandler',
            'PreCheckoutQueryHandler', 'ShippingQueryHandler', 'MessageQueue', 'DelayQueue',
            'DispatcherHandlerStop', 'run_async', 'CallbackContext', 'BasePersistence',
            'PicklePersistence', 'DictPersistence', 'PrefixHandler', 'PollAnswerHandler',
-           'PollHandler', 'Defaults')
+           'PollHandler', 'Defaults', 'Role', 'Roles')

--- a/telegram/ext/basepersistence.py
+++ b/telegram/ext/basepersistence.py
@@ -31,6 +31,8 @@ class BasePersistence(object):
       :meth:`update_chat_data`.
     * If :attr:`store_user_data` is ``True`` you must overwrite :meth:`get_user_data` and
       :meth:`update_user_data`.
+    * If :attr:`store_roles` is ``True`` you must overwrite :meth:`get_roles` and
+      :meth:`update_roles`.
     * If you want to store conversation data with :class:`telegram.ext.ConversationHandler`, you
       must overwrite :meth:`get_conversations` and :meth:`update_conversation`.
     * :meth:`flush` will be called when the bot is shutdown.

--- a/telegram/ext/basepersistence.py
+++ b/telegram/ext/basepersistence.py
@@ -42,6 +42,8 @@ class BasePersistence(object):
             persistence class.
         store_bot_data (:obj:`bool`): Optional. Whether bot_data should be saved by this
             persistence class.
+        store_roles (:obj:`bool`): Optional. Whether roles should be saved by this persistence
+            class.
 
     Args:
         store_user_data (:obj:`bool`, optional): Whether user_data should be saved by this
@@ -50,12 +52,16 @@ class BasePersistence(object):
             persistence class. Default is ``True`` .
         store_bot_data (:obj:`bool`, optional): Whether bot_data should be saved by this
             persistence class. Default is ``True`` .
+        store_roles (:obj:`bool`, optional): Whether roles should be saved by this persistence
+            class. Default is ``True``.
     """
 
-    def __init__(self, store_user_data=True, store_chat_data=True, store_bot_data=True):
+    def __init__(self, store_user_data=True, store_chat_data=True, store_bot_data=True,
+                 store_roles=True):
         self.store_user_data = store_user_data
         self.store_chat_data = store_chat_data
         self.store_bot_data = store_bot_data
+        self.store_roles = store_roles
 
     def get_user_data(self):
         """"Will be called by :class:`telegram.ext.Dispatcher` upon creation with a
@@ -84,6 +90,19 @@ class BasePersistence(object):
 
         Returns:
             :obj:`defaultdict`: The restored bot data.
+        """
+        raise NotImplementedError
+
+    def get_roles(self):
+        """"Will be called by :class:`telegram.ext.Dispatcher` upon creation with a
+        persistence object.
+
+        Warning:
+            The produced roles instance usually will have no bot assigned. Use
+            :attr:`telegram.ext.Roles.set_bot` to set it.
+
+        Returns:
+            :class:`telegram.ext.Roles`: The restored roles.
         """
         raise NotImplementedError
 
@@ -138,6 +157,15 @@ class BasePersistence(object):
 
         Args:
             data (:obj:`dict`): The :attr:`telegram.ext.dispatcher.bot_data` .
+        """
+        raise NotImplementedError
+
+    def update_roles(self, data):
+        """Will be called by the :class:`telegram.ext.Dispatcher` after a handler has
+        handled an update.
+
+        Args:
+            data (:class:`telegram.ext.Roles`): The :attr:`telegram.ext.dispatcher.roles` .
         """
         raise NotImplementedError
 

--- a/telegram/ext/callbackcontext.py
+++ b/telegram/ext/callbackcontext.py
@@ -82,6 +82,7 @@ class CallbackContext(object):
             raise ValueError('CallbackContext should not be used with a non context aware '
                              'dispatcher!')
         self._dispatcher = dispatcher
+        self._roles = dispatcher.roles
         self._bot_data = dispatcher.bot_data
         self._chat_data = None
         self._user_data = None
@@ -94,6 +95,14 @@ class CallbackContext(object):
     def dispatcher(self):
         """:class:`telegram.ext.Dispatcher`: The dispatcher associated with this context."""
         return self._dispatcher
+
+    @property
+    def roles(self):
+        return self._roles
+
+    @roles.setter
+    def roles(self, value):
+        raise AttributeError("You can not assign a new value to roles.")
 
     @property
     def bot_data(self):

--- a/telegram/ext/callbackqueryhandler.py
+++ b/telegram/ext/callbackqueryhandler.py
@@ -33,6 +33,8 @@ class CallbackQueryHandler(Handler):
 
     Attributes:
         callback (:obj:`callable`): The callback function for this handler.
+        roles (:obj:`telegram.ext.Role`): Optional. A user role used to restrict access to the
+            handler.
         pass_update_queue (:obj:`bool`): Determines whether ``update_queue`` will be
             passed to the callback function.
         pass_job_queue (:obj:`bool`): Determines whether ``job_queue`` will be passed to
@@ -66,6 +68,9 @@ class CallbackQueryHandler(Handler):
 
             The return value of the callback is usually ignored except for the special case of
             :class:`telegram.ext.ConversationHandler`.
+        roles (:obj:`telegram.ext.Role`, optional): A user role used to restrict access to the
+            handler. Roles can be combined using bitwise operators (& for and, | for or, ~ for
+            not).
         pass_update_queue (:obj:`bool`, optional): If set to ``True``, a keyword argument called
             ``update_queue`` will be passed to the callback function. It will be the ``Queue``
             instance used by the :class:`telegram.ext.Updater` and :class:`telegram.ext.Dispatcher`
@@ -104,13 +109,15 @@ class CallbackQueryHandler(Handler):
                  pass_groups=False,
                  pass_groupdict=False,
                  pass_user_data=False,
-                 pass_chat_data=False):
+                 pass_chat_data=False,
+                 roles=None):
         super(CallbackQueryHandler, self).__init__(
             callback,
             pass_update_queue=pass_update_queue,
             pass_job_queue=pass_job_queue,
             pass_user_data=pass_user_data,
-            pass_chat_data=pass_chat_data)
+            pass_chat_data=pass_chat_data,
+            roles=roles)
 
         if isinstance(pattern, string_types):
             pattern = re.compile(pattern)

--- a/telegram/ext/choseninlineresulthandler.py
+++ b/telegram/ext/choseninlineresulthandler.py
@@ -27,6 +27,8 @@ class ChosenInlineResultHandler(Handler):
 
     Attributes:
         callback (:obj:`callable`): The callback function for this handler.
+        roles (:obj:`telegram.ext.Role`): Optional. A user role used to restrict access to the
+            handler.
         pass_update_queue (:obj:`bool`): Determines whether ``update_queue`` will be
             passed to the callback function.
         pass_job_queue (:obj:`bool`): Determines whether ``job_queue`` will be passed to
@@ -54,6 +56,9 @@ class ChosenInlineResultHandler(Handler):
 
             The return value of the callback is usually ignored except for the special case of
             :class:`telegram.ext.ConversationHandler`.
+        roles (:obj:`telegram.ext.Role`, optional): A user role used to restrict access to the
+            handler. Roles can be combined using bitwise operators (& for and, | for or, ~ for
+            not).
         pass_update_queue (:obj:`bool`, optional): If set to ``True``, a keyword argument called
             ``update_queue`` will be passed to the callback function. It will be the ``Queue``
             instance used by the :class:`telegram.ext.Updater` and :class:`telegram.ext.Dispatcher`

--- a/telegram/ext/commandhandler.py
+++ b/telegram/ext/commandhandler.py
@@ -47,6 +47,8 @@ class CommandHandler(Handler):
         callback (:obj:`callable`): The callback function for this handler.
         filters (:class:`telegram.ext.BaseFilter`): Optional. Only allow updates with these
             Filters.
+        roles (:obj:`telegram.ext.Role`): Optional. A user role used to restrict access to the
+            handler.
         allow_edited (:obj:`bool`): Determines Whether the handler should also accept
             edited messages.
         pass_args (:obj:`bool`): Determines whether the handler should be passed
@@ -85,6 +87,9 @@ class CommandHandler(Handler):
             :class:`telegram.ext.filters.BaseFilter`. Standard filters can be found in
             :class:`telegram.ext.filters.Filters`. Filters can be combined using bitwise
             operators (& for and, | for or, ~ for not).
+        roles (:obj:`telegram.ext.Role`, optional): A user role used to restrict access to the
+            handler. Roles can be combined using bitwise operators (& for and, | for or, ~ for
+            not).
         allow_edited (:obj:`bool`, optional): Determines whether the handler should also accept
             edited messages. Default is ``False``.
             DEPRECATED: Edited is allowed by default. To change this behavior use
@@ -124,13 +129,15 @@ class CommandHandler(Handler):
                  pass_update_queue=False,
                  pass_job_queue=False,
                  pass_user_data=False,
-                 pass_chat_data=False):
+                 pass_chat_data=False,
+                 roles=None):
         super(CommandHandler, self).__init__(
             callback,
             pass_update_queue=pass_update_queue,
             pass_job_queue=pass_job_queue,
             pass_user_data=pass_user_data,
-            pass_chat_data=pass_chat_data)
+            pass_chat_data=pass_chat_data,
+            roles=roles)
 
         if isinstance(command, string_types):
             self.command = [command.lower()]
@@ -231,6 +238,8 @@ class PrefixHandler(CommandHandler):
         callback (:obj:`callable`): The callback function for this handler.
         filters (:class:`telegram.ext.BaseFilter`): Optional. Only allow updates with these
             Filters.
+        roles (:obj:`telegram.ext.Role`): Optional. A user role used to restrict access to the
+            handler.
         pass_args (:obj:`bool`): Determines whether the handler should be passed
             ``args``.
         pass_update_queue (:obj:`bool`): Determines whether ``update_queue`` will be
@@ -267,6 +276,9 @@ class PrefixHandler(CommandHandler):
             :class:`telegram.ext.filters.BaseFilter`. Standard filters can be found in
             :class:`telegram.ext.filters.Filters`. Filters can be combined using bitwise
             operators (& for and, | for or, ~ for not).
+        roles (:obj:`telegram.ext.Role`, optional): A user role used to restrict access to the
+            handler. Roles can be combined using bitwise operators (& for and, | for or, ~ for
+            not).
         pass_args (:obj:`bool`, optional): Determines whether the handler should be passed the
             arguments passed to the command as a keyword argument called ``args``. It will contain
             a list of strings, which is the text following the command split on single or
@@ -300,7 +312,8 @@ class PrefixHandler(CommandHandler):
                  pass_update_queue=False,
                  pass_job_queue=False,
                  pass_user_data=False,
-                 pass_chat_data=False):
+                 pass_chat_data=False,
+                 roles=None):
 
         self._prefix = list()
         self._command = list()
@@ -311,7 +324,8 @@ class PrefixHandler(CommandHandler):
             pass_update_queue=pass_update_queue,
             pass_job_queue=pass_job_queue,
             pass_user_data=pass_user_data,
-            pass_chat_data=pass_chat_data)
+            pass_chat_data=pass_chat_data,
+            roles=roles)
 
         self.prefix = prefix
         self.command = command

--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -105,6 +105,8 @@ class ConversationHandler(Handler):
         map_to_parent (Dict[:obj:`object`, :obj:`object`]): Optional. A :obj:`dict` that can be
             used to instruct a nested conversationhandler to transition into a mapped state on
             its parent conversationhandler in place of a specified nested state.
+        roles (:obj:`telegram.ext.Role`): Optional. A user role used to restrict access to the
+            handler.
 
     Args:
         entry_points (List[:class:`telegram.ext.Handler`]): A list of ``Handler`` objects that can
@@ -139,6 +141,9 @@ class ConversationHandler(Handler):
         map_to_parent (Dict[:obj:`object`, :obj:`object`], optional): A :obj:`dict` that can be
             used to instruct a nested conversationhandler to transition into a mapped state on
             its parent conversationhandler in place of a specified nested state.
+        roles (:obj:`telegram.ext.Role`, optional): A user role used to restrict access to the
+            handler. Roles can be combined using bitwise operators (& for and, | for or, ~ for
+            not).
 
     Raises:
         ValueError
@@ -163,7 +168,8 @@ class ConversationHandler(Handler):
                  conversation_timeout=None,
                  name=None,
                  persistent=False,
-                 map_to_parent=None):
+                 map_to_parent=None,
+                 roles=None):
 
         self._entry_points = entry_points
         self._states = states
@@ -182,6 +188,7 @@ class ConversationHandler(Handler):
         """:obj:`telegram.ext.BasePersistance`: The persistence used to store conversations.
         Set by dispatcher"""
         self._map_to_parent = map_to_parent
+        self.roles = roles
 
         self.timeout_jobs = dict()
         self._timeout_jobs_lock = Lock()

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -889,10 +889,12 @@ officedocument.wordprocessingml.document")``-
             if (user_id is None) == (self.usernames is None):
                 raise ValueError('One and only one of user_id or username must be used')
             with self._user_ids_lock:
-                if isinstance(user_id, int):
-                    self._user_ids = [user_id]
+                if user_id is None:
+                    self._user_ids = None
+                elif isinstance(user_id, int):
+                    self._user_ids = set([user_id])
                 else:
-                    self._user_ids = user_id
+                    self._user_ids = set(user_id)
 
         @property
         def usernames(self):
@@ -905,11 +907,11 @@ officedocument.wordprocessingml.document")``-
                 raise ValueError('One and only one of user_id or username must be used')
             with self._usernames_lock:
                 if username is None:
-                    self._usernames = username
+                    self._usernames = None
                 elif isinstance(username, str):
-                    self._usernames = [username.replace('@', '')]
+                    self._usernames = set([username.replace('@', '')])
                 else:
-                    self._usernames = [user.replace('@', '') for user in username]
+                    self._usernames = set([user.replace('@', '') for user in username])
 
         def filter(self, message):
             """"""  # remove method from docs

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -869,15 +869,15 @@ officedocument.wordprocessingml.document")``-
             if (user_id is None) == (username is None):
                 raise ValueError('One and only one of user_id or username must be used')
 
+            self._user_ids_lock = Lock()
+            self._usernames_lock = Lock()
+
             # Initialize in a way that will not fail the first setter calls
             self._user_ids = user_id
             self._usernames = username
             # Actually initialize
             self.user_ids = user_id
             self.usernames = username
-
-            self._user_ids_lock = Lock()
-            self._usernames_lock = Lock()
 
         @property
         def user_ids(self):
@@ -886,9 +886,9 @@ officedocument.wordprocessingml.document")``-
 
         @user_ids.setter
         def user_ids(self, user_id):
+            if (user_id is None) == (self.usernames is None):
+                raise ValueError('One and only one of user_id or username must be used')
             with self._user_ids_lock:
-                if (user_id is None) == (self.usernames is None):
-                    raise ValueError('One and only one of user_id or username must be used')
                 if isinstance(user_id, int):
                     self._user_ids = [user_id]
                 else:
@@ -901,9 +901,9 @@ officedocument.wordprocessingml.document")``-
 
         @usernames.setter
         def usernames(self, username):
+            if (username is None) == (self.user_ids is None):
+                raise ValueError('One and only one of user_id or username must be used')
             with self._usernames_lock:
-                if (username is None) == (self.user_ids is None):
-                    raise ValueError('One and only one of user_id or username must be used')
                 if username is None:
                     self._usernames = username
                 elif isinstance(username, str):
@@ -913,10 +913,9 @@ officedocument.wordprocessingml.document")``-
 
         def filter(self, message):
             """"""  # remove method from docs
-            with self._user_ids_lock:
-                if self.user_ids is not None:
-                    return bool(message.from_user and message.from_user.id in self.user_ids)
-            with self._usernames_lock:
+            if self.user_ids is not None:
+                return bool(message.from_user and message.from_user.id in self.user_ids)
+            else:
                 # self.usernames is not None
                 return bool(message.from_user and message.from_user.username
                             and message.from_user.username in self.usernames)

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -881,31 +881,35 @@ officedocument.wordprocessingml.document")``-
 
         @property
         def user_ids(self):
-            return self._user_ids
+            with self._user_ids_lock:
+                return self._user_ids
 
         @user_ids.setter
         def user_ids(self, user_id):
-            if (user_id is None) == (self.usernames is None):
-                raise ValueError('One and only one of user_id or username must be used')
-            if isinstance(user_id, int):
-                self._user_ids = [user_id]
-            else:
-                self._user_ids = user_id
+            with self._user_ids_lock:
+                if (user_id is None) == (self.usernames is None):
+                    raise ValueError('One and only one of user_id or username must be used')
+                if isinstance(user_id, int):
+                    self._user_ids = [user_id]
+                else:
+                    self._user_ids = user_id
 
         @property
         def usernames(self):
-            return self._usernames
+            with self._usernames_lock:
+                return self._usernames
 
         @usernames.setter
         def usernames(self, username):
-            if (username is None) == (self.user_ids is None):
-                raise ValueError('One and only one of user_id or username must be used')
-            if username is None:
-                self._usernames = username
-            elif isinstance(username, str):
-                self._usernames = [username.replace('@', '')]
-            else:
-                self._usernames = [user.replace('@', '') for user in username]
+            with self._usernames_lock:
+                if (username is None) == (self.user_ids is None):
+                    raise ValueError('One and only one of user_id or username must be used')
+                if username is None:
+                    self._usernames = username
+                elif isinstance(username, str):
+                    self._usernames = [username.replace('@', '')]
+                else:
+                    self._usernames = [user.replace('@', '') for user in username]
 
         def filter(self, message):
             """"""  # remove method from docs

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -852,13 +852,14 @@ officedocument.wordprocessingml.document")``-
             ``MessageHandler(Filters.user(1234), callback_method)``
 
         Attributes:
-            user_id(List[:obj:`int`], optional): Which user ID(s) to allow through.
-            username(List[:obj:`str`], optional): Which username(s) (without leading '@') to allow
+            user_ids(set(:obj:`int`), optional): Which user ID(s) to allow through.
+            usernames(set(:obj:`str`), optional): Which username(s) (without leading '@') to allow
                 through.
         Args:
-            user_id(:obj:`int` | List[:obj:`int`], optional): Which user ID(s) to allow through.
-            username(:obj:`str` | List[:obj:`str`], optional): Which username(s) to allow through.
-                If username starts with '@' symbol, it will be ignored.
+            user_id(:obj:`int` | iterable(:obj:`int`), optional): Which user ID(s) to allow
+                through.
+            username(:obj:`str` | iterable(:obj:`str`), optional): Which username(s) to allow
+                through. If username starts with '@' symbol, it will be ignored.
 
         Raises:
             ValueError: If chat_id and username are both present, or neither is.

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -21,6 +21,7 @@
 import re
 
 from future.utils import string_types
+from threading import Lock
 
 from telegram import Chat, Update, MessageEntity
 
@@ -850,6 +851,10 @@ officedocument.wordprocessingml.document")``-
         Examples:
             ``MessageHandler(Filters.user(1234), callback_method)``
 
+        Attributes:
+            user_id(List[:obj:`int`], optional): Which user ID(s) to allow through.
+            username(List[:obj:`str`], optional): Which username(s) (without leading '@') to allow
+                through.
         Args:
             user_id(:obj:`int` | List[:obj:`int`], optional): Which user ID(s) to allow through.
             username(:obj:`str` | List[:obj:`str`], optional): Which username(s) to allow through.
@@ -861,24 +866,53 @@ officedocument.wordprocessingml.document")``-
         """
 
         def __init__(self, user_id=None, username=None):
-            if not (bool(user_id) ^ bool(username)):
+            if (user_id is None) == (username is None):
                 raise ValueError('One and only one of user_id or username must be used')
-            if user_id is not None and isinstance(user_id, int):
-                self.user_ids = [user_id]
+
+            # Initialize in a way that will not fail the first setter calls
+            self._user_ids = user_id
+            self._usernames = username
+            # Actually initialize
+            self.user_ids = user_id
+            self.usernames = username
+
+            self._user_ids_lock = Lock()
+            self._usernames_lock = Lock()
+
+        @property
+        def user_ids(self):
+            return self._user_ids
+
+        @user_ids.setter
+        def user_ids(self, user_id):
+            if (user_id is None) == (self.usernames is None):
+                raise ValueError('One and only one of user_id or username must be used')
+            if isinstance(user_id, int):
+                self._user_ids = [user_id]
             else:
-                self.user_ids = user_id
+                self._user_ids = user_id
+
+        @property
+        def usernames(self):
+            return self._usernames
+
+        @usernames.setter
+        def usernames(self, username):
+            if (username is None) == (self.user_ids is None):
+                raise ValueError('One and only one of user_id or username must be used')
             if username is None:
-                self.usernames = username
-            elif isinstance(username, string_types):
-                self.usernames = [username.replace('@', '')]
+                self._usernames = username
+            elif isinstance(username, str):
+                self._usernames = [username.replace('@', '')]
             else:
-                self.usernames = [user.replace('@', '') for user in username]
+                self._usernames = [user.replace('@', '') for user in username]
 
         def filter(self, message):
             """"""  # remove method from docs
-            if self.user_ids is not None:
-                return bool(message.from_user and message.from_user.id in self.user_ids)
-            else:
+            with self._user_ids_lock:
+                if self.user_ids is not None:
+                    return bool(message.from_user and message.from_user.id in self.user_ids)
+            with self._usernames_lock:
                 # self.usernames is not None
                 return bool(message.from_user and message.from_user.username
                             and message.from_user.username in self.usernames)

--- a/telegram/ext/inlinequeryhandler.py
+++ b/telegram/ext/inlinequeryhandler.py
@@ -32,6 +32,8 @@ class InlineQueryHandler(Handler):
 
     Attributes:
         callback (:obj:`callable`): The callback function for this handler.
+        roles (:obj:`telegram.ext.Role`): Optional. A user role used to restrict access to the
+            handler.
         pass_update_queue (:obj:`bool`): Determines whether ``update_queue`` will be
             passed to the callback function.
         pass_job_queue (:obj:`bool`): Determines whether ``job_queue`` will be passed to
@@ -65,6 +67,9 @@ class InlineQueryHandler(Handler):
 
             The return value of the callback is usually ignored except for the special case of
             :class:`telegram.ext.ConversationHandler`.
+        roles (:obj:`telegram.ext.Role`, optional): A user role used to restrict access to the
+            handler. Roles can be combined using bitwise operators (& for and, | for or, ~ for
+            not).
         pass_update_queue (:obj:`bool`, optional): If set to ``True``, a keyword argument called
             ``update_queue`` will be passed to the callback function. It will be the ``Queue``
             instance used by the :class:`telegram.ext.Updater` and :class:`telegram.ext.Dispatcher`
@@ -103,13 +108,15 @@ class InlineQueryHandler(Handler):
                  pass_groups=False,
                  pass_groupdict=False,
                  pass_user_data=False,
-                 pass_chat_data=False):
+                 pass_chat_data=False,
+                 roles=None):
         super(InlineQueryHandler, self).__init__(
             callback,
             pass_update_queue=pass_update_queue,
             pass_job_queue=pass_job_queue,
             pass_user_data=pass_user_data,
-            pass_chat_data=pass_chat_data)
+            pass_chat_data=pass_chat_data,
+            roles=roles)
 
         if isinstance(pattern, string_types):
             pattern = re.compile(pattern)

--- a/telegram/ext/messagehandler.py
+++ b/telegram/ext/messagehandler.py
@@ -34,6 +34,8 @@ class MessageHandler(Handler):
         filters (:obj:`Filter`): Only allow updates with these Filters. See
             :mod:`telegram.ext.filters` for a full list of all available filters.
         callback (:obj:`callable`): The callback function for this handler.
+        roles (:obj:`telegram.ext.Role`): Optional. A user role used to restrict access to the
+            handler.
         pass_update_queue (:obj:`bool`): Determines whether ``update_queue`` will be
             passed to the callback function.
         pass_job_queue (:obj:`bool`): Determines whether ``job_queue`` will be passed to
@@ -75,6 +77,9 @@ class MessageHandler(Handler):
 
             The return value of the callback is usually ignored except for the special case of
             :class:`telegram.ext.ConversationHandler`.
+        roles (:obj:`telegram.ext.Role`, optional): A user role used to restrict access to the
+            handler. Roles can be combined using bitwise operators (& for and, | for or, ~ for
+            not).
         pass_update_queue (:obj:`bool`, optional): If set to ``True``, a keyword argument called
             ``update_queue`` will be passed to the callback function. It will be the ``Queue``
             instance used by the :class:`telegram.ext.Updater` and :class:`telegram.ext.Dispatcher`
@@ -115,14 +120,16 @@ class MessageHandler(Handler):
                  pass_chat_data=False,
                  message_updates=None,
                  channel_post_updates=None,
-                 edited_updates=None):
+                 edited_updates=None,
+                 roles=None):
 
         super(MessageHandler, self).__init__(
             callback,
             pass_update_queue=pass_update_queue,
             pass_job_queue=pass_job_queue,
             pass_user_data=pass_user_data,
-            pass_chat_data=pass_chat_data)
+            pass_chat_data=pass_chat_data,
+            roles=roles)
         if message_updates is False and channel_post_updates is False and edited_updates is False:
             raise ValueError(
                 'message_updates, channel_post_updates and edited_updates are all False')

--- a/telegram/ext/picklepersistence.py
+++ b/telegram/ext/picklepersistence.py
@@ -94,7 +94,7 @@ class PicklePersistence(BasePersistence):
                 self.chat_data = defaultdict(dict, data['chat_data'])
                 # For backwards compatibility with files not containing bot data
                 self.bot_data = data.get('bot_data', {})
-                self.roles = all.get('roles', Roles(None))
+                self.roles = data.get('roles', Roles(None))
                 if self.roles:
                     self.roles = Roles.decode_from_json(self.roles, None)
                 self.conversations = data['conversations']

--- a/telegram/ext/pollanswerhandler.py
+++ b/telegram/ext/pollanswerhandler.py
@@ -26,6 +26,8 @@ class PollAnswerHandler(Handler):
 
     Attributes:
         callback (:obj:`callable`): The callback function for this handler.
+        roles (:obj:`telegram.ext.Role`): Optional. A user role used to restrict access to the
+            handler.
         pass_update_queue (:obj:`bool`): Determines whether ``update_queue`` will be
             passed to the callback function.
         pass_job_queue (:obj:`bool`): Determines whether ``job_queue`` will be passed to
@@ -53,6 +55,9 @@ class PollAnswerHandler(Handler):
 
             The return value of the callback is usually ignored except for the special case of
             :class:`telegram.ext.ConversationHandler`.
+        roles (:obj:`telegram.ext.Role`, optional): A user role used to restrict access to the
+            handler. Roles can be combined using bitwise operators (& for and, | for or, ~ for
+            not).
         pass_update_queue (:obj:`bool`, optional): If set to ``True``, a keyword argument called
             ``update_queue`` will be passed to the callback function. It will be the ``Queue``
             instance used by the :class:`telegram.ext.Updater` and :class:`telegram.ext.Dispatcher`

--- a/telegram/ext/precheckoutqueryhandler.py
+++ b/telegram/ext/precheckoutqueryhandler.py
@@ -27,6 +27,8 @@ class PreCheckoutQueryHandler(Handler):
 
     Attributes:
         callback (:obj:`callable`): The callback function for this handler.
+        roles (:obj:`telegram.ext.Role`): Optional. A user role used to restrict access to the
+            handler.
         pass_update_queue (:obj:`bool`): Determines whether ``update_queue`` will be
             passed to the callback function.
         pass_job_queue (:obj:`bool`): Determines whether ``job_queue`` will be passed to
@@ -54,6 +56,9 @@ class PreCheckoutQueryHandler(Handler):
 
             The return value of the callback is usually ignored except for the special case of
             :class:`telegram.ext.ConversationHandler`.
+        roles (:obj:`telegram.ext.Role`, optional): A user role used to restrict access to the
+            handler. Roles can be combined using bitwise operators (& for and, | for or, ~ for
+            not).
         pass_update_queue (:obj:`bool`, optional): If set to ``True``, a keyword argument called
             ``update_queue`` will be passed to the callback function. It will be the ``Queue``
             DEPRECATED: Please switch to context based callbacks.

--- a/telegram/ext/regexhandler.py
+++ b/telegram/ext/regexhandler.py
@@ -36,6 +36,8 @@ class RegexHandler(MessageHandler):
     Attributes:
         pattern (:obj:`str` | :obj:`Pattern`): The regex pattern.
         callback (:obj:`callable`): The callback function for this handler.
+        roles (:obj:`telegram.ext.Role`): Optional. A user role used to restrict access to the
+            handler.
         pass_groups (:obj:`bool`): Determines whether ``groups`` will be passed to the
             callback function.
         pass_groupdict (:obj:`bool`): Determines whether ``groupdict``. will be passed to
@@ -64,6 +66,9 @@ class RegexHandler(MessageHandler):
 
             The return value of the callback is usually ignored except for the special case of
             :class:`telegram.ext.ConversationHandler`.
+        roles (:obj:`telegram.ext.Role`, optional): A user role used to restrict access to the
+            handler. Roles can be combined using bitwise operators (& for and, | for or, ~ for
+            not).
         pass_groups (:obj:`bool`, optional): If the callback should be passed the result of
             ``re.match(pattern, data).groups()`` as a keyword argument called ``groups``.
             Default is ``False``
@@ -106,7 +111,8 @@ class RegexHandler(MessageHandler):
                  allow_edited=False,
                  message_updates=True,
                  channel_post_updates=False,
-                 edited_updates=False):
+                 edited_updates=False,
+                 roles=None):
         warnings.warn('RegexHandler is deprecated. See https://git.io/fxJuV for more info',
                       TelegramDeprecationWarning,
                       stacklevel=2)
@@ -118,7 +124,8 @@ class RegexHandler(MessageHandler):
                                            pass_chat_data=pass_chat_data,
                                            message_updates=message_updates,
                                            channel_post_updates=channel_post_updates,
-                                           edited_updates=edited_updates)
+                                           edited_updates=edited_updates,
+                                           roles=roles)
         self.pass_groups = pass_groups
         self.pass_groupdict = pass_groupdict
 

--- a/telegram/ext/roles.py
+++ b/telegram/ext/roles.py
@@ -26,16 +26,16 @@ from .filters import Filters
 
 class Role(Filters.user):
     """This class represents a security level used by :class:`telegram.ext.Roles`. Roles have a
-    hierarchie, i.e. a role can do everthing, its child roles can do. To compare two roles you may
+    hierarchy, i.e. a role can do everthing, its child roles can do. To compare two roles you may
     use the following syntax::
 
         role_1 < role_2
         role 2 >= role_3
 
-    Note:
-        ``role_1 == role_2`` does not test for the hierarchical order of the roles, but in fact for
-        equality. Two roles are considerd equal, if their :attr:`user_ids` and :attr:`parent_roles`
-        coincide.
+    Warning:
+        ``role_1 == role_2`` does not test for the hierarchical order of the roles, but in fact if
+        both roles are the same object. To test for equality in terms of hierarchical order, i.e.
+        if both :attr:`parent_roles` and :attr:`user_ids` coincide, use :attr:`equals`.
 
     Attributes:
         user_ids (set(:obj:`int`)): The ids of the users of this role. May be empty.
@@ -98,6 +98,8 @@ class Role(Filters.user):
         Args:
             parent_role (:class:`telegram.ext.Role`): The parent role
         """
+        if self is parent_role:
+            raise ValueError('You must not add a role is its own parent!')
         self.parent_roles.add(parent_role)
 
     def remove_parent_role(self, parent_role):
@@ -129,17 +131,31 @@ class Role(Filters.user):
         return self > other
 
     def __eq__(self, other):
-        # Acutally tests for equality in terms of parent roles and user_ids
-        if isinstance(other, Role):
-            return (self.parent_roles == other.parent_roles
-                    and self.user_ids == other.user_ids)
-        return False
+        return self is other
 
     def __ne__(self, other):
         return not self == other
 
+    def equals(self, other):
+        """Test if two roles are equal in terms of hierarchy. Returns ``True``, if the user_ids
+        coincide and the parent roles are equal in terms of this method.
+
+        Args:
+            other (:class:`telegram.ext.Role`):
+
+        Returns:
+            :obj:`bool`:
+        """
+        for pr in self.parent_roles:
+            if not any([pr.equals(opr) for opr in other.parent_roles]):
+                return False
+        for opr in other.parent_roles:
+            if not any([opr.equals(pr) for pr in self.parent_roles]):
+                return False
+        return self.user_ids == other.user_ids
+
     def __hash__(self):
-        return hash((self.name, tuple(sorted(self.user_ids))))
+        return id(self)
 
     def __deepcopy__(self, memo):
         new_role = Role(user_ids=self.user_ids, name=self._name)
@@ -296,6 +312,22 @@ class Roles(dict):
         """
         role = self._pop(name, None)
         role.remove_parent_role(self.ADMINS)
+
+    def __eq__(self, other):
+        if isinstance(other, Roles):
+            for name, role in self.items():
+                orole = other.get(name, None)
+                if not orole:
+                    return False
+                if not role.equals(orole):
+                    return False
+            if any([self.get(name, None) is None for name in other]):
+                return False
+            return self.ADMINS.equals(other.ADMINS)
+        return False
+
+    def __ne__(self, other):
+        return not self == other
 
     def __deepcopy__(self, memo):
         new_roles = Roles(self._bot)

--- a/telegram/ext/roles.py
+++ b/telegram/ext/roles.py
@@ -25,7 +25,7 @@ except ImportError:
 
 from copy import deepcopy
 
-from telegram import ChatMember, TelegramError
+from telegram import ChatMember, TelegramError, Bot
 from .filters import Filters
 
 
@@ -64,11 +64,18 @@ class Role(Filters.user):
         if chat_ids is None:
             chat_ids = set()
         super(Role, self).__init__(chat_ids)
-        self.chat_ids = self.user_ids
         self.parent_roles = set()
         self._name = name
         if parent_role:
             self.add_parent_role(parent_role)
+
+    @property
+    def chat_ids(self):
+        return self.user_ids
+
+    @chat_ids.setter
+    def chat_ids(self, chat_id):
+        self.user_ids = chat_id
 
     @property
     def name(self):
@@ -245,6 +252,21 @@ class Roles(dict):
         self.ADMINS = Role(name='admins')
         self.CHAT_ADMINS = _chat_admins(bot=self._bot)
         self.CHAT_CREATOR = _chat_creator(bot=self._bot)
+
+    def set_bot(self, bot):
+        """If for some reason you can't pass the bot on initialization, you can set it with this
+        method. Make sure to set the bot before the first call of :attr:`CHAT_ADMINS` or
+        :attr:`CHAT_CREATOR`.
+
+        Args:
+            bot (:class:`telegram.Bot`): The bot to set.
+
+        Raises:
+            ValueError
+        """
+        if isinstance(self._bot, Bot):
+            raise ValueError('Bot is already set for this Roles instance')
+        self._bot = bot
 
     def __delitem__(self, key):
         """"""  # Remove method from docs

--- a/telegram/ext/roles.py
+++ b/telegram/ext/roles.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python
+#
+# A library that provides a Python interface to the Telegram Bot API
+# Copyright (C) 2020
+# Leandro Toledo de Souza <devs@python-telegram-bot.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+"""This module contains the class Role, which allows to restrict access to handlers."""
+
+from telegram import ChatMember, TelegramError
+from . import Filters
+
+
+class Role(Filters.user):
+    """This class represents a security level used by :class:`telegram.ext.Roles`. Roles have a
+    hierarchie, i.e. a role can do everthing, its child roles can do. To compare two roles you may
+    use the following syntax::
+
+        role_1 < role_2
+        role 2 >= role_3
+
+    Note:
+        ``role_1 == role_2`` does not test for the hierarchical order of the roles, but in fact for
+        equality. Two roles are considerd equal, if their :attr:`user_ids`, :attr:`child_roles`
+        and :attr:`parent_roles` coincide.
+
+    Attributes:
+        user_ids (set(:obj:`int`)): The ids of the users of this role. May be empty.
+        child_roles (set(:class:`telegram.ext.Role`)): Child roles of this role. This role can do
+            anything, the child roles can do. May be empty.
+        parent_roles (set(:class:`telegram.ext.Role`)): Parent roles of this role. All the parent
+            roles can do anything, this role can do. May be empty.
+        name (:obj:`str`): A string representation of this role.
+
+    Args:
+        user_ids (set(:obj:`int`), optional): The ids of the users of this role.
+        parent_roles (set(:class:`telegram.ext.Role`), optional): Parent roles of this role.
+        name (:obj:`str`, optional): A name for this role.
+
+    """
+    update_filter = True
+
+    def __init__(self, user_ids=None, parent_role=None, name=None):
+        if user_ids is None:
+            user_ids = set()
+        super(Role, self).__init__(user_ids)
+        self.child_roles = set()
+        self.parent_roles = set()
+        self._name = name
+        if parent_role:
+            self.add_parent_role(parent_role)
+
+    @property
+    def name(self):
+        if self._name:
+            return 'Role({})'.format(self._name)
+        elif self.user_ids or self.usernames:
+            return 'Role({})'.format(self.user_ids or self.usernames)
+        else:
+            return 'Role({})'
+
+    def filter(self, update):
+        user = update.effective_user
+        if user:
+            if user.id in self.user_ids:
+                return True
+            return any([parent(update) for parent in self.parent_roles])
+
+    def add_member(self, user_id):
+        """Adds a user to this role. Will do nothing, if user is already present.
+
+        Args:
+            user_id (:obj:`int`): The users id
+        """
+        self.user_ids.add(user_id)
+
+    def kick_member(self, user_id):
+        """Kicks a user to from role. Will do nothing, if user is not present.
+
+        Args:
+            user_id (:obj:`int`): The users id
+        """
+        self.user_ids.discard(user_id)
+
+    def add_child_role(self, child_role):
+        """Adds a child role to this role. Will do nothing, if child role is already present.
+
+        Args:
+            child_role (:class:`telegram.ext.Role`): The child role
+        """
+        self.child_roles.add(child_role)
+        child_role.parent_roles.add(self)
+
+    def remove_child_role(self, child_role):
+        """Removes a child role from this role. Will do nothing, if child role is not present.
+
+        Args:
+            child_role (:class:`telegram.ext.Role`): The child role
+        """
+        self.child_roles.discard(child_role)
+        child_role.parent_roles.discard(self)
+
+    def add_parent_role(self, parent_role):
+        """Adds a parent role to this role. Will do nothing, if parent role is already present.
+
+        Args:
+            parent_role (:class:`telegram.ext.Role`): The parent role
+        """
+        self.parent_roles.add(parent_role)
+        parent_role.child_roles.add(self)
+
+    def remove_parent_role(self, parent_role):
+        """Removes a parent role from this role. Will do nothing, if parent role is not present.
+
+        Args:
+            parent_role (:class:`telegram.ext.Role`): The parent role
+        """
+        self.parent_roles.discard(parent_role)
+        parent_role.child_roles.discard(self)
+
+    def __lt__(self, other):
+        # Test for hierarchical order
+        if isinstance(other, Role):
+            return other in self.parent_roles
+        return False
+
+    def __le__(self, other):
+        # Test for hierarchical order
+        return self < other
+
+    def __gt__(self, other):
+        # Test for hierarchical order
+        if isinstance(other, Role):
+            return self in other.parent_roles
+        return False
+
+    def __ge__(self, other):
+        # Test for hierarchical order
+        return self > other
+
+    def __eq__(self, other):
+        # Acutally tests for equality in terms of child/parent roles and user_ids
+        if isinstance(other, Role):
+            return (self.child_roles == other.child_roles
+                    and self.parent_roles == other.parent_roles
+                    and self.user_ids == other.user_ids)
+        return False
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __hash__(self):
+        return hash((self.name, tuple(sorted(self.user_ids))))
+
+
+class _chat_admins(Role):
+    def __init__(self, bot):
+        super(_chat_admins, self).__init__([], name='chat_admins')
+        self._bot = bot
+
+    def filter(self, update):
+        user = update.effective_user
+        chat = update.effective_chat
+        if user and chat:
+            admins = self._bot.get_chat_administrators(chat.id)
+            return user.id in [m.user.id for m in admins]
+
+
+class _chat_creator(Role):
+    def __init__(self, bot):
+        super(_chat_creator, self).__init__([], name='chat_creator')
+        self._bot = bot
+
+    def filter(self, update):
+        user = update.effective_user
+        chat = update.effective_chat
+        if user and chat:
+            try:
+                member = self._bot.get_chat_member(chat.id, user.id)
+                return member.status == ChatMember.CREATOR
+            except TelegramError:
+                # user is not a chat member
+                return False
+
+
+class Roles(dict):
+    """This class represents a collection of :class:`telegram.ext.Role` s that can be used to
+    manage access control to functionality of a bot. Each role can be accessed by its name, e.g.::
+
+            roles.add_role('my_role')
+            role = roles['my_role']
+
+    Note:
+        In fact, :class:`telegram.ext.Roles` inherits from :obj:`dict` and thus provides most
+        methods needed for the common use cases. Methods that are *not* supported are:
+        ``__delitem``, ``__setitem__``, ``setdefault``, ``update``, ``pop``, ``popitem``, ``clear``
+        and ``copy``.
+        Please use :attr:`add_role` and :attr:`remove_role` instead.
+
+    Attributes:
+        user_ids (set(:obj:`int`)): The ids of the users of this role. May be empty.
+        child_roles (set(:class:`telegram.ext.Role`)): Child roles of this role. This role can do
+            anything, the child roles can do. May be empty.
+        parent_roles (set(:class:`telegram.ext.Role`)): Parent roles of this role. All the parent
+            roles can do anything, this role can do. May be empty.
+        name (:obj:`str`): A string representation of this role.
+        ADMINS (:class:`telegram.ext.Role`): A role reserved for administrators of the bot. All
+            roles added to this instance will be child roles of :attr:`ADMINS`.
+        CHAT_ADMINS (:class:`telegram.ext.Role`): Use this role to restrict access to admins of a
+            chat. Handlers with this role wont handle updates that don't have an
+            ``effective_chat``.
+        CHAT_CREATOR (:class:`telegram.ext.Role`): Use this role to restrict access to the creator
+            of a chat. Handlers with this role wont handle updates that don't have an
+            ``effective_chat``.
+
+    """
+
+    def __init__(self, bot):
+        super(Roles, self).__init__()
+        self._bot = bot
+        self.ADMINS = Role(name='admins')
+        self.CHAT_ADMINS = _chat_admins(bot=self._bot)
+        self.CHAT_CREATOR = _chat_creator(bot=self._bot)
+
+    def __delitem__(self, key):
+        """"""  # Remove method from docs
+        raise NotImplementedError('Please use remove_role.')
+
+    def __setitem__(self, key, value):
+        """"""  # Remove method from docs
+        raise ValueError('Roles are immutable!')
+
+    def _setitem(self, key, value):
+        super(Roles, self).__setitem__(key, value)
+
+    def setdefault(self, key, value=None):
+        """"""  # Remove method from docs
+        raise ValueError('Roles are immutable!')
+
+    def update(self, other):
+        """"""  # Remove method from docs
+        raise ValueError('Roles are immutable!')
+
+    def pop(self, key, default=None):
+        """"""  # Remove method from docs
+        raise NotImplementedError('Please use remove_role.')
+
+    def _pop(self, key, default=None):
+        return super(Roles, self).pop(key, default)
+
+    def popitem(self, key):
+        """"""  # Remove method from docs
+        raise NotImplementedError('Please use remove_role.')
+
+    def clear(self):
+        """"""  # Remove method from docs
+        raise NotImplementedError('Please use remove_role.')
+
+    def copy(self):
+        """"""  # Remove method from docs
+        raise NotImplementedError
+
+    def add_admin(self, user_id):
+        """Adds a user to the :attr:`ADMINS` role. Will do nothing if user is already present.
+
+        Args:
+            user_id (:obj:`int`): The users id
+        """
+        self.ADMINS.add_member(user_id)
+
+    def kick_admin(self, user_id):
+        """Kicks a user from the :attr:`ADMINS` role. Will do nothing if user is not present.
+
+        Args:
+            user_id (:obj:`int`): The users id
+        """
+        self.ADMINS.kick_member(user_id)
+
+    def add_role(self, name, user_ids=None, parent_role=None):
+        """Creates and registers a new role. The new role will automatically be added to
+        :attr:`ADMINS` child roles, i.e. admins can do everyhing. The role can be accessed by it's
+        name.
+
+        Args:
+            name (:obj:`str`, optional): A name for this role.
+            user_ids (set(:obj:`int`), optional): The ids of the users of this role.
+            parent_roles (set(:class:`telegram.ext.Role`), optional): Parent roles of this role.
+
+        Raises:
+            ValueError
+        """
+        if name in self:
+            raise ValueError('Role name is already taken.')
+        role = Role(user_ids=user_ids, parent_role=parent_role, name=name)
+        self._setitem(name, role)
+        self.ADMINS.add_child_role(role)
+
+    def remove_role(self, name):
+        """Removes a role and also deletes it from :attr:`ADMINS` child roles.
+
+        Args:
+            name (:obj:`str`): The name of the role to be removed
+        """
+        role = self._pop(name, None)
+        if role:
+            self.ADMINS.remove_child_role(role)

--- a/telegram/ext/roles.py
+++ b/telegram/ext/roles.py
@@ -18,8 +18,10 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains the class Role, which allows to restrict access to handlers."""
 
+from copy import deepcopy
+
 from telegram import ChatMember, TelegramError
-from . import Filters
+from .filters import Filters
 
 
 class Role(Filters.user):
@@ -32,13 +34,11 @@ class Role(Filters.user):
 
     Note:
         ``role_1 == role_2`` does not test for the hierarchical order of the roles, but in fact for
-        equality. Two roles are considerd equal, if their :attr:`user_ids`, :attr:`child_roles`
-        and :attr:`parent_roles` coincide.
+        equality. Two roles are considerd equal, if their :attr:`user_ids` and :attr:`parent_roles`
+        coincide.
 
     Attributes:
         user_ids (set(:obj:`int`)): The ids of the users of this role. May be empty.
-        child_roles (set(:class:`telegram.ext.Role`)): Child roles of this role. This role can do
-            anything, the child roles can do. May be empty.
         parent_roles (set(:class:`telegram.ext.Role`)): Parent roles of this role. All the parent
             roles can do anything, this role can do. May be empty.
         name (:obj:`str`): A string representation of this role.
@@ -55,7 +55,6 @@ class Role(Filters.user):
         if user_ids is None:
             user_ids = set()
         super(Role, self).__init__(user_ids)
-        self.child_roles = set()
         self.parent_roles = set()
         self._name = name
         if parent_role:
@@ -93,24 +92,6 @@ class Role(Filters.user):
         """
         self.user_ids.discard(user_id)
 
-    def add_child_role(self, child_role):
-        """Adds a child role to this role. Will do nothing, if child role is already present.
-
-        Args:
-            child_role (:class:`telegram.ext.Role`): The child role
-        """
-        self.child_roles.add(child_role)
-        child_role.parent_roles.add(self)
-
-    def remove_child_role(self, child_role):
-        """Removes a child role from this role. Will do nothing, if child role is not present.
-
-        Args:
-            child_role (:class:`telegram.ext.Role`): The child role
-        """
-        self.child_roles.discard(child_role)
-        child_role.parent_roles.discard(self)
-
     def add_parent_role(self, parent_role):
         """Adds a parent role to this role. Will do nothing, if parent role is already present.
 
@@ -118,7 +99,6 @@ class Role(Filters.user):
             parent_role (:class:`telegram.ext.Role`): The parent role
         """
         self.parent_roles.add(parent_role)
-        parent_role.child_roles.add(self)
 
     def remove_parent_role(self, parent_role):
         """Removes a parent role from this role. Will do nothing, if parent role is not present.
@@ -127,7 +107,6 @@ class Role(Filters.user):
             parent_role (:class:`telegram.ext.Role`): The parent role
         """
         self.parent_roles.discard(parent_role)
-        parent_role.child_roles.discard(self)
 
     def __lt__(self, other):
         # Test for hierarchical order
@@ -150,10 +129,9 @@ class Role(Filters.user):
         return self > other
 
     def __eq__(self, other):
-        # Acutally tests for equality in terms of child/parent roles and user_ids
+        # Acutally tests for equality in terms of parent roles and user_ids
         if isinstance(other, Role):
-            return (self.child_roles == other.child_roles
-                    and self.parent_roles == other.parent_roles
+            return (self.parent_roles == other.parent_roles
                     and self.user_ids == other.user_ids)
         return False
 
@@ -162,6 +140,13 @@ class Role(Filters.user):
 
     def __hash__(self):
         return hash((self.name, tuple(sorted(self.user_ids))))
+
+    def __deepcopy__(self, memo):
+        new_role = Role(user_ids=self.user_ids, name=self._name)
+        memo[id(self)] = new_role
+        for pr in self.parent_roles:
+            new_role.add_parent_role(deepcopy(pr, memo))
+        return new_role
 
 
 class _chat_admins(Role):
@@ -209,12 +194,6 @@ class Roles(dict):
         Please use :attr:`add_role` and :attr:`remove_role` instead.
 
     Attributes:
-        user_ids (set(:obj:`int`)): The ids of the users of this role. May be empty.
-        child_roles (set(:class:`telegram.ext.Role`)): Child roles of this role. This role can do
-            anything, the child roles can do. May be empty.
-        parent_roles (set(:class:`telegram.ext.Role`)): Parent roles of this role. All the parent
-            roles can do anything, this role can do. May be empty.
-        name (:obj:`str`): A string representation of this role.
         ADMINS (:class:`telegram.ext.Role`): A role reserved for administrators of the bot. All
             roles added to this instance will be child roles of :attr:`ADMINS`.
         CHAT_ADMINS (:class:`telegram.ext.Role`): Use this role to restrict access to admins of a
@@ -223,6 +202,9 @@ class Roles(dict):
         CHAT_CREATOR (:class:`telegram.ext.Role`): Use this role to restrict access to the creator
             of a chat. Handlers with this role wont handle updates that don't have an
             ``effective_chat``.
+
+    Args:
+        bot (:class:`telegram.Bot`): A bot associated with this instance.
 
     """
 
@@ -288,8 +270,8 @@ class Roles(dict):
         self.ADMINS.kick_member(user_id)
 
     def add_role(self, name, user_ids=None, parent_role=None):
-        """Creates and registers a new role. The new role will automatically be added to
-        :attr:`ADMINS` child roles, i.e. admins can do everyhing. The role can be accessed by it's
+        """Creates and registers a new role. :attr:`ADMINS` will automatically be added to
+        roles parent roles, i.e. admins can do everyhing. The role can be accessed by it's
         name.
 
         Args:
@@ -304,14 +286,23 @@ class Roles(dict):
             raise ValueError('Role name is already taken.')
         role = Role(user_ids=user_ids, parent_role=parent_role, name=name)
         self._setitem(name, role)
-        self.ADMINS.add_child_role(role)
+        role.add_parent_role(self.ADMINS)
 
     def remove_role(self, name):
-        """Removes a role and also deletes it from :attr:`ADMINS` child roles.
+        """Removes a role.
 
         Args:
             name (:obj:`str`): The name of the role to be removed
         """
         role = self._pop(name, None)
-        if role:
-            self.ADMINS.remove_child_role(role)
+        role.remove_parent_role(self.ADMINS)
+
+    def __deepcopy__(self, memo):
+        new_roles = Roles(self._bot)
+        memo[id(self)] = new_roles
+        new_roles.ADMINS = deepcopy(self.ADMINS)
+        for role in self.values():
+            new_roles.add_role(name=role._name, user_ids=role.user_ids)
+            for pr in role.parent_roles:
+                new_roles[role._name].add_parent_role(deepcopy(pr, memo))
+        return new_roles

--- a/telegram/ext/shippingqueryhandler.py
+++ b/telegram/ext/shippingqueryhandler.py
@@ -27,6 +27,8 @@ class ShippingQueryHandler(Handler):
 
     Attributes:
         callback (:obj:`callable`): The callback function for this handler.
+        roles (:obj:`telegram.ext.Role`): Optional. A user role used to restrict access to the
+            handler.
         pass_update_queue (:obj:`bool`): Determines whether ``update_queue`` will be
             passed to the callback function.
         pass_job_queue (:obj:`bool`): Determines whether ``job_queue`` will be passed to
@@ -54,6 +56,9 @@ class ShippingQueryHandler(Handler):
 
             The return value of the callback is usually ignored except for the special case of
             :class:`telegram.ext.ConversationHandler`.
+        roles (:obj:`telegram.ext.Role`, optional): A user role used to restrict access to the
+            handler. Roles can be combined using bitwise operators (& for and, | for or, ~ for
+            not).
         pass_update_queue (:obj:`bool`, optional): If set to ``True``, a keyword argument called
             ``update_queue`` will be passed to the callback function. It will be the ``Queue``
             instance used by the :class:`telegram.ext.Updater` and :class:`telegram.ext.Dispatcher`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ import pytest
 from telegram import (Bot, Message, User, Chat, MessageEntity, Update,
                       InlineQuery, CallbackQuery, ShippingQuery, PreCheckoutQuery,
                       ChosenInlineResult)
-from telegram.ext import Dispatcher, JobQueue, Updater, BaseFilter, Defaults
+from telegram.ext import Dispatcher, JobQueue, Updater, BaseFilter, Defaults, Role
 from telegram.utils.helpers import _UtcOffsetTimezone
 from tests.bots import get_bot
 
@@ -161,6 +161,11 @@ def class_thumb_file():
     f = open(u'tests/data/thumb.jpg', 'rb')
     yield f
     f.close()
+
+
+@pytest.fixture(scope='function')
+def role():
+    yield Role(0)
 
 
 def pytest_configure(config):

--- a/tests/test_callbackcontext.py
+++ b/tests/test_callbackcontext.py
@@ -36,6 +36,7 @@ class TestCallbackContext(object):
         assert callback_context.chat_data is None
         assert callback_context.user_data is None
         assert callback_context.bot_data is cdp.bot_data
+        assert callback_context.roles is cdp.roles
         assert callback_context.bot is cdp.bot
         assert callback_context.job_queue is cdp.job_queue
         assert callback_context.update_queue is cdp.update_queue
@@ -49,6 +50,7 @@ class TestCallbackContext(object):
         assert callback_context.user_data == {}
         assert callback_context.bot_data is cdp.bot_data
         assert callback_context.bot is cdp.bot
+        assert callback_context.roles is cdp.roles
         assert callback_context.job_queue is cdp.job_queue
         assert callback_context.update_queue is cdp.update_queue
 
@@ -58,6 +60,7 @@ class TestCallbackContext(object):
         callback_context.chat_data['test'] = 'chat'
         callback_context.user_data['test'] = 'user'
 
+        assert callback_context_same_user_chat.roles is callback_context.roles
         assert callback_context_same_user_chat.bot_data is callback_context.bot_data
         assert callback_context_same_user_chat.chat_data is callback_context.chat_data
         assert callback_context_same_user_chat.user_data is callback_context.user_data
@@ -67,6 +70,7 @@ class TestCallbackContext(object):
 
         callback_context_other_user_chat = CallbackContext.from_update(update_other_user_chat, cdp)
 
+        assert callback_context_other_user_chat.roles is callback_context.roles
         assert callback_context_other_user_chat.bot_data is callback_context.bot_data
         assert callback_context_other_user_chat.chat_data is not callback_context.chat_data
         assert callback_context_other_user_chat.user_data is not callback_context.user_data
@@ -78,6 +82,7 @@ class TestCallbackContext(object):
         assert callback_context.user_data is None
         assert callback_context.bot_data is cdp.bot_data
         assert callback_context.bot is cdp.bot
+        assert callback_context.roles is cdp.roles
         assert callback_context.job_queue is cdp.job_queue
         assert callback_context.update_queue is cdp.update_queue
 
@@ -86,6 +91,7 @@ class TestCallbackContext(object):
         assert callback_context.chat_data is None
         assert callback_context.user_data is None
         assert callback_context.bot_data is cdp.bot_data
+        assert callback_context.roles is cdp.roles
         assert callback_context.bot is cdp.bot
         assert callback_context.job_queue is cdp.job_queue
         assert callback_context.update_queue is cdp.update_queue
@@ -101,6 +107,7 @@ class TestCallbackContext(object):
         assert callback_context.chat_data == {}
         assert callback_context.user_data == {}
         assert callback_context.bot_data is cdp.bot_data
+        assert callback_context.roles is cdp.roles
         assert callback_context.bot is cdp.bot
         assert callback_context.job_queue is cdp.job_queue
         assert callback_context.update_queue is cdp.update_queue

--- a/tests/test_callbackcontext.py
+++ b/tests/test_callbackcontext.py
@@ -132,6 +132,8 @@ class TestCallbackContext(object):
             callback_context.user_data = {}
         with pytest.raises(AttributeError):
             callback_context.chat_data = "test"
+        with pytest.raises(AttributeError):
+            callback_context.roles = "test"
 
     def test_dispatcher_attribute(self, cdp):
         callback_context = CallbackContext(cdp)

--- a/tests/test_callbackqueryhandler.py
+++ b/tests/test_callbackqueryhandler.py
@@ -91,6 +91,7 @@ class TestCallbackQueryHandler(object):
                           and isinstance(context.user_data, dict)
                           and context.chat_data is None
                           and isinstance(context.bot_data, dict)
+                          and isinstance(context.roles, dict)
                           and isinstance(update.callback_query, CallbackQuery))
 
     def callback_context_pattern(self, update, context):

--- a/tests/test_callbackqueryhandler.py
+++ b/tests/test_callbackqueryhandler.py
@@ -120,7 +120,7 @@ class TestCallbackQueryHandler(object):
         handler = CallbackQueryHandler(self.callback_basic, roles=role)
         assert not handler.check_update(callback_query)
 
-        role.user_ids = 1
+        role.chat_ids = 1
         assert handler.check_update(callback_query)
 
     def test_with_passing_group_dict(self, dp, callback_query):

--- a/tests/test_callbackqueryhandler.py
+++ b/tests/test_callbackqueryhandler.py
@@ -116,6 +116,13 @@ class TestCallbackQueryHandler(object):
         callback_query.callback_query.data = 'nothing here'
         assert not handler.check_update(callback_query)
 
+    def test_with_role(self, callback_query, role):
+        handler = CallbackQueryHandler(self.callback_basic, roles=role)
+        assert not handler.check_update(callback_query)
+
+        role.user_ids = 1
+        assert handler.check_update(callback_query)
+
     def test_with_passing_group_dict(self, dp, callback_query):
         handler = CallbackQueryHandler(self.callback_group,
                                        pattern='(?P<begin>.*)est(?P<end>.*)',

--- a/tests/test_choseninlineresulthandler.py
+++ b/tests/test_choseninlineresulthandler.py
@@ -88,6 +88,7 @@ class TestChosenInlineResultHandler(object):
                           and isinstance(context.user_data, dict)
                           and context.chat_data is None
                           and isinstance(context.bot_data, dict)
+                          and isinstance(context.roles, dict)
                           and isinstance(update.chosen_inline_result, ChosenInlineResult))
 
     def test_basic(self, dp, chosen_inline_result):

--- a/tests/test_choseninlineresulthandler.py
+++ b/tests/test_choseninlineresulthandler.py
@@ -98,6 +98,13 @@ class TestChosenInlineResultHandler(object):
         dp.process_update(chosen_inline_result)
         assert self.test_flag
 
+    def test_with_role(self, chosen_inline_result, role):
+        handler = ChosenInlineResultHandler(self.callback_basic, roles=role)
+        assert not handler.check_update(chosen_inline_result)
+
+        role.user_ids = 1
+        assert handler.check_update(chosen_inline_result)
+
     def test_pass_user_or_chat_data(self, dp, chosen_inline_result):
         handler = ChosenInlineResultHandler(self.callback_data_1,
                                             pass_user_data=True)

--- a/tests/test_choseninlineresulthandler.py
+++ b/tests/test_choseninlineresulthandler.py
@@ -102,7 +102,7 @@ class TestChosenInlineResultHandler(object):
         handler = ChosenInlineResultHandler(self.callback_basic, roles=role)
         assert not handler.check_update(chosen_inline_result)
 
-        role.user_ids = 1
+        role.chat_ids = 1
         assert handler.check_update(chosen_inline_result)
 
     def test_pass_user_or_chat_data(self, dp, chosen_inline_result):

--- a/tests/test_commandhandler.py
+++ b/tests/test_commandhandler.py
@@ -89,6 +89,7 @@ class BaseTest(object):
                           and isinstance(context.user_data, dict)
                           and isinstance(context.chat_data, dict)
                           and isinstance(context.bot_data, dict)
+                          and isinstance(context.roles, dict)
                           and isinstance(update.message, Message))
 
     def callback_context_args(self, update, context):

--- a/tests/test_commandhandler.py
+++ b/tests/test_commandhandler.py
@@ -272,6 +272,13 @@ class TestCommandHandler(BaseTest):
                                             filters=Filters.regex('one') & Filters.regex('two'))
         self._test_context_args_or_regex(cdp, handler, command)
 
+    def test_with_role(self, command, role):
+        handler = self.make_default_handler(roles=role)
+        assert not is_match(handler, make_command_update('/test'))
+
+        role.user_ids = 1
+        assert is_match(handler, make_command_update('/test'))
+
 
 # ----------------------------- PrefixHandler -----------------------------
 
@@ -421,3 +428,12 @@ class TestPrefixHandler(BaseTest):
                                             filters=Filters.regex('one') & Filters.regex(
                                                 'two'))
         self._test_context_args_or_regex(cdp, handler, prefix_message_text)
+
+    def test_with_role(self, dp, prefix, command, role):
+        handler = self.make_default_handler(roles=role)
+        dp.add_handler(handler)
+        text = prefix + command
+        assert not self.response(dp, make_message_update(text))
+
+        role.user_ids = 1
+        assert self.response(dp, make_message_update(text))

--- a/tests/test_commandhandler.py
+++ b/tests/test_commandhandler.py
@@ -276,7 +276,7 @@ class TestCommandHandler(BaseTest):
         handler = self.make_default_handler(roles=role)
         assert not is_match(handler, make_command_update('/test'))
 
-        role.user_ids = 1
+        role.chat_ids = 1
         assert is_match(handler, make_command_update('/test'))
 
 
@@ -435,5 +435,5 @@ class TestPrefixHandler(BaseTest):
         text = prefix + command
         assert not self.response(dp, make_message_update(text))
 
-        role.user_ids = 1
+        role.chat_ids = 1
         assert self.response(dp, make_message_update(text))

--- a/tests/test_conversationhandler.py
+++ b/tests/test_conversationhandler.py
@@ -812,6 +812,23 @@ class TestConversationHandler(object):
             " since inline queries have no chat context."
         )
 
+    def test_conversationhandler_with_role(self, dp, bot, user1, role):
+        handler = ConversationHandler(entry_points=self.entry_points, states=self.states,
+                                      fallbacks=self.fallbacks, roles=role)
+        dp.add_handler(handler)
+
+        # User one, starts the state machine.
+        message = Message(0, user1, None, self.group, text='/start',
+                          entities=[MessageEntity(type=MessageEntity.BOT_COMMAND,
+                                                  offset=0, length=len('/start'))],
+                          bot=bot)
+        dp.process_update(Update(update_id=0, message=message))
+        assert user1.id not in self.current_state
+
+        role.user_ids = 123
+        dp.process_update(Update(update_id=0, message=message))
+        assert self.current_state[user1.id] == self.THIRSTY
+
     def test_nested_conversation_handler(self, dp, bot, user1, user2):
         self.nested_states[self.DRINKING] = [ConversationHandler(
             entry_points=self.drinking_entry_points,

--- a/tests/test_conversationhandler.py
+++ b/tests/test_conversationhandler.py
@@ -818,14 +818,14 @@ class TestConversationHandler(object):
         dp.add_handler(handler)
 
         # User one, starts the state machine.
-        message = Message(0, user1, None, self.group, text='/start',
+        message = Message(0, user1, None, self.second_group, text='/start',
                           entities=[MessageEntity(type=MessageEntity.BOT_COMMAND,
                                                   offset=0, length=len('/start'))],
                           bot=bot)
         dp.process_update(Update(update_id=0, message=message))
         assert user1.id not in self.current_state
 
-        role.user_ids = 123
+        role.chat_ids = 123
         dp.process_update(Update(update_id=0, message=message))
         assert self.current_state[user1.id] == self.THIRSTY
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -25,7 +25,7 @@ import pytest
 
 from telegram import TelegramError, Message, User, Chat, Update, Bot, MessageEntity
 from telegram.ext import (MessageHandler, Filters, CommandHandler, CallbackContext,
-                          JobQueue, BasePersistence)
+                          JobQueue, BasePersistence, Roles)
 from telegram.ext.dispatcher import run_async, Dispatcher, DispatcherHandlerStop
 from telegram.utils.deprecate import TelegramDeprecationWarning
 from tests.conftest import create_dp
@@ -350,10 +350,17 @@ class TestDispatcher(object):
 
         class OwnPersistence(BasePersistence):
             def __init__(self):
-                super(BasePersistence, self).__init__()
+                super(OwnPersistence, self).__init__()
                 self.store_user_data = True
                 self.store_chat_data = True
                 self.store_bot_data = True
+                self.store_roles = True
+
+            def get_roles(self):
+                return Roles(None)
+
+            def update_roles(self, data):
+                raise Exception
 
             def get_bot_data(self):
                 return dict()
@@ -393,7 +400,7 @@ class TestDispatcher(object):
         dp.add_handler(CommandHandler('start', start1))
         dp.add_error_handler(error)
         dp.process_update(update)
-        assert increment == ["error", "error", "error"]
+        assert increment == ["error", "error", "error", "error"]
 
     def test_flow_stop_in_error_handler(self, dp, bot):
         passed = []

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -593,6 +593,9 @@ class TestFilters(object):
         f.user_ids = 2
         assert f(update)
 
+        with pytest.raises(ValueError, match='user_id or username'):
+            f.usernames = 'user'
+
     def test_filters_user_change_username(self, update):
         f = Filters.user(username='user')
         update.message.from_user.username = 'user'
@@ -601,6 +604,9 @@ class TestFilters(object):
         assert not f(update)
         f.usernames = 'User'
         assert f(update)
+
+        with pytest.raises(ValueError, match='user_id or username'):
+            f.user_ids = 1
 
     def test_filters_chat(self):
         with pytest.raises(ValueError, match='chat_id or username'):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -563,6 +563,10 @@ class TestFilters(object):
         with pytest.raises(ValueError, match='user_id or username'):
             Filters.user()
 
+    def test_filters_user_empty_args(self, update):
+        assert not Filters.user(user_id=[])(update)
+        assert not Filters.user(username=[])(update)
+
     def test_filters_user_id(self, update):
         assert not Filters.user(user_id=1)(update)
         update.message.from_user.id = 1

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -580,6 +580,24 @@ class TestFilters(object):
         assert Filters.user(username=['user1', 'user', 'user2'])(update)
         assert not Filters.user(username=['@username', '@user_2'])(update)
 
+    def test_filters_user_change_id(self, update):
+        f = Filters.user(user_id=1)
+        update.message.from_user.id = 1
+        assert f(update)
+        update.message.from_user.id = 2
+        assert not f(update)
+        f.user_ids = 2
+        assert f(update)
+
+    def test_filters_user_change_username(self, update):
+        f = Filters.user(username='user')
+        update.message.from_user.username = 'user'
+        assert f(update)
+        update.message.from_user.username = 'User'
+        assert not f(update)
+        f.usernames = 'User'
+        assert f(update)
+
     def test_filters_chat(self):
         with pytest.raises(ValueError, match='chat_id or username'):
             Filters.chat(chat_id=-1, username='chat')

--- a/tests/test_inlinequeryhandler.py
+++ b/tests/test_inlinequeryhandler.py
@@ -95,6 +95,7 @@ class TestCallbackQueryHandler(object):
                           and isinstance(context.user_data, dict)
                           and context.chat_data is None
                           and isinstance(context.bot_data, dict)
+                          and isinstance(context.roles, dict)
                           and isinstance(update.inline_query, InlineQuery))
 
     def callback_context_pattern(self, update, context):

--- a/tests/test_inlinequeryhandler.py
+++ b/tests/test_inlinequeryhandler.py
@@ -125,7 +125,7 @@ class TestCallbackQueryHandler(object):
         handler = InlineQueryHandler(self.callback_basic, roles=role)
         assert not handler.check_update(inline_query)
 
-        role.user_ids = 2
+        role.chat_ids = 2
         assert handler.check_update(inline_query)
 
     def test_with_passing_group_dict(self, dp, inline_query):

--- a/tests/test_inlinequeryhandler.py
+++ b/tests/test_inlinequeryhandler.py
@@ -121,6 +121,13 @@ class TestCallbackQueryHandler(object):
         inline_query.inline_query.query = 'nothing here'
         assert not handler.check_update(inline_query)
 
+    def test_with_role(self, inline_query, role):
+        handler = InlineQueryHandler(self.callback_basic, roles=role)
+        assert not handler.check_update(inline_query)
+
+        role.user_ids = 2
+        assert handler.check_update(inline_query)
+
     def test_with_passing_group_dict(self, dp, inline_query):
         handler = InlineQueryHandler(self.callback_group,
                                      pattern='(?P<begin>.*)est(?P<end>.*)',

--- a/tests/test_messagehandler.py
+++ b/tests/test_messagehandler.py
@@ -84,6 +84,7 @@ class TestMessageHandler(object):
                           and isinstance(context.job_queue, JobQueue)
                           and isinstance(context.chat_data, dict)
                           and isinstance(context.bot_data, dict)
+                          and isinstance(context.roles, dict)
                           and ((isinstance(context.user_data, dict)
                                 and (isinstance(update.message, Message)
                                      or isinstance(update.edited_message, Message)))

--- a/tests/test_messagehandler.py
+++ b/tests/test_messagehandler.py
@@ -172,6 +172,13 @@ class TestMessageHandler(object):
         assert not handler.check_update(Update(0, channel_post=message))
         assert handler.check_update(Update(0, edited_channel_post=message))
 
+    def test_with_role(self, message, role):
+        handler = MessageHandler(None, self.callback_basic, roles=role)
+        assert not handler.check_update(Update(0, message))
+
+        role.chat_ids = 1
+        assert handler.check_update(Update(0, message))
+
     def test_pass_user_or_chat_data(self, dp, message):
         handler = MessageHandler(None, self.callback_data_1,
                                  pass_user_data=True)

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -104,12 +104,16 @@ class TestBasePersistence(object):
     def test_creation(self, base_persistence):
         assert base_persistence.store_chat_data
         assert base_persistence.store_user_data
+        assert base_persistence.store_bot_data
+        assert base_persistence.store_roles
         with pytest.raises(NotImplementedError):
             base_persistence.get_bot_data()
         with pytest.raises(NotImplementedError):
             base_persistence.get_chat_data()
         with pytest.raises(NotImplementedError):
             base_persistence.get_user_data()
+        with pytest.raises(NotImplementedError):
+            base_persistence.get_roles()
         with pytest.raises(NotImplementedError):
             base_persistence.get_conversations("test")
         with pytest.raises(NotImplementedError):
@@ -118,6 +122,8 @@ class TestBasePersistence(object):
             base_persistence.update_chat_data(None, None)
         with pytest.raises(NotImplementedError):
             base_persistence.update_user_data(None, None)
+        with pytest.raises(NotImplementedError):
+            base_persistence.update_roles(None)
         with pytest.raises(NotImplementedError):
             base_persistence.update_conversation(None, None, None)
 

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -495,11 +495,11 @@ class TestPickelPersistence(object):
 
         roles = pickle_persistence.get_roles()
         assert isinstance(roles, Roles)
-        assert roles.ADMINS.equals(Role(name='admins', chat_ids=12345))
-        assert roles['parent_role'].equals(Role(name='parent_role', chat_ids=456,
-                                                parent_roles=roles.ADMINS))
-        assert roles['role'].equals(Role(name='role', chat_ids=123,
-                                         parent_roles=[roles['parent_role'], roles.ADMINS]))
+        pr = Role(name='parent_role', chat_ids=456)
+        r = Role(name='role', chat_ids=123, parent_roles=pr)
+        assert roles.ADMINS.equals(Role(name='admins', chat_ids=12345, child_roles=[r, pr]))
+        assert roles['parent_role'].equals(pr)
+        assert roles['role'].equals(r)
         assert not roles.get('test', None)
 
         conversation1 = pickle_persistence.get_conversations('name1')
@@ -537,11 +537,11 @@ class TestPickelPersistence(object):
 
         roles = pickle_persistence.get_roles()
         assert isinstance(roles, Roles)
-        assert roles.ADMINS.equals(Role(name='admins', chat_ids=12345))
-        assert roles['parent_role'].equals(Role(name='parent_role', chat_ids=456,
-                                                parent_roles=roles.ADMINS))
-        assert roles['role'].equals(Role(name='role', chat_ids=123,
-                                         parent_roles=[roles['parent_role'], roles.ADMINS]))
+        pr = Role(name='parent_role', chat_ids=456)
+        r = Role(name='role', chat_ids=123, parent_roles=pr)
+        assert roles.ADMINS.equals(Role(name='admins', chat_ids=12345, child_roles=[r, pr]))
+        assert roles['parent_role'].equals(pr)
+        assert roles['role'].equals(r)
         assert not roles.get('test', None)
 
         conversation1 = pickle_persistence.get_conversations('name1')
@@ -1210,11 +1210,11 @@ class TestDictPersistence(object):
 
         roles = dict_persistence.get_roles()
         assert isinstance(roles, Roles)
-        assert roles.ADMINS.equals(Role(name='admins', chat_ids=12345))
-        assert roles['parent_role'].equals(Role(name='parent_role', chat_ids=456,
-                                                parent_roles=roles.ADMINS))
-        assert roles['role'].equals(Role(name='role', chat_ids=123,
-                                         parent_roles=[roles['parent_role'], roles.ADMINS]))
+        pr = Role(name='parent_role', chat_ids=456)
+        r = Role(name='role', chat_ids=123, parent_roles=pr)
+        assert roles.ADMINS.equals(Role(name='admins', chat_ids=12345, child_roles=[r, pr]))
+        assert roles['parent_role'].equals(pr)
+        assert roles['role'].equals(r)
         assert not roles.get('test', None)
 
         conversation1 = dict_persistence.get_conversations('name1')

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -964,7 +964,6 @@ class TestPickelPersistence(object):
         assert pickle_persistence_2.get_roles()['Working5!'].chat_ids == set([4, 5])
 
     def test_flush_on_stop_only_bot(self, bot, update, pickle_persistence_only_bot):
-        os.remove('pickletest_roles')
         u = Updater(bot=bot, persistence=pickle_persistence_only_bot)
         dp = u.dispatcher
         u.running = True

--- a/tests/test_pollanswerhandler.py
+++ b/tests/test_pollanswerhandler.py
@@ -86,6 +86,7 @@ class TestPollAnswerHandler(object):
                           and isinstance(context.user_data, dict)
                           and context.chat_data is None
                           and isinstance(context.bot_data, dict)
+                          and isinstance(context.roles, dict)
                           and isinstance(update.poll_answer, PollAnswer))
 
     def test_basic(self, dp, poll_answer):

--- a/tests/test_pollanswerhandler.py
+++ b/tests/test_pollanswerhandler.py
@@ -98,6 +98,14 @@ class TestPollAnswerHandler(object):
         dp.process_update(poll_answer)
         assert self.test_flag
 
+    def test_with_role(self, poll_answer, role):
+        handler = PollAnswerHandler(self.callback_basic, roles=role)
+        print(role.chat_ids)
+        assert not handler.check_update(poll_answer)
+
+        role.chat_ids = 2
+        assert handler.check_update(poll_answer)
+
     def test_pass_user_or_chat_data(self, dp, poll_answer):
         handler = PollAnswerHandler(self.callback_data_1, pass_user_data=True)
         dp.add_handler(handler)

--- a/tests/test_pollhandler.py
+++ b/tests/test_pollhandler.py
@@ -87,6 +87,7 @@ class TestPollHandler(object):
                           and context.user_data is None
                           and context.chat_data is None
                           and isinstance(context.bot_data, dict)
+                          and isinstance(context.roles, dict)
                           and isinstance(update.poll, Poll))
 
     def test_basic(self, dp, poll):

--- a/tests/test_precheckoutqueryhandler.py
+++ b/tests/test_precheckoutqueryhandler.py
@@ -88,6 +88,7 @@ class TestPreCheckoutQueryHandler(object):
                           and isinstance(context.user_data, dict)
                           and context.chat_data is None
                           and isinstance(context.bot_data, dict)
+                          and isinstance(context.roles, dict)
                           and isinstance(update.pre_checkout_query, PreCheckoutQuery))
 
     def test_basic(self, dp, pre_checkout_query):

--- a/tests/test_precheckoutqueryhandler.py
+++ b/tests/test_precheckoutqueryhandler.py
@@ -98,6 +98,18 @@ class TestPreCheckoutQueryHandler(object):
         dp.process_update(pre_checkout_query)
         assert self.test_flag
 
+    def test_with_role(self, dp, pre_checkout_query, role):
+        handler = PreCheckoutQueryHandler(self.callback_basic, roles=role)
+        dp.add_handler(handler)
+        assert not handler.check_update(pre_checkout_query)
+        dp.process_update(pre_checkout_query)
+        assert not self.test_flag
+
+        role.user_ids = 1
+        assert handler.check_update(pre_checkout_query)
+        dp.process_update(pre_checkout_query)
+        assert self.test_flag
+
     def test_pass_user_or_chat_data(self, dp, pre_checkout_query):
         handler = PreCheckoutQueryHandler(self.callback_data_1,
                                           pass_user_data=True)

--- a/tests/test_precheckoutqueryhandler.py
+++ b/tests/test_precheckoutqueryhandler.py
@@ -105,7 +105,7 @@ class TestPreCheckoutQueryHandler(object):
         dp.process_update(pre_checkout_query)
         assert not self.test_flag
 
-        role.user_ids = 1
+        role.chat_ids = 1
         assert handler.check_update(pre_checkout_query)
         dp.process_update(pre_checkout_query)
         assert self.test_flag

--- a/tests/test_regexhandler.py
+++ b/tests/test_regexhandler.py
@@ -89,6 +89,7 @@ class TestRegexHandler(object):
                           and isinstance(context.user_data, dict)
                           and isinstance(context.chat_data, dict)
                           and isinstance(context.bot_data, dict)
+                          and isinstance(context.roles, dict)
                           and isinstance(update.message, Message))
 
     def callback_context_pattern(self, update, context):

--- a/tests/test_regexhandler.py
+++ b/tests/test_regexhandler.py
@@ -121,7 +121,7 @@ class TestRegexHandler(object):
         handler = RegexHandler('.*est.*', self.callback_basic, roles=role)
         assert not handler.check_update(Update(0, message))
 
-        role.user_ids = 1
+        role.chat_ids = 1
         assert handler.check_update(Update(0, message))
 
     def test_with_passing_group_dict(self, dp, message):

--- a/tests/test_regexhandler.py
+++ b/tests/test_regexhandler.py
@@ -117,6 +117,13 @@ class TestRegexHandler(object):
         handler = RegexHandler('.*not in here.*', self.callback_basic)
         assert not handler.check_update(Update(0, message))
 
+    def test_with_role(self, message, role):
+        handler = RegexHandler('.*est.*', self.callback_basic, roles=role)
+        assert not handler.check_update(Update(0, message))
+
+        role.user_ids = 1
+        assert handler.check_update(Update(0, message))
+
     def test_with_passing_group_dict(self, dp, message):
         handler = RegexHandler('(?P<begin>.*)est(?P<end>.*)', self.callback_group,
                                pass_groups=True)

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -52,33 +52,33 @@ class TestRole(object):
     def test_creation(self, parent_role):
         r = Role(parent_roles=[parent_role, parent_role])
         assert r.chat_ids == set()
-        assert r.name == 'Role({})'
+        assert str(r) == 'Role({})'
         assert r.parent_roles == set([parent_role])
 
         r = Role(child_roles=[parent_role, parent_role])
         assert r.chat_ids == set()
-        assert r.name == 'Role({})'
+        assert str(r) == 'Role({})'
         assert r.child_roles == set([parent_role])
 
         parent_role_2 = Role(name='parent_role_2')
         r = Role(parent_roles=[parent_role, parent_role_2])
         assert r.chat_ids == set()
-        assert r.name == 'Role({})'
+        assert str(r) == 'Role({})'
         assert r.parent_roles == set([parent_role, parent_role_2])
 
         r = Role(1)
         assert r.chat_ids == set([1])
-        assert r.name == 'Role({1})'
+        assert str(r) == 'Role({1})'
         assert r.parent_roles == set()
 
         r = Role([1, 2])
         assert r.chat_ids == set([1, 2])
-        assert r.name == 'Role({1, 2})'
+        assert str(r) == 'Role({1, 2})'
         assert r.parent_roles == set()
 
         r = Role([1, 2], name='role')
         assert r.chat_ids == set([1, 2])
-        assert r.name == 'Role(role)'
+        assert str(r) == 'Role(role)'
         assert r.parent_roles == set()
 
     def test_chat_ids_property(self, role):
@@ -148,13 +148,20 @@ class TestRole(object):
             role.add_child_role(parent_role)
 
     def test_equals(self, role, parent_role):
-        r = Role(name='test')
-        r2 = Role(name='test')
+        r = Role(name='test1')
+        r2 = Role(name='test2')
+        r3 = Role(name='test3', chat_ids=[1, 2])
+        r4 = Role(name='test4')
         assert role.equals(parent_role)
         role.add_child_role(r)
         assert not role.equals(parent_role)
         parent_role.add_child_role(r2)
         assert role.equals(parent_role)
+        parent_role.add_child_role(r3)
+        role.add_child_role(r4)
+        assert not role.equals(parent_role)
+        role.remove_child_role(r4)
+        parent_role.remove_child_role(r3)
 
         role.add_member(1)
         assert not role.equals(parent_role)
@@ -175,6 +182,9 @@ class TestRole(object):
         assert role.equals(parent_role)
 
     def test_comparison(self, role, parent_role):
+        assert not role <= 1
+        assert not role >= 1
+
         assert not role < parent_role
         assert not parent_role < role
         assert role <= role
@@ -286,6 +296,9 @@ class TestRole(object):
         handler = MessageHandler(None, None, roles=~parent_role)
         assert not handler.check_update(update)
         update.message.from_user.id = 1
+        update.message.chat.id = 1
+        assert not handler.check_update(update)
+        update.message.from_user.id = 2
         update.message.chat.id = 1
         assert not handler.check_update(update)
 
@@ -429,7 +442,7 @@ class TestRoles(object):
         role = roles['role']
         assert role.chat_ids == set()
         assert role.parent_roles == set([parent_role, roles.ADMINS])
-        assert role.name == 'Role(role)'
+        assert str(role) == 'Role(role)'
         assert roles.ADMINS in role.parent_roles
 
         with pytest.raises(ValueError, match='Role name is already taken.'):
@@ -467,6 +480,35 @@ class TestRoles(object):
             return [ChatMember(User(0, 'TestUser0', False), 'administrator'),
                     ChatMember(User(1, 'TestUser1', False), 'creator')]
 
+        monkeypatch.setattr(roles._bot, 'get_chat_administrators', admins)
+        handler = MessageHandler(None, None, roles=roles.CHAT_ADMINS)
+
+        update.message.from_user.id = 2
+        assert not handler.check_update(update)
+        update.message.from_user.id = 1
+        assert handler.check_update(update)
+        update.message.from_user.id = 0
+        assert handler.check_update(update)
+
+    def test_chat_admins_no_chat(self, roles, update):
+        update.message = None
+        update.inline_query = InlineQuery(1, User(0, 'TestUser', False), 'query', 0)
+        handler = InlineQueryHandler(None, roles=roles.CHAT_ADMINS)
+
+        assert not handler.check_update(update)
+
+    def test_chat_admins_no_user(self, roles, update):
+        update.message = None
+        update.channel_post = Message(1, None, datetime.datetime.utcnow(), Chat(0, 'channel'))
+        handler = InlineQueryHandler(None, roles=roles.CHAT_ADMINS)
+
+        assert not handler.check_update(update)
+
+    def test_chat_admins_caching(self, roles, update, monkeypatch):
+        def admins(*args, **kwargs):
+            return [ChatMember(User(0, 'TestUser0', False), 'administrator'),
+                    ChatMember(User(1, 'TestUser1', False), 'creator')]
+
         roles.CHAT_ADMINS._timeout = 0.05
         monkeypatch.setattr(roles._bot, 'get_chat_administrators', admins)
         handler = MessageHandler(None, None, roles=roles.CHAT_ADMINS)
@@ -498,35 +540,6 @@ class TestRoles(object):
         assert pytest.approx(roles.CHAT_ADMINS._cache[0][0]) == time.time()
         assert roles.CHAT_ADMINS._cache[0][1] == [2]
 
-    def test_chat_admins_no_chat(self, roles, update):
-        update.message = None
-        update.inline_query = InlineQuery(1, User(0, 'TestUser', False), 'query', 0)
-        handler = InlineQueryHandler(None, roles=roles.CHAT_ADMINS)
-
-        assert not handler.check_update(update)
-
-    def test_chat_admins_no_user(self, roles, update):
-        update.message = None
-        update.channel_post = Message(1, None, datetime.datetime.utcnow(), Chat(0, 'channel'))
-        handler = InlineQueryHandler(None, roles=roles.CHAT_ADMINS)
-
-        assert not handler.check_update(update)
-
-    def test_chat_admins_caching(self, roles, update, monkeypatch):
-        def admins(*args, **kwargs):
-            return [ChatMember(User(0, 'TestUser0', False), 'administrator'),
-                    ChatMember(User(1, 'TestUser1', False), 'creator')]
-
-        monkeypatch.setattr(roles._bot, 'get_chat_administrators', admins)
-        handler = MessageHandler(None, None, roles=roles.CHAT_ADMINS)
-
-        update.message.from_user.id = 2
-        assert not handler.check_update(update)
-        update.message.from_user.id = 1
-        assert handler.check_update(update)
-        update.message.from_user.id = 0
-        assert handler.check_update(update)
-
     def test_chat_creator_simple(self, roles, update, monkeypatch):
         def member(*args, **kwargs):
             if args[1] == 0:
@@ -541,8 +554,10 @@ class TestRoles(object):
         update.message.from_user.id = 0
         assert not handler.check_update(update)
         update.message.from_user.id = 1
+        update.message.chat.id = 1
         assert handler.check_update(update)
         update.message.from_user.id = 2
+        update.message.chat.id = 2
         assert not handler.check_update(update)
 
     def test_chat_creator_no_chat(self, roles, update):

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -20,6 +20,7 @@ import datetime
 
 import pytest
 
+from copy import deepcopy
 from telegram import Message, User, InlineQuery, Update, Bot, ChatMember, Chat, TelegramError
 from telegram.ext import Role, Roles, MessageHandler, InlineQueryHandler, Filters
 
@@ -30,7 +31,7 @@ def update():
                              Chat(0, 'private')))
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope='function')
 def roles(bot):
     return Roles(bot)
 
@@ -49,28 +50,23 @@ class TestRole(object):
     def test_creation(self, parent_role):
         r = Role(parent_role=parent_role)
         assert r.user_ids == set()
-        assert r.child_roles == set()
         assert r.name == 'Role({})'
-        assert r in parent_role.child_roles
-        parent_role.remove_child_role(r)
+        assert r.parent_roles == set([parent_role])
 
         r = Role(1)
         assert r.user_ids == set([1])
-        assert r.child_roles == set()
         assert r.name == 'Role({1})'
-        assert r not in parent_role.child_roles
+        assert r.parent_roles == set()
 
         r = Role([1, 2])
         assert r.user_ids == set([1, 2])
-        assert r.child_roles == set()
         assert r.name == 'Role({1, 2})'
-        assert r not in parent_role.child_roles
+        assert r.parent_roles == set()
 
         r = Role([1, 2], name='role')
         assert r.user_ids == set([1, 2])
-        assert r.child_roles == set()
         assert r.name == 'Role(role)'
-        assert r not in parent_role.child_roles
+        assert r.parent_roles == set()
 
     def test_add_member(self, role):
         assert role.user_ids == set()
@@ -93,42 +89,20 @@ class TestRole(object):
         role.kick_member(2)
         assert role.user_ids == set()
 
-    def test_add_remove_child_role(self, role, parent_role):
-        assert role.child_roles == set()
-        role.add_child_role(parent_role)
-        assert role.child_roles == set([parent_role])
-        role.add_child_role(role)
-        assert role.child_roles == set([parent_role, role])
-        role.add_child_role(parent_role)
-        assert role.child_roles == set([parent_role, role])
-
-        role.remove_child_role(parent_role)
-        assert role.child_roles == set([role])
-        role.remove_child_role(role)
-        assert role.child_roles == set()
-        role.remove_child_role(role)
-        assert role.child_roles == set()
-
     def test_add_remove_parent_role(self, role, parent_role):
-        assert parent_role.child_roles == set()
+        assert role.parent_roles == set()
         role.add_parent_role(parent_role)
-        assert parent_role.child_roles == set([role])
+        assert role.parent_roles == set([parent_role])
         role.add_parent_role(role)
-        assert role.child_roles == set([role])
+        assert role.parent_roles == set([parent_role, role])
 
         role.remove_parent_role(parent_role)
-        assert parent_role.child_roles == set()
+        assert role.parent_roles == set([role])
         role.remove_parent_role(role)
-        assert role.child_roles == set()
-        role.remove_parent_role(role)
-        assert role.child_roles == set()
+        assert role.parent_roles == set()
 
     def test_equality(self, role, parent_role):
         r = Role(name='test')
-        assert role == parent_role
-        role.add_child_role(r)
-        assert role != parent_role
-        parent_role.add_child_role(r)
         assert role == parent_role
         role.add_parent_role(r)
         assert role != parent_role
@@ -151,20 +125,14 @@ class TestRole(object):
     def test_comparison(self, role, parent_role):
         assert not role < parent_role
         assert not parent_role < role
-        parent_role.add_child_role(role)
-        assert role < parent_role
-        assert role <= parent_role
-        assert parent_role >= role
-        assert parent_role > role
-
-        parent_role.remove_child_role(role)
-        assert not role < parent_role
-        assert not parent_role < role
         role.add_parent_role(parent_role)
         assert role < parent_role
         assert role <= parent_role
         assert parent_role >= role
         assert parent_role > role
+        role.remove_parent_role(parent_role)
+        assert not role < parent_role
+        assert not parent_role < role
 
     def test_hash(self):
         a = Role([1, 2])
@@ -178,6 +146,21 @@ class TestRole(object):
         assert hash(a) != hash(d)
         assert hash(a) != hash(e)
 
+    def test_deepcopy(self, role, parent_role):
+        role.add_parent_role(parent_role)
+        crole = deepcopy(role)
+
+        assert role is not crole
+        assert role == crole
+        assert role.user_ids is not crole.user_ids
+        assert role.user_ids == crole.user_ids
+        assert role.parent_roles is not crole.parent_roles
+        assert role.parent_roles == crole.parent_roles
+        parent = role.parent_roles.pop()
+        cparent = crole.parent_roles.pop()
+        assert parent is not cparent
+        assert parent == cparent
+
     def test_handler_simple(self, update, role, parent_role):
         handler = MessageHandler(role, None)
         assert not handler.check_update(update)
@@ -188,7 +171,7 @@ class TestRole(object):
         assert handler.check_update(update)
         update.message.from_user.id = 1
         assert not handler.check_update(update)
-        parent_role.add_child_role(role)
+        role.add_parent_role(parent_role)
         assert handler.check_update(update)
 
     def test_handler_merged_roles(self, update, role):
@@ -282,20 +265,35 @@ class TestRoles(object):
         d = [r.user_ids for r in roles.values()]
         assert d == [set([k]) for k in range(3)]
 
+    def test_deepcopy(self, roles, parent_role):
+        roles.add_admin(123)
+        roles.add_role(name='test', user_ids=[1, 2], parent_role=parent_role)
+        croles = deepcopy(roles)
+
+        assert croles is not roles
+        assert croles == roles
+        assert roles.ADMINS is not croles.ADMINS
+        assert roles.ADMINS == croles.ADMINS
+        assert roles['test'] is not croles['test']
+        assert roles['test'] == croles['test']
+
     def test_add_remove_role(self, roles, parent_role):
         roles.add_role('role', parent_role=parent_role)
         role = roles['role']
         assert role.user_ids == set()
         assert role.parent_roles == set([parent_role, roles.ADMINS])
         assert role.name == 'Role(role)'
-        assert role in roles.ADMINS.child_roles
+        assert roles.ADMINS in role.parent_roles
 
         with pytest.raises(ValueError, match='Role name is already taken.'):
             roles.add_role('role', parent_role=parent_role)
 
+        role.restored_from_persistence = True
+        assert not roles.add_role('role', parent_role=parent_role)
+
         roles.remove_role('role')
         assert not roles.get('role', None)
-        assert role not in roles.ADMINS.child_roles
+        assert roles.ADMINS not in role.parent_roles
 
     def test_handler_admins(self, roles, update):
         roles.add_role('role', 0)

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -48,10 +48,16 @@ def role():
 
 class TestRole(object):
     def test_creation(self, parent_role):
-        r = Role(parent_role=parent_role)
+        r = Role(parent_roles=parent_role)
         assert r.chat_ids == set()
         assert r.name == 'Role({})'
         assert r.parent_roles == set([parent_role])
+
+        parent_role_2 = Role(name='parent_role_2')
+        r = Role(parent_roles=[parent_role, parent_role_2])
+        assert r.chat_ids == set()
+        assert r.name == 'Role({})'
+        assert r.parent_roles == set([parent_role, parent_role_2])
 
         r = Role(1)
         assert r.chat_ids == set([1])
@@ -336,7 +342,7 @@ class TestRoles(object):
 
     def test_deepcopy(self, roles, parent_role):
         roles.add_admin(123)
-        roles.add_role(name='test', chat_ids=[1, 2], parent_role=parent_role)
+        roles.add_role(name='test', chat_ids=[1, 2], parent_roles=parent_role)
         croles = deepcopy(roles)
 
         assert croles is not roles
@@ -346,7 +352,7 @@ class TestRoles(object):
         assert roles['test'].equals(croles['test'])
 
     def test_add_remove_role(self, roles, parent_role):
-        roles.add_role('role', parent_role=parent_role)
+        roles.add_role('role', parent_roles=parent_role)
         role = roles['role']
         assert role.chat_ids == set()
         assert role.parent_roles == set([parent_role, roles.ADMINS])
@@ -354,10 +360,7 @@ class TestRoles(object):
         assert roles.ADMINS in role.parent_roles
 
         with pytest.raises(ValueError, match='Role name is already taken.'):
-            roles.add_role('role', parent_role=parent_role)
-
-        role.restored_from_persistence = True
-        assert not roles.add_role('role', parent_role=parent_role)
+            roles.add_role('role', parent_roles=parent_role)
 
         roles.remove_role('role')
         assert not roles.get('role', None)
@@ -437,8 +440,8 @@ class TestRoles(object):
 
     def test_json_encoding_decoding(self, roles, parent_role, bot):
         roles.add_role('role_1', chat_ids=[1, 2, 3])
-        roles.add_role('role_2', chat_ids=[4, 5, 6], parent_role=parent_role)
-        roles.add_role('role_3', chat_ids=[7, 8], parent_role=parent_role)
+        roles.add_role('role_2', chat_ids=[4, 5, 6], parent_roles=parent_role)
+        roles.add_role('role_3', chat_ids=[7, 8], parent_roles=parent_role)
         roles.add_admin(9)
         roles.add_admin(10)
 

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -21,7 +21,7 @@ import datetime
 import pytest
 
 from copy import deepcopy
-from telegram import Message, User, InlineQuery, Update, Bot, ChatMember, Chat, TelegramError
+from telegram import Message, User, InlineQuery, Update, ChatMember, Chat, TelegramError
 from telegram.ext import Role, Roles, MessageHandler, InlineQueryHandler, Filters
 
 
@@ -67,6 +67,11 @@ class TestRole(object):
         assert r.chat_ids == set([1, 2])
         assert r.name == 'Role(role)'
         assert r.parent_roles == set()
+
+    def test_chat_ids_property(self, role):
+        assert role.chat_ids is role.user_ids
+        role.chat_ids = 5
+        assert role.chat_ids == set([5])
 
     def test_add_member(self, role):
         assert role.chat_ids == set()
@@ -236,10 +241,20 @@ class TestRoles(object):
         assert isinstance(roles, dict)
         assert isinstance(roles.ADMINS, Role)
         assert isinstance(roles.CHAT_ADMINS, Role)
-        assert isinstance(roles.CHAT_ADMINS._bot, Bot)
+        assert roles.CHAT_ADMINS._bot is bot
         assert isinstance(roles.CHAT_CREATOR, Role)
-        assert isinstance(roles.CHAT_CREATOR._bot, Bot)
-        assert isinstance(roles._bot, Bot)
+        assert roles.CHAT_CREATOR._bot is bot
+        assert roles._bot is bot
+
+    def test_set_bot(self, bot):
+        roles = Roles(1)
+        assert roles._bot == 1
+        roles.set_bot(2)
+        assert roles._bot == 2
+        roles.set_bot(bot)
+        assert roles._bot is bot
+        with pytest.raises(ValueError, match='already set'):
+            roles.set_bot(bot)
 
     def test_add_kick_admin(self, roles):
         assert roles.ADMINS.chat_ids == set()
@@ -256,39 +271,30 @@ class TestRoles(object):
         roles2 = Roles(bot)
         parent_role_2 = deepcopy(parent_role)
         assert roles == roles2
-        # assert hash(roles) == hash(roles2)
 
         roles.add_admin(1)
         assert roles != roles2
-        # assert hash(roles) != hash(roles2)
 
         roles2.add_admin(1)
         assert roles == roles2
-        # assert hash(roles) == hash(roles2)
 
         roles.add_role('test_role', chat_ids=123)
         assert roles != roles2
-        # assert hash(roles) != hash(roles2)
 
         roles2.add_role('test_role', chat_ids=123)
         assert roles == roles2
-        # assert hash(roles) == hash(roles2)
 
         roles.add_role('test_role_2', chat_ids=456)
         assert roles != roles2
-        # assert hash(roles) != hash(roles2)
 
         roles2.add_role('test_role_2', chat_ids=456)
         assert roles == roles2
-        # assert hash(roles) == hash(roles2)
 
         roles['test_role'].add_parent_role(parent_role)
         assert roles != roles2
-        # assert hash(roles) != hash(roles2)
 
         roles2['test_role'].add_parent_role(parent_role_2)
         assert roles == roles2
-        # assert hash(roles) == hash(roles2)
 
     def test_raise_errors(self, roles):
         with pytest.raises(NotImplementedError, match='remove_role'):
@@ -442,7 +448,7 @@ class TestRoles(object):
 
         rroles = Roles.decode_from_json(json_str, bot)
         assert rroles == roles
-        assert isinstance(rroles._bot, Bot)
+        assert rroles._bot is bot
         for name in rroles:
             assert rroles[name] <= rroles.ADMINS
         assert rroles.ADMINS.chat_ids == set([9, 10])

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -328,10 +328,10 @@ class TestChatAdminsRole(object):
     def test_creation(self, bot):
         admins = ChatAdminsRole(bot, timeout=7)
         assert admins.timeout == 7
-        assert admins._bot is bot
+        assert admins.bot is bot
 
     def test_deepcopy(self, chat_admins_role):
-        chat_admins_role._cache.update({1: 2, 3: 4})
+        chat_admins_role.cache.update({1: 2, 3: 4})
         cadmins = deepcopy(chat_admins_role)
 
         assert chat_admins_role is not cadmins
@@ -341,8 +341,8 @@ class TestChatAdminsRole(object):
         assert chat_admins_role.parent_roles is not cadmins.parent_roles
         assert chat_admins_role.child_roles is not cadmins.child_roles
 
-        assert chat_admins_role._bot is cadmins._bot
-        assert chat_admins_role._cache == cadmins._cache
+        assert chat_admins_role.bot is cadmins.bot
+        assert chat_admins_role.cache == cadmins.cache
         assert chat_admins_role.timeout == cadmins.timeout
 
     def test_simple(self, chat_admins_role, update, monkeypatch):
@@ -350,7 +350,7 @@ class TestChatAdminsRole(object):
             return [ChatMember(User(0, 'TestUser0', False), 'administrator'),
                     ChatMember(User(1, 'TestUser1', False), 'creator')]
 
-        monkeypatch.setattr(chat_admins_role._bot, 'get_chat_administrators', admins)
+        monkeypatch.setattr(chat_admins_role.bot, 'get_chat_administrators', admins)
         handler = MessageHandler(None, None, roles=chat_admins_role)
 
         update.message.from_user.id = 2
@@ -386,19 +386,19 @@ class TestChatAdminsRole(object):
             return [ChatMember(User(0, 'TestUser0', False), 'administrator'),
                     ChatMember(User(1, 'TestUser1', False), 'creator')]
 
-        monkeypatch.setattr(chat_admins_role._bot, 'get_chat_administrators', admins)
+        monkeypatch.setattr(chat_admins_role.bot, 'get_chat_administrators', admins)
         handler = MessageHandler(None, None, roles=chat_admins_role)
 
         update.message.from_user.id = 2
         assert not handler.check_update(update)
-        assert isinstance(chat_admins_role._cache[0], tuple)
-        assert pytest.approx(chat_admins_role._cache[0][0]) == time.time()
-        assert chat_admins_role._cache[0][1] == [0, 1]
+        assert isinstance(chat_admins_role.cache[0], tuple)
+        assert pytest.approx(chat_admins_role.cache[0][0]) == time.time()
+        assert chat_admins_role.cache[0][1] == [0, 1]
 
         def admins(*args, **kwargs):
             raise ValueError('This method should not be called!')
 
-        monkeypatch.setattr(chat_admins_role._bot, 'get_chat_administrators', admins)
+        monkeypatch.setattr(chat_admins_role.bot, 'get_chat_administrators', admins)
 
         update.message.from_user.id = 1
         assert handler.check_update(update)
@@ -408,22 +408,22 @@ class TestChatAdminsRole(object):
         def admins(*args, **kwargs):
             return [ChatMember(User(2, 'TestUser0', False), 'administrator')]
 
-        monkeypatch.setattr(chat_admins_role._bot, 'get_chat_administrators', admins)
+        monkeypatch.setattr(chat_admins_role.bot, 'get_chat_administrators', admins)
 
         update.message.from_user.id = 2
         assert handler.check_update(update)
-        assert isinstance(chat_admins_role._cache[0], tuple)
-        assert pytest.approx(chat_admins_role._cache[0][0]) == time.time()
-        assert chat_admins_role._cache[0][1] == [2]
+        assert isinstance(chat_admins_role.cache[0], tuple)
+        assert pytest.approx(chat_admins_role.cache[0][0]) == time.time()
+        assert chat_admins_role.cache[0][1] == [2]
 
 
 class TestChatCreatorRole(object):
     def test_creation(self, bot):
         creator = ChatCreatorRole(bot)
-        assert creator._bot is bot
+        assert creator.bot is bot
 
     def test_deepcopy(self, chat_creator_role):
-        chat_creator_role._cache.update({1: 2, 3: 4})
+        chat_creator_role.cache.update({1: 2, 3: 4})
         ccreator = deepcopy(chat_creator_role)
 
         assert chat_creator_role is not ccreator
@@ -433,8 +433,8 @@ class TestChatCreatorRole(object):
         assert chat_creator_role.parent_roles is not ccreator.parent_roles
         assert chat_creator_role.child_roles is not ccreator.child_roles
 
-        assert chat_creator_role._bot is ccreator._bot
-        assert chat_creator_role._cache == ccreator._cache
+        assert chat_creator_role.bot is ccreator.bot
+        assert chat_creator_role.cache == ccreator.cache
 
     def test_simple(self, chat_creator_role, monkeypatch, update):
         def member(*args, **kwargs):
@@ -444,7 +444,7 @@ class TestChatCreatorRole(object):
                 return ChatMember(User(1, 'TestUser1', False), 'creator')
             raise TelegramError('User is not a member')
 
-        monkeypatch.setattr(chat_creator_role._bot, 'get_chat_member', member)
+        monkeypatch.setattr(chat_creator_role.bot, 'get_chat_member', member)
         handler = MessageHandler(None, None, roles=chat_creator_role)
 
         update.message.from_user.id = 0
@@ -486,17 +486,17 @@ class TestChatCreatorRole(object):
                 return ChatMember(User(1, 'TestUser1', False), 'creator')
             raise TelegramError('User is not a member')
 
-        monkeypatch.setattr(chat_creator_role._bot, 'get_chat_member', member)
+        monkeypatch.setattr(chat_creator_role.bot, 'get_chat_member', member)
         handler = MessageHandler(None, None, roles=chat_creator_role)
 
         update.message.from_user.id = 1
         assert handler.check_update(update)
-        assert chat_creator_role._cache == {0: 1}
+        assert chat_creator_role.cache == {0: 1}
 
         def member(*args, **kwargs):
             raise ValueError('This method should not be called!')
 
-        monkeypatch.setattr(chat_creator_role._bot, 'get_chat_member', member)
+        monkeypatch.setattr(chat_creator_role.bot, 'get_chat_member', member)
 
         update.message.from_user.id = 1
         assert handler.check_update(update)
@@ -511,18 +511,18 @@ class TestRoles(object):
         assert isinstance(roles, dict)
         assert isinstance(roles.ADMINS, Role)
         assert isinstance(roles.CHAT_ADMINS, Role)
-        assert roles.CHAT_ADMINS._bot is bot
+        assert roles.CHAT_ADMINS.bot is bot
         assert isinstance(roles.CHAT_CREATOR, Role)
-        assert roles.CHAT_CREATOR._bot is bot
-        assert roles._bot is bot
+        assert roles.CHAT_CREATOR.bot is bot
+        assert roles.bot is bot
 
     def test_set_bot(self, bot):
         roles = Roles(1)
-        assert roles._bot == 1
+        assert roles.bot == 1
         roles.set_bot(2)
-        assert roles._bot == 2
+        assert roles.bot == 2
         roles.set_bot(bot)
-        assert roles._bot is bot
+        assert roles.bot is bot
         with pytest.raises(ValueError, match='already set'):
             roles.set_bot(bot)
 
@@ -685,7 +685,7 @@ class TestRoles(object):
 
         rroles = Roles.decode_from_json(json_str, bot)
         assert rroles == roles
-        assert rroles._bot is bot
+        assert rroles.bot is bot
         for name in rroles:
             assert rroles[name] <= rroles.ADMINS
         assert rroles.ADMINS.chat_ids == set([9, 10])

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python
+#
+# A library that provides a Python interface to the Telegram Bot API
+# Copyright (C) 2015-2020
+# Leandro Toledo de Souza <devs@python-telegram-bot.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+import datetime
+
+import pytest
+
+from telegram import Message, User, InlineQuery, Update, Bot, ChatMember, Chat, TelegramError
+from telegram.ext import Role, Roles, MessageHandler, InlineQueryHandler, Filters
+
+
+@pytest.fixture(scope='function')
+def update():
+    return Update(0, Message(0, User(0, 'Testuser', False), datetime.datetime.utcnow(),
+                             Chat(0, 'private')))
+
+
+@pytest.fixture(scope='class')
+def roles(bot):
+    return Roles(bot)
+
+
+@pytest.fixture(scope='function')
+def parent_role():
+    return Role(name='parent_role')
+
+
+@pytest.fixture(scope='function')
+def role():
+    return Role(name='role')
+
+
+class TestRole(object):
+    def test_creation(self, parent_role):
+        r = Role(parent_role=parent_role)
+        assert r.user_ids == set()
+        assert r.child_roles == set()
+        assert r.name == 'Role({})'
+        assert r in parent_role.child_roles
+        parent_role.remove_child_role(r)
+
+        r = Role(1)
+        assert r.user_ids == set([1])
+        assert r.child_roles == set()
+        assert r.name == 'Role({1})'
+        assert r not in parent_role.child_roles
+
+        r = Role([1, 2])
+        assert r.user_ids == set([1, 2])
+        assert r.child_roles == set()
+        assert r.name == 'Role({1, 2})'
+        assert r not in parent_role.child_roles
+
+        r = Role([1, 2], name='role')
+        assert r.user_ids == set([1, 2])
+        assert r.child_roles == set()
+        assert r.name == 'Role(role)'
+        assert r not in parent_role.child_roles
+
+    def test_add_member(self, role):
+        assert role.user_ids == set()
+        role.add_member(1)
+        assert role.user_ids == set([1])
+        role.add_member(2)
+        assert role.user_ids == set([1, 2])
+        role.add_member(1)
+        assert role.user_ids == set([1, 2])
+
+    def test_kick_member(self, role):
+        assert role.user_ids == set()
+        role.add_member(1)
+        role.add_member(2)
+        assert role.user_ids == set([1, 2])
+        role.kick_member(1)
+        assert role.user_ids == set([2])
+        role.kick_member(1)
+        assert role.user_ids == set([2])
+        role.kick_member(2)
+        assert role.user_ids == set()
+
+    def test_add_remove_child_role(self, role, parent_role):
+        assert role.child_roles == set()
+        role.add_child_role(parent_role)
+        assert role.child_roles == set([parent_role])
+        role.add_child_role(role)
+        assert role.child_roles == set([parent_role, role])
+        role.add_child_role(parent_role)
+        assert role.child_roles == set([parent_role, role])
+
+        role.remove_child_role(parent_role)
+        assert role.child_roles == set([role])
+        role.remove_child_role(role)
+        assert role.child_roles == set()
+        role.remove_child_role(role)
+        assert role.child_roles == set()
+
+    def test_add_remove_parent_role(self, role, parent_role):
+        assert parent_role.child_roles == set()
+        role.add_parent_role(parent_role)
+        assert parent_role.child_roles == set([role])
+        role.add_parent_role(role)
+        assert role.child_roles == set([role])
+
+        role.remove_parent_role(parent_role)
+        assert parent_role.child_roles == set()
+        role.remove_parent_role(role)
+        assert role.child_roles == set()
+        role.remove_parent_role(role)
+        assert role.child_roles == set()
+
+    def test_equality(self, role, parent_role):
+        r = Role(name='test')
+        assert role == parent_role
+        role.add_child_role(r)
+        assert role != parent_role
+        parent_role.add_child_role(r)
+        assert role == parent_role
+        role.add_parent_role(r)
+        assert role != parent_role
+        parent_role.add_parent_role(r)
+        assert role == parent_role
+
+        role.add_member(1)
+        assert role != parent_role
+        parent_role.add_member(1)
+        assert role == parent_role
+        role.add_member(2)
+        assert role != parent_role
+        parent_role.add_member(2)
+        assert role == parent_role
+        role.kick_member(2)
+        assert role != parent_role
+        parent_role.kick_member(2)
+        assert role == parent_role
+
+    def test_comparison(self, role, parent_role):
+        assert not role < parent_role
+        assert not parent_role < role
+        parent_role.add_child_role(role)
+        assert role < parent_role
+        assert role <= parent_role
+        assert parent_role >= role
+        assert parent_role > role
+
+        parent_role.remove_child_role(role)
+        assert not role < parent_role
+        assert not parent_role < role
+        role.add_parent_role(parent_role)
+        assert role < parent_role
+        assert role <= parent_role
+        assert parent_role >= role
+        assert parent_role > role
+
+    def test_hash(self):
+        a = Role([1, 2])
+        b = Role([1, 2])
+        c = Role([2, 1])
+        d = Role()
+        e = Role([1, 2, 3])
+
+        assert hash(a) == hash(b)
+        assert hash(a) == hash(c)
+        assert hash(a) != hash(d)
+        assert hash(a) != hash(e)
+
+    def test_handler_simple(self, update, role, parent_role):
+        handler = MessageHandler(role, None)
+        assert not handler.check_update(update)
+
+        role.add_member(0)
+        parent_role.add_member(1)
+
+        assert handler.check_update(update)
+        update.message.from_user.id = 1
+        assert not handler.check_update(update)
+        parent_role.add_child_role(role)
+        assert handler.check_update(update)
+
+    def test_handler_merged_roles(self, update, role):
+        role.add_member(0)
+        r = Role(0)
+
+        handler = MessageHandler(role & (~r), None)
+        assert not handler.check_update(update)
+
+        r = Role(1)
+        handler = MessageHandler(role & r, None)
+        assert not handler.check_update(update)
+        handler = MessageHandler(role | r, None)
+        assert handler.check_update(update)
+
+    def test_handler_merged_filters(self, update, role):
+        role.add_member(0)
+
+        handler = MessageHandler(role & Filters.sticker, None)
+        assert not handler.check_update(update)
+        handler = MessageHandler(role | Filters.sticker, None)
+        assert handler.check_update(update)
+        handler = MessageHandler(role & Filters.all, None)
+        assert handler.check_update(update)
+
+    def test_handler_without_user(self, update, role):
+        handler = MessageHandler(role, None)
+        role.add_member(0)
+        update.message = None
+        update.channel_post = True
+        assert not handler.check_update(update)
+
+
+class TestRoles(object):
+    def test_creation(self, bot):
+        roles = Roles(bot)
+        assert isinstance(roles, dict)
+        assert isinstance(roles.ADMINS, Role)
+        assert isinstance(roles.CHAT_ADMINS, Role)
+        assert isinstance(roles.CHAT_ADMINS._bot, Bot)
+        assert isinstance(roles.CHAT_CREATOR, Role)
+        assert isinstance(roles.CHAT_CREATOR._bot, Bot)
+        assert isinstance(roles._bot, Bot)
+
+    def test_add_kick_admin(self, roles):
+        assert roles.ADMINS.user_ids == set()
+        roles.add_admin(1)
+        assert roles.ADMINS.user_ids == set([1])
+        roles.add_admin(2)
+        assert roles.ADMINS.user_ids == set([1, 2])
+        roles.kick_admin(1)
+        assert roles.ADMINS.user_ids == set([2])
+        roles.kick_admin(2)
+        assert roles.ADMINS.user_ids == set()
+
+    def test_raise_errors(self, roles):
+        with pytest.raises(NotImplementedError, match='remove_role'):
+            del roles['test']
+        with pytest.raises(ValueError, match='immutable'):
+            roles['test'] = True
+        with pytest.raises(ValueError, match='immutable'):
+            roles.setdefault('test', None)
+        with pytest.raises(ValueError, match='immutable'):
+            roles.update({'test': None})
+        with pytest.raises(NotImplementedError, match='remove_role'):
+            roles.pop('test', None)
+        with pytest.raises(NotImplementedError, match='remove_role'):
+            roles.popitem('test')
+        with pytest.raises(NotImplementedError, match='remove_role'):
+            roles.clear()
+        with pytest.raises(NotImplementedError):
+            roles.copy()
+
+    def test_dict_functionality(self, roles):
+        roles.add_role('role0', 0)
+        roles.add_role('role1', 1)
+        roles.add_role('role2', 2)
+
+        assert 'role2' in roles
+        assert 'role3' not in roles
+
+        a = set([name for name in roles])
+        assert a == set(['role{}'.format(k) for k in range(3)])
+
+        b = {name: role.user_ids for name, role in roles.items()}
+        assert b == {'role{}'.format(k): set([k]) for k in range(3)}
+
+        c = [name for name in roles.keys()]
+        assert c == ['role{}'.format(k) for k in range(3)]
+
+        d = [r.user_ids for r in roles.values()]
+        assert d == [set([k]) for k in range(3)]
+
+    def test_add_remove_role(self, roles, parent_role):
+        roles.add_role('role', parent_role=parent_role)
+        role = roles['role']
+        assert role.user_ids == set()
+        assert role.parent_roles == set([parent_role, roles.ADMINS])
+        assert role.name == 'Role(role)'
+        assert role in roles.ADMINS.child_roles
+
+        with pytest.raises(ValueError, match='Role name is already taken.'):
+            roles.add_role('role', parent_role=parent_role)
+
+        roles.remove_role('role')
+        assert not roles.get('role', None)
+        assert role not in roles.ADMINS.child_roles
+
+    def test_handler_admins(self, roles, update):
+        roles.add_role('role', 0)
+        roles.add_admin(1)
+        handler = MessageHandler(roles['role'], None)
+        assert handler.check_update(update)
+        update.message.from_user.id = 1
+        assert handler.check_update(update)
+        roles.kick_admin(1)
+        assert not handler.check_update(update)
+
+    def test_chat_admins_simple(self, roles, update, monkeypatch):
+        def admins(*args, **kwargs):
+            return [ChatMember(User(0, 'TestUser0', False), 'administrator'),
+                    ChatMember(User(1, 'TestUser1', False), 'creator')]
+
+        monkeypatch.setattr(roles._bot, 'get_chat_administrators', admins)
+        handler = MessageHandler(roles.CHAT_ADMINS, None)
+
+        update.message.from_user.id = 2
+        assert not handler.check_update(update)
+        update.message.from_user.id = 1
+        assert handler.check_update(update)
+        update.message.from_user.id = 0
+        assert handler.check_update(update)
+
+    def test_chat_admins_no_chat(self, roles, update):
+        update.message = None
+        update.inline_query = InlineQuery(1, User(0, 'TestUser', False), 'query', 0)
+        handler = InlineQueryHandler(None, roles=roles.CHAT_ADMINS)
+
+        assert not handler.check_update(update)
+
+    def test_chat_admins_no_user(self, roles, update):
+        update.message = None
+        update.channel_post = Message(1, None, datetime.datetime.utcnow(), Chat(0, 'channel'))
+        handler = InlineQueryHandler(None, roles=roles.CHAT_ADMINS)
+
+        assert not handler.check_update(update)
+
+    def test_chat_creator_simple(self, roles, update, monkeypatch):
+        def member(*args, **kwargs):
+            if args[1] == 0:
+                return ChatMember(User(0, 'TestUser0', False), 'administrator')
+            if args[1] == 1:
+                return ChatMember(User(1, 'TestUser1', False), 'creator')
+            raise TelegramError('User is not a member')
+
+        monkeypatch.setattr(roles._bot, 'get_chat_member', member)
+        handler = MessageHandler(roles.CHAT_CREATOR, None)
+
+        update.message.from_user.id = 0
+        assert not handler.check_update(update)
+        update.message.from_user.id = 1
+        assert handler.check_update(update)
+        update.message.from_user.id = 2
+        assert not handler.check_update(update)
+
+    def test_chat_creator_no_chat(self, roles, update):
+        update.message = None
+        update.inline_query = InlineQuery(1, User(0, 'TestUser', False), 'query', 0)
+        handler = InlineQueryHandler(None, roles=roles.CHAT_CREATOR)
+
+        assert not handler.check_update(update)
+
+    def test_chat_creator_no_user(self, roles, update):
+        update.message = None
+        update.channel_post = Message(1, None, datetime.datetime.utcnow(), Chat(0, 'channel'))
+        handler = InlineQueryHandler(None, roles=roles.CHAT_CREATOR)
+
+        assert not handler.check_update(update)

--- a/tests/test_shippingqueryhandler.py
+++ b/tests/test_shippingqueryhandler.py
@@ -89,6 +89,7 @@ class TestShippingQueryHandler(object):
                           and isinstance(context.user_data, dict)
                           and context.chat_data is None
                           and isinstance(context.bot_data, dict)
+                          and isinstance(context.roles, dict)
                           and isinstance(update.shipping_query, ShippingQuery))
 
     def test_basic(self, dp, shiping_query):

--- a/tests/test_shippingqueryhandler.py
+++ b/tests/test_shippingqueryhandler.py
@@ -107,7 +107,7 @@ class TestShippingQueryHandler(object):
         dp.process_update(shiping_query)
         assert not self.test_flag
 
-        role.user_ids = 1
+        role.chat_ids = 1
         assert handler.check_update(shiping_query)
         dp.process_update(shiping_query)
         assert self.test_flag

--- a/tests/test_shippingqueryhandler.py
+++ b/tests/test_shippingqueryhandler.py
@@ -99,6 +99,19 @@ class TestShippingQueryHandler(object):
         dp.process_update(shiping_query)
         assert self.test_flag
 
+    def test_with_role(self, dp, shiping_query, role):
+        handler = ShippingQueryHandler(self.callback_basic, roles=role)
+        dp.add_handler(handler)
+
+        assert not handler.check_update(shiping_query)
+        dp.process_update(shiping_query)
+        assert not self.test_flag
+
+        role.user_ids = 1
+        assert handler.check_update(shiping_query)
+        dp.process_update(shiping_query)
+        assert self.test_flag
+
     def test_pass_user_or_chat_data(self, dp, shiping_query):
         handler = ShippingQueryHandler(self.callback_data_1,
                                        pass_user_data=True)


### PR DESCRIPTION
This PR adds the functionality of restricting access to handlers to

* specified users (by id)
* specified chats (by id)
* chat admins
* chat creators

Builds upon #1757 (see below)
Closes #1151, #1562 

## Example usage:

```python

updater = Updater('TOKEN')
dp = updater.dispatcher
roles = updater.dispatcher.roles

roles.add_admin('authors_user_id')
roles.add_role(name='my_role_1')
my_role_1 = roles['my_role_1']
roles.add_role(name='my_role_2', parent_roles=roles['my_role_1'])
my_role_2 = roles['my_role_2']

def add_to_my_role_2(update, context):
    user = update.effective_user
    context.roles['my_role_2'].add_member(user.id)
    
def add_to_my_role_1(update, context):
    user_id = update.message.text
    context.roles['my_role_1'].add_member(user_id)

....

# Anyone can add themself to my_role_2
dp.add_handler(TypeHandler(Update, add_to_my_role_2))

# Only the admin can add users to my_role_1
dp.add_handler(MessageHandler(Filters.message, add_to_my_role_1, roles=roles.ADMINS))

# This will be accessable by my_role_2, my_role_1 and the admin
dp.add_handler(SomeHandler(..., roles=my_role_2))

# This will be accessable by my_role_1 and the admin
dp.add_handler(SomeHandler(..., roles=my_role_1))

# This will be accessable by anyone except my_role_1 and my_role_2
dp.add_handler(SomeHandler(..., roles=~my_role_1))

# This will be accessable by users, who are in my_role_2 bot not in my_role_1
dp.add_handler(SomeHandler(..., roles=~my_role_1 & my_role_2))

# This will be accessable only by the admins of the group the update was sent in
dp.add_handler(SomeHandler(..., roles=roles.CHAT_ADMINS))

# This will be accessable only by the creator of the group the update was sent in
dp.add_handler(SomeHandler(..., roles=roles.CHAT_CREATOR))

# You can compare the roles regarding hierarchy:
roles.ADMINS >=  roles['my_role_1'] #True
roles.ADMINS >=  roles['my_role_2'] #True
roles['my_role_1'] < roles['my_role_2'] #False
roles.ADMINS >= Role(...) #False, since neither of those is a parent of the other
```

## How does it work

### Added Classes

#### Role

* Inherits from `Filters.user` (This is, where #1757 comes in. Can be changed to inherinting from `BaseFilter` if the reviewer want that)
* Can be combined by bitwise operations (This is why I'm Inheriting from `Filters`)
* Can be compared w.r.t. hierarchy. E.g. in above example: `my_role_1 > my_role_2`
* Dynamically add/kick members

#### Roles

A container for multiple roles

* Inherits from `dict` to allow accessing the roles by `roles['role_name']`
* `Roles.ADMINS` is parent to every role
* `Roles.CHAT_ADMINS`, `Roles.CHAT_CREATOR` as shortcuts for restricting acces in group chats
* Dynamically add/remove admins and roles

### Integration with handlers

The base class `Handler` now has a `__new__` method that makes sure, that `check_update` is called only, if the roles checked out. Alternatives approaches would be

* Make `Handler.check_update` check the roles directly and call `super().check_updater` in all the specific handlers. This means that custom handlers would have to change their `check_update` implementation. Then again, they may have to be adjusted to accept the `roles` argument anyway
* Add a metho `Handler.check_update_with_roles` that calles `Handler.check_update` after checking the roles. In the current code base, replace all calls to `check_update` with `check_update_with_role`. This would leave current implementation of `check_update` untouched.

### Integration with dispatcher

* `Dispatcher.roles` is the `Roles` instance managing the roles
* `Dispatcher.roles` is available as `context.roles` to allow editing roles in callbacks
* `store_roles` is added to persistence to allow keeping track of roles over restarts. I know that adding stuff to persistence should be done with care. But if we want dynamic access control (and I do), we need persistence here.

## ToDo

- [x] Add roles to new `PollAnswerHandler`. As `Poll` updates have neither user nor chat, we don't need roles with `PollHandler`
- [x] Cache chat admins and creators (timeout is customizable via `roles.CHAT_ADMINS.timeout = ...`)
- [x] Handle private chats correctly with `roles.CHAT_ADMINS/CHAT_CREATOR` (this is as easy if checking `chat.id == user.id`)
- [ ] When merged, we should create a wiki page. Important points to mention there:

  * Hard coding `dp.roles.add_admin(id)` will *always* add the user to admins on start up with persistence, even if they are removed by dynamic access control. Thus, only the author of the bot should be hard coded as admin.
  * Admins should *only* be in `roles.ADMINS`, else they might be excluded by `roles=~roles['my_role']`, if they are in `my_role`
  * Hard coding `dp.roles.add_role(name='my_group')` will lead to `ValueError` on restart with persistence because after restoring the data, the role `my_group` will already be set. Use `'my_group' in dp.roles` to check for that before adding the group.

- [ ] Depending on how long it will take to merge this:
    - [x] Don't use `all` in persistence (see #1766)
    - [x] Use `tempfile` module in persistence tests (see #1765)
    - [ ] Add type hinting (see #1373)