### PR TITLE
Improve Persistence

### DIFF
--- a/telegram/ext/dictpersistence.py
+++ b/telegram/ext/dictpersistence.py
@@ -226,6 +226,8 @@ class DictPersistence(BasePersistence):
             user_id (:obj:`int`): The user the data might have been changed for.
             data (:obj:`dict`): The :attr:`telegram.ext.dispatcher.user_data` [user_id].
         """
+        if self._user_data is None:
+            self._user_data = defaultdict(dict)
         if self._user_data.get(user_id) == data:
             return
         self._user_data[user_id] = data
@@ -238,6 +240,8 @@ class DictPersistence(BasePersistence):
             chat_id (:obj:`int`): The chat the data might have been changed for.
             data (:obj:`dict`): The :attr:`telegram.ext.dispatcher.chat_data` [chat_id].
         """
+        if self._chat_data is None:
+            self._chat_data = defaultdict(dict)
         if self._chat_data.get(chat_id) == data:
             return
         self._chat_data[chat_id] = data

--- a/telegram/ext/jobqueue.py
+++ b/telegram/ext/jobqueue.py
@@ -288,6 +288,7 @@ class JobQueue(object):
                     if any(day == current_week_day for day in job.days):
                         self.logger.debug('Running job %s', job.name)
                         job.run(self._dispatcher)
+                        self._dispatcher.update_persistence()
 
                 except Exception:
                     self.logger.exception('An uncaught error was raised while executing job %s',

--- a/telegram/ext/picklepersistence.py
+++ b/telegram/ext/picklepersistence.py
@@ -224,6 +224,8 @@ class PicklePersistence(BasePersistence):
             user_id (:obj:`int`): The user the data might have been changed for.
             data (:obj:`dict`): The :attr:`telegram.ext.dispatcher.user_data` [user_id].
         """
+        if self.user_data is None:
+            self.user_data = defaultdict(dict)
         if self.user_data.get(user_id) == data:
             return
         self.user_data[user_id] = data
@@ -242,6 +244,8 @@ class PicklePersistence(BasePersistence):
             chat_id (:obj:`int`): The chat the data might have been changed for.
             data (:obj:`dict`): The :attr:`telegram.ext.dispatcher.chat_data` [chat_id].
         """
+        if self.chat_data is None:
+            self.chat_data = defaultdict(dict)
         if self.chat_data.get(chat_id) == data:
             return
         self.chat_data[chat_id] = data

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -938,7 +938,7 @@ class TestPickelPersistence(object):
         job_queue.set_dispatcher(cdp)
         job_queue.start()
         job_queue.run_once(job_callback, 0.01)
-        sleep(0.02)
+        sleep(0.05)
         bot_data = pickle_persistence.get_bot_data()
         assert bot_data == {'test1': '456'}
         chat_data = pickle_persistence.get_chat_data()
@@ -1240,7 +1240,7 @@ class TestDictPersistence(object):
         job_queue.set_dispatcher(cdp)
         job_queue.start()
         job_queue.run_once(job_callback, 0.01)
-        sleep(0.02)
+        sleep(0.05)
         bot_data = dict_persistence.get_bot_data()
         assert bot_data == {'test1': '456'}
         chat_data = dict_persistence.get_chat_data()

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -29,12 +29,13 @@ import logging
 import os
 import pickle
 from collections import defaultdict
+from time import sleep
 
 import pytest
 
 from telegram import Update, Message, User, Chat, MessageEntity
 from telegram.ext import BasePersistence, Updater, ConversationHandler, MessageHandler, Filters, \
-    PicklePersistence, CommandHandler, DictPersistence, TypeHandler
+    PicklePersistence, CommandHandler, DictPersistence, TypeHandler, JobQueue
 
 
 @pytest.fixture(autouse=True)
@@ -85,6 +86,13 @@ def updater(bot, base_persistence):
     base_persistence.store_chat_data = True
     base_persistence.store_user_data = True
     return u
+
+
+@pytest.fixture(scope='function')
+def job_queue(bot):
+    jq = JobQueue()
+    yield jq
+    jq.stop()
 
 
 class TestBasePersistence(object):
@@ -920,6 +928,24 @@ class TestPickelPersistence(object):
         assert nested_ch.conversations[nested_ch._get_key(update)] == 1
         assert nested_ch.conversations == pickle_persistence.conversations['name3']
 
+    def test_with_job(self, job_queue, cdp, pickle_persistence):
+        def job_callback(context):
+            context.bot_data['test1'] = '456'
+            context.dispatcher.chat_data[123]['test2'] = '789'
+            context.dispatcher.user_data[789]['test3'] = '123'
+
+        cdp.persistence = pickle_persistence
+        job_queue.set_dispatcher(cdp)
+        job_queue.start()
+        job_queue.run_once(job_callback, 0.01)
+        sleep(0.02)
+        bot_data = pickle_persistence.get_bot_data()
+        assert bot_data == {'test1': '456'}
+        chat_data = pickle_persistence.get_chat_data()
+        assert chat_data[123] == {'test2': '789'}
+        user_data = pickle_persistence.get_user_data()
+        assert user_data[789] == {'test3': '123'}
+
 
 @pytest.fixture(scope='function')
 def user_data_json(user_data):
@@ -1202,3 +1228,22 @@ class TestDictPersistence(object):
         assert ch.conversations == dict_persistence.conversations['name2']
         assert nested_ch.conversations[nested_ch._get_key(update)] == 1
         assert nested_ch.conversations == dict_persistence.conversations['name3']
+
+    def test_with_job(self, job_queue, cdp):
+        def job_callback(context):
+            context.bot_data['test1'] = '456'
+            context.dispatcher.chat_data[123]['test2'] = '789'
+            context.dispatcher.user_data[789]['test3'] = '123'
+
+        dict_persistence = DictPersistence()
+        cdp.persistence = dict_persistence
+        job_queue.set_dispatcher(cdp)
+        job_queue.start()
+        job_queue.run_once(job_callback, 0.01)
+        sleep(0.02)
+        bot_data = dict_persistence.get_bot_data()
+        assert bot_data == {'test1': '456'}
+        chat_data = dict_persistence.get_chat_data()
+        assert chat_data[123] == {'test2': '789'}
+        user_data = dict_persistence.get_user_data()
+        assert user_data[789] == {'test3': '123'}


### PR DESCRIPTION
Originally intended to close #1671 , this now does 3 things:

1. Unify the two methods of dispatcher used to update the persistence. This makes sure that
    1. If persistence is updated after handling an update, only the corresponding user/chat_data is updated
    2. Errors that appear when updating persistence on shutting down the bot will be handled correctly
2. Fixing a minor bug in Pickle/DictPersistence: When calling `update_*_data` before calling `get_*_data`, we need to check that the internal attributes are not `None`
3. Actually close #1671 by updating the persistence after running a job