### PR TITLE
Remove builtin names where possible

### DIFF
--- a/telegram/ext/picklepersistence.py
+++ b/telegram/ext/picklepersistence.py
@@ -81,12 +81,12 @@ class PicklePersistence(BasePersistence):
         try:
             filename = self.filename
             with open(self.filename, "rb") as f:
-                all = pickle.load(f)
-                self.user_data = defaultdict(dict, all['user_data'])
-                self.chat_data = defaultdict(dict, all['chat_data'])
+                data = pickle.load(f)
+                self.user_data = defaultdict(dict, data['user_data'])
+                self.chat_data = defaultdict(dict, data['chat_data'])
                 # For backwards compatibility with files not containing bot data
-                self.bot_data = all.get('bot_data', {})
-                self.conversations = all['conversations']
+                self.bot_data = data.get('bot_data', {})
+                self.conversations = data['conversations']
         except IOError:
             self.conversations = {}
             self.user_data = defaultdict(dict)
@@ -110,9 +110,9 @@ class PicklePersistence(BasePersistence):
 
     def dump_singlefile(self):
         with open(self.filename, "wb") as f:
-            all = {'conversations': self.conversations, 'user_data': self.user_data,
-                   'chat_data': self.chat_data, 'bot_data': self.bot_data}
-            pickle.dump(all, f)
+            data = {'conversations': self.conversations, 'user_data': self.user_data,
+                    'chat_data': self.chat_data, 'bot_data': self.bot_data}
+            pickle.dump(data, f)
 
     def dump_file(self, filename, data):
         with open(filename, "wb") as f:

--- a/tests/test_callbackquery.py
+++ b/tests/test_callbackquery.py
@@ -24,7 +24,7 @@ from telegram import CallbackQuery, User, Message, Chat, Audio
 
 @pytest.fixture(scope='class', params=['message', 'inline'])
 def callback_query(bot, request):
-    cbq = CallbackQuery(TestCallbackQuery.id,
+    cbq = CallbackQuery(TestCallbackQuery.id_,
                         TestCallbackQuery.from_user,
                         TestCallbackQuery.chat_instance,
                         data=TestCallbackQuery.data,
@@ -38,7 +38,7 @@ def callback_query(bot, request):
 
 
 class TestCallbackQuery(object):
-    id = 'id'
+    id_ = 'id'
     from_user = User(1, 'test_user', False)
     chat_instance = 'chat_instance'
     message = Message(3, User(5, 'bot', False), None, Chat(4, 'private'))
@@ -47,7 +47,7 @@ class TestCallbackQuery(object):
     game_short_name = 'the_game'
 
     def test_de_json(self, bot):
-        json_dict = {'id': self.id,
+        json_dict = {'id': self.id_,
                      'from': self.from_user.to_dict(),
                      'chat_instance': self.chat_instance,
                      'message': self.message.to_dict(),
@@ -57,7 +57,7 @@ class TestCallbackQuery(object):
                      'default_quote': True}
         callback_query = CallbackQuery.de_json(json_dict, bot)
 
-        assert callback_query.id == self.id
+        assert callback_query.id == self.id_
         assert callback_query.from_user == self.from_user
         assert callback_query.chat_instance == self.chat_instance
         assert callback_query.message == self.message
@@ -92,8 +92,8 @@ class TestCallbackQuery(object):
         def test(*args, **kwargs):
             text = args[0] == 'test'
             try:
-                id = kwargs['inline_message_id'] == callback_query.inline_message_id
-                return id and text
+                id_ = kwargs['inline_message_id'] == callback_query.inline_message_id
+                return id_ and text
             except KeyError:
                 chat_id = kwargs['chat_id'] == callback_query.message.chat_id
                 message_id = kwargs['message_id'] == callback_query.message.message_id
@@ -107,12 +107,12 @@ class TestCallbackQuery(object):
         def test(*args, **kwargs):
             caption = kwargs['caption'] == 'new caption'
             try:
-                id = kwargs['inline_message_id'] == callback_query.inline_message_id
-                return id and caption
+                id_ = kwargs['inline_message_id'] == callback_query.inline_message_id
+                return id_ and caption
             except KeyError:
-                id = kwargs['chat_id'] == callback_query.message.chat_id
+                id_ = kwargs['chat_id'] == callback_query.message.chat_id
                 message = kwargs['message_id'] == callback_query.message.message_id
-                return id and message and caption
+                return id_ and message and caption
 
         monkeypatch.setattr(callback_query.bot, 'edit_message_caption', test)
         assert callback_query.edit_message_caption(caption='new caption')
@@ -122,23 +122,23 @@ class TestCallbackQuery(object):
         def test(*args, **kwargs):
             reply_markup = kwargs['reply_markup'] == [['1', '2']]
             try:
-                id = kwargs['inline_message_id'] == callback_query.inline_message_id
-                return id and reply_markup
+                id_ = kwargs['inline_message_id'] == callback_query.inline_message_id
+                return id_ and reply_markup
             except KeyError:
-                id = kwargs['chat_id'] == callback_query.message.chat_id
+                id_ = kwargs['chat_id'] == callback_query.message.chat_id
                 message = kwargs['message_id'] == callback_query.message.message_id
-                return id and message and reply_markup
+                return id_ and message and reply_markup
 
         monkeypatch.setattr(callback_query.bot, 'edit_message_reply_markup', test)
         assert callback_query.edit_message_reply_markup(reply_markup=[['1', '2']])
         assert callback_query.edit_message_reply_markup([['1', '2']])
 
     def test_equality(self):
-        a = CallbackQuery(self.id, self.from_user, 'chat')
-        b = CallbackQuery(self.id, self.from_user, 'chat')
-        c = CallbackQuery(self.id, None, '')
+        a = CallbackQuery(self.id_, self.from_user, 'chat')
+        b = CallbackQuery(self.id_, self.from_user, 'chat')
+        c = CallbackQuery(self.id_, None, '')
         d = CallbackQuery('', None, 'chat')
-        e = Audio(self.id, 1)
+        e = Audio(self.id_, 1)
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -25,7 +25,7 @@ from telegram import User, Message
 
 @pytest.fixture(scope='class')
 def chat(bot):
-    return Chat(TestChat.id, TestChat.title, TestChat.type, username=TestChat.username,
+    return Chat(TestChat.id_, TestChat.title, TestChat.type_, username=TestChat.username,
                 all_members_are_administrators=TestChat.all_members_are_administrators,
                 bot=bot, sticker_set_name=TestChat.sticker_set_name,
                 can_set_sticker_set=TestChat.can_set_sticker_set,
@@ -33,9 +33,9 @@ def chat(bot):
 
 
 class TestChat(object):
-    id = -28767330
+    id_ = -28767330
     title = 'ToledosPalaceBot - Group'
-    type = 'group'
+    type_ = 'group'
     username = 'username'
     all_members_are_administrators = False
     sticker_set_name = 'stickers'
@@ -48,9 +48,9 @@ class TestChat(object):
 
     def test_de_json(self, bot):
         json_dict = {
-            'id': self.id,
+            'id': self.id_,
             'title': self.title,
-            'type': self.type,
+            'type': self.type_,
             'username': self.username,
             'all_members_are_administrators': self.all_members_are_administrators,
             'sticker_set_name': self.sticker_set_name,
@@ -59,9 +59,9 @@ class TestChat(object):
         }
         chat = Chat.de_json(json_dict, bot)
 
-        assert chat.id == self.id
+        assert chat.id == self.id_
         assert chat.title == self.title
-        assert chat.type == self.type
+        assert chat.type == self.type_
         assert chat.username == self.username
         assert chat.all_members_are_administrators == self.all_members_are_administrators
         assert chat.sticker_set_name == self.sticker_set_name
@@ -70,8 +70,8 @@ class TestChat(object):
 
     def test_de_json_default_quote(self, bot):
         json_dict = {
-            'id': self.id,
-            'type': self.type,
+            'id': self.id_,
+            'type': self.type_,
             'pinned_message': Message(
                 message_id=123,
                 from_user=None,
@@ -102,9 +102,9 @@ class TestChat(object):
 
     def test_send_action(self, monkeypatch, chat):
         def test(*args, **kwargs):
-            id = args[0] == chat.id
+            id_ = args[0] == chat.id
             action = kwargs['action'] == ChatAction.TYPING
-            return id and action
+            return id_ and action
 
         monkeypatch.setattr(chat.bot, 'send_chat_action', test)
         assert chat.send_action(action=ChatAction.TYPING)
@@ -238,11 +238,11 @@ class TestChat(object):
         assert chat.send_poll('test_poll')
 
     def test_equality(self):
-        a = Chat(self.id, self.title, self.type)
-        b = Chat(self.id, self.title, self.type)
-        c = Chat(self.id, '', '')
-        d = Chat(0, self.title, self.type)
-        e = User(self.id, '', False)
+        a = Chat(self.id_, self.title, self.type_)
+        b = Chat(self.id_, self.title, self.type_)
+        c = Chat(self.id_, '', '')
+        d = Chat(0, self.title, self.type_)
+        e = User(self.id_, '', False)
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_encryptedpassportelement.py
+++ b/tests/test_encryptedpassportelement.py
@@ -24,7 +24,7 @@ from telegram import EncryptedPassportElement, PassportFile, PassportElementErro
 
 @pytest.fixture(scope='class')
 def encrypted_passport_element():
-    return EncryptedPassportElement(TestEncryptedPassportElement.type,
+    return EncryptedPassportElement(TestEncryptedPassportElement.type_,
                                     data=TestEncryptedPassportElement.data,
                                     phone_number=TestEncryptedPassportElement.phone_number,
                                     email=TestEncryptedPassportElement.email,
@@ -35,7 +35,7 @@ def encrypted_passport_element():
 
 
 class TestEncryptedPassportElement(object):
-    type = 'type'
+    type_ = 'type'
     data = 'data'
     phone_number = 'phone_number'
     email = 'email'
@@ -45,7 +45,7 @@ class TestEncryptedPassportElement(object):
     selfie = PassportFile('file_id', 50, 0)
 
     def test_expected_values(self, encrypted_passport_element):
-        assert encrypted_passport_element.type == self.type
+        assert encrypted_passport_element.type == self.type_
         assert encrypted_passport_element.data == self.data
         assert encrypted_passport_element.phone_number == self.phone_number
         assert encrypted_passport_element.email == self.email
@@ -75,8 +75,8 @@ class TestEncryptedPassportElement(object):
                 == encrypted_passport_element.selfie.to_dict())
 
     def test_equality(self):
-        a = EncryptedPassportElement(self.type, data=self.data)
-        b = EncryptedPassportElement(self.type, data=self.data)
+        a = EncryptedPassportElement(self.type_, data=self.data)
+        b = EncryptedPassportElement(self.type_, data=self.data)
         c = EncryptedPassportElement(self.data, '')
         d = PassportElementError('source', 'type', 'message')
 

--- a/tests/test_inlinequery.py
+++ b/tests/test_inlinequery.py
@@ -24,12 +24,12 @@ from telegram import User, Location, InlineQuery, Update
 
 @pytest.fixture(scope='class')
 def inline_query(bot):
-    return InlineQuery(TestInlineQuery.id, TestInlineQuery.from_user, TestInlineQuery.query,
+    return InlineQuery(TestInlineQuery.id_, TestInlineQuery.from_user, TestInlineQuery.query,
                        TestInlineQuery.offset, location=TestInlineQuery.location, bot=bot)
 
 
 class TestInlineQuery(object):
-    id = 1234
+    id_ = 1234
     from_user = User(1, 'First name', False)
     query = 'query text'
     offset = 'offset'
@@ -37,7 +37,7 @@ class TestInlineQuery(object):
 
     def test_de_json(self, bot):
         json_dict = {
-            'id': self.id,
+            'id': self.id_,
             'from': self.from_user.to_dict(),
             'query': self.query,
             'offset': self.offset,
@@ -45,7 +45,7 @@ class TestInlineQuery(object):
         }
         inline_query_json = InlineQuery.de_json(json_dict, bot)
 
-        assert inline_query_json.id == self.id
+        assert inline_query_json.id == self.id_
         assert inline_query_json.from_user == self.from_user
         assert inline_query_json.location == self.location
         assert inline_query_json.query == self.query
@@ -69,11 +69,11 @@ class TestInlineQuery(object):
         assert inline_query.answer()
 
     def test_equality(self):
-        a = InlineQuery(self.id, User(1, '', False), '', '')
-        b = InlineQuery(self.id, User(1, '', False), '', '')
-        c = InlineQuery(self.id, User(0, '', False), '', '')
+        a = InlineQuery(self.id_, User(1, '', False), '', '')
+        b = InlineQuery(self.id_, User(1, '', False), '', '')
+        c = InlineQuery(self.id_, User(0, '', False), '', '')
         d = InlineQuery(0, User(1, '', False), '', '')
-        e = Update(self.id)
+        e = Update(self.id_)
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_inlinequeryresultarticle.py
+++ b/tests/test_inlinequeryresultarticle.py
@@ -26,7 +26,7 @@ from telegram import (InlineKeyboardMarkup, InlineQueryResultAudio, InlineQueryR
 @pytest.fixture(scope='class')
 def inline_query_result_article():
     return InlineQueryResultArticle(
-        TestInlineQueryResultArticle.id,
+        TestInlineQueryResultArticle.id_,
         TestInlineQueryResultArticle.title,
         input_message_content=TestInlineQueryResultArticle.input_message_content,
         reply_markup=TestInlineQueryResultArticle.reply_markup,
@@ -39,8 +39,8 @@ def inline_query_result_article():
 
 
 class TestInlineQueryResultArticle(object):
-    id = 'id'
-    type = 'article'
+    id_ = 'id'
+    type_ = 'article'
     title = 'title'
     input_message_content = InputTextMessageContent('input_message_content')
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton('reply_markup')]])
@@ -52,8 +52,8 @@ class TestInlineQueryResultArticle(object):
     thumb_width = 15
 
     def test_expected_values(self, inline_query_result_article):
-        assert inline_query_result_article.type == self.type
-        assert inline_query_result_article.id == self.id
+        assert inline_query_result_article.type == self.type_
+        assert inline_query_result_article.id == self.id_
         assert inline_query_result_article.title == self.title
         assert (inline_query_result_article.input_message_content.to_dict()
                 == self.input_message_content.to_dict())
@@ -88,11 +88,11 @@ class TestInlineQueryResultArticle(object):
                 == inline_query_result_article.thumb_width)
 
     def test_equality(self):
-        a = InlineQueryResultArticle(self.id, self.title, self.input_message_content)
-        b = InlineQueryResultArticle(self.id, self.title, self.input_message_content)
-        c = InlineQueryResultArticle(self.id, '', self.input_message_content)
+        a = InlineQueryResultArticle(self.id_, self.title, self.input_message_content)
+        b = InlineQueryResultArticle(self.id_, self.title, self.input_message_content)
+        c = InlineQueryResultArticle(self.id_, '', self.input_message_content)
         d = InlineQueryResultArticle('', self.title, self.input_message_content)
-        e = InlineQueryResultAudio(self.id, '', '')
+        e = InlineQueryResultAudio(self.id_, '', '')
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_inlinequeryresultaudio.py
+++ b/tests/test_inlinequeryresultaudio.py
@@ -26,7 +26,7 @@ from telegram import (InlineKeyboardMarkup, InlineKeyboardButton, InlineQueryRes
 @pytest.fixture(scope='class')
 def inline_query_result_audio():
     return InlineQueryResultAudio(
-        TestInlineQueryResultAudio.id,
+        TestInlineQueryResultAudio.id_,
         TestInlineQueryResultAudio.audio_url,
         TestInlineQueryResultAudio.title,
         performer=TestInlineQueryResultAudio.performer,
@@ -38,8 +38,8 @@ def inline_query_result_audio():
 
 
 class TestInlineQueryResultAudio(object):
-    id = 'id'
-    type = 'audio'
+    id_ = 'id'
+    type_ = 'audio'
     audio_url = 'audio url'
     title = 'title'
     performer = 'performer'
@@ -50,8 +50,8 @@ class TestInlineQueryResultAudio(object):
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton('reply_markup')]])
 
     def test_expected_values(self, inline_query_result_audio):
-        assert inline_query_result_audio.type == self.type
-        assert inline_query_result_audio.id == self.id
+        assert inline_query_result_audio.type == self.type_
+        assert inline_query_result_audio.id == self.id_
         assert inline_query_result_audio.audio_url == self.audio_url
         assert inline_query_result_audio.title == self.title
         assert inline_query_result_audio.performer == self.performer
@@ -81,11 +81,11 @@ class TestInlineQueryResultAudio(object):
                 == inline_query_result_audio.reply_markup.to_dict())
 
     def test_equality(self):
-        a = InlineQueryResultAudio(self.id, self.audio_url, self.title)
-        b = InlineQueryResultAudio(self.id, self.title, self.title)
-        c = InlineQueryResultAudio(self.id, '', self.title)
+        a = InlineQueryResultAudio(self.id_, self.audio_url, self.title)
+        b = InlineQueryResultAudio(self.id_, self.title, self.title)
+        c = InlineQueryResultAudio(self.id_, '', self.title)
         d = InlineQueryResultAudio('', self.audio_url, self.title)
-        e = InlineQueryResultVoice(self.id, '', '')
+        e = InlineQueryResultVoice(self.id_, '', '')
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_inlinequeryresultcachedaudio.py
+++ b/tests/test_inlinequeryresultcachedaudio.py
@@ -26,7 +26,7 @@ from telegram import (InputTextMessageContent, InlineQueryResultCachedAudio, Inl
 @pytest.fixture(scope='class')
 def inline_query_result_cached_audio():
     return InlineQueryResultCachedAudio(
-        TestInlineQueryResultCachedAudio.id,
+        TestInlineQueryResultCachedAudio.id_,
         TestInlineQueryResultCachedAudio.audio_file_id,
         caption=TestInlineQueryResultCachedAudio.caption,
         parse_mode=TestInlineQueryResultCachedAudio.parse_mode,
@@ -35,8 +35,8 @@ def inline_query_result_cached_audio():
 
 
 class TestInlineQueryResultCachedAudio(object):
-    id = 'id'
-    type = 'audio'
+    id_ = 'id'
+    type_ = 'audio'
     audio_file_id = 'audio file id'
     caption = 'caption'
     parse_mode = 'HTML'
@@ -44,8 +44,8 @@ class TestInlineQueryResultCachedAudio(object):
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton('reply_markup')]])
 
     def test_expected_values(self, inline_query_result_cached_audio):
-        assert inline_query_result_cached_audio.type == self.type
-        assert inline_query_result_cached_audio.id == self.id
+        assert inline_query_result_cached_audio.type == self.type_
+        assert inline_query_result_cached_audio.id == self.id_
         assert inline_query_result_cached_audio.audio_file_id == self.audio_file_id
         assert inline_query_result_cached_audio.caption == self.caption
         assert inline_query_result_cached_audio.parse_mode == self.parse_mode
@@ -73,11 +73,11 @@ class TestInlineQueryResultCachedAudio(object):
                 == inline_query_result_cached_audio.reply_markup.to_dict())
 
     def test_equality(self):
-        a = InlineQueryResultCachedAudio(self.id, self.audio_file_id)
-        b = InlineQueryResultCachedAudio(self.id, self.audio_file_id)
-        c = InlineQueryResultCachedAudio(self.id, '')
+        a = InlineQueryResultCachedAudio(self.id_, self.audio_file_id)
+        b = InlineQueryResultCachedAudio(self.id_, self.audio_file_id)
+        c = InlineQueryResultCachedAudio(self.id_, '')
         d = InlineQueryResultCachedAudio('', self.audio_file_id)
-        e = InlineQueryResultCachedVoice(self.id, '', '')
+        e = InlineQueryResultCachedVoice(self.id_, '', '')
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_inlinequeryresultcacheddocument.py
+++ b/tests/test_inlinequeryresultcacheddocument.py
@@ -26,7 +26,7 @@ from telegram import (InlineQueryResultCachedDocument, InlineKeyboardButton, Inl
 @pytest.fixture(scope='class')
 def inline_query_result_cached_document():
     return InlineQueryResultCachedDocument(
-        TestInlineQueryResultCachedDocument.id,
+        TestInlineQueryResultCachedDocument.id_,
         TestInlineQueryResultCachedDocument.title,
         TestInlineQueryResultCachedDocument.document_file_id,
         caption=TestInlineQueryResultCachedDocument.caption,
@@ -37,8 +37,8 @@ def inline_query_result_cached_document():
 
 
 class TestInlineQueryResultCachedDocument(object):
-    id = 'id'
-    type = 'document'
+    id_ = 'id'
+    type_ = 'document'
     document_file_id = 'document file id'
     title = 'title'
     caption = 'caption'
@@ -48,8 +48,8 @@ class TestInlineQueryResultCachedDocument(object):
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton('reply_markup')]])
 
     def test_expected_values(self, inline_query_result_cached_document):
-        assert inline_query_result_cached_document.id == self.id
-        assert inline_query_result_cached_document.type == self.type
+        assert inline_query_result_cached_document.id == self.id_
+        assert inline_query_result_cached_document.type == self.type_
         assert inline_query_result_cached_document.document_file_id == self.document_file_id
         assert inline_query_result_cached_document.title == self.title
         assert inline_query_result_cached_document.caption == self.caption
@@ -84,11 +84,11 @@ class TestInlineQueryResultCachedDocument(object):
                 == inline_query_result_cached_document.reply_markup.to_dict())
 
     def test_equality(self):
-        a = InlineQueryResultCachedDocument(self.id, self.title, self.document_file_id)
-        b = InlineQueryResultCachedDocument(self.id, self.title, self.document_file_id)
-        c = InlineQueryResultCachedDocument(self.id, self.title, '')
+        a = InlineQueryResultCachedDocument(self.id_, self.title, self.document_file_id)
+        b = InlineQueryResultCachedDocument(self.id_, self.title, self.document_file_id)
+        c = InlineQueryResultCachedDocument(self.id_, self.title, '')
         d = InlineQueryResultCachedDocument('', self.title, self.document_file_id)
-        e = InlineQueryResultCachedVoice(self.id, '', '')
+        e = InlineQueryResultCachedVoice(self.id_, '', '')
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_inlinequeryresultcachedgif.py
+++ b/tests/test_inlinequeryresultcachedgif.py
@@ -26,7 +26,7 @@ from telegram import (InlineKeyboardButton, InputTextMessageContent, InlineQuery
 @pytest.fixture(scope='class')
 def inline_query_result_cached_gif():
     return InlineQueryResultCachedGif(
-        TestInlineQueryResultCachedGif.id,
+        TestInlineQueryResultCachedGif.id_,
         TestInlineQueryResultCachedGif.gif_file_id,
         title=TestInlineQueryResultCachedGif.title,
         caption=TestInlineQueryResultCachedGif.caption,
@@ -36,8 +36,8 @@ def inline_query_result_cached_gif():
 
 
 class TestInlineQueryResultCachedGif(object):
-    id = 'id'
-    type = 'gif'
+    id_ = 'id'
+    type_ = 'gif'
     gif_file_id = 'gif file id'
     title = 'title'
     caption = 'caption'
@@ -46,8 +46,8 @@ class TestInlineQueryResultCachedGif(object):
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton('reply_markup')]])
 
     def test_expected_values(self, inline_query_result_cached_gif):
-        assert inline_query_result_cached_gif.type == self.type
-        assert inline_query_result_cached_gif.id == self.id
+        assert inline_query_result_cached_gif.type == self.type_
+        assert inline_query_result_cached_gif.id == self.id_
         assert inline_query_result_cached_gif.gif_file_id == self.gif_file_id
         assert inline_query_result_cached_gif.title == self.title
         assert inline_query_result_cached_gif.caption == self.caption
@@ -75,11 +75,11 @@ class TestInlineQueryResultCachedGif(object):
                 == inline_query_result_cached_gif.reply_markup.to_dict())
 
     def test_equality(self):
-        a = InlineQueryResultCachedGif(self.id, self.gif_file_id)
-        b = InlineQueryResultCachedGif(self.id, self.gif_file_id)
-        c = InlineQueryResultCachedGif(self.id, '')
+        a = InlineQueryResultCachedGif(self.id_, self.gif_file_id)
+        b = InlineQueryResultCachedGif(self.id_, self.gif_file_id)
+        c = InlineQueryResultCachedGif(self.id_, '')
         d = InlineQueryResultCachedGif('', self.gif_file_id)
-        e = InlineQueryResultCachedVoice(self.id, '', '')
+        e = InlineQueryResultCachedVoice(self.id_, '', '')
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_inlinequeryresultcachedmpeg4gif.py
+++ b/tests/test_inlinequeryresultcachedmpeg4gif.py
@@ -26,7 +26,7 @@ from telegram import (InlineQueryResultCachedMpeg4Gif, InlineKeyboardButton,
 @pytest.fixture(scope='class')
 def inline_query_result_cached_mpeg4_gif():
     return InlineQueryResultCachedMpeg4Gif(
-        TestInlineQueryResultCachedMpeg4Gif.id,
+        TestInlineQueryResultCachedMpeg4Gif.id_,
         TestInlineQueryResultCachedMpeg4Gif.mpeg4_file_id,
         title=TestInlineQueryResultCachedMpeg4Gif.title,
         caption=TestInlineQueryResultCachedMpeg4Gif.caption,
@@ -36,8 +36,8 @@ def inline_query_result_cached_mpeg4_gif():
 
 
 class TestInlineQueryResultCachedMpeg4Gif(object):
-    id = 'id'
-    type = 'mpeg4_gif'
+    id_ = 'id'
+    type_ = 'mpeg4_gif'
     mpeg4_file_id = 'mpeg4 file id'
     title = 'title'
     caption = 'caption'
@@ -46,8 +46,8 @@ class TestInlineQueryResultCachedMpeg4Gif(object):
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton('reply_markup')]])
 
     def test_expected_values(self, inline_query_result_cached_mpeg4_gif):
-        assert inline_query_result_cached_mpeg4_gif.type == self.type
-        assert inline_query_result_cached_mpeg4_gif.id == self.id
+        assert inline_query_result_cached_mpeg4_gif.type == self.type_
+        assert inline_query_result_cached_mpeg4_gif.id == self.id_
         assert inline_query_result_cached_mpeg4_gif.mpeg4_file_id == self.mpeg4_file_id
         assert inline_query_result_cached_mpeg4_gif.title == self.title
         assert inline_query_result_cached_mpeg4_gif.caption == self.caption
@@ -79,11 +79,11 @@ class TestInlineQueryResultCachedMpeg4Gif(object):
                 == inline_query_result_cached_mpeg4_gif.reply_markup.to_dict())
 
     def test_equality(self):
-        a = InlineQueryResultCachedMpeg4Gif(self.id, self.mpeg4_file_id)
-        b = InlineQueryResultCachedMpeg4Gif(self.id, self.mpeg4_file_id)
-        c = InlineQueryResultCachedMpeg4Gif(self.id, '')
+        a = InlineQueryResultCachedMpeg4Gif(self.id_, self.mpeg4_file_id)
+        b = InlineQueryResultCachedMpeg4Gif(self.id_, self.mpeg4_file_id)
+        c = InlineQueryResultCachedMpeg4Gif(self.id_, '')
         d = InlineQueryResultCachedMpeg4Gif('', self.mpeg4_file_id)
-        e = InlineQueryResultCachedVoice(self.id, '', '')
+        e = InlineQueryResultCachedVoice(self.id_, '', '')
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_inlinequeryresultcachedphoto.py
+++ b/tests/test_inlinequeryresultcachedphoto.py
@@ -26,7 +26,7 @@ from telegram import (InputTextMessageContent, InlineQueryResultCachedPhoto, Inl
 @pytest.fixture(scope='class')
 def inline_query_result_cached_photo():
     return InlineQueryResultCachedPhoto(
-        TestInlineQueryResultCachedPhoto.id,
+        TestInlineQueryResultCachedPhoto.id_,
         TestInlineQueryResultCachedPhoto.photo_file_id,
         title=TestInlineQueryResultCachedPhoto.title,
         description=TestInlineQueryResultCachedPhoto.description,
@@ -37,8 +37,8 @@ def inline_query_result_cached_photo():
 
 
 class TestInlineQueryResultCachedPhoto(object):
-    id = 'id'
-    type = 'photo'
+    id_ = 'id'
+    type_ = 'photo'
     photo_file_id = 'photo file id'
     title = 'title'
     description = 'description'
@@ -48,8 +48,8 @@ class TestInlineQueryResultCachedPhoto(object):
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton('reply_markup')]])
 
     def test_expected_values(self, inline_query_result_cached_photo):
-        assert inline_query_result_cached_photo.type == self.type
-        assert inline_query_result_cached_photo.id == self.id
+        assert inline_query_result_cached_photo.type == self.type_
+        assert inline_query_result_cached_photo.id == self.id_
         assert inline_query_result_cached_photo.photo_file_id == self.photo_file_id
         assert inline_query_result_cached_photo.title == self.title
         assert inline_query_result_cached_photo.description == self.description
@@ -83,11 +83,11 @@ class TestInlineQueryResultCachedPhoto(object):
                 == inline_query_result_cached_photo.reply_markup.to_dict())
 
     def test_equality(self):
-        a = InlineQueryResultCachedPhoto(self.id, self.photo_file_id)
-        b = InlineQueryResultCachedPhoto(self.id, self.photo_file_id)
-        c = InlineQueryResultCachedPhoto(self.id, '')
+        a = InlineQueryResultCachedPhoto(self.id_, self.photo_file_id)
+        b = InlineQueryResultCachedPhoto(self.id_, self.photo_file_id)
+        c = InlineQueryResultCachedPhoto(self.id_, '')
         d = InlineQueryResultCachedPhoto('', self.photo_file_id)
-        e = InlineQueryResultCachedVoice(self.id, '', '')
+        e = InlineQueryResultCachedVoice(self.id_, '', '')
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_inlinequeryresultcachedsticker.py
+++ b/tests/test_inlinequeryresultcachedsticker.py
@@ -27,22 +27,22 @@ from telegram import (InputTextMessageContent, InlineKeyboardButton,
 @pytest.fixture(scope='class')
 def inline_query_result_cached_sticker():
     return InlineQueryResultCachedSticker(
-        TestInlineQueryResultCachedSticker.id,
+        TestInlineQueryResultCachedSticker.id_,
         TestInlineQueryResultCachedSticker.sticker_file_id,
         input_message_content=TestInlineQueryResultCachedSticker.input_message_content,
         reply_markup=TestInlineQueryResultCachedSticker.reply_markup)
 
 
 class TestInlineQueryResultCachedSticker(object):
-    id = 'id'
-    type = 'sticker'
+    id_ = 'id'
+    type_ = 'sticker'
     sticker_file_id = 'sticker file id'
     input_message_content = InputTextMessageContent('input_message_content')
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton('reply_markup')]])
 
     def test_expected_values(self, inline_query_result_cached_sticker):
-        assert inline_query_result_cached_sticker.type == self.type
-        assert inline_query_result_cached_sticker.id == self.id
+        assert inline_query_result_cached_sticker.type == self.type_
+        assert inline_query_result_cached_sticker.id == self.id_
         assert inline_query_result_cached_sticker.sticker_file_id == self.sticker_file_id
         assert (inline_query_result_cached_sticker.input_message_content.to_dict()
                 == self.input_message_content.to_dict())
@@ -65,11 +65,11 @@ class TestInlineQueryResultCachedSticker(object):
                 == inline_query_result_cached_sticker.reply_markup.to_dict())
 
     def test_equality(self):
-        a = InlineQueryResultCachedSticker(self.id, self.sticker_file_id)
-        b = InlineQueryResultCachedSticker(self.id, self.sticker_file_id)
-        c = InlineQueryResultCachedSticker(self.id, '')
+        a = InlineQueryResultCachedSticker(self.id_, self.sticker_file_id)
+        b = InlineQueryResultCachedSticker(self.id_, self.sticker_file_id)
+        c = InlineQueryResultCachedSticker(self.id_, '')
         d = InlineQueryResultCachedSticker('', self.sticker_file_id)
-        e = InlineQueryResultCachedVoice(self.id, '', '')
+        e = InlineQueryResultCachedVoice(self.id_, '', '')
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_inlinequeryresultcachedvideo.py
+++ b/tests/test_inlinequeryresultcachedvideo.py
@@ -26,7 +26,7 @@ from telegram import (InlineKeyboardMarkup, InlineKeyboardButton, InputTextMessa
 @pytest.fixture(scope='class')
 def inline_query_result_cached_video():
     return InlineQueryResultCachedVideo(
-        TestInlineQueryResultCachedVideo.id,
+        TestInlineQueryResultCachedVideo.id_,
         TestInlineQueryResultCachedVideo.video_file_id,
         TestInlineQueryResultCachedVideo.title,
         caption=TestInlineQueryResultCachedVideo.caption,
@@ -37,8 +37,8 @@ def inline_query_result_cached_video():
 
 
 class TestInlineQueryResultCachedVideo(object):
-    id = 'id'
-    type = 'video'
+    id_ = 'id'
+    type_ = 'video'
     video_file_id = 'video file id'
     title = 'title'
     caption = 'caption'
@@ -48,8 +48,8 @@ class TestInlineQueryResultCachedVideo(object):
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton('reply_markup')]])
 
     def test_expected_values(self, inline_query_result_cached_video):
-        assert inline_query_result_cached_video.type == self.type
-        assert inline_query_result_cached_video.id == self.id
+        assert inline_query_result_cached_video.type == self.type_
+        assert inline_query_result_cached_video.id == self.id_
         assert inline_query_result_cached_video.video_file_id == self.video_file_id
         assert inline_query_result_cached_video.title == self.title
         assert inline_query_result_cached_video.description == self.description
@@ -83,11 +83,11 @@ class TestInlineQueryResultCachedVideo(object):
                 == inline_query_result_cached_video.reply_markup.to_dict())
 
     def test_equality(self):
-        a = InlineQueryResultCachedVideo(self.id, self.video_file_id, self.title)
-        b = InlineQueryResultCachedVideo(self.id, self.video_file_id, self.title)
-        c = InlineQueryResultCachedVideo(self.id, '', self.title)
+        a = InlineQueryResultCachedVideo(self.id_, self.video_file_id, self.title)
+        b = InlineQueryResultCachedVideo(self.id_, self.video_file_id, self.title)
+        c = InlineQueryResultCachedVideo(self.id_, '', self.title)
         d = InlineQueryResultCachedVideo('', self.video_file_id, self.title)
-        e = InlineQueryResultCachedVoice(self.id, '', '')
+        e = InlineQueryResultCachedVoice(self.id_, '', '')
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_inlinequeryresultcachedvoice.py
+++ b/tests/test_inlinequeryresultcachedvoice.py
@@ -26,7 +26,7 @@ from telegram import (InlineQueryResultCachedVoice, InlineKeyboardButton, Inline
 @pytest.fixture(scope='class')
 def inline_query_result_cached_voice():
     return InlineQueryResultCachedVoice(
-        TestInlineQueryResultCachedVoice.id,
+        TestInlineQueryResultCachedVoice.id_,
         TestInlineQueryResultCachedVoice.voice_file_id,
         TestInlineQueryResultCachedVoice.title,
         caption=TestInlineQueryResultCachedVoice.caption,
@@ -36,8 +36,8 @@ def inline_query_result_cached_voice():
 
 
 class TestInlineQueryResultCachedVoice(object):
-    id = 'id'
-    type = 'voice'
+    id_ = 'id'
+    type_ = 'voice'
     voice_file_id = 'voice file id'
     title = 'title'
     caption = 'caption'
@@ -46,8 +46,8 @@ class TestInlineQueryResultCachedVoice(object):
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton('reply_markup')]])
 
     def test_expected_values(self, inline_query_result_cached_voice):
-        assert inline_query_result_cached_voice.type == self.type
-        assert inline_query_result_cached_voice.id == self.id
+        assert inline_query_result_cached_voice.type == self.type_
+        assert inline_query_result_cached_voice.id == self.id_
         assert inline_query_result_cached_voice.voice_file_id == self.voice_file_id
         assert inline_query_result_cached_voice.title == self.title
         assert inline_query_result_cached_voice.caption == self.caption
@@ -78,11 +78,11 @@ class TestInlineQueryResultCachedVoice(object):
                 == inline_query_result_cached_voice.reply_markup.to_dict())
 
     def test_equality(self):
-        a = InlineQueryResultCachedVoice(self.id, self.voice_file_id, self.title)
-        b = InlineQueryResultCachedVoice(self.id, self.voice_file_id, self.title)
-        c = InlineQueryResultCachedVoice(self.id, '', self.title)
+        a = InlineQueryResultCachedVoice(self.id_, self.voice_file_id, self.title)
+        b = InlineQueryResultCachedVoice(self.id_, self.voice_file_id, self.title)
+        c = InlineQueryResultCachedVoice(self.id_, '', self.title)
         d = InlineQueryResultCachedVoice('', self.voice_file_id, self.title)
-        e = InlineQueryResultCachedAudio(self.id, '', '')
+        e = InlineQueryResultCachedAudio(self.id_, '', '')
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_inlinequeryresultcontact.py
+++ b/tests/test_inlinequeryresultcontact.py
@@ -26,7 +26,7 @@ from telegram import (InlineQueryResultVoice, InputTextMessageContent, InlineKey
 @pytest.fixture(scope='class')
 def inline_query_result_contact():
     return InlineQueryResultContact(
-        TestInlineQueryResultContact.id,
+        TestInlineQueryResultContact.id_,
         TestInlineQueryResultContact.phone_number,
         TestInlineQueryResultContact.first_name,
         last_name=TestInlineQueryResultContact.last_name,
@@ -38,8 +38,8 @@ def inline_query_result_contact():
 
 
 class TestInlineQueryResultContact(object):
-    id = 'id'
-    type = 'contact'
+    id_ = 'id'
+    type_ = 'contact'
     phone_number = 'phone_number'
     first_name = 'first_name'
     last_name = 'last_name'
@@ -50,8 +50,8 @@ class TestInlineQueryResultContact(object):
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton('reply_markup')]])
 
     def test_expected_values(self, inline_query_result_contact):
-        assert inline_query_result_contact.id == self.id
-        assert inline_query_result_contact.type == self.type
+        assert inline_query_result_contact.id == self.id_
+        assert inline_query_result_contact.type == self.type_
         assert inline_query_result_contact.phone_number == self.phone_number
         assert inline_query_result_contact.first_name == self.first_name
         assert inline_query_result_contact.last_name == self.last_name
@@ -86,11 +86,11 @@ class TestInlineQueryResultContact(object):
                 == inline_query_result_contact.reply_markup.to_dict())
 
     def test_equality(self):
-        a = InlineQueryResultContact(self.id, self.phone_number, self.first_name)
-        b = InlineQueryResultContact(self.id, self.phone_number, self.first_name)
-        c = InlineQueryResultContact(self.id, '', self.first_name)
+        a = InlineQueryResultContact(self.id_, self.phone_number, self.first_name)
+        b = InlineQueryResultContact(self.id_, self.phone_number, self.first_name)
+        c = InlineQueryResultContact(self.id_, '', self.first_name)
         d = InlineQueryResultContact('', self.phone_number, self.first_name)
-        e = InlineQueryResultVoice(self.id, '', '')
+        e = InlineQueryResultVoice(self.id_, '', '')
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_inlinequeryresultdocument.py
+++ b/tests/test_inlinequeryresultdocument.py
@@ -26,7 +26,7 @@ from telegram import (InlineKeyboardButton, InputTextMessageContent, InlineQuery
 @pytest.fixture(scope='class')
 def inline_query_result_document():
     return InlineQueryResultDocument(
-        TestInlineQueryResultDocument.id,
+        TestInlineQueryResultDocument.id_,
         TestInlineQueryResultDocument.document_url,
         TestInlineQueryResultDocument.title,
         TestInlineQueryResultDocument.mime_type,
@@ -41,8 +41,8 @@ def inline_query_result_document():
 
 
 class TestInlineQueryResultDocument(object):
-    id = 'id'
-    type = 'document'
+    id_ = 'id'
+    type_ = 'document'
     document_url = 'document url'
     title = 'title'
     caption = 'caption'
@@ -56,8 +56,8 @@ class TestInlineQueryResultDocument(object):
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton('reply_markup')]])
 
     def test_expected_values(self, inline_query_result_document):
-        assert inline_query_result_document.id == self.id
-        assert inline_query_result_document.type == self.type
+        assert inline_query_result_document.id == self.id_
+        assert inline_query_result_document.type == self.type_
         assert inline_query_result_document.document_url == self.document_url
         assert inline_query_result_document.title == self.title
         assert inline_query_result_document.caption == self.caption
@@ -99,13 +99,13 @@ class TestInlineQueryResultDocument(object):
                 == inline_query_result_document.reply_markup.to_dict())
 
     def test_equality(self):
-        a = InlineQueryResultDocument(self.id, self.document_url, self.title,
+        a = InlineQueryResultDocument(self.id_, self.document_url, self.title,
                                       self.mime_type)
-        b = InlineQueryResultDocument(self.id, self.document_url, self.title,
+        b = InlineQueryResultDocument(self.id_, self.document_url, self.title,
                                       self.mime_type)
-        c = InlineQueryResultDocument(self.id, '', self.title, self.mime_type)
+        c = InlineQueryResultDocument(self.id_, '', self.title, self.mime_type)
         d = InlineQueryResultDocument('', self.document_url, self.title, self.mime_type)
-        e = InlineQueryResultVoice(self.id, '', '')
+        e = InlineQueryResultVoice(self.id_, '', '')
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_inlinequeryresultgame.py
+++ b/tests/test_inlinequeryresultgame.py
@@ -25,20 +25,20 @@ from telegram import (InlineKeyboardButton, InlineQueryResultGame,
 
 @pytest.fixture(scope='class')
 def inline_query_result_game():
-    return InlineQueryResultGame(TestInlineQueryResultGame.id,
+    return InlineQueryResultGame(TestInlineQueryResultGame.id_,
                                  TestInlineQueryResultGame.game_short_name,
                                  reply_markup=TestInlineQueryResultGame.reply_markup)
 
 
 class TestInlineQueryResultGame(object):
-    id = 'id'
-    type = 'game'
+    id_ = 'id'
+    type_ = 'game'
     game_short_name = 'game short name'
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton('reply_markup')]])
 
     def test_expected_values(self, inline_query_result_game):
-        assert inline_query_result_game.type == self.type
-        assert inline_query_result_game.id == self.id
+        assert inline_query_result_game.type == self.type_
+        assert inline_query_result_game.id == self.id_
         assert inline_query_result_game.game_short_name == self.game_short_name
         assert (inline_query_result_game.reply_markup.to_dict()
                 == self.reply_markup.to_dict())
@@ -55,11 +55,11 @@ class TestInlineQueryResultGame(object):
                 == inline_query_result_game.reply_markup.to_dict())
 
     def test_equality(self):
-        a = InlineQueryResultGame(self.id, self.game_short_name)
-        b = InlineQueryResultGame(self.id, self.game_short_name)
-        c = InlineQueryResultGame(self.id, '')
+        a = InlineQueryResultGame(self.id_, self.game_short_name)
+        b = InlineQueryResultGame(self.id_, self.game_short_name)
+        c = InlineQueryResultGame(self.id_, '')
         d = InlineQueryResultGame('', self.game_short_name)
-        e = InlineQueryResultVoice(self.id, '', '')
+        e = InlineQueryResultVoice(self.id_, '', '')
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_inlinequeryresultgif.py
+++ b/tests/test_inlinequeryresultgif.py
@@ -26,7 +26,7 @@ from telegram import (InlineKeyboardButton, InputTextMessageContent, InlineQuery
 @pytest.fixture(scope='class')
 def inline_query_result_gif():
     return InlineQueryResultGif(
-        TestInlineQueryResultGif.id,
+        TestInlineQueryResultGif.id_,
         TestInlineQueryResultGif.gif_url,
         TestInlineQueryResultGif.thumb_url,
         gif_width=TestInlineQueryResultGif.gif_width,
@@ -40,8 +40,8 @@ def inline_query_result_gif():
 
 
 class TestInlineQueryResultGif(object):
-    id = 'id'
-    type = 'gif'
+    id_ = 'id'
+    type_ = 'gif'
     gif_url = 'gif url'
     gif_width = 10
     gif_height = 15
@@ -54,8 +54,8 @@ class TestInlineQueryResultGif(object):
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton('reply_markup')]])
 
     def test_expected_values(self, inline_query_result_gif):
-        assert inline_query_result_gif.type == self.type
-        assert inline_query_result_gif.id == self.id
+        assert inline_query_result_gif.type == self.type_
+        assert inline_query_result_gif.id == self.id_
         assert inline_query_result_gif.gif_url == self.gif_url
         assert inline_query_result_gif.gif_width == self.gif_width
         assert inline_query_result_gif.gif_height == self.gif_height
@@ -88,11 +88,11 @@ class TestInlineQueryResultGif(object):
                 == inline_query_result_gif.reply_markup.to_dict())
 
     def test_equality(self):
-        a = InlineQueryResultGif(self.id, self.gif_url, self.thumb_url)
-        b = InlineQueryResultGif(self.id, self.gif_url, self.thumb_url)
-        c = InlineQueryResultGif(self.id, '', self.thumb_url)
+        a = InlineQueryResultGif(self.id_, self.gif_url, self.thumb_url)
+        b = InlineQueryResultGif(self.id_, self.gif_url, self.thumb_url)
+        c = InlineQueryResultGif(self.id_, '', self.thumb_url)
         d = InlineQueryResultGif('', self.gif_url, self.thumb_url)
-        e = InlineQueryResultVoice(self.id, '', '')
+        e = InlineQueryResultVoice(self.id_, '', '')
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_inlinequeryresultlocation.py
+++ b/tests/test_inlinequeryresultlocation.py
@@ -26,7 +26,7 @@ from telegram import (InputTextMessageContent, InlineQueryResultLocation, Inline
 @pytest.fixture(scope='class')
 def inline_query_result_location():
     return InlineQueryResultLocation(
-        TestInlineQueryResultLocation.id,
+        TestInlineQueryResultLocation.id_,
         TestInlineQueryResultLocation.latitude,
         TestInlineQueryResultLocation.longitude,
         TestInlineQueryResultLocation.title,
@@ -39,8 +39,8 @@ def inline_query_result_location():
 
 
 class TestInlineQueryResultLocation(object):
-    id = 'id'
-    type = 'location'
+    id_ = 'id'
+    type_ = 'location'
     latitude = 0.0
     longitude = 1.0
     title = 'title'
@@ -52,8 +52,8 @@ class TestInlineQueryResultLocation(object):
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton('reply_markup')]])
 
     def test_expected_values(self, inline_query_result_location):
-        assert inline_query_result_location.id == self.id
-        assert inline_query_result_location.type == self.type
+        assert inline_query_result_location.id == self.id_
+        assert inline_query_result_location.type == self.type_
         assert inline_query_result_location.latitude == self.latitude
         assert inline_query_result_location.longitude == self.longitude
         assert inline_query_result_location.title == self.title
@@ -90,11 +90,11 @@ class TestInlineQueryResultLocation(object):
                 == inline_query_result_location.reply_markup.to_dict())
 
     def test_equality(self):
-        a = InlineQueryResultLocation(self.id, self.longitude, self.latitude, self.title)
-        b = InlineQueryResultLocation(self.id, self.longitude, self.latitude, self.title)
-        c = InlineQueryResultLocation(self.id, 0, self.latitude, self.title)
+        a = InlineQueryResultLocation(self.id_, self.longitude, self.latitude, self.title)
+        b = InlineQueryResultLocation(self.id_, self.longitude, self.latitude, self.title)
+        c = InlineQueryResultLocation(self.id_, 0, self.latitude, self.title)
         d = InlineQueryResultLocation('', self.longitude, self.latitude, self.title)
-        e = InlineQueryResultVoice(self.id, '', '')
+        e = InlineQueryResultVoice(self.id_, '', '')
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_inlinequeryresultmpeg4gif.py
+++ b/tests/test_inlinequeryresultmpeg4gif.py
@@ -26,7 +26,7 @@ from telegram import (InlineQueryResultMpeg4Gif, InlineKeyboardButton, InlineQue
 @pytest.fixture(scope='class')
 def inline_query_result_mpeg4_gif():
     return InlineQueryResultMpeg4Gif(
-        TestInlineQueryResultMpeg4Gif.id,
+        TestInlineQueryResultMpeg4Gif.id_,
         TestInlineQueryResultMpeg4Gif.mpeg4_url,
         TestInlineQueryResultMpeg4Gif.thumb_url,
         mpeg4_width=TestInlineQueryResultMpeg4Gif.mpeg4_width,
@@ -40,8 +40,8 @@ def inline_query_result_mpeg4_gif():
 
 
 class TestInlineQueryResultMpeg4Gif(object):
-    id = 'id'
-    type = 'mpeg4_gif'
+    id_ = 'id'
+    type_ = 'mpeg4_gif'
     mpeg4_url = 'mpeg4 url'
     mpeg4_width = 10
     mpeg4_height = 15
@@ -54,8 +54,8 @@ class TestInlineQueryResultMpeg4Gif(object):
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton('reply_markup')]])
 
     def test_expected_values(self, inline_query_result_mpeg4_gif):
-        assert inline_query_result_mpeg4_gif.type == self.type
-        assert inline_query_result_mpeg4_gif.id == self.id
+        assert inline_query_result_mpeg4_gif.type == self.type_
+        assert inline_query_result_mpeg4_gif.id == self.id_
         assert inline_query_result_mpeg4_gif.mpeg4_url == self.mpeg4_url
         assert inline_query_result_mpeg4_gif.mpeg4_width == self.mpeg4_width
         assert inline_query_result_mpeg4_gif.mpeg4_height == self.mpeg4_height
@@ -95,11 +95,11 @@ class TestInlineQueryResultMpeg4Gif(object):
                 == inline_query_result_mpeg4_gif.reply_markup.to_dict())
 
     def test_equality(self):
-        a = InlineQueryResultMpeg4Gif(self.id, self.mpeg4_url, self.thumb_url)
-        b = InlineQueryResultMpeg4Gif(self.id, self.mpeg4_url, self.thumb_url)
-        c = InlineQueryResultMpeg4Gif(self.id, '', self.thumb_url)
+        a = InlineQueryResultMpeg4Gif(self.id_, self.mpeg4_url, self.thumb_url)
+        b = InlineQueryResultMpeg4Gif(self.id_, self.mpeg4_url, self.thumb_url)
+        c = InlineQueryResultMpeg4Gif(self.id_, '', self.thumb_url)
         d = InlineQueryResultMpeg4Gif('', self.mpeg4_url, self.thumb_url)
-        e = InlineQueryResultVoice(self.id, '', '')
+        e = InlineQueryResultVoice(self.id_, '', '')
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_inlinequeryresultphoto.py
+++ b/tests/test_inlinequeryresultphoto.py
@@ -26,7 +26,7 @@ from telegram import (InputTextMessageContent, InlineKeyboardButton, InlineKeybo
 @pytest.fixture(scope='class')
 def inline_query_result_photo():
     return InlineQueryResultPhoto(
-        TestInlineQueryResultPhoto.id,
+        TestInlineQueryResultPhoto.id_,
         TestInlineQueryResultPhoto.photo_url,
         TestInlineQueryResultPhoto.thumb_url,
         photo_width=TestInlineQueryResultPhoto.photo_width,
@@ -40,8 +40,8 @@ def inline_query_result_photo():
 
 
 class TestInlineQueryResultPhoto(object):
-    id = 'id'
-    type = 'photo'
+    id_ = 'id'
+    type_ = 'photo'
     photo_url = 'photo url'
     photo_width = 10
     photo_height = 15
@@ -54,8 +54,8 @@ class TestInlineQueryResultPhoto(object):
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton('reply_markup')]])
 
     def test_expected_values(self, inline_query_result_photo):
-        assert inline_query_result_photo.type == self.type
-        assert inline_query_result_photo.id == self.id
+        assert inline_query_result_photo.type == self.type_
+        assert inline_query_result_photo.id == self.id_
         assert inline_query_result_photo.photo_url == self.photo_url
         assert inline_query_result_photo.photo_width == self.photo_width
         assert inline_query_result_photo.photo_height == self.photo_height
@@ -91,11 +91,11 @@ class TestInlineQueryResultPhoto(object):
                 == inline_query_result_photo.reply_markup.to_dict())
 
     def test_equality(self):
-        a = InlineQueryResultPhoto(self.id, self.photo_url, self.thumb_url)
-        b = InlineQueryResultPhoto(self.id, self.photo_url, self.thumb_url)
-        c = InlineQueryResultPhoto(self.id, '', self.thumb_url)
+        a = InlineQueryResultPhoto(self.id_, self.photo_url, self.thumb_url)
+        b = InlineQueryResultPhoto(self.id_, self.photo_url, self.thumb_url)
+        c = InlineQueryResultPhoto(self.id_, '', self.thumb_url)
         d = InlineQueryResultPhoto('', self.photo_url, self.thumb_url)
-        e = InlineQueryResultVoice(self.id, '', '')
+        e = InlineQueryResultVoice(self.id_, '', '')
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_inlinequeryresultvenue.py
+++ b/tests/test_inlinequeryresultvenue.py
@@ -26,7 +26,7 @@ from telegram import (InlineQueryResultVoice, InputTextMessageContent, InlineKey
 @pytest.fixture(scope='class')
 def inline_query_result_venue():
     return InlineQueryResultVenue(
-        TestInlineQueryResultVenue.id,
+        TestInlineQueryResultVenue.id_,
         TestInlineQueryResultVenue.latitude,
         TestInlineQueryResultVenue.longitude,
         TestInlineQueryResultVenue.title,
@@ -41,8 +41,8 @@ def inline_query_result_venue():
 
 
 class TestInlineQueryResultVenue(object):
-    id = 'id'
-    type = 'venue'
+    id_ = 'id'
+    type_ = 'venue'
     latitude = 'latitude'
     longitude = 'longitude'
     title = 'title'
@@ -56,8 +56,8 @@ class TestInlineQueryResultVenue(object):
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton('reply_markup')]])
 
     def test_expected_values(self, inline_query_result_venue):
-        assert inline_query_result_venue.id == self.id
-        assert inline_query_result_venue.type == self.type
+        assert inline_query_result_venue.id == self.id_
+        assert inline_query_result_venue.type == self.type_
         assert inline_query_result_venue.latitude == self.latitude
         assert inline_query_result_venue.longitude == self.longitude
         assert inline_query_result_venue.title == self.title
@@ -96,14 +96,14 @@ class TestInlineQueryResultVenue(object):
                 == inline_query_result_venue.reply_markup.to_dict())
 
     def test_equality(self):
-        a = InlineQueryResultVenue(self.id, self.longitude, self.latitude, self.title,
+        a = InlineQueryResultVenue(self.id_, self.longitude, self.latitude, self.title,
                                    self.address)
-        b = InlineQueryResultVenue(self.id, self.longitude, self.latitude, self.title,
+        b = InlineQueryResultVenue(self.id_, self.longitude, self.latitude, self.title,
                                    self.address)
-        c = InlineQueryResultVenue(self.id, '', self.latitude, self.title, self.address)
+        c = InlineQueryResultVenue(self.id_, '', self.latitude, self.title, self.address)
         d = InlineQueryResultVenue('', self.longitude, self.latitude, self.title,
                                    self.address)
-        e = InlineQueryResultVoice(self.id, '', '')
+        e = InlineQueryResultVoice(self.id_, '', '')
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_inlinequeryresultvideo.py
+++ b/tests/test_inlinequeryresultvideo.py
@@ -26,7 +26,7 @@ from telegram import (InlineKeyboardButton, InputTextMessageContent, InlineQuery
 @pytest.fixture(scope='class')
 def inline_query_result_video():
     return InlineQueryResultVideo(
-        TestInlineQueryResultVideo.id,
+        TestInlineQueryResultVideo.id_,
         TestInlineQueryResultVideo.video_url,
         TestInlineQueryResultVideo.mime_type,
         TestInlineQueryResultVideo.thumb_url,
@@ -42,8 +42,8 @@ def inline_query_result_video():
 
 
 class TestInlineQueryResultVideo(object):
-    id = 'id'
-    type = 'video'
+    id_ = 'id'
+    type_ = 'video'
     video_url = 'video url'
     mime_type = 'mime type'
     video_width = 10
@@ -58,8 +58,8 @@ class TestInlineQueryResultVideo(object):
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton('reply_markup')]])
 
     def test_expected_values(self, inline_query_result_video):
-        assert inline_query_result_video.type == self.type
-        assert inline_query_result_video.id == self.id
+        assert inline_query_result_video.type == self.type_
+        assert inline_query_result_video.id == self.id_
         assert inline_query_result_video.video_url == self.video_url
         assert inline_query_result_video.mime_type == self.mime_type
         assert inline_query_result_video.video_width == self.video_width
@@ -100,15 +100,15 @@ class TestInlineQueryResultVideo(object):
                 == inline_query_result_video.reply_markup.to_dict())
 
     def test_equality(self):
-        a = InlineQueryResultVideo(self.id, self.video_url, self.mime_type,
+        a = InlineQueryResultVideo(self.id_, self.video_url, self.mime_type,
                                    self.thumb_url, self.title)
-        b = InlineQueryResultVideo(self.id, self.video_url, self.mime_type,
+        b = InlineQueryResultVideo(self.id_, self.video_url, self.mime_type,
                                    self.thumb_url, self.title)
-        c = InlineQueryResultVideo(self.id, '', self.mime_type, self.thumb_url,
+        c = InlineQueryResultVideo(self.id_, '', self.mime_type, self.thumb_url,
                                    self.title)
         d = InlineQueryResultVideo('', self.video_url, self.mime_type, self.thumb_url,
                                    self.title)
-        e = InlineQueryResultVoice(self.id, '', '')
+        e = InlineQueryResultVoice(self.id_, '', '')
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_inlinequeryresultvoice.py
+++ b/tests/test_inlinequeryresultvoice.py
@@ -26,8 +26,8 @@ from telegram import (InlineKeyboardButton, InputTextMessageContent, InlineQuery
 @pytest.fixture(scope='class')
 def inline_query_result_voice():
     return InlineQueryResultVoice(
-        type=TestInlineQueryResultVoice.type,
-        id=TestInlineQueryResultVoice.id,
+        type=TestInlineQueryResultVoice.type_,
+        id=TestInlineQueryResultVoice.id_,
         voice_url=TestInlineQueryResultVoice.voice_url,
         title=TestInlineQueryResultVoice.title,
         voice_duration=TestInlineQueryResultVoice.voice_duration,
@@ -38,8 +38,8 @@ def inline_query_result_voice():
 
 
 class TestInlineQueryResultVoice(object):
-    id = 'id'
-    type = 'voice'
+    id_ = 'id'
+    type_ = 'voice'
     voice_url = 'voice url'
     title = 'title'
     voice_duration = 'voice_duration'
@@ -49,8 +49,8 @@ class TestInlineQueryResultVoice(object):
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton('reply_markup')]])
 
     def test_expected_values(self, inline_query_result_voice):
-        assert inline_query_result_voice.type == self.type
-        assert inline_query_result_voice.id == self.id
+        assert inline_query_result_voice.type == self.type_
+        assert inline_query_result_voice.id == self.id_
         assert inline_query_result_voice.voice_url == self.voice_url
         assert inline_query_result_voice.title == self.title
         assert inline_query_result_voice.voice_duration == self.voice_duration
@@ -78,11 +78,11 @@ class TestInlineQueryResultVoice(object):
                 == inline_query_result_voice.reply_markup.to_dict())
 
     def test_equality(self):
-        a = InlineQueryResultVoice(self.id, self.voice_url, self.title)
-        b = InlineQueryResultVoice(self.id, self.voice_url, self.title)
-        c = InlineQueryResultVoice(self.id, '', self.title)
+        a = InlineQueryResultVoice(self.id_, self.voice_url, self.title)
+        b = InlineQueryResultVoice(self.id_, self.voice_url, self.title)
+        c = InlineQueryResultVoice(self.id_, '', self.title)
         d = InlineQueryResultVoice('', self.voice_url, self.title)
-        e = InlineQueryResultAudio(self.id, '', '')
+        e = InlineQueryResultAudio(self.id_, '', '')
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_inputmedia.py
+++ b/tests/test_inputmedia.py
@@ -83,7 +83,7 @@ def input_media_document(class_thumb_file):
 
 
 class TestInputMediaVideo(object):
-    type = "video"
+    type_ = "video"
     media = "NOTAREALFILEID"
     caption = "My Caption"
     width = 3
@@ -93,7 +93,7 @@ class TestInputMediaVideo(object):
     supports_streaming = True
 
     def test_expected_values(self, input_media_video):
-        assert input_media_video.type == self.type
+        assert input_media_video.type == self.type_
         assert input_media_video.media == self.media
         assert input_media_video.caption == self.caption
         assert input_media_video.width == self.width
@@ -117,7 +117,7 @@ class TestInputMediaVideo(object):
     def test_with_video(self, video):  # noqa: F811
         # fixture found in test_video
         input_media_video = InputMediaVideo(video, caption="test 3")
-        assert input_media_video.type == self.type
+        assert input_media_video.type == self.type_
         assert input_media_video.media == video.file_id
         assert input_media_video.width == video.width
         assert input_media_video.height == video.height
@@ -127,19 +127,19 @@ class TestInputMediaVideo(object):
     def test_with_video_file(self, video_file):  # noqa: F811
         # fixture found in test_video
         input_media_video = InputMediaVideo(video_file, caption="test 3")
-        assert input_media_video.type == self.type
+        assert input_media_video.type == self.type_
         assert isinstance(input_media_video.media, InputFile)
         assert input_media_video.caption == "test 3"
 
 
 class TestInputMediaPhoto(object):
-    type = "photo"
+    type_ = "photo"
     media = "NOTAREALFILEID"
     caption = "My Caption"
     parse_mode = 'Markdown'
 
     def test_expected_values(self, input_media_photo):
-        assert input_media_photo.type == self.type
+        assert input_media_photo.type == self.type_
         assert input_media_photo.media == self.media
         assert input_media_photo.caption == self.caption
         assert input_media_photo.parse_mode == self.parse_mode
@@ -154,20 +154,20 @@ class TestInputMediaPhoto(object):
     def test_with_photo(self, photo):  # noqa: F811
         # fixture found in test_photo
         input_media_photo = InputMediaPhoto(photo, caption="test 2")
-        assert input_media_photo.type == self.type
+        assert input_media_photo.type == self.type_
         assert input_media_photo.media == photo.file_id
         assert input_media_photo.caption == "test 2"
 
     def test_with_photo_file(self, photo_file):  # noqa: F811
         # fixture found in test_photo
         input_media_photo = InputMediaPhoto(photo_file, caption="test 2")
-        assert input_media_photo.type == self.type
+        assert input_media_photo.type == self.type_
         assert isinstance(input_media_photo.media, InputFile)
         assert input_media_photo.caption == "test 2"
 
 
 class TestInputMediaAnimation(object):
-    type = "animation"
+    type_ = "animation"
     media = "NOTAREALFILEID"
     caption = "My Caption"
     parse_mode = 'Markdown'
@@ -176,7 +176,7 @@ class TestInputMediaAnimation(object):
     duration = 1
 
     def test_expected_values(self, input_media_animation):
-        assert input_media_animation.type == self.type
+        assert input_media_animation.type == self.type_
         assert input_media_animation.media == self.media
         assert input_media_animation.caption == self.caption
         assert input_media_animation.parse_mode == self.parse_mode
@@ -195,20 +195,20 @@ class TestInputMediaAnimation(object):
     def test_with_animation(self, animation):  # noqa: F811
         # fixture found in test_animation
         input_media_animation = InputMediaAnimation(animation, caption="test 2")
-        assert input_media_animation.type == self.type
+        assert input_media_animation.type == self.type_
         assert input_media_animation.media == animation.file_id
         assert input_media_animation.caption == "test 2"
 
     def test_with_animation_file(self, animation_file):  # noqa: F811
         # fixture found in test_animation
         input_media_animation = InputMediaAnimation(animation_file, caption="test 2")
-        assert input_media_animation.type == self.type
+        assert input_media_animation.type == self.type_
         assert isinstance(input_media_animation.media, InputFile)
         assert input_media_animation.caption == "test 2"
 
 
 class TestInputMediaAudio(object):
-    type = "audio"
+    type_ = "audio"
     media = "NOTAREALFILEID"
     caption = "My Caption"
     duration = 3
@@ -217,7 +217,7 @@ class TestInputMediaAudio(object):
     parse_mode = 'HTML'
 
     def test_expected_values(self, input_media_audio):
-        assert input_media_audio.type == self.type
+        assert input_media_audio.type == self.type_
         assert input_media_audio.media == self.media
         assert input_media_audio.caption == self.caption
         assert input_media_audio.duration == self.duration
@@ -239,7 +239,7 @@ class TestInputMediaAudio(object):
     def test_with_audio(self, audio):  # noqa: F811
         # fixture found in test_audio
         input_media_audio = InputMediaAudio(audio, caption="test 3")
-        assert input_media_audio.type == self.type
+        assert input_media_audio.type == self.type_
         assert input_media_audio.media == audio.file_id
         assert input_media_audio.duration == audio.duration
         assert input_media_audio.performer == audio.performer
@@ -249,19 +249,19 @@ class TestInputMediaAudio(object):
     def test_with_audio_file(self, audio_file):  # noqa: F811
         # fixture found in test_audio
         input_media_audio = InputMediaAudio(audio_file, caption="test 3")
-        assert input_media_audio.type == self.type
+        assert input_media_audio.type == self.type_
         assert isinstance(input_media_audio.media, InputFile)
         assert input_media_audio.caption == "test 3"
 
 
 class TestInputMediaDocument(object):
-    type = "document"
+    type_ = "document"
     media = "NOTAREALFILEID"
     caption = "My Caption"
     parse_mode = 'HTML'
 
     def test_expected_values(self, input_media_document):
-        assert input_media_document.type == self.type
+        assert input_media_document.type == self.type_
         assert input_media_document.media == self.media
         assert input_media_document.caption == self.caption
         assert input_media_document.parse_mode == self.parse_mode
@@ -277,14 +277,14 @@ class TestInputMediaDocument(object):
     def test_with_document(self, document):  # noqa: F811
         # fixture found in test_document
         input_media_document = InputMediaDocument(document, caption="test 3")
-        assert input_media_document.type == self.type
+        assert input_media_document.type == self.type_
         assert input_media_document.media == document.file_id
         assert input_media_document.caption == "test 3"
 
     def test_with_document_file(self, document_file):  # noqa: F811
         # fixture found in test_document
         input_media_document = InputMediaDocument(document_file, caption="test 3")
-        assert input_media_document.type == self.type
+        assert input_media_document.type == self.type_
         assert isinstance(input_media_document.media, InputFile)
         assert input_media_document.caption == "test 3"
 

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -67,8 +67,8 @@ class TestLocation(object):
         def test(_, url, data, **kwargs):
             lat = data['latitude'] == location.latitude
             lon = data['longitude'] == location.longitude
-            id = data['inline_message_id'] == 1234
-            return lat and lon and id
+            id_ = data['inline_message_id'] == 1234
+            return lat and lon and id_
 
         monkeypatch.setattr('telegram.utils.request.Request.post', test)
         assert bot.edit_message_live_location(inline_message_id=1234, location=location)
@@ -76,8 +76,8 @@ class TestLocation(object):
     # TODO: Needs improvement with in inline sent live location.
     def test_stop_live_inline_message(self, monkeypatch, bot):
         def test(_, url, data, **kwargs):
-            id = data['inline_message_id'] == 1234
-            return id
+            id_ = data['inline_message_id'] == 1234
+            return id_
 
         monkeypatch.setattr('telegram.utils.request.Request.post', test)
         assert bot.stop_message_live_location(inline_message_id=1234)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -28,7 +28,7 @@ from tests.test_passport import RAW_PASSPORT_DATA
 
 @pytest.fixture(scope='class')
 def message(bot):
-    return Message(TestMessage.id, TestMessage.from_user, TestMessage.date, TestMessage.chat,
+    return Message(TestMessage.id_, TestMessage.from_user, TestMessage.date, TestMessage.chat,
                    bot=bot)
 
 
@@ -107,14 +107,14 @@ def message(bot):
                      'photo_from_media_group', 'passport_data', 'poll', 'reply_markup',
                      'default_quote'])
 def message_params(bot, request):
-    return Message(message_id=TestMessage.id,
+    return Message(message_id=TestMessage.id_,
                    from_user=TestMessage.from_user,
                    date=TestMessage.date,
                    chat=TestMessage.chat, bot=bot, **request.param)
 
 
 class TestMessage(object):
-    id = 1
+    id_ = 1
     from_user = User(2, 'testuser', False)
     date = datetime.utcnow()
     chat = Chat(3, 'private')
@@ -345,13 +345,13 @@ class TestMessage(object):
 
     def test_reply_text(self, monkeypatch, message):
         def test(*args, **kwargs):
-            id = args[0] == message.chat_id
+            id_ = args[0] == message.chat_id
             text = args[1] == 'test'
             if kwargs.get('reply_to_message_id'):
                 reply = kwargs['reply_to_message_id'] == message.message_id
             else:
                 reply = True
-            return id and text and reply
+            return id_ and text and reply
 
         monkeypatch.setattr(message.bot, 'send_message', test)
         assert message.reply_text('test')
@@ -411,13 +411,13 @@ class TestMessage(object):
 
     def test_reply_media_group(self, monkeypatch, message):
         def test(*args, **kwargs):
-            id = args[0] == message.chat_id
+            id_ = args[0] == message.chat_id
             media = kwargs['media'] == 'reply_media_group'
             if kwargs.get('reply_to_message_id'):
                 reply = kwargs['reply_to_message_id'] == message.message_id
             else:
                 reply = True
-            return id and media and reply
+            return id_ and media and reply
 
         monkeypatch.setattr(message.bot, 'send_media_group', test)
         assert message.reply_media_group(media='reply_media_group')
@@ -425,13 +425,13 @@ class TestMessage(object):
 
     def test_reply_photo(self, monkeypatch, message):
         def test(*args, **kwargs):
-            id = args[0] == message.chat_id
+            id_ = args[0] == message.chat_id
             photo = kwargs['photo'] == 'test_photo'
             if kwargs.get('reply_to_message_id'):
                 reply = kwargs['reply_to_message_id'] == message.message_id
             else:
                 reply = True
-            return id and photo and reply
+            return id_ and photo and reply
 
         monkeypatch.setattr(message.bot, 'send_photo', test)
         assert message.reply_photo(photo='test_photo')
@@ -439,13 +439,13 @@ class TestMessage(object):
 
     def test_reply_audio(self, monkeypatch, message):
         def test(*args, **kwargs):
-            id = args[0] == message.chat_id
+            id_ = args[0] == message.chat_id
             audio = kwargs['audio'] == 'test_audio'
             if kwargs.get('reply_to_message_id'):
                 reply = kwargs['reply_to_message_id'] == message.message_id
             else:
                 reply = True
-            return id and audio and reply
+            return id_ and audio and reply
 
         monkeypatch.setattr(message.bot, 'send_audio', test)
         assert message.reply_audio(audio='test_audio')
@@ -453,13 +453,13 @@ class TestMessage(object):
 
     def test_reply_document(self, monkeypatch, message):
         def test(*args, **kwargs):
-            id = args[0] == message.chat_id
+            id_ = args[0] == message.chat_id
             document = kwargs['document'] == 'test_document'
             if kwargs.get('reply_to_message_id'):
                 reply = kwargs['reply_to_message_id'] == message.message_id
             else:
                 reply = True
-            return id and document and reply
+            return id_ and document and reply
 
         monkeypatch.setattr(message.bot, 'send_document', test)
         assert message.reply_document(document='test_document')
@@ -467,13 +467,13 @@ class TestMessage(object):
 
     def test_reply_animation(self, monkeypatch, message):
         def test(*args, **kwargs):
-            id = args[0] == message.chat_id
+            id_ = args[0] == message.chat_id
             animation = kwargs['animation'] == 'test_animation'
             if kwargs.get('reply_to_message_id'):
                 reply = kwargs['reply_to_message_id'] == message.message_id
             else:
                 reply = True
-            return id and animation and reply
+            return id_ and animation and reply
 
         monkeypatch.setattr(message.bot, 'send_animation', test)
         assert message.reply_animation(animation='test_animation')
@@ -481,13 +481,13 @@ class TestMessage(object):
 
     def test_reply_sticker(self, monkeypatch, message):
         def test(*args, **kwargs):
-            id = args[0] == message.chat_id
+            id_ = args[0] == message.chat_id
             sticker = kwargs['sticker'] == 'test_sticker'
             if kwargs.get('reply_to_message_id'):
                 reply = kwargs['reply_to_message_id'] == message.message_id
             else:
                 reply = True
-            return id and sticker and reply
+            return id_ and sticker and reply
 
         monkeypatch.setattr(message.bot, 'send_sticker', test)
         assert message.reply_sticker(sticker='test_sticker')
@@ -495,13 +495,13 @@ class TestMessage(object):
 
     def test_reply_video(self, monkeypatch, message):
         def test(*args, **kwargs):
-            id = args[0] == message.chat_id
+            id_ = args[0] == message.chat_id
             video = kwargs['video'] == 'test_video'
             if kwargs.get('reply_to_message_id'):
                 reply = kwargs['reply_to_message_id'] == message.message_id
             else:
                 reply = True
-            return id and video and reply
+            return id_ and video and reply
 
         monkeypatch.setattr(message.bot, 'send_video', test)
         assert message.reply_video(video='test_video')
@@ -509,13 +509,13 @@ class TestMessage(object):
 
     def test_reply_video_note(self, monkeypatch, message):
         def test(*args, **kwargs):
-            id = args[0] == message.chat_id
+            id_ = args[0] == message.chat_id
             video_note = kwargs['video_note'] == 'test_video_note'
             if kwargs.get('reply_to_message_id'):
                 reply = kwargs['reply_to_message_id'] == message.message_id
             else:
                 reply = True
-            return id and video_note and reply
+            return id_ and video_note and reply
 
         monkeypatch.setattr(message.bot, 'send_video_note', test)
         assert message.reply_video_note(video_note='test_video_note')
@@ -523,13 +523,13 @@ class TestMessage(object):
 
     def test_reply_voice(self, monkeypatch, message):
         def test(*args, **kwargs):
-            id = args[0] == message.chat_id
+            id_ = args[0] == message.chat_id
             voice = kwargs['voice'] == 'test_voice'
             if kwargs.get('reply_to_message_id'):
                 reply = kwargs['reply_to_message_id'] == message.message_id
             else:
                 reply = True
-            return id and voice and reply
+            return id_ and voice and reply
 
         monkeypatch.setattr(message.bot, 'send_voice', test)
         assert message.reply_voice(voice='test_voice')
@@ -537,13 +537,13 @@ class TestMessage(object):
 
     def test_reply_location(self, monkeypatch, message):
         def test(*args, **kwargs):
-            id = args[0] == message.chat_id
+            id_ = args[0] == message.chat_id
             location = kwargs['location'] == 'test_location'
             if kwargs.get('reply_to_message_id'):
                 reply = kwargs['reply_to_message_id'] == message.message_id
             else:
                 reply = True
-            return id and location and reply
+            return id_ and location and reply
 
         monkeypatch.setattr(message.bot, 'send_location', test)
         assert message.reply_location(location='test_location')
@@ -551,13 +551,13 @@ class TestMessage(object):
 
     def test_reply_venue(self, monkeypatch, message):
         def test(*args, **kwargs):
-            id = args[0] == message.chat_id
+            id_ = args[0] == message.chat_id
             venue = kwargs['venue'] == 'test_venue'
             if kwargs.get('reply_to_message_id'):
                 reply = kwargs['reply_to_message_id'] == message.message_id
             else:
                 reply = True
-            return id and venue and reply
+            return id_ and venue and reply
 
         monkeypatch.setattr(message.bot, 'send_venue', test)
         assert message.reply_venue(venue='test_venue')
@@ -565,13 +565,13 @@ class TestMessage(object):
 
     def test_reply_contact(self, monkeypatch, message):
         def test(*args, **kwargs):
-            id = args[0] == message.chat_id
+            id_ = args[0] == message.chat_id
             contact = kwargs['contact'] == 'test_contact'
             if kwargs.get('reply_to_message_id'):
                 reply = kwargs['reply_to_message_id'] == message.message_id
             else:
                 reply = True
-            return id and contact and reply
+            return id_ and contact and reply
 
         monkeypatch.setattr(message.bot, 'send_contact', test)
         assert message.reply_contact(contact='test_contact')
@@ -579,13 +579,13 @@ class TestMessage(object):
 
     def test_reply_poll(self, monkeypatch, message):
         def test(*args, **kwargs):
-            id = args[0] == message.chat_id
+            id_ = args[0] == message.chat_id
             contact = kwargs['contact'] == 'test_poll'
             if kwargs.get('reply_to_message_id'):
                 reply = kwargs['reply_to_message_id'] == message.message_id
             else:
                 reply = True
-            return id and contact and reply
+            return id_ and contact and reply
 
         monkeypatch.setattr(message.bot, 'send_poll', test)
         assert message.reply_poll(contact='test_poll')
@@ -678,12 +678,12 @@ class TestMessage(object):
         assert 'reply_to_message_id' in kwargs
 
     def test_equality(self):
-        id = 1
-        a = Message(id, self.from_user, self.date, self.chat)
-        b = Message(id, self.from_user, self.date, self.chat)
-        c = Message(id, User(0, '', False), self.date, self.chat)
+        id_ = 1
+        a = Message(id_, self.from_user, self.date, self.chat)
+        b = Message(id_, self.from_user, self.date, self.chat)
+        c = Message(id_, User(0, '', False), self.date, self.chat)
         d = Message(0, self.from_user, self.date, self.chat)
-        e = Update(id)
+        e = Update(id_)
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_messageentity.py
+++ b/tests/test_messageentity.py
@@ -25,31 +25,31 @@ from telegram import MessageEntity, User
 @pytest.fixture(scope="class",
                 params=MessageEntity.ALL_TYPES)
 def message_entity(request):
-    type = request.param
+    type_ = request.param
     url = None
-    if type == MessageEntity.TEXT_LINK:
+    if type_ == MessageEntity.TEXT_LINK:
         url = 't.me'
     user = None
-    if type == MessageEntity.TEXT_MENTION:
+    if type_ == MessageEntity.TEXT_MENTION:
         user = User(1, 'test_user', False)
     return MessageEntity(type, 1, 3, url=url, user=user)
 
 
 class TestMessageEntity(object):
-    type = 'url'
+    type_ = 'url'
     offset = 1
     length = 2
     url = 'url'
 
     def test_de_json(self, bot):
         json_dict = {
-            'type': self.type,
+            'type': self.type_,
             'offset': self.offset,
             'length': self.length
         }
         entity = MessageEntity.de_json(json_dict, bot)
 
-        assert entity.type == self.type
+        assert entity.type == self.type_
         assert entity.offset == self.offset
         assert entity.length == self.length
 

--- a/tests/test_messagequeue.py
+++ b/tests/test_messagequeue.py
@@ -43,7 +43,7 @@ class TestDelayQueue(object):
                             autostart=True)
         assert dsp.is_alive() is True
 
-        for i in range(self.N):
+        for _ in range(self.N):
             dsp(self.call)
 
         starttime = mq.curtime()

--- a/tests/test_passportelementerrordatafield.py
+++ b/tests/test_passportelementerrordatafield.py
@@ -24,7 +24,7 @@ from telegram import PassportElementErrorDataField, PassportElementErrorSelfie
 
 @pytest.fixture(scope='class')
 def passport_element_error_data_field():
-    return PassportElementErrorDataField(TestPassportElementErrorDataField.type,
+    return PassportElementErrorDataField(TestPassportElementErrorDataField.type_,
                                          TestPassportElementErrorDataField.field_name,
                                          TestPassportElementErrorDataField.data_hash,
                                          TestPassportElementErrorDataField.message)
@@ -32,14 +32,14 @@ def passport_element_error_data_field():
 
 class TestPassportElementErrorDataField(object):
     source = 'data'
-    type = 'test_type'
+    type_ = 'test_type'
     field_name = 'test_field'
     data_hash = 'data_hash'
     message = 'Error message'
 
     def test_expected_values(self, passport_element_error_data_field):
         assert passport_element_error_data_field.source == self.source
-        assert passport_element_error_data_field.type == self.type
+        assert passport_element_error_data_field.type == self.type_
         assert passport_element_error_data_field.field_name == self.field_name
         assert passport_element_error_data_field.data_hash == self.data_hash
         assert passport_element_error_data_field.message == self.message
@@ -60,13 +60,15 @@ class TestPassportElementErrorDataField(object):
                 == passport_element_error_data_field.message)
 
     def test_equality(self):
-        a = PassportElementErrorDataField(self.type, self.field_name, self.data_hash, self.message)
-        b = PassportElementErrorDataField(self.type, self.field_name, self.data_hash, self.message)
-        c = PassportElementErrorDataField(self.type, '', '', '')
+        a = PassportElementErrorDataField(self.type_, self.field_name, self.data_hash,
+                                          self.message)
+        b = PassportElementErrorDataField(self.type_, self.field_name, self.data_hash,
+                                          self.message)
+        c = PassportElementErrorDataField(self.type_, '', '', '')
         d = PassportElementErrorDataField('', self.field_name, '', '')
         e = PassportElementErrorDataField('', '', self.data_hash, '')
         f = PassportElementErrorDataField('', '', '', self.message)
-        g = PassportElementErrorSelfie(self.type, '', self.message)
+        g = PassportElementErrorSelfie(self.type_, '', self.message)
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_passportelementerrorfile.py
+++ b/tests/test_passportelementerrorfile.py
@@ -24,20 +24,20 @@ from telegram import PassportElementErrorFile, PassportElementErrorSelfie
 
 @pytest.fixture(scope='class')
 def passport_element_error_file():
-    return PassportElementErrorFile(TestPassportElementErrorFile.type,
+    return PassportElementErrorFile(TestPassportElementErrorFile.type_,
                                     TestPassportElementErrorFile.file_hash,
                                     TestPassportElementErrorFile.message)
 
 
 class TestPassportElementErrorFile(object):
     source = 'file'
-    type = 'test_type'
+    type_ = 'test_type'
     file_hash = 'file_hash'
     message = 'Error message'
 
     def test_expected_values(self, passport_element_error_file):
         assert passport_element_error_file.source == self.source
-        assert passport_element_error_file.type == self.type
+        assert passport_element_error_file.type == self.type_
         assert passport_element_error_file.file_hash == self.file_hash
         assert passport_element_error_file.message == self.message
 
@@ -55,12 +55,12 @@ class TestPassportElementErrorFile(object):
                 == passport_element_error_file.message)
 
     def test_equality(self):
-        a = PassportElementErrorFile(self.type, self.file_hash, self.message)
-        b = PassportElementErrorFile(self.type, self.file_hash, self.message)
-        c = PassportElementErrorFile(self.type, '', '')
+        a = PassportElementErrorFile(self.type_, self.file_hash, self.message)
+        b = PassportElementErrorFile(self.type_, self.file_hash, self.message)
+        c = PassportElementErrorFile(self.type_, '', '')
         d = PassportElementErrorFile('', self.file_hash, '')
         e = PassportElementErrorFile('', '', self.message)
-        f = PassportElementErrorSelfie(self.type, self.file_hash, self.message)
+        f = PassportElementErrorSelfie(self.type_, self.file_hash, self.message)
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_passportelementerrorfiles.py
+++ b/tests/test_passportelementerrorfiles.py
@@ -24,20 +24,20 @@ from telegram import PassportElementErrorFiles, PassportElementErrorSelfie
 
 @pytest.fixture(scope='class')
 def passport_element_error_files():
-    return PassportElementErrorFiles(TestPassportElementErrorFiles.type,
+    return PassportElementErrorFiles(TestPassportElementErrorFiles.type_,
                                      TestPassportElementErrorFiles.file_hashes,
                                      TestPassportElementErrorFiles.message)
 
 
 class TestPassportElementErrorFiles(object):
     source = 'files'
-    type = 'test_type'
+    type_ = 'test_type'
     file_hashes = ['hash1', 'hash2']
     message = 'Error message'
 
     def test_expected_values(self, passport_element_error_files):
         assert passport_element_error_files.source == self.source
-        assert passport_element_error_files.type == self.type
+        assert passport_element_error_files.type == self.type_
         assert isinstance(passport_element_error_files.file_hashes, list)
         assert passport_element_error_files.file_hashes == self.file_hashes
         assert passport_element_error_files.message == self.message
@@ -56,12 +56,12 @@ class TestPassportElementErrorFiles(object):
                 == passport_element_error_files.message)
 
     def test_equality(self):
-        a = PassportElementErrorFiles(self.type, self.file_hashes, self.message)
-        b = PassportElementErrorFiles(self.type, self.file_hashes, self.message)
-        c = PassportElementErrorFiles(self.type, '', '')
+        a = PassportElementErrorFiles(self.type_, self.file_hashes, self.message)
+        b = PassportElementErrorFiles(self.type_, self.file_hashes, self.message)
+        c = PassportElementErrorFiles(self.type_, '', '')
         d = PassportElementErrorFiles('', self.file_hashes, '')
         e = PassportElementErrorFiles('', '', self.message)
-        f = PassportElementErrorSelfie(self.type, '', self.message)
+        f = PassportElementErrorSelfie(self.type_, '', self.message)
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_passportelementerrorfrontside.py
+++ b/tests/test_passportelementerrorfrontside.py
@@ -24,20 +24,20 @@ from telegram import PassportElementErrorFrontSide, PassportElementErrorSelfie
 
 @pytest.fixture(scope='class')
 def passport_element_error_front_side():
-    return PassportElementErrorFrontSide(TestPassportElementErrorFrontSide.type,
+    return PassportElementErrorFrontSide(TestPassportElementErrorFrontSide.type_,
                                          TestPassportElementErrorFrontSide.file_hash,
                                          TestPassportElementErrorFrontSide.message)
 
 
 class TestPassportElementErrorFrontSide(object):
     source = 'front_side'
-    type = 'test_type'
+    type_ = 'test_type'
     file_hash = 'file_hash'
     message = 'Error message'
 
     def test_expected_values(self, passport_element_error_front_side):
         assert passport_element_error_front_side.source == self.source
-        assert passport_element_error_front_side.type == self.type
+        assert passport_element_error_front_side.type == self.type_
         assert passport_element_error_front_side.file_hash == self.file_hash
         assert passport_element_error_front_side.message == self.message
 
@@ -55,12 +55,12 @@ class TestPassportElementErrorFrontSide(object):
                 == passport_element_error_front_side.message)
 
     def test_equality(self):
-        a = PassportElementErrorFrontSide(self.type, self.file_hash, self.message)
-        b = PassportElementErrorFrontSide(self.type, self.file_hash, self.message)
-        c = PassportElementErrorFrontSide(self.type, '', '')
+        a = PassportElementErrorFrontSide(self.type_, self.file_hash, self.message)
+        b = PassportElementErrorFrontSide(self.type_, self.file_hash, self.message)
+        c = PassportElementErrorFrontSide(self.type_, '', '')
         d = PassportElementErrorFrontSide('', self.file_hash, '')
         e = PassportElementErrorFrontSide('', '', self.message)
-        f = PassportElementErrorSelfie(self.type, self.file_hash, self.message)
+        f = PassportElementErrorSelfie(self.type_, self.file_hash, self.message)
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_passportelementerrorreverseside.py
+++ b/tests/test_passportelementerrorreverseside.py
@@ -24,20 +24,20 @@ from telegram import PassportElementErrorReverseSide, PassportElementErrorSelfie
 
 @pytest.fixture(scope='class')
 def passport_element_error_reverse_side():
-    return PassportElementErrorReverseSide(TestPassportElementErrorReverseSide.type,
+    return PassportElementErrorReverseSide(TestPassportElementErrorReverseSide.type_,
                                            TestPassportElementErrorReverseSide.file_hash,
                                            TestPassportElementErrorReverseSide.message)
 
 
 class TestPassportElementErrorReverseSide(object):
     source = 'reverse_side'
-    type = 'test_type'
+    type_ = 'test_type'
     file_hash = 'file_hash'
     message = 'Error message'
 
     def test_expected_values(self, passport_element_error_reverse_side):
         assert passport_element_error_reverse_side.source == self.source
-        assert passport_element_error_reverse_side.type == self.type
+        assert passport_element_error_reverse_side.type == self.type_
         assert passport_element_error_reverse_side.file_hash == self.file_hash
         assert passport_element_error_reverse_side.message == self.message
 
@@ -55,12 +55,12 @@ class TestPassportElementErrorReverseSide(object):
                 == passport_element_error_reverse_side.message)
 
     def test_equality(self):
-        a = PassportElementErrorReverseSide(self.type, self.file_hash, self.message)
-        b = PassportElementErrorReverseSide(self.type, self.file_hash, self.message)
-        c = PassportElementErrorReverseSide(self.type, '', '')
+        a = PassportElementErrorReverseSide(self.type_, self.file_hash, self.message)
+        b = PassportElementErrorReverseSide(self.type_, self.file_hash, self.message)
+        c = PassportElementErrorReverseSide(self.type_, '', '')
         d = PassportElementErrorReverseSide('', self.file_hash, '')
         e = PassportElementErrorReverseSide('', '', self.message)
-        f = PassportElementErrorSelfie(self.type, self.file_hash, self.message)
+        f = PassportElementErrorSelfie(self.type_, self.file_hash, self.message)
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_passportelementerrorselfie.py
+++ b/tests/test_passportelementerrorselfie.py
@@ -24,20 +24,20 @@ from telegram import PassportElementErrorSelfie, PassportElementErrorDataField
 
 @pytest.fixture(scope='class')
 def passport_element_error_selfie():
-    return PassportElementErrorSelfie(TestPassportElementErrorSelfie.type,
+    return PassportElementErrorSelfie(TestPassportElementErrorSelfie.type_,
                                       TestPassportElementErrorSelfie.file_hash,
                                       TestPassportElementErrorSelfie.message)
 
 
 class TestPassportElementErrorSelfie(object):
     source = 'selfie'
-    type = 'test_type'
+    type_ = 'test_type'
     file_hash = 'file_hash'
     message = 'Error message'
 
     def test_expected_values(self, passport_element_error_selfie):
         assert passport_element_error_selfie.source == self.source
-        assert passport_element_error_selfie.type == self.type
+        assert passport_element_error_selfie.type == self.type_
         assert passport_element_error_selfie.file_hash == self.file_hash
         assert passport_element_error_selfie.message == self.message
 
@@ -55,12 +55,12 @@ class TestPassportElementErrorSelfie(object):
                 == passport_element_error_selfie.message)
 
     def test_equality(self):
-        a = PassportElementErrorSelfie(self.type, self.file_hash, self.message)
-        b = PassportElementErrorSelfie(self.type, self.file_hash, self.message)
-        c = PassportElementErrorSelfie(self.type, '', '')
+        a = PassportElementErrorSelfie(self.type_, self.file_hash, self.message)
+        b = PassportElementErrorSelfie(self.type_, self.file_hash, self.message)
+        c = PassportElementErrorSelfie(self.type_, '', '')
         d = PassportElementErrorSelfie('', self.file_hash, '')
         e = PassportElementErrorSelfie('', '', self.message)
-        f = PassportElementErrorDataField(self.type, '', '', self.message)
+        f = PassportElementErrorDataField(self.type_, '', '', self.message)
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_passportelementerrortranslationfile.py
+++ b/tests/test_passportelementerrortranslationfile.py
@@ -24,20 +24,20 @@ from telegram import PassportElementErrorTranslationFile, PassportElementErrorDa
 
 @pytest.fixture(scope='class')
 def passport_element_error_translation_file():
-    return PassportElementErrorTranslationFile(TestPassportElementErrorTranslationFile.type,
+    return PassportElementErrorTranslationFile(TestPassportElementErrorTranslationFile.type_,
                                                TestPassportElementErrorTranslationFile.file_hash,
                                                TestPassportElementErrorTranslationFile.message)
 
 
 class TestPassportElementErrorTranslationFile(object):
     source = 'translation_file'
-    type = 'test_type'
+    type_ = 'test_type'
     file_hash = 'file_hash'
     message = 'Error message'
 
     def test_expected_values(self, passport_element_error_translation_file):
         assert passport_element_error_translation_file.source == self.source
-        assert passport_element_error_translation_file.type == self.type
+        assert passport_element_error_translation_file.type == self.type_
         assert passport_element_error_translation_file.file_hash == self.file_hash
         assert passport_element_error_translation_file.message == self.message
 
@@ -56,12 +56,12 @@ class TestPassportElementErrorTranslationFile(object):
                 == passport_element_error_translation_file.message)
 
     def test_equality(self):
-        a = PassportElementErrorTranslationFile(self.type, self.file_hash, self.message)
-        b = PassportElementErrorTranslationFile(self.type, self.file_hash, self.message)
-        c = PassportElementErrorTranslationFile(self.type, '', '')
+        a = PassportElementErrorTranslationFile(self.type_, self.file_hash, self.message)
+        b = PassportElementErrorTranslationFile(self.type_, self.file_hash, self.message)
+        c = PassportElementErrorTranslationFile(self.type_, '', '')
         d = PassportElementErrorTranslationFile('', self.file_hash, '')
         e = PassportElementErrorTranslationFile('', '', self.message)
-        f = PassportElementErrorDataField(self.type, '', '', self.message)
+        f = PassportElementErrorDataField(self.type_, '', '', self.message)
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_passportelementerrortranslationfiles.py
+++ b/tests/test_passportelementerrortranslationfiles.py
@@ -25,20 +25,20 @@ from telegram import PassportElementErrorTranslationFiles, PassportElementErrorS
 @pytest.fixture(scope='class')
 def passport_element_error_translation_files():
     return PassportElementErrorTranslationFiles(
-        TestPassportElementErrorTranslationFiles.type,
+        TestPassportElementErrorTranslationFiles.type_,
         TestPassportElementErrorTranslationFiles.file_hashes,
         TestPassportElementErrorTranslationFiles.message)
 
 
 class TestPassportElementErrorTranslationFiles(object):
     source = 'translation_files'
-    type = 'test_type'
+    type_ = 'test_type'
     file_hashes = ['hash1', 'hash2']
     message = 'Error message'
 
     def test_expected_values(self, passport_element_error_translation_files):
         assert passport_element_error_translation_files.source == self.source
-        assert passport_element_error_translation_files.type == self.type
+        assert passport_element_error_translation_files.type == self.type_
         assert isinstance(passport_element_error_translation_files.file_hashes, list)
         assert passport_element_error_translation_files.file_hashes == self.file_hashes
         assert passport_element_error_translation_files.message == self.message
@@ -58,12 +58,12 @@ class TestPassportElementErrorTranslationFiles(object):
                 == passport_element_error_translation_files.message)
 
     def test_equality(self):
-        a = PassportElementErrorTranslationFiles(self.type, self.file_hashes, self.message)
-        b = PassportElementErrorTranslationFiles(self.type, self.file_hashes, self.message)
-        c = PassportElementErrorTranslationFiles(self.type, '', '')
+        a = PassportElementErrorTranslationFiles(self.type_, self.file_hashes, self.message)
+        b = PassportElementErrorTranslationFiles(self.type_, self.file_hashes, self.message)
+        c = PassportElementErrorTranslationFiles(self.type_, '', '')
         d = PassportElementErrorTranslationFiles('', self.file_hashes, '')
         e = PassportElementErrorTranslationFiles('', '', self.message)
-        f = PassportElementErrorSelfie(self.type, '', self.message)
+        f = PassportElementErrorSelfie(self.type_, '', self.message)
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_passportelementerrorunspecified.py
+++ b/tests/test_passportelementerrorunspecified.py
@@ -24,20 +24,20 @@ from telegram import PassportElementErrorUnspecified, PassportElementErrorDataFi
 
 @pytest.fixture(scope='class')
 def passport_element_error_unspecified():
-    return PassportElementErrorUnspecified(TestPassportElementErrorUnspecified.type,
+    return PassportElementErrorUnspecified(TestPassportElementErrorUnspecified.type_,
                                            TestPassportElementErrorUnspecified.element_hash,
                                            TestPassportElementErrorUnspecified.message)
 
 
 class TestPassportElementErrorUnspecified(object):
     source = 'unspecified'
-    type = 'test_type'
+    type_ = 'test_type'
     element_hash = 'element_hash'
     message = 'Error message'
 
     def test_expected_values(self, passport_element_error_unspecified):
         assert passport_element_error_unspecified.source == self.source
-        assert passport_element_error_unspecified.type == self.type
+        assert passport_element_error_unspecified.type == self.type_
         assert passport_element_error_unspecified.element_hash == self.element_hash
         assert passport_element_error_unspecified.message == self.message
 
@@ -55,12 +55,12 @@ class TestPassportElementErrorUnspecified(object):
                 == passport_element_error_unspecified.message)
 
     def test_equality(self):
-        a = PassportElementErrorUnspecified(self.type, self.element_hash, self.message)
-        b = PassportElementErrorUnspecified(self.type, self.element_hash, self.message)
-        c = PassportElementErrorUnspecified(self.type, '', '')
+        a = PassportElementErrorUnspecified(self.type_, self.element_hash, self.message)
+        b = PassportElementErrorUnspecified(self.type_, self.element_hash, self.message)
+        c = PassportElementErrorUnspecified(self.type_, '', '')
         d = PassportElementErrorUnspecified('', self.element_hash, '')
         e = PassportElementErrorUnspecified('', '', self.message)
-        f = PassportElementErrorDataField(self.type, '', '', self.message)
+        f = PassportElementErrorDataField(self.type_, '', '', self.message)
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -317,8 +317,8 @@ def bad_pickle_files():
 
 @pytest.fixture(scope='function')
 def good_pickle_files(user_data, chat_data, bot_data, conversations):
-    all = {'user_data': user_data, 'chat_data': chat_data,
-           'bot_data': bot_data, 'conversations': conversations}
+    data = {'user_data': user_data, 'chat_data': chat_data,
+            'bot_data': bot_data, 'conversations': conversations}
     with open('pickletest_user_data', 'wb') as f:
         pickle.dump(user_data, f)
     with open('pickletest_chat_data', 'wb') as f:
@@ -328,7 +328,7 @@ def good_pickle_files(user_data, chat_data, bot_data, conversations):
     with open('pickletest_conversations', 'wb') as f:
         pickle.dump(conversations, f)
     with open('pickletest', 'wb') as f:
-        pickle.dump(all, f)
+        pickle.dump(data, f)
     yield True
     for name in ['pickletest_user_data', 'pickletest_chat_data', 'pickletest_bot_data',
                  'pickletest_conversations', 'pickletest']:
@@ -337,7 +337,7 @@ def good_pickle_files(user_data, chat_data, bot_data, conversations):
 
 @pytest.fixture(scope='function')
 def pickle_files_wo_bot_data(user_data, chat_data, conversations):
-    all = {'user_data': user_data, 'chat_data': chat_data, 'conversations': conversations}
+    data = {'user_data': user_data, 'chat_data': chat_data, 'conversations': conversations}
     with open('pickletest_user_data', 'wb') as f:
         pickle.dump(user_data, f)
     with open('pickletest_chat_data', 'wb') as f:
@@ -345,7 +345,7 @@ def pickle_files_wo_bot_data(user_data, chat_data, conversations):
     with open('pickletest_conversations', 'wb') as f:
         pickle.dump(conversations, f)
     with open('pickletest', 'wb') as f:
-        pickle.dump(all, f)
+        pickle.dump(data, f)
     yield True
     for name in ['pickletest_user_data', 'pickletest_chat_data',
                  'pickletest_conversations', 'pickletest']:

--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -52,28 +52,28 @@ class TestPollOption(object):
 
 @pytest.fixture(scope='class')
 def poll():
-    return Poll(TestPoll.id,
+    return Poll(TestPoll.id_,
                 TestPoll.question,
                 TestPoll.options,
                 TestPoll.is_closed)
 
 
 class TestPoll(object):
-    id = 'id'
+    id_ = 'id'
     question = 'Test?'
     options = [PollOption('test', 10), PollOption('test2', 11)]
     is_closed = True
 
     def test_de_json(self):
         json_dict = {
-            'id': self.id,
+            'id': self.id_,
             'question': self.question,
             'options': [o.to_dict() for o in self.options],
             'is_closed': self.is_closed
         }
         poll = Poll.de_json(json_dict, None)
 
-        assert poll.id == self.id
+        assert poll.id == self.id_
         assert poll.question == self.question
         assert poll.options == self.options
         assert poll.options[0].text == self.options[0].text

--- a/tests/test_precheckoutquery.py
+++ b/tests/test_precheckoutquery.py
@@ -24,7 +24,7 @@ from telegram import Update, User, PreCheckoutQuery, OrderInfo
 
 @pytest.fixture(scope='class')
 def pre_checkout_query(bot):
-    return PreCheckoutQuery(TestPreCheckoutQuery.id,
+    return PreCheckoutQuery(TestPreCheckoutQuery.id_,
                             TestPreCheckoutQuery.from_user,
                             TestPreCheckoutQuery.currency,
                             TestPreCheckoutQuery.total_amount,
@@ -35,7 +35,7 @@ def pre_checkout_query(bot):
 
 
 class TestPreCheckoutQuery(object):
-    id = 5
+    id_ = 5
     invoice_payload = 'invoice_payload'
     shipping_option_id = 'shipping_option_id'
     currency = 'EUR'
@@ -45,7 +45,7 @@ class TestPreCheckoutQuery(object):
 
     def test_de_json(self, bot):
         json_dict = {
-            'id': self.id,
+            'id': self.id_,
             'invoice_payload': self.invoice_payload,
             'shipping_option_id': self.shipping_option_id,
             'currency': self.currency,
@@ -56,7 +56,7 @@ class TestPreCheckoutQuery(object):
         pre_checkout_query = PreCheckoutQuery.de_json(json_dict, bot)
 
         assert pre_checkout_query.bot is bot
-        assert pre_checkout_query.id == self.id
+        assert pre_checkout_query.id == self.id_
         assert pre_checkout_query.invoice_payload == self.invoice_payload
         assert pre_checkout_query.shipping_option_id == self.shipping_option_id
         assert pre_checkout_query.currency == self.currency
@@ -83,14 +83,14 @@ class TestPreCheckoutQuery(object):
         assert pre_checkout_query.answer()
 
     def test_equality(self):
-        a = PreCheckoutQuery(self.id, self.from_user, self.currency, self.total_amount,
+        a = PreCheckoutQuery(self.id_, self.from_user, self.currency, self.total_amount,
                              self.invoice_payload)
-        b = PreCheckoutQuery(self.id, self.from_user, self.currency, self.total_amount,
+        b = PreCheckoutQuery(self.id_, self.from_user, self.currency, self.total_amount,
                              self.invoice_payload)
-        c = PreCheckoutQuery(self.id, None, '', 0, '')
+        c = PreCheckoutQuery(self.id_, None, '', 0, '')
         d = PreCheckoutQuery(0, self.from_user, self.currency, self.total_amount,
                              self.invoice_payload)
-        e = Update(self.id)
+        e = Update(self.id_)
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_shippingoption.py
+++ b/tests/test_shippingoption.py
@@ -24,12 +24,12 @@ from telegram import LabeledPrice, ShippingOption, Voice
 
 @pytest.fixture(scope='class')
 def shipping_option():
-    return ShippingOption(TestShippingOption.id, TestShippingOption.title,
+    return ShippingOption(TestShippingOption.id_, TestShippingOption.title,
                           TestShippingOption.prices)
 
 
 class TestShippingOption(object):
-    id = 'id'
+    id_ = 'id'
     title = 'title'
     prices = [
         LabeledPrice('Fish Container', 100),
@@ -37,7 +37,7 @@ class TestShippingOption(object):
     ]
 
     def test_expected_values(self, shipping_option):
-        assert shipping_option.id == self.id
+        assert shipping_option.id == self.id_
         assert shipping_option.title == self.title
         assert shipping_option.prices == self.prices
 
@@ -51,11 +51,11 @@ class TestShippingOption(object):
         assert shipping_option_dict['prices'][1] == shipping_option.prices[1].to_dict()
 
     def test_equality(self):
-        a = ShippingOption(self.id, self.title, self.prices)
-        b = ShippingOption(self.id, self.title, self.prices)
-        c = ShippingOption(self.id, '', [])
+        a = ShippingOption(self.id_, self.title, self.prices)
+        b = ShippingOption(self.id_, self.title, self.prices)
+        c = ShippingOption(self.id_, '', [])
         d = ShippingOption(0, self.title, self.prices)
-        e = Voice(self.id, 0)
+        e = Voice(self.id_, 0)
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_shippingquery.py
+++ b/tests/test_shippingquery.py
@@ -24,7 +24,7 @@ from telegram import Update, User, ShippingAddress, ShippingQuery
 
 @pytest.fixture(scope='class')
 def shipping_query(bot):
-    return ShippingQuery(TestShippingQuery.id,
+    return ShippingQuery(TestShippingQuery.id_,
                          TestShippingQuery.from_user,
                          TestShippingQuery.invoice_payload,
                          TestShippingQuery.shipping_address,
@@ -32,21 +32,21 @@ def shipping_query(bot):
 
 
 class TestShippingQuery(object):
-    id = 5
+    id_ = 5
     invoice_payload = 'invoice_payload'
     from_user = User(0, '', False)
     shipping_address = ShippingAddress('GB', '', 'London', '12 Grimmauld Place', '', 'WC1')
 
     def test_de_json(self, bot):
         json_dict = {
-            'id': TestShippingQuery.id,
+            'id': TestShippingQuery.id_,
             'invoice_payload': TestShippingQuery.invoice_payload,
             'from': TestShippingQuery.from_user.to_dict(),
             'shipping_address': TestShippingQuery.shipping_address.to_dict()
         }
         shipping_query = ShippingQuery.de_json(json_dict, bot)
 
-        assert shipping_query.id == self.id
+        assert shipping_query.id == self.id_
         assert shipping_query.invoice_payload == self.invoice_payload
         assert shipping_query.from_user == self.from_user
         assert shipping_query.shipping_address == self.shipping_address
@@ -69,11 +69,11 @@ class TestShippingQuery(object):
         assert shipping_query.answer()
 
     def test_equality(self):
-        a = ShippingQuery(self.id, self.from_user, self.invoice_payload, self.shipping_address)
-        b = ShippingQuery(self.id, self.from_user, self.invoice_payload, self.shipping_address)
-        c = ShippingQuery(self.id, None, '', None)
+        a = ShippingQuery(self.id_, self.from_user, self.invoice_payload, self.shipping_address)
+        b = ShippingQuery(self.id_, self.from_user, self.invoice_payload, self.shipping_address)
+        c = ShippingQuery(self.id_, None, '', None)
         d = ShippingQuery(0, self.from_user, self.invoice_payload, self.shipping_address)
-        e = Update(self.id)
+        e = Update(self.id_)
 
         assert a == b
         assert hash(a) == hash(b)

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -24,7 +24,7 @@ from telegram import User, Update
 @pytest.fixture(scope='function')
 def json_dict():
     return {
-        'id': TestUser.id,
+        'id': TestUser.id_,
         'is_bot': TestUser.is_bot,
         'first_name': TestUser.first_name,
         'last_name': TestUser.last_name,
@@ -35,13 +35,13 @@ def json_dict():
 
 @pytest.fixture(scope='function')
 def user(bot):
-    return User(id=TestUser.id, first_name=TestUser.first_name, is_bot=TestUser.is_bot,
+    return User(id=TestUser.id_, first_name=TestUser.first_name, is_bot=TestUser.is_bot,
                 last_name=TestUser.last_name, username=TestUser.username,
                 language_code=TestUser.language_code, bot=bot)
 
 
 class TestUser(object):
-    id = 1
+    id_ = 1
     is_bot = True
     first_name = u'first\u2022name'
     last_name = u'last\u2022name'
@@ -51,7 +51,7 @@ class TestUser(object):
     def test_de_json(self, json_dict, bot):
         user = User.de_json(json_dict, bot)
 
-        assert user.id == self.id
+        assert user.id == self.id_
         assert user.is_bot == self.is_bot
         assert user.first_name == self.first_name
         assert user.last_name == self.last_name
@@ -63,7 +63,7 @@ class TestUser(object):
 
         user = User.de_json(json_dict, bot)
 
-        assert user.id == self.id
+        assert user.id == self.id_
         assert user.is_bot == self.is_bot
         assert user.first_name == self.first_name
         assert user.last_name == self.last_name
@@ -76,7 +76,7 @@ class TestUser(object):
 
         user = User.de_json(json_dict, bot)
 
-        assert user.id == self.id
+        assert user.id == self.id_
         assert user.is_bot == self.is_bot
         assert user.first_name == self.first_name
         assert user.last_name is None
@@ -189,11 +189,11 @@ class TestUser(object):
         assert user.mention_markdown(user.username) == expected.format(user.username, user.id)
 
     def test_equality(self):
-        a = User(self.id, self.first_name, self.is_bot, self.last_name)
-        b = User(self.id, self.first_name, self.is_bot, self.last_name)
-        c = User(self.id, self.first_name, self.is_bot)
+        a = User(self.id_, self.first_name, self.is_bot, self.last_name)
+        b = User(self.id_, self.first_name, self.is_bot, self.last_name)
+        c = User(self.id_, self.first_name, self.is_bot)
         d = User(0, self.first_name, self.is_bot, self.last_name)
-        e = Update(self.id)
+        e = Update(self.id_)
 
         assert a == b
         assert hash(a) == hash(b)


### PR DESCRIPTION
Closes #1766 

`all` is still used in `filters.py` for `Filters.all`.
`id` and `type` are used multiple times in the files classes, but that's API …
However, in the tests I changed all `id` and `type` variables to `id_` and `type_`.