### PR TITLE
Stabelizing CI

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -30,6 +30,7 @@ from telegram import (Bot, Update, ChatAction, TelegramError, User, InlineKeyboa
                       InlineQueryResultDocument)
 from telegram.error import BadRequest, InvalidToken, NetworkError, RetryAfter
 from telegram.utils.helpers import from_timestamp, escape_markdown
+from tests.conftest import expect_bad_request
 
 BASE_TIME = time.time()
 HIGHSCORE_DELTA = 1450000000
@@ -816,13 +817,19 @@ class TestBot(object):
     @flaky(3, 1)
     @pytest.mark.timeout(10)
     def test_set_chat_photo(self, bot, channel_id):
-        with open('tests/data/telegram_test_channel.jpg', 'rb') as f:
+        def func():
             assert bot.set_chat_photo(channel_id, f)
+
+        with open('tests/data/telegram_test_channel.jpg', 'rb') as f:
+            expect_bad_request(func, 'Type of file mismatch', 'Telegram did not accept the file.')
 
     @flaky(3, 1)
     @pytest.mark.timeout(10)
     def test_delete_chat_photo(self, bot, channel_id):
-        assert bot.delete_chat_photo(channel_id)
+        def func():
+            assert bot.delete_chat_photo(channel_id)
+
+        expect_bad_request(func, 'Chat_not_modified', 'Chat photo was not set.')
 
     @flaky(3, 1)
     @pytest.mark.timeout(10)

--- a/tests/test_chatphoto.py
+++ b/tests/test_chatphoto.py
@@ -22,6 +22,7 @@ import pytest
 from flaky import flaky
 
 from telegram import ChatPhoto, Voice, TelegramError
+from tests.conftest import expect_bad_request
 
 
 @pytest.fixture(scope='function')
@@ -33,7 +34,10 @@ def chatphoto_file():
 
 @pytest.fixture(scope='function')
 def chat_photo(bot, super_group_id):
-    return bot.get_chat(super_group_id, timeout=50).photo
+    def func():
+        return bot.get_chat(super_group_id, timeout=50).photo
+
+    return expect_bad_request(func, 'Type of file mismatch', 'Telegram did not accept the file.')
 
 
 class TestChatPhoto(object):
@@ -46,7 +50,10 @@ class TestChatPhoto(object):
     @flaky(3, 1)
     @pytest.mark.timeout(10)
     def test_send_all_args(self, bot, super_group_id, chatphoto_file, chat_photo, thumb_file):
-        assert bot.set_chat_photo(super_group_id, chatphoto_file)
+        def func():
+            assert bot.set_chat_photo(super_group_id, chatphoto_file)
+
+        expect_bad_request(func, 'Type of file mismatch', 'Telegram did not accept the file.')
 
     @flaky(3, 1)
     @pytest.mark.timeout(10)

--- a/tests/test_inputmedia.py
+++ b/tests/test_inputmedia.py
@@ -31,6 +31,7 @@ from .test_document import document, document_file  # noqa: F401
 from .test_photo import _photo, photo_file, photo, thumb  # noqa: F401
 # noinspection PyUnresolvedReferences
 from .test_video import video, video_file  # noqa: F401
+from tests.conftest import expect_bad_request
 
 
 @pytest.fixture(scope='class')
@@ -320,10 +321,14 @@ class TestSendMediaGroup(object):
     @pytest.mark.timeout(10)  # noqa: F811
     def test_send_media_group_new_files(self, bot, chat_id, video_file, photo_file,  # noqa: F811
                                         animation_file):  # noqa: F811
-        messages = bot.send_media_group(chat_id, [
-            InputMediaVideo(video_file),
-            InputMediaPhoto(photo_file)
-        ])
+        def func():
+            return bot.send_media_group(chat_id, [
+                InputMediaVideo(video_file),
+                InputMediaPhoto(photo_file)
+            ])
+        messages = expect_bad_request(func, 'Type of file mismatch',
+                                      'Telegram did not accept the file.')
+
         assert isinstance(messages, list)
         assert len(messages) == 2
         assert all([isinstance(mes, Message) for mes in messages])

--- a/tests/test_photo.py
+++ b/tests/test_photo.py
@@ -24,6 +24,7 @@ from flaky import flaky
 
 from telegram import Sticker, TelegramError, PhotoSize, InputFile
 from telegram.utils.helpers import escape_markdown
+from tests.conftest import expect_bad_request
 
 
 @pytest.fixture(scope='function')
@@ -35,8 +36,11 @@ def photo_file():
 
 @pytest.fixture(scope='class')
 def _photo(bot, chat_id):
-    with open('tests/data/telegram.jpg', 'rb') as f:
-        return bot.send_photo(chat_id, photo=f, timeout=50).photo
+    def func():
+        with open('tests/data/telegram.jpg', 'rb') as f:
+            return bot.send_photo(chat_id, photo=f, timeout=50).photo
+
+    return expect_bad_request(func, 'Type of file mismatch', 'Telegram did not accept the file.')
 
 
 @pytest.fixture(scope='class')

--- a/tests/test_sticker.py
+++ b/tests/test_sticker.py
@@ -25,6 +25,7 @@ from flaky import flaky
 from future.utils import PY2
 
 from telegram import Sticker, PhotoSize, TelegramError, StickerSet, Audio, MaskPosition
+from telegram.error import BadRequest
 
 
 @pytest.fixture(scope='function')
@@ -260,7 +261,11 @@ class TestSticker(object):
 def sticker_set(bot):
     ss = bot.get_sticker_set('test_by_{}'.format(bot.username))
     if len(ss.stickers) > 100:
-        raise Exception('stickerset is growing too large.')
+        try:
+            for i in range(1, 50):
+                bot.delete_sticker_from_set(ss.stickers[-i].file_id)
+        except BadRequest:
+            raise Exception('stickerset is growing too large.')
     return ss
 
 
@@ -268,7 +273,11 @@ def sticker_set(bot):
 def animated_sticker_set(bot):
     ss = bot.get_sticker_set('animated_test_by_{}'.format(bot.username))
     if len(ss.stickers) > 100:
-        raise Exception('stickerset is growing too large.')
+        try:
+            for i in range(1, 50):
+                bot.delete_sticker_from_set(ss.stickers[-i].file_id)
+        except BadRequest:
+            raise Exception('stickerset is growing too large.')
     return ss
 
 


### PR DESCRIPTION
* adds `expect_bad_request` to deal with `Type of file mismatch` errors (makes them xfail)
* Makes flood control errors xfail. Actually respecting them, i.e. retrying later, doesn't play well with `pytest.mark.timeout`, unfortunately …
* Deletes stickers from sets, if it gets full.