### PR TITLE
Doc fixes

### DIFF
--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -549,9 +549,10 @@ class Bot(TelegramObject):
                 JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
                 to remove reply keyboard or to force a reply from the user.
             thumb (`filelike object`, optional): Thumbnail of the file sent; can be ignored if
-                thumbnail generation for the file is supported server-side. The thumbnail should
-                be in JPEG format and less than 200 kB in size. A thumbnail's width and height
-                should not exceed 320. Ignored if the file is not is passed as a string or file_id.
+                thumbnail generation for the file is supported server-side. The thumbnail should be
+                in JPEG format and less than 200 kB in size. A thumbnail's width and height should
+                not exceed 320. Ignored if the file is not uploaded using multipart/form-data.
+                Thumbnails can't be reused and can be only uploaded as a new file.
             timeout (:obj:`int` | :obj:`float`, optional): Send file timeout (default: 20 seconds).
             **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
@@ -636,9 +637,11 @@ class Bot(TelegramObject):
                 JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
                 to remove reply keyboard or to force a reply from the user.
             thumb (`filelike object`, optional): Thumbnail of the file sent; can be ignored if
-                thumbnail generation for the file is supported server-side. The thumbnail should
-                be in JPEG format and less than 200 kB in size. A thumbnail's width and height
-                should not exceed 320. Ignored if the file is not passed as a string or file_id.
+                thumbnail generation for the file is supported server-side. The thumbnail should be
+                in JPEG format and less than 200 kB in size. A thumbnail's width and height should
+                not exceed 320. Ignored if the file is not uploaded using multipart/form-data.
+                Thumbnails can't be reused and can be only uploaded as a new file.
+                multipart/form-data under ``<file_attach_name>``.
             timeout (:obj:`int` | :obj:`float`, optional): Send file timeout (default: 20 seconds).
             **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
@@ -778,9 +781,10 @@ class Bot(TelegramObject):
                 JSON-serialized object for an inline keyboard, custom reply keyboard, instructions
                 to remove reply keyboard or to force a reply from the user.
             thumb (`filelike object`, optional): Thumbnail of the file sent; can be ignored if
-                thumbnail generation for the file is supported server-side. The thumbnail should
-                be in JPEG format and less than 200 kB in size. A thumbnail‘s width and height
-                should not exceed 320. Ignored if the file is not is passed as a string or file_id.
+                thumbnail generation for the file is supported server-side. The thumbnail should be
+                in JPEG format and less than 200 kB in size. A thumbnail's width and height should
+                not exceed 320. Ignored if the file is not uploaded using multipart/form-data.
+                Thumbnails can't be reused and can be only uploaded as a new file.
             timeout (:obj:`int` | :obj:`float`, optional): Send file timeout (default: 20 seconds).
             **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
@@ -860,9 +864,10 @@ class Bot(TelegramObject):
                 JSON-serialized object for an inline keyboard, custom reply keyboard,
                 instructions to remove reply keyboard or to force a reply from the user.
             thumb (`filelike object`, optional): Thumbnail of the file sent; can be ignored if
-                thumbnail generation for the file is supported server-side. The thumbnail should
-                be in JPEG format and less than 200 kB in size. A thumbnail‘s width and height
-                should not exceed 320. Ignored if the file is not is passed as a string or file_id.
+                thumbnail generation for the file is supported server-side. The thumbnail should be
+                in JPEG format and less than 200 kB in size. A thumbnail's width and height should
+                not exceed 320. Ignored if the file is not uploaded using multipart/form-data.
+                Thumbnails can't be reused and can be only uploaded as a new file.
             timeout (:obj:`int` | :obj:`float`, optional): Send file timeout (default: 20 seconds).
             **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
@@ -927,9 +932,10 @@ class Bot(TelegramObject):
             width (:obj:`int`, optional): Animation width.
             height (:obj:`int`, optional): Animation height.
             thumb (`filelike object`, optional): Thumbnail of the file sent; can be ignored if
-                thumbnail generation for the file is supported server-side. The thumbnail should
-                be in JPEG format and less than 200 kB in size. A thumbnail‘s width and height
-                should not exceed 320. Ignored if the file is not is passed as a string or file_id.
+                thumbnail generation for the file is supported server-side. The thumbnail should be
+                in JPEG format and less than 200 kB in size. A thumbnail's width and height should
+                not exceed 320. Ignored if the file is not uploaded using multipart/form-data.
+                Thumbnails can't be reused and can be only uploaded as a new file.
             caption (:obj:`str`, optional): Animation caption (may also be used when resending
                 animations by file_id), 0-1024 characters after entities parsing.
             parse_mode (:obj:`str`, optional): Send Markdown or HTML, if you want Telegram apps to

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -641,7 +641,6 @@ class Bot(TelegramObject):
                 in JPEG format and less than 200 kB in size. A thumbnail's width and height should
                 not exceed 320. Ignored if the file is not uploaded using multipart/form-data.
                 Thumbnails can't be reused and can be only uploaded as a new file.
-                multipart/form-data under ``<file_attach_name>``.
             timeout (:obj:`int` | :obj:`float`, optional): Send file timeout (default: 20 seconds).
             **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 

--- a/telegram/ext/callbackcontext.py
+++ b/telegram/ext/callbackcontext.py
@@ -43,9 +43,9 @@ class CallbackContext(object):
          that you think you added will not be present.
 
     Attributes:
-        bot_data (:obj:`dict`, optional): A dict that can be used to keep any data in. For each
+        bot_data (:obj:`dict`): Optional. A dict that can be used to keep any data in. For each
             update it will be the same ``dict``.
-        chat_data (:obj:`dict`, optional): A dict that can be used to keep any data in. For each
+        chat_data (:obj:`dict`): Optional. A dict that can be used to keep any data in. For each
             update from the same chat id it will be the same ``dict``.
 
             Warning:
@@ -54,18 +54,18 @@ class CallbackContext(object):
                 <https://github.com/python-telegram-bot/python-telegram-bot/wiki/
                 Storing-user--and-chat-related-data#chat-migration>`_.
 
-        user_data (:obj:`dict`, optional): A dict that can be used to keep any data in. For each
+        user_data (:obj:`dict`): Optional. A dict that can be used to keep any data in. For each
             update from the same user it will be the same ``dict``.
-        matches (List[:obj:`re match object`], optional): If the associated update originated from
+        matches (List[:obj:`re match object`]): Optional. If the associated update originated from
             a regex-supported handler or had a :class:`Filters.regex`, this will contain a list of
             match objects for every pattern where ``re.search(pattern, string)`` returned a match.
             Note that filters short circuit, so combined regex filters will not always
             be evaluated.
-        args (List[:obj:`str`], optional): Arguments passed to a command if the associated update
+        args (List[:obj:`str`]): Optional. Arguments passed to a command if the associated update
             is handled by :class:`telegram.ext.CommandHandler`, :class:`telegram.ext.PrefixHandler`
             or :class:`telegram.ext.StringCommandHandler`. It contains a list of the words in the
             text after the command, using any whitespace string as a delimiter.
-        error (:class:`telegram.TelegramError`, optional): The Telegram error that was raised.
+        error (:class:`telegram.TelegramError`): Optional. The Telegram error that was raised.
             Only present when passed to a error handler registered with
             :attr:`telegram.ext.Dispatcher.add_error_handler`.
         job (:class:`telegram.ext.Job`): The job that that originated this callback.

--- a/telegram/ext/updater.py
+++ b/telegram/ext/updater.py
@@ -47,7 +47,8 @@ class Updater(object):
 
     Attributes:
         bot (:class:`telegram.Bot`): The bot used with this Updater.
-        user_sig_handler (:obj:`signal`): signals the updater will respond to.
+        user_sig_handler (:obj:`function`): Optional. Function to be called when a signal is
+            received.
         update_queue (:obj:`Queue`): Queue for the updates.
         job_queue (:class:`telegram.ext.JobQueue`): Jobqueue for the updater.
         dispatcher (:class:`telegram.ext.Dispatcher`): Dispatcher that handles the updates and
@@ -55,7 +56,7 @@ class Updater(object):
         running (:obj:`bool`): Indicates if the updater is running.
         persistence (:class:`telegram.ext.BasePersistence`): Optional. The persistence class to
             store data that should be persistent over restarts.
-        use_context (:obj:`bool`, optional): ``True`` if using context based callbacks.
+        use_context (:obj:`bool`): Optional. ``True`` if using context based callbacks.
 
     Args:
         token (:obj:`str`, optional): The bot's token given by the @BotFather.

--- a/telegram/files/inputmedia.py
+++ b/telegram/files/inputmedia.py
@@ -38,8 +38,7 @@ class InputMediaAnimation(InputMedia):
 
     Attributes:
         type (:obj:`str`): ``animation``.
-        media (:obj:`str` | :class:`telegram.InputFile` | :class:`telegram.Animation`): Animation
-            to send.
+        media (:obj:`str` | :class:`telegram.InputFile`): Animation to send.
         caption (:obj:`str`): Optional. Caption of the document to be sent.
         parse_mode (:obj:`str`): Optional. The parse mode to use for text formatting.
         thumb (:class:`telegram.InputFile`): Optional. Thumbnail of the file to send.
@@ -114,8 +113,7 @@ class InputMediaPhoto(InputMedia):
 
     Attributes:
         type (:obj:`str`): ``photo``.
-        media (:obj:`str` | :class:`telegram.InputFile` | :class:`telegram.PhotoSize`): Photo to
-            send.
+        media (:obj:`str` | :class:`telegram.InputFile`): Photo to send.
         caption (:obj:`str`): Optional. Caption of the document to be sent.
         parse_mode (:obj:`str`): Optional. The parse mode to use for text formatting.
 
@@ -151,8 +149,7 @@ class InputMediaVideo(InputMedia):
 
     Attributes:
         type (:obj:`str`): ``video``.
-        media (:obj:`str` | :class:`telegram.InputFile` | :class:`telegram.Video`): Video file to
-            send.
+        media (:obj:`str` | :class:`telegram.InputFile`): Video file to send.
         caption (:obj:`str`): Optional. Caption of the document to be sent.
         parse_mode (:obj:`str`): Optional. The parse mode to use for text formatting.
         width (:obj:`int`): Optional. Video width.
@@ -226,8 +223,7 @@ class InputMediaAudio(InputMedia):
 
     Attributes:
         type (:obj:`str`): ``audio``.
-        media (:obj:`str` | :class:`telegram.InputFile` | :class:`telegram.Audio`): Audio file to
-            send.
+        media (:obj:`str` | :class:`telegram.InputFile`): Audio file to send.
         caption (:obj:`str`): Optional. Caption of the document to be sent.
         parse_mode (:obj:`str`): Optional. The parse mode to use for text formatting.
         duration (:obj:`int`): Duration of the audio in seconds.
@@ -297,8 +293,7 @@ class InputMediaDocument(InputMedia):
 
     Attributes:
         type (:obj:`str`): ``document``.
-        media (:obj:`str` | :class:`telegram.InputFile` | :class:`telegram.Document`): File to
-            send.
+        media (:obj:`str` | :class:`telegram.InputFile`): File to send.
         caption (:obj:`str`): Optional. Caption of the document to be sent.
         parse_mode (:obj:`str`): Optional. The parse mode to use for text formatting.
         thumb (:class:`telegram.InputFile`): Optional. Thumbnail of the file to send.

--- a/telegram/files/inputmedia.py
+++ b/telegram/files/inputmedia.py
@@ -38,33 +38,26 @@ class InputMediaAnimation(InputMedia):
 
     Attributes:
         type (:obj:`str`): ``animation``.
-        media (:obj:`str` | `filelike object` | :class:`telegram.Animation`): Animation to
-            send. Pass a file_id as String to send an animation that exists on the Telegram
-            servers (recommended), pass an HTTP URL as a String for Telegram to get an
-            animation from the Internet, or upload a new animation using multipart/form-data.
-            Lastly you can pass an existing :class:`telegram.Animation` object to send.
-        thumb (`filelike object`): Optional. Thumbnail of the
-            file sent. The thumbnail should be in JPEG format and less than 200 kB in size.
-            A thumbnail's width and height should not exceed 320. Ignored if the file is not
-            is passed as a string or file_id.
-        caption (:obj:`str`): Optional. Caption of the animation to be sent, 0-1024 characters
-            after entities parsing.
-        parse_mode (:obj:`str`): Optional. Send Markdown or HTML, if you want Telegram apps to show
-            bold, italic, fixed-width text or inline URLs in the media caption. See the constants
-            in :class:`telegram.ParseMode` for the available modes.
+        media (:obj:`str` | :class:`telegram.InputFile` | :class:`telegram.Animation`): Animation
+            to send.
+        caption (:obj:`str`): Optional. Caption of the document to be sent.
+        parse_mode (:obj:`str`): Optional. The parse mode to use for text formatting.
+        thumb (:class:`telegram.InputFile`): Optional. Thumbnail of the file to send.
         width (:obj:`int`): Optional. Animation width.
         height (:obj:`int`): Optional. Animation height.
         duration (:obj:`int`): Optional. Animation duration.
 
 
     Args:
-        media (:obj:`str`): File to send. Pass a file_id to send a file that exists on the Telegram
-            servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet.
-            Lastly you can pass an existing :class:`telegram.Animation` object to send.
-        thumb (`filelike object`, optional): Thumbnail of the
-            file sent. The thumbnail should be in JPEG format and less than 200 kB in size.
-            A thumbnail's width and height should not exceed 320. Ignored if the file is not
-            is passed as a string or file_id.
+        media (:obj:`str` | `filelike object` | :class:`telegram.Animation`): File to send. Pass a
+            file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP
+            URL for Telegram to get a file from the Internet. Lastly you can pass an existing
+            :class:`telegram.Animation` object to send.
+        thumb (`filelike object`, optional): Thumbnail of the file sent; can be ignored if
+            thumbnail generation for the file is supported server-side. The thumbnail should be
+            in JPEG format and less than 200 kB in size. A thumbnail's width and height should
+            not exceed 320. Ignored if the file is not uploaded using multipart/form-data.
+            Thumbnails can't be reused and can be only uploaded as a new file.
         caption (:obj:`str`, optional): Caption of the animation to be sent, 0-1024 characters
             after entities parsing.
         parse_mode (:obj:`str`, optional): Send Markdown or HTML, if you want Telegram apps to show
@@ -121,21 +114,16 @@ class InputMediaPhoto(InputMedia):
 
     Attributes:
         type (:obj:`str`): ``photo``.
-        media (:obj:`str` | `filelike object` | :class:`telegram.PhotoSize`): Photo to send.
-            Pass a file_id as String to send a photo that exists on the Telegram servers
-            (recommended), pass an HTTP URL as a String for Telegram to get a photo from the
-            Internet, or upload a new photo using multipart/form-data. Lastly you can pass
-            an existing :class:`telegram.PhotoSize` object to send.
-        caption (:obj:`str`): Optional. Caption of the photo to be sent, 0-1024 characters after
-            entities parsing.
-        parse_mode (:obj:`str`): Optional. Send Markdown or HTML, if you want Telegram apps to show
-            bold, italic, fixed-width text or inline URLs in the media caption. See the constants
-            in :class:`telegram.ParseMode` for the available modes.
+        media (:obj:`str` | :class:`telegram.InputFile` | :class:`telegram.PhotoSize`): Photo to
+            send.
+        caption (:obj:`str`): Optional. Caption of the document to be sent.
+        parse_mode (:obj:`str`): Optional. The parse mode to use for text formatting.
 
     Args:
-        media (:obj:`str`): File to send. Pass a file_id to send a file that exists on the
-            Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the
-            Internet. Lastly you can pass an existing :class:`telegram.PhotoSize` object to send.
+        media (:obj:`str` | `filelike object` | :class:`telegram.PhotoSize`): File to send. Pass a
+            file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP
+            URL for Telegram to get a file from the Internet. Lastly you can pass an existing
+            :class:`telegram.PhotoSize` object to send.
         caption (:obj:`str`, optional ): Caption of the photo to be sent, 0-1024 characters after
             entities parsing.
         parse_mode (:obj:`str`, optional): Send Markdown or HTML, if you want Telegram apps to show
@@ -163,30 +151,22 @@ class InputMediaVideo(InputMedia):
 
     Attributes:
         type (:obj:`str`): ``video``.
-        media (:obj:`str` | `filelike object` | :class:`telegram.Video`): Video file to send.
-            Pass a file_id as String to send an video file that exists on the Telegram servers
-            (recommended), pass an HTTP URL as a String for Telegram to get an video file from
-            the Internet, or upload a new one using multipart/form-data. Lastly you can pass
-            an existing :class:`telegram.Video` object to send.
-        caption (:obj:`str`): Optional. Caption of the video to be sent, 0-1024 characters after
-            entities parsing.
-        parse_mode (:obj:`str`): Optional. Send Markdown or HTML, if you want Telegram apps to show
-            bold, italic, fixed-width text or inline URLs in the media caption. See the constants
-            in :class:`telegram.ParseMode` for the available modes.
+        media (:obj:`str` | :class:`telegram.InputFile` | :class:`telegram.Video`): Video file to
+            send.
+        caption (:obj:`str`): Optional. Caption of the document to be sent.
+        parse_mode (:obj:`str`): Optional. The parse mode to use for text formatting.
         width (:obj:`int`): Optional. Video width.
         height (:obj:`int`): Optional. Video height.
         duration (:obj:`int`): Optional. Video duration.
         supports_streaming (:obj:`bool`): Optional. Pass True, if the uploaded video is suitable
             for streaming.
-        thumb (`filelike object`): Optional. Thumbnail of the
-            file sent. The thumbnail should be in JPEG format and less than 200 kB in size.
-            A thumbnail's width and height should not exceed 320. Ignored if the file is not
-            is passed as a string or file_id.
+        thumb (:class:`telegram.InputFile`): Optional. Thumbnail of the file to send.
 
     Args:
-        media (:obj:`str`): File to send. Pass a file_id to send a file that exists on the Telegram
-            servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet.
-            Lastly you can pass an existing :class:`telegram.Video` object to send.
+        media (:obj:`str` | `filelike object` | :class:`telegram.Video`): File to send. Pass a
+            file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP
+            URL for Telegram to get a file from the Internet. Lastly you can pass an existing
+            :class:`telegram.Video` object to send.
         caption (:obj:`str`, optional): Caption of the video to be sent, 0-1024 characters after
             entities parsing.
         parse_mode (:obj:`str`, optional): Send Markdown or HTML, if you want Telegram apps to show
@@ -197,10 +177,11 @@ class InputMediaVideo(InputMedia):
         duration (:obj:`int`, optional): Video duration.
         supports_streaming (:obj:`bool`, optional): Pass True, if the uploaded video is suitable
             for streaming.
-        thumb (`filelike object`, optional): Thumbnail of the
-            file sent. The thumbnail should be in JPEG format and less than 200 kB in size.
-            A thumbnail's width and height should not exceed 320. Ignored if the file is not
-            is passed as a string or file_id.
+        thumb (`filelike object`, optional): Thumbnail of the file sent; can be ignored if
+            thumbnail generation for the file is supported server-side. The thumbnail should be
+            in JPEG format and less than 200 kB in size. A thumbnail's width and height should
+            not exceed 320. Ignored if the file is not uploaded using multipart/form-data.
+            Thumbnails can't be reused and can be only uploaded as a new file.
 
     Note:
         When using a :class:`telegram.Video` for the :attr:`media` attribute. It will take the
@@ -245,29 +226,21 @@ class InputMediaAudio(InputMedia):
 
     Attributes:
         type (:obj:`str`): ``audio``.
-        media (:obj:`str` | `filelike object` | :class:`telegram.Audio`): Audio file to send.
-            Pass a file_id as String to send an audio file that exists on the Telegram servers
-            (recommended), pass an HTTP URL as a String for Telegram to get an audio file from
-            the Internet, or upload a new one using multipart/form-data. Lastly you can pass
-            an existing :class:`telegram.Audio` object to send.
-        caption (:obj:`str`): Optional. Caption of the audio to be sent, 0-1024 characters after
-            entities parsing.
-        parse_mode (:obj:`str`): Optional. Send Markdown or HTML, if you want Telegram apps to show
-            bold, italic, fixed-width text or inline URLs in the media caption. See the constants
-            in :class:`telegram.ParseMode` for the available modes.
+        media (:obj:`str` | :class:`telegram.InputFile` | :class:`telegram.Audio`): Audio file to
+            send.
+        caption (:obj:`str`): Optional. Caption of the document to be sent.
+        parse_mode (:obj:`str`): Optional. The parse mode to use for text formatting.
         duration (:obj:`int`): Duration of the audio in seconds.
         performer (:obj:`str`): Optional. Performer of the audio as defined by sender or by audio
             tags.
         title (:obj:`str`): Optional. Title of the audio as defined by sender or by audio tags.
-        thumb (`filelike object`): Optional. Thumbnail of the
-            file sent. The thumbnail should be in JPEG format and less than 200 kB in size.
-            A thumbnail's width and height should not exceed 320. Ignored if the file is not
-            is passed as a string or file_id.
+        thumb (:class:`telegram.InputFile`): Optional. Thumbnail of the file to send.
 
     Args:
-        media (:obj:`str`): File to send. Pass a file_id to send a file that exists on the Telegram
-            servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet.
-            Lastly you can pass an existing :class:`telegram.Document` object to send.
+        media (:obj:`str` | `filelike object` | :class:`telegram.Audio`): File to send. Pass a
+            file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP
+            URL for Telegram to get a file from the Internet. Lastly you can pass an existing
+            :class:`telegram.Document` object to send.
         caption (:obj:`str`, optional): Caption of the audio to be sent, 0-1024 characters after
             entities parsing.
         parse_mode (:obj:`str`, optional): Send Markdown or HTML, if you want Telegram apps to show
@@ -277,10 +250,11 @@ class InputMediaAudio(InputMedia):
         performer (:obj:`str`, optional): Performer of the audio as defined by sender or by audio
             tags.
         title (:obj:`str`, optional): Title of the audio as defined by sender or by audio tags.
-        thumb (`filelike object`, optional): Thumbnail of the
-            file sent. The thumbnail should be in JPEG format and less than 200 kB in size.
-            A thumbnail's width and height should not exceed 320. Ignored if the file is not
-            is passed as a string or file_id.
+        thumb (`filelike object`, optional): Thumbnail of the file sent; can be ignored if
+            thumbnail generation for the file is supported server-side. The thumbnail should be
+            in JPEG format and less than 200 kB in size. A thumbnail's width and height should
+            not exceed 320. Ignored if the file is not uploaded using multipart/form-data.
+            Thumbnails can't be reused and can be only uploaded as a new file.
 
     Note:
         When using a :class:`telegram.Audio` for the :attr:`media` attribute. It will take the
@@ -323,34 +297,27 @@ class InputMediaDocument(InputMedia):
 
     Attributes:
         type (:obj:`str`): ``document``.
-        media (:obj:`str` | `filelike object` | :class:`telegram.Document`): File to send.
-            Pass a file_id as String to send a file that exists on the Telegram servers
-            (recommended), pass an HTTP URL as a String for Telegram to get a file from the
-            Internet, or upload a new one using multipart/form-data. Lastly you can pass
-            an existing :class:`telegram.Document` object to send.
-        caption (:obj:`str`): Optional. Caption of the document to be sent, 0-1024 characters after
-            entities parsing.
-        parse_mode (:obj:`str`): Optional. Send Markdown or HTML, if you want Telegram apps to show
-            bold, italic, fixed-width text or inline URLs in the media caption. See the constants
-            in :class:`telegram.ParseMode` for the available modes.
-        thumb (`filelike object`): Optional. Thumbnail of the
-            file sent. The thumbnail should be in JPEG format and less than 200 kB in size.
-            A thumbnail's width and height should not exceed 320. Ignored if the file is not
-            is passed as a string or file_id.
+        media (:obj:`str` | :class:`telegram.InputFile` | :class:`telegram.Document`): File to
+            send.
+        caption (:obj:`str`): Optional. Caption of the document to be sent.
+        parse_mode (:obj:`str`): Optional. The parse mode to use for text formatting.
+        thumb (:class:`telegram.InputFile`): Optional. Thumbnail of the file to send.
 
     Args:
-        media (:obj:`str`): File to send. Pass a file_id to send a file that exists on the Telegram
-            servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet.
-            Lastly you can pass an existing :class:`telegram.Document` object to send.
+        media (:obj:`str` | `filelike object` | :class:`telegram.Document`): File to send. Pass a
+            file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP
+            URL for Telegram to get a file from the Internet. Lastly you can pass an existing
+            :class:`telegram.Document` object to send.
         caption (:obj:`str`, optional): Caption of the document to be sent, 0-1024 characters after
             entities parsing.
         parse_mode (:obj:`str`, optional): Send Markdown or HTML, if you want Telegram apps to show
             bold, italic, fixed-width text or inline URLs in the media caption. See the constants
             in :class:`telegram.ParseMode` for the available modes.
-        thumb (`filelike object`, optional): Thumbnail of the
-            file sent. The thumbnail should be in JPEG format and less than 200 kB in size.
-            A thumbnail's width and height should not exceed 320. Ignored if the file is not
-            is passed as a string or file_id.
+        thumb (`filelike object`, optional): Thumbnail of the file sent; can be ignored if
+            thumbnail generation for the file is supported server-side. The thumbnail should be
+            in JPEG format and less than 200 kB in size. A thumbnail's width and height should
+            not exceed 320. Ignored if the file is not uploaded using multipart/form-data.
+            Thumbnails can't be reused and can be only uploaded as a new file.
     """
 
     def __init__(self, media, thumb=None, caption=None, parse_mode=DEFAULT_NONE):

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -859,9 +859,9 @@ class Message(TelegramObject):
                                   **kwargs)
 
         Note:
-            You can only edit messages that the bot sent itself,
-            therefore this method can only be used on the
-            return value of the ``bot.send_*`` family of methods.
+            You can only edit messages that the bot sent itself (i.e. of the ``bot.send_*`` family
+            of methods) or channel posts, if the bot is an admin in that channel. However, this
+            behaviour is undocumented and might be changed by Telegram.
 
         Returns:
             :class:`telegram.Message`: On success, instance representing the edited message.
@@ -879,9 +879,9 @@ class Message(TelegramObject):
                                      **kwargs)
 
         Note:
-            You can only edit messages that the bot sent itself,
-            therefore this method can only be used on the
-            return value of the ``bot.send_*`` family of methods.
+            You can only edit messages that the bot sent itself (i.e. of the ``bot.send_*`` family
+            of methods) or channel posts, if the bot is an admin in that channel. However, this
+            behaviour is undocumented and might be changed by Telegram.
 
         Returns:
             :class:`telegram.Message`: On success, instance representing the edited message.
@@ -893,21 +893,21 @@ class Message(TelegramObject):
     def edit_media(self, media, *args, **kwargs):
         """Shortcut for::
 
-                    bot.edit_message_media(chat_id=message.chat_id,
-                                             message_id=message.message_id,
-                                             *args,
-                                             **kwargs)
+            bot.edit_message_media(chat_id=message.chat_id,
+                                     message_id=message.message_id,
+                                     *args,
+                                     **kwargs)
 
-                Note:
-                    You can only edit messages that the bot sent itself,
-                    therefore this method can only be used on the
-                    return value of the ``bot.send_*`` family of methods.
+        Note:
+            You can only edit messages that the bot sent itself (i.e. of the ``bot.send_*`` family
+            of methods) or channel posts, if the bot is an admin in that channel. However, this
+            behaviour is undocumented and might be changed by Telegram.
 
-                Returns:
-                    :class:`telegram.Message`: On success, instance representing the edited
-                    message.
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the edited
+            message.
 
-                """
+        """
         return self.bot.edit_message_media(
             chat_id=self.chat_id, message_id=self.message_id, media=media, *args, **kwargs)
 
@@ -920,9 +920,9 @@ class Message(TelegramObject):
                                           **kwargs)
 
         Note:
-            You can only edit messages that the bot sent itself,
-            therefore this method can only be used on the
-            return value of the ``bot.send_*`` family of methods.
+            You can only edit messages that the bot sent itself (i.e. of the ``bot.send_*`` family
+            of methods) or channel posts, if the bot is an admin in that channel. However, this
+            behaviour is undocumented and might be changed by Telegram.
 
         Returns:
             :class:`telegram.Message`: On success, instance representing the edited message.


### PR DESCRIPTION
* Updates the notes on which messages can be edited for `Message.edit_*`, closes #1932
* Updates the docstring on the `thumb` argument of `Bot.send_*` and `InputMedia*`, closes #1938 
* Shortens the description of `InputMedia*` attributes: I.e. the limitations should be listet for the arguments, but not for the attributes
* Corrects the type statements of `InputMedia.{media, thumb}`: After initializing both are either `string`, `Audio/Video/...` or `InputFile`
* Corrects attribute docstring of `Updater.user_sig_handler`
* Improves rendering of `CallbackContexts` attributes ("Optional" goes in the description, not in the type)