### PR TITLE
add new predefined filter 'Filters.Date' to filter on message age.

### DIFF
--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains the Filters for use with the MessageHandler class."""
 
-import re
+import re, time
 
 from abc import ABC, abstractmethod
 from future.utils import string_types
@@ -1397,3 +1397,32 @@ officedocument.wordprocessingml.document")``-
         channel_posts: Updates with either :attr:`telegram.Update.channel_post` or
             :attr:`telegram.Update.edited_channel_post`
     """
+
+    class date(BaseFilter):
+        """Filters messages to allow only those which are not older than a specified no. of sec ago.
+
+        Examples:
+            ``MessageHandler(Filters.date(15), callback_method)``
+
+        Args:
+            seconds_ago(:obj:`int`, optional): Max time diff between when the message was sent
+                (message.date) and 'now' for message to be allowed through, in seconds.
+
+        Raises:
+            ValueError: If seconds_ago not set or smaller than 2.
+        """
+
+        def __init__(self, seconds_ago=None):
+            if not (bool(seconds_ago)):
+                raise ValueError('seconds_ago must be used')
+            elif seconds_ago is not None and isinstance(seconds_ago, int) and seconds_ago < 2:
+                raise ValueError('seconds_ago must be 2 at minumum')
+            elif seconds_ago is not None and isinstance(seconds_ago, int) and seconds_ago >= 2:
+                self.seconds_ago = seconds_ago
+            else:
+                #should never end up here
+                raise ValueError('Unknown error!')
+
+        def filter(self, message):
+            # msg.date > (now - seconds_ago)
+            return bool(int(message.date.timestamp()) > (int(time.time()) - int(self.seconds_ago)))

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -1404,7 +1404,7 @@ officedocument.wordprocessingml.document")``-
             of sec ago.
 
         Examples:
-            ``MessageHandler(Filters.date(15), callback_method)``
+            ``MessageHandler(Filters.date(seconds_ago=15), callback_method)``
 
         Args:
             seconds_ago(:obj:`int`, optional): Max time diff between when the message was sent

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -1416,7 +1416,7 @@ officedocument.wordprocessingml.document")``-
             if not (bool(seconds_ago)):
                 raise ValueError('seconds_ago must be used')
             elif seconds_ago is not None and isinstance(seconds_ago, int) and seconds_ago < 2:
-                raise ValueError('seconds_ago must be 2 at minumum')
+                raise ValueError('seconds_ago must be 2 at minimum')
             elif seconds_ago is not None and isinstance(seconds_ago, int) and seconds_ago >= 2:
                 self.seconds_ago = seconds_ago
             else:

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -1400,7 +1400,8 @@ officedocument.wordprocessingml.document")``-
     """
 
     class date(BaseFilter):
-        """Filters messages to allow only those which are not older than a specified no. of sec ago.
+        """Filters messages to allow only those which are not older than a specified number
+            of sec ago.
 
         Examples:
             ``MessageHandler(Filters.date(15), callback_method)``
@@ -1414,7 +1415,7 @@ officedocument.wordprocessingml.document")``-
         """
 
         def __init__(self, seconds_ago=None):
-            if not (bool(seconds_ago)):
+            if not bool(seconds_ago):
                 raise ValueError('seconds_ago must be used')
             elif seconds_ago is not None and isinstance(seconds_ago, int) and seconds_ago < 2:
                 raise ValueError('seconds_ago must be 2 at minimum')

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -18,7 +18,8 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains the Filters for use with the MessageHandler class."""
 
-import re, time
+import re
+import time
 
 from abc import ABC, abstractmethod
 from future.utils import string_types
@@ -1420,7 +1421,7 @@ officedocument.wordprocessingml.document")``-
             elif seconds_ago is not None and isinstance(seconds_ago, int) and seconds_ago >= 2:
                 self.seconds_ago = seconds_ago
             else:
-                #should never end up here
+                # should never end up here
                 raise ValueError('Unknown error!')
 
         def filter(self, message):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -48,8 +48,10 @@ class TestFilters(object):
         assert (Filters.text)(update)
 
     def test_filters_date_init(self):
-        with pytest.raises(ValueError, match='at minimum'):
+        with pytest.raises(ValueError, match='must be used'):
             Filters.date(seconds_ago=0)
+        with pytest.raises(ValueError, match='at minimum'):
+            Filters.date(seconds_ago=1)
 
     def test_filters_date(self, update):
         update.message.date = datetime.datetime.utcnow()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -47,6 +47,16 @@ class TestFilters(object):
         update.message.text = '/test'
         assert (Filters.text)(update)
 
+    def test_filters_date_init(self):
+        with pytest.raises(ValueError, match='at minimum'):
+            Filters.date(seconds_ago=0)
+
+    def test_filters_date(self, update):
+        update.message.date = datetime.datetime.utcnow()
+        assert Filters.date(seconds_ago=10)(update)
+        update.message.date = datetime.datetime.utcnow() - datetime.timedelta(seconds = 100)
+        assert not Filters.date(seconds_ago=10)(update)
+
     def test_filters_text_strings(self, update):
         update.message.text = '/test'
         assert Filters.text({'/test', 'test1'})(update)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -56,7 +56,7 @@ class TestFilters(object):
     def test_filters_date(self, update):
         update.message.date = datetime.datetime.utcnow()
         assert Filters.date(seconds_ago=10)(update)
-        update.message.date = datetime.datetime.utcnow() - datetime.timedelta(seconds = 100)
+        update.message.date = datetime.datetime.utcnow() - datetime.timedelta(seconds=100)
         assert not Filters.date(seconds_ago=10)(update)
 
     def test_filters_text_strings(self, update):


### PR DESCRIPTION
This allows for filtering messages based on the date they were send by specifying the maximum time difference between 'now' and when the message was send.

I've added some basis tests. Pls verify these as I'm not familiar with pytest and can't seem to get them to fail (ex. change 'seconds_ago' to 15 in test_filters_date_init doesn't throw an error in testing)
