### PR TITLE
Remove NullHandlers to unsuppress lastResort loging handler

### DIFF
--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -44,8 +44,6 @@ from telegram.error import InvalidToken, TelegramError
 from telegram.utils.helpers import to_timestamp, DEFAULT_NONE
 from telegram.utils.request import Request
 
-logging.getLogger(__name__).addHandler(logging.NullHandler())
-
 
 def info(func):
     @functools.wraps(func)

--- a/telegram/ext/dispatcher.py
+++ b/telegram/ext/dispatcher.py
@@ -38,7 +38,6 @@ from telegram.utils.deprecate import TelegramDeprecationWarning
 from telegram.utils.promise import Promise
 from telegram.ext import BasePersistence
 
-logging.getLogger(__name__).addHandler(logging.NullHandler())
 DEFAULT_GROUP = 0
 
 

--- a/telegram/ext/updater.py
+++ b/telegram/ext/updater.py
@@ -32,8 +32,6 @@ from telegram.utils.helpers import get_signal_name
 from telegram.utils.request import Request
 from telegram.utils.webhookhandler import (WebhookServer, WebhookAppClass)
 
-logging.getLogger(__name__).addHandler(logging.NullHandler())
-
 
 class Updater(object):
     """

--- a/telegram/utils/promise.py
+++ b/telegram/utils/promise.py
@@ -23,7 +23,6 @@ from threading import Event
 
 
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 
 class Promise(object):

--- a/telegram/utils/webhookhandler.py
+++ b/telegram/utils/webhookhandler.py
@@ -29,8 +29,6 @@ from tornado.httpserver import HTTPServer
 from tornado.ioloop import IOLoop
 import tornado.web
 
-logging.getLogger(__name__).addHandler(logging.NullHandler())
-
 
 class WebhookServer(object):
 


### PR DESCRIPTION
This removes the requirement to call `logging.basicConfig()` to see errors raised in handlers.

Users that already configure logging are unaffected by this change. Users that rely on python default logging configuration will now see warning+ level logs from PTB in stderr.

Suppressing default logging handler is not a good way control whether or not PTB logging is enabled, since users that actually do want to disable PTB logs might need to use basicConfig to configure something else. For this reason I removed all NullHandlers and not just the ones in dispatcher and updater.