### PR TITLE
Update label in question template

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -2,7 +2,7 @@
 name: Question
 about: Get help with errors or general questions
 title: "[QUESTION]"
-labels: 'question :question:'
+labels: question
 assignees: ''
 
 ---


### PR DESCRIPTION
While setting up the stale bot, I removed the question mark from the `question` label because I didn't know how stale would handle it. This lead to the question issue template not labelling new issues automatically.