### PR TITLE
API 4.9 update

### DIFF
--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -3787,13 +3787,14 @@ class Bot(TelegramObject):
                   emoji=None,
                   **kwargs):
         """
-        Use this method to send a dice, which will have a random value from 1 to 6. On success, the
+        Use this method to send an animated emoji, which will have a random value. On success, the
         sent Message is returned.
 
         Args:
             chat_id (:obj:`int` | :obj:`str`): Unique identifier for the target private chat.
             emoji (:obj:`str`, optional): Emoji on which the dice throw animation is based.
-                Currently, must be one of “🎲”, “🎯” or “🏀”. Defaults to “🎲”
+                Currently, must be one of “🎲”, “🎯” or “🏀”. Dice can have values 1-6 for “🎲” and
+                “🎯”, and values 1-5 for “🏀” . Defaults to “🎲”
             disable_notification (:obj:`bool`, optional): Sends the message silently. Users will
                 receive a notification with no sound.
             reply_to_message_id (:obj:`int`, optional): If the message is a reply, ID of the

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -3793,7 +3793,7 @@ class Bot(TelegramObject):
         Args:
             chat_id (:obj:`int` | :obj:`str`): Unique identifier for the target private chat.
             emoji (:obj:`str`, optional): Emoji on which the dice throw animation is based.
-                Currently, must be one of “🎲” or “🎯”. Defaults to “🎲”
+                Currently, must be one of “🎲”, “🎯” or “🏀”. Defaults to “🎲”
             disable_notification (:obj:`bool`, optional): Sends the message silently. Users will
                 receive a notification with no sound.
             reply_to_message_id (:obj:`int`, optional): If the message is a reply, ID of the

--- a/telegram/dice.py
+++ b/telegram/dice.py
@@ -23,9 +23,9 @@ from telegram import TelegramObject
 
 class Dice(TelegramObject):
     """
-    This object represents an animated emoji with a random value for currently supported base emoji.
-    (The singular form of "dice" is "die". However, PTB mimics the Telegram API, which uses the
-    term "dice".)
+    This object represents an animated emoji with a random value for currently supported base
+    emoji. (The singular form of "dice" is "die". However, PTB mimics the Telegram API, which uses
+    the term "dice".)
 
     Note:
         If :attr:`emoji` is "🎯", a value of 6 currently represents a bullseye, while a value of 1

--- a/telegram/dice.py
+++ b/telegram/dice.py
@@ -23,7 +23,7 @@ from telegram import TelegramObject
 
 class Dice(TelegramObject):
     """
-    This object represents a dice with random value from 1 to 6 for currently supported base eomji.
+    This object represents an animated emoji with a random value for currently supported base emoji.
     (The singular form of "dice" is "die". However, PTB mimics the Telegram API, which uses the
     term "dice".)
 

--- a/telegram/dice.py
+++ b/telegram/dice.py
@@ -41,7 +41,7 @@ class Dice(TelegramObject):
         emoji (:obj:`str`): Emoji on which the dice throw animation is based.
 
     Args:
-        value (:obj:`int`): Value of the dice
+        value (:obj:`int`): Value of the dice. 1-6 for dice and darts, 1-5 for basketball.
         emoji (:obj:`str`): Emoji on which the dice throw animation is based.
     """
     def __init__(self, value, emoji, **kwargs):

--- a/telegram/dice.py
+++ b/telegram/dice.py
@@ -32,12 +32,16 @@ class Dice(TelegramObject):
         indicates that the dartboard was missed. However, this behaviour is undocumented and might
         be changed by Telegram.
 
+        If :attr:`emoji` is "🏀", a value of 4 or 5 currently score a basket, while a value of 1 to
+        3 indicates that the basket was missed. However, this behaviour is undocumented and might
+        be changed by Telegram.
+
     Attributes:
         value (:obj:`int`): Value of the dice.
         emoji (:obj:`str`): Emoji on which the dice throw animation is based.
 
     Args:
-        value (:obj:`int`): Value of the dice, 1-6.
+        value (:obj:`int`): Value of the dice
         emoji (:obj:`str`): Emoji on which the dice throw animation is based.
     """
     def __init__(self, value, emoji, **kwargs):
@@ -55,6 +59,8 @@ class Dice(TelegramObject):
     """:obj:`str`: '🎲'"""
     DARTS = '🎯'
     """:obj:`str`: '🎯'"""
-    ALL_EMOJI = [DICE, DARTS]
-    """List[:obj:`str`]: List of all supported base emoji. Currently :attr:`DICE` and
-    :attr:`DARTS`."""
+    BASKETBALL = '🏀'
+    """:obj:`str`: '🏀'"""
+    ALL_EMOJI = [DICE, DARTS, BASKETBALL]
+    """List[:obj:`str`]: List of all supported base emoji. Currently :attr:`DICE`,
+    :attr:`DARTS` and :attr:`BASKETBALL`."""

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -1260,6 +1260,7 @@ officedocument.wordprocessingml.document")``-
     class _Dice(_DiceEmoji):
         dice = _DiceEmoji('🎲', 'dice')
         darts = _DiceEmoji('🎯', 'darts')
+        basketball = _DiceEmoji('🏀', 'basketball')
 
     dice = _Dice()
     """Dice Messages. If an integer or a list of integers is passed, it filters messages to only
@@ -1286,6 +1287,8 @@ officedocument.wordprocessingml.document")``-
             :attr:`Filters.dice`.
         darts: Dice messages with the emoji 🎯. Passing a list of integers is supported just as for
             :attr:`Filters.dice`.
+        basketball: Dice messages with the emoji 🏀. Passing a list of integers is supported just
+            as for :attr:`Filters.dice`.
     """
 
     class language(BaseFilter):

--- a/telegram/inline/inlinequeryresultgif.py
+++ b/telegram/inline/inlinequeryresultgif.py
@@ -36,6 +36,7 @@ class InlineQueryResultGif(InlineQueryResult):
         gif_height (:obj:`int`): Optional. Height of the GIF.
         gif_duration (:obj:`int`): Optional. Duration of the GIF.
         thumb_url (:obj:`str`): URL of the static thumbnail for the result (jpeg or gif).
+        thumb_mime_type (:obj:`str`): Optional. MIME type of the thumbnail.
         title (:obj:`str`): Optional. Title for the result.
         caption (:obj:`str`): Optional. Caption of the GIF file to be sent, 0-1024 characters
             after entities parsing.
@@ -54,6 +55,8 @@ class InlineQueryResultGif(InlineQueryResult):
         gif_height (:obj:`int`, optional): Height of the GIF.
         gif_duration (:obj:`int`, optional): Duration of the GIF
         thumb_url (:obj:`str`): URL of the static thumbnail for the result (jpeg or gif).
+        thumb_mime_type (:obj:`str`): Optional. MIME type of the thumbnail, must be one of
+            “image/jpeg”, “image/gif”, or “video/mp4”. Defaults to “image/jpeg”.
         title (:obj:`str`, optional): Title for the result.
         caption (:obj:`str`, optional): Caption of the GIF file to be sent, 0-1024 characters
             after entities parsing.
@@ -80,6 +83,7 @@ class InlineQueryResultGif(InlineQueryResult):
                  input_message_content=None,
                  gif_duration=None,
                  parse_mode=DEFAULT_NONE,
+                 thumb_mime_type=None,
                  **kwargs):
 
         # Required
@@ -96,3 +100,4 @@ class InlineQueryResultGif(InlineQueryResult):
         self.parse_mode = parse_mode
         self.reply_markup = reply_markup
         self.input_message_content = input_message_content
+        self.thumb_mime_type = thumb_mime_type

--- a/telegram/inline/inlinequeryresultmpeg4gif.py
+++ b/telegram/inline/inlinequeryresultmpeg4gif.py
@@ -37,6 +37,7 @@ class InlineQueryResultMpeg4Gif(InlineQueryResult):
         mpeg4_height (:obj:`int`): Optional. Video height.
         mpeg4_duration (:obj:`int`): Optional. Video duration.
         thumb_url (:obj:`str`): URL of the static thumbnail (jpeg or gif) for the result.
+        thumb_mime_type (:obj:`str`): Optional. MIME type of the thumbnail.
         title (:obj:`str`): Optional. Title for the result.
         caption (:obj:`str`): Optional. Caption of the MPEG-4 file to be sent, 0-1024 characters
             after entities parsing.
@@ -55,6 +56,8 @@ class InlineQueryResultMpeg4Gif(InlineQueryResult):
         mpeg4_height (:obj:`int`, optional): Video height.
         mpeg4_duration (:obj:`int`, optional): Video duration.
         thumb_url (:obj:`str`): URL of the static thumbnail (jpeg or gif) for the result.
+        thumb_mime_type (:obj:`str`): Optional. MIME type of the thumbnail, must be one of
+            “image/jpeg”, “image/gif”, or “video/mp4”. Defaults to “image/jpeg”.
         title (:obj:`str`, optional): Title for the result.
         caption (:obj:`str`, optional): Caption of the MPEG-4 file to be sent, 0-1024 characters
             after entities parsing.
@@ -81,6 +84,7 @@ class InlineQueryResultMpeg4Gif(InlineQueryResult):
                  input_message_content=None,
                  mpeg4_duration=None,
                  parse_mode=DEFAULT_NONE,
+                 thumb_mime_type=None,
                  **kwargs):
 
         # Required
@@ -97,3 +101,4 @@ class InlineQueryResultMpeg4Gif(InlineQueryResult):
         self.parse_mode = parse_mode
         self.reply_markup = reply_markup
         self.input_message_content = input_message_content
+        self.thumb_mime_type = thumb_mime_type

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -217,7 +217,7 @@ class Message(TelegramObject):
         poll (:class:`telegram.Poll`, optional): Message is a native poll,
             information about the poll.
         dice (:class:`telegram.Dice`, optional): Message is a dice with random value from 1 to 6.
-        via_bot (:class:`telegram.User`, optional): Message was send through an inline bot.
+        via_bot (:class:`telegram.User`, optional): Message was sent through an inline bot.
         reply_markup (:class:`telegram.InlineKeyboardMarkup`, optional): Inline keyboard attached
             to the message. login_url buttons are represented as ordinary url buttons.
         default_quote (:obj:`bool`, optional): Default setting for the `quote` parameter of the

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -107,6 +107,7 @@ class Message(TelegramObject):
         poll (:class:`telegram.Poll`): Optional. Message is a native poll,
             information about the poll.
         dice (:class:`telegram.Dice`): Optional. Message is a dice.
+        via_bot (:class:`telegram.User`): Optional. Bot through which the message was sent.
         reply_markup (:class:`telegram.InlineKeyboardMarkup`): Optional. Inline keyboard attached
             to the message.
         bot (:class:`telegram.Bot`): Optional. The Bot to use for instance methods.
@@ -216,6 +217,7 @@ class Message(TelegramObject):
         poll (:class:`telegram.Poll`, optional): Message is a native poll,
             information about the poll.
         dice (:class:`telegram.Dice`, optional): Message is a dice with random value from 1 to 6.
+        via_bot (:class:`telegram.User`, optional): Message was send through an inline bot.
         reply_markup (:class:`telegram.InlineKeyboardMarkup`, optional): Inline keyboard attached
             to the message. login_url buttons are represented as ordinary url buttons.
         default_quote (:obj:`bool`, optional): Default setting for the `quote` parameter of the
@@ -285,6 +287,7 @@ class Message(TelegramObject):
                  bot=None,
                  default_quote=None,
                  dice=None,
+                 via_bot=None,
                  **kwargs):
         # Required
         self.message_id = int(message_id)
@@ -335,6 +338,7 @@ class Message(TelegramObject):
         self.passport_data = passport_data
         self.poll = poll
         self.dice = dice
+        self.via_bot = via_bot
         self.reply_markup = reply_markup
         self.bot = bot
         self.default_quote = default_quote
@@ -409,6 +413,7 @@ class Message(TelegramObject):
         data['passport_data'] = PassportData.de_json(data.get('passport_data'), bot)
         data['poll'] = Poll.de_json(data.get('poll'), bot)
         data['dice'] = Dice.de_json(data.get('dice'), bot)
+        data['via_bot'] = User.de_json(data.get('via_bot'), bot)
         data['reply_markup'] = InlineKeyboardMarkup.de_json(data.get('reply_markup'), bot)
 
         return cls(bot=bot, **data)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -850,13 +850,22 @@ class TestFilters(object):
         assert Filters.dice.dice(update)
         assert Filters.dice.dice([4, 5])(update)
         assert not Filters.dice.darts(update)
+        assert not Filters.dice.basketball(update)
         assert not Filters.dice.dice([6])(update)
 
         update.message.dice = Dice(5, '🎯')
         assert Filters.dice.darts(update)
         assert Filters.dice.darts([4, 5])(update)
         assert not Filters.dice.dice(update)
+        assert not Filters.dice.basketball(update)
         assert not Filters.dice.darts([6])(update)
+
+        update.message.dice = Dice(5, '🏀')
+        assert Filters.dice.basketball(update)
+        assert Filters.dice.basketball([4, 5])(update)
+        assert not Filters.dice.dice(update)
+        assert not Filters.dice.darts(update)
+        assert not Filters.dice.basketball([4])(update)
 
     def test_language_filter_single(self, update):
         update.message.from_user.language_code = 'en_US'

--- a/tests/test_inlinequeryresultgif.py
+++ b/tests/test_inlinequeryresultgif.py
@@ -36,7 +36,8 @@ def inline_query_result_gif():
         caption=TestInlineQueryResultGif.caption,
         parse_mode=TestInlineQueryResultGif.parse_mode,
         input_message_content=TestInlineQueryResultGif.input_message_content,
-        reply_markup=TestInlineQueryResultGif.reply_markup)
+        reply_markup=TestInlineQueryResultGif.reply_markup,
+        thumb_mime_type=TestInlineQueryResultGif.thumb_mime_type)
 
 
 class TestInlineQueryResultGif(object):
@@ -47,6 +48,7 @@ class TestInlineQueryResultGif(object):
     gif_height = 15
     gif_duration = 1
     thumb_url = 'thumb url'
+    thumb_mime_type = 'image/jpeg'
     title = 'title'
     caption = 'caption'
     parse_mode = 'HTML'
@@ -61,6 +63,7 @@ class TestInlineQueryResultGif(object):
         assert inline_query_result_gif.gif_height == self.gif_height
         assert inline_query_result_gif.gif_duration == self.gif_duration
         assert inline_query_result_gif.thumb_url == self.thumb_url
+        assert inline_query_result_gif.thumb_mime_type == self.thumb_mime_type
         assert inline_query_result_gif.title == self.title
         assert inline_query_result_gif.caption == self.caption
         assert inline_query_result_gif.parse_mode == self.parse_mode
@@ -79,6 +82,8 @@ class TestInlineQueryResultGif(object):
         assert inline_query_result_gif_dict['gif_height'] == inline_query_result_gif.gif_height
         assert inline_query_result_gif_dict['gif_duration'] == inline_query_result_gif.gif_duration
         assert inline_query_result_gif_dict['thumb_url'] == inline_query_result_gif.thumb_url
+        assert (inline_query_result_gif_dict['thumb_mime_type']
+                == inline_query_result_gif.thumb_mime_type)
         assert inline_query_result_gif_dict['title'] == inline_query_result_gif.title
         assert inline_query_result_gif_dict['caption'] == inline_query_result_gif.caption
         assert inline_query_result_gif_dict['parse_mode'] == inline_query_result_gif.parse_mode

--- a/tests/test_inlinequeryresultmpeg4gif.py
+++ b/tests/test_inlinequeryresultmpeg4gif.py
@@ -36,7 +36,8 @@ def inline_query_result_mpeg4_gif():
         caption=TestInlineQueryResultMpeg4Gif.caption,
         parse_mode=TestInlineQueryResultMpeg4Gif.parse_mode,
         input_message_content=TestInlineQueryResultMpeg4Gif.input_message_content,
-        reply_markup=TestInlineQueryResultMpeg4Gif.reply_markup)
+        reply_markup=TestInlineQueryResultMpeg4Gif.reply_markup,
+        thumb_mime_type=TestInlineQueryResultMpeg4Gif.thumb_mime_type)
 
 
 class TestInlineQueryResultMpeg4Gif(object):
@@ -47,6 +48,7 @@ class TestInlineQueryResultMpeg4Gif(object):
     mpeg4_height = 15
     mpeg4_duration = 1
     thumb_url = 'thumb url'
+    thumb_mime_type = 'image/jpeg'
     title = 'title'
     caption = 'caption'
     parse_mode = 'Markdown'
@@ -61,6 +63,7 @@ class TestInlineQueryResultMpeg4Gif(object):
         assert inline_query_result_mpeg4_gif.mpeg4_height == self.mpeg4_height
         assert inline_query_result_mpeg4_gif.mpeg4_duration == self.mpeg4_duration
         assert inline_query_result_mpeg4_gif.thumb_url == self.thumb_url
+        assert inline_query_result_mpeg4_gif.thumb_mime_type == self.thumb_mime_type
         assert inline_query_result_mpeg4_gif.title == self.title
         assert inline_query_result_mpeg4_gif.caption == self.caption
         assert inline_query_result_mpeg4_gif.parse_mode == self.parse_mode
@@ -84,6 +87,8 @@ class TestInlineQueryResultMpeg4Gif(object):
                 == inline_query_result_mpeg4_gif.mpeg4_duration)
         assert (inline_query_result_mpeg4_gif_dict['thumb_url']
                 == inline_query_result_mpeg4_gif.thumb_url)
+        assert (inline_query_result_mpeg4_gif_dict['thumb_mime_type']
+                == inline_query_result_mpeg4_gif.thumb_mime_type)
         assert inline_query_result_mpeg4_gif_dict['title'] == inline_query_result_mpeg4_gif.title
         assert (inline_query_result_mpeg4_gif_dict['caption']
                 == inline_query_result_mpeg4_gif.caption)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -98,7 +98,8 @@ def message(bot):
                         'text': 'next', 'callback_data': 'abcd'}],
                         [{'text': 'Cancel', 'callback_data': 'Cancel'}]]}},
                     {'quote': True},
-                    {'dice': Dice(4, '🎲')}
+                    {'dice': Dice(4, '🎲')},
+                    {'via_bot': User(9, 'A_Bot', True)}
                 ],
                 ids=['forwarded_user', 'forwarded_channel', 'reply', 'edited', 'text',
                      'caption_entities', 'audio', 'document', 'animation', 'game', 'photo',
@@ -108,7 +109,7 @@ def message(bot):
                      'migrated_from', 'pinned', 'invoice', 'successful_payment',
                      'connected_website', 'forward_signature', 'author_signature',
                      'photo_from_media_group', 'passport_data', 'poll', 'reply_markup',
-                     'default_quote', 'dice'])
+                     'default_quote', 'dice', 'via_bot'])
 def message_params(bot, request):
     return Message(message_id=TestMessage.id_,
                    from_user=TestMessage.from_user,


### PR DESCRIPTION
Basketball was added by @code1mountain, rest done by me.
Open questions:

- [x] How to test for via_bot attribute of a Message
- [ ] Do we want to offer the mime types of the InlineQueryResults thumb urls as constants? If yes, where?
