### PR TITLE
Add Py3.8 to docs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,5 +64,5 @@ with codecs.open('README.rst', 'r', 'utf-8') as fd:
               'Programming Language :: Python :: 3.5',
               'Programming Language :: Python :: 3.6',
               'Programming Language :: Python :: 3.7',
-              'Programming Language :: Python :: 3.8'
+              'Programming Language :: Python :: 3.8',
           ],)

--- a/setup.py
+++ b/setup.py
@@ -63,5 +63,6 @@ with codecs.open('README.rst', 'r', 'utf-8') as fd:
               'Programming Language :: Python :: 3',
               'Programming Language :: Python :: 3.5',
               'Programming Language :: Python :: 3.6',
-              'Programming Language :: Python :: 3.7'
+              'Programming Language :: Python :: 3.7',
+              'Programming Language :: Python :: 3.8'
           ],)


### PR DESCRIPTION
The README already says python 3.5+, so we're good there.
Added py38 to setup.py
If I understand correctly, the pypi badge will state py3.8 as soon as we release with the new setup.py

@Poolitzer, do we need to do something with the pytest yml?

```yml
matrix:
  python-version: [3.5, 3.6, 3.7, 3.8]
  os: [ubuntu-latest, windows-latest]
  include:
    - os: ubuntu-latest
      python-version: 3.7
      test-build: True
    - os: windows-latest
      python-version: 3.7
      test-build: True
```
