### PR TITLE
Fix pre-commit for flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         files: ^(telegram|tests)/.*\.py$
         args:
         - --diff
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: git://github.com/PyCQA/flake8
     rev: 3.7.1
     hooks:
     -   id: flake8


### PR DESCRIPTION
For some reason, the CI currently gives

```bash
fatal: unable to access 'https://gitlab.com/pycqa/flake8/': Could not resolve host: gitlab.com
```
Using the github mirror https://github.com/PyCQA/flake8. Let's see, if that helps.