### PR TITLE
Remove error handlers from examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -34,5 +34,8 @@ A basic example of a bot that can accept payments. Don't forget to enable and co
 ### [`persistentconversationbot.py`](https://github.com/python-telegram-bot/python-telegram-bot/blob/master/examples/persistentconversationbot.py)
 A basic example of a bot store conversation state and user_data over multiple restarts.
 
+### [`errorhandlerbot.py`](https://github.com/python-telegram-bot/python-telegram-bot/blob/master/examples/errorhandlerbot.py)
+A simple example of a bot that has a custom error handler.
+
 ## Pure API
 The [`echobot.py`](https://github.com/python-telegram-bot/python-telegram-bot/blob/master/examples/echobot.py) example uses only the pure, "bare-metal" API wrapper.

--- a/examples/conversationbot.py
+++ b/examples/conversationbot.py
@@ -108,11 +108,6 @@ def cancel(update, context):
     return ConversationHandler.END
 
 
-def error(update, context):
-    """Log Errors caused by Updates."""
-    logger.warning('Update "%s" caused error "%s"', update, context.error)
-
-
 def main():
     # Create the Updater and pass it your bot's token.
     # Make sure to set use_context=True to use the new context based callbacks
@@ -142,9 +137,6 @@ def main():
     )
 
     dp.add_handler(conv_handler)
-
-    # log all errors
-    dp.add_error_handler(error)
 
     # Start the Bot
     updater.start_polling()

--- a/examples/conversationbot2.py
+++ b/examples/conversationbot2.py
@@ -96,11 +96,6 @@ def done(update, context):
     return ConversationHandler.END
 
 
-def error(update, context):
-    """Log Errors caused by Updates."""
-    logger.warning('Update "%s" caused error "%s"', update, context.error)
-
-
 def main():
     # Create the Updater and pass it your bot's token.
     # Make sure to set use_context=True to use the new context based callbacks
@@ -134,9 +129,6 @@ def main():
     )
 
     dp.add_handler(conv_handler)
-
-    # log all errors
-    dp.add_error_handler(error)
 
     # Start the Bot
     updater.start_polling()

--- a/examples/deeplinking.py
+++ b/examples/deeplinking.py
@@ -72,11 +72,6 @@ def deep_linked_level_3(update, context):
                               "The payload was: {0}".format(payload))
 
 
-def error(update, context):
-    """Log Errors caused by Updates."""
-    logger.warning('Update "%s" caused error "%s"', update, context.error)
-
-
 def main():
     """Start the bot."""
     # Create the Updater and pass it your bot's token.
@@ -102,9 +97,6 @@ def main():
 
     # Make sure the deep-linking handlers occur *before* the normal /start handler.
     dp.add_handler(CommandHandler("start", start))
-
-    # log all errors
-    dp.add_error_handler(error)
 
     # Start the Bot
     updater.start_polling()

--- a/examples/echobot2.py
+++ b/examples/echobot2.py
@@ -43,11 +43,6 @@ def echo(update, context):
     update.message.reply_text(update.message.text)
 
 
-def error(update, context):
-    """Log Errors caused by Updates."""
-    logger.warning('Update "%s" caused error "%s"', update, context.error)
-
-
 def main():
     """Start the bot."""
     # Create the Updater and pass it your bot's token.
@@ -64,9 +59,6 @@ def main():
 
     # on noncommand i.e message - echo the message on Telegram
     dp.add_handler(MessageHandler(Filters.text, echo))
-
-    # log all errors
-    dp.add_error_handler(error)
 
     # Start the Bot
     updater.start_polling()

--- a/examples/error_handler.py
+++ b/examples/error_handler.py
@@ -6,6 +6,7 @@
 This is a very simple example on how one could implement a custom error handler
 """
 import html
+import json
 import logging
 import traceback
 
@@ -40,7 +41,7 @@ def error_handler(update: Update, context: CallbackContext):
         '<pre>context.user_data = {}</pre>\n\n'
         '<pre>{}</pre>'
     ).format(
-        html.escape(update.to_json()),
+        html.escape(json.dumps(update.to_dict(), indent=2, ensure_ascii=False)),
         html.escape(str(context.chat_data)),
         html.escape(str(context.user_data)),
         html.escape(tb)
@@ -50,7 +51,7 @@ def error_handler(update: Update, context: CallbackContext):
     context.bot.send_message(chat_id=DEVELOPER_CHAT_ID, text=message, parse_mode=ParseMode.HTML)
 
 
-def bad_command(udpate: Update, context: CallbackContext):
+def bad_command(update: Update, context: CallbackContext):
     """Raise an error to trigger the error handler."""
     context.bot.wrong_method_name()
 

--- a/examples/error_handler.py
+++ b/examples/error_handler.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# This program is dedicated to the public domain under the CC0 license.
+
+"""
+This is a very simple example on how one could implement a custom error handler
+"""
+import logging
+
+from telegram import Update, ParseMode
+from telegram.ext import Updater, CallbackContext
+
+import traceback
+
+logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+                    level=logging.INFO)
+
+logger = logging.getLogger(__name__)
+# this can be your own ID, or one for a developer group/channel
+BOT_DEV = 208589966
+
+
+def on_error(update: Update, context: CallbackContext):
+    # lets log the error before we do anything else, so this appears at least in the logs
+    logger.error(msg="The following error happened while handling an update",
+                 exc_info=context.error)
+    # now we collect chat and user data
+    chat_data = str(context.chat_data)
+    user_data = str(context.user_data)
+    # format_tb returns the traceback in a list. We take the traceback from the error object
+    tb_list = traceback.format_tb(context.error.__traceback__)
+    # now we turn the list into a string
+    tb = ''.join(tb_list)
+    # build the message with some markdown
+    message = 'Update <pre>{}</pre> caused the error <i>{}</i>. The current chat data is ' \
+              '<i>{}</i>, the user data <i>{}</i>. The traceback is as follows:\n<pre>{}</pre>'
+    # and send it away
+    context.bot.send_message(chat_id=BOT_DEV,
+                             text=message.format(update, context.error, chat_data, user_data, tb),
+                             parse_mode=ParseMode.HTML)
+
+
+def main():
+    """Start the bot."""
+    # Create the Updater and pass it your bot's token.
+    # Make sure to set use_context=True to use the new context based callbacks
+    # Post version 12 this will no longer be necessary
+    updater = Updater("TOKEN", use_context=True)
+
+    # Get the dispatcher to register handlers
+    dp = updater.dispatcher
+
+    # when an error happens, forward the error to the error handler
+    dp.add_error_handler(on_error)
+
+    # Start the Bot
+    updater.start_polling()
+    # Run the bot until you press Ctrl-C or the process receives SIGINT,
+    # SIGTERM or SIGABRT. This should be used most of the time, since
+    # start_polling() is non-blocking and will stop the bot gracefully.
+    updater.idle()
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/error_handler.py
+++ b/examples/error_handler.py
@@ -22,10 +22,8 @@ DEVELOPER_CHAT_ID = 208589966
 
 
 def error_handler(update: Update, context: CallbackContext):
-    """To be used with Dispatcher.add_error_handler, sends notification to the developer"""
+    """Log the error and send a telegram message to notify the developer."""
     # Log the error before we do anything else, so we can see it even if something breaks.
-    # If you are going to use multiple error handlers, which is totally possible, you might want
-    # to put this line in its own separate error handler.
     logger.error(msg="Exception while handling an update:", exc_info=context.error)
 
     # traceback.format_exception returns the usual python message about an exception, but as a
@@ -34,7 +32,7 @@ def error_handler(update: Update, context: CallbackContext):
     tb = ''.join(tb_list)
 
     # Build the message with some markup and additional information about what happened.
-    # You might need to add some logic to deal with messages longer then the 4096 character limit.
+    # You might need to add some logic to deal with messages longer than the 4096 character limit.
     message = (
         'An exception was raised while handling an update\n'
         '<pre>update = {}</pre>\n\n'

--- a/examples/error_handler.py
+++ b/examples/error_handler.py
@@ -10,7 +10,7 @@ import logging
 import traceback
 
 from telegram import Update, ParseMode
-from telegram.ext import Updater, CallbackContext
+from telegram.ext import Updater, CallbackContext, CommandHandler
 
 logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
                     level=logging.INFO)
@@ -52,6 +52,11 @@ def error_handler(update: Update, context: CallbackContext):
     context.bot.send_message(chat_id=DEVELOPER_CHAT_ID, text=message, parse_mode=ParseMode.HTML)
 
 
+def bad_command(udpate: Update, context: CallbackContext):
+    """Raise an error to trigger the error handler."""
+    context.bot.wrong_method_name()
+
+
 def main():
     # Create the Updater and pass it your bot's token.
     # Make sure to set use_context=True to use the new context based callbacks
@@ -61,7 +66,10 @@ def main():
     # Get the dispatcher to register handlers
     dp = updater.dispatcher
 
-    # When an error happens, forward the error to the error handler
+    # Register the command...
+    dp.add_handler(CommandHandler('bad_command', bad_command))
+
+    # ...and the error handler
     dp.add_error_handler(error_handler)
 
     # Start the Bot

--- a/examples/errorhandlerbot.py
+++ b/examples/errorhandlerbot.py
@@ -56,6 +56,10 @@ def bad_command(update: Update, context: CallbackContext):
     context.bot.wrong_method_name()
 
 
+def start(update: Update, context: CallbackContext):
+    update.effective_message.reply_text('Use /bad_command to cause an error.')
+
+
 def main():
     # Create the Updater and pass it your bot's token.
     # Make sure to set use_context=True to use the new context based callbacks
@@ -65,7 +69,8 @@ def main():
     # Get the dispatcher to register handlers
     dp = updater.dispatcher
 
-    # Register the command...
+    # Register the commands...
+    dp.add_handler(CommandHandler('start', start))
     dp.add_handler(CommandHandler('bad_command', bad_command))
 
     # ...and the error handler

--- a/examples/errorhandlerbot.py
+++ b/examples/errorhandlerbot.py
@@ -18,8 +18,11 @@ logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s
 
 logger = logging.getLogger(__name__)
 
-# this can be your own ID, or one for a developer group/channel
-DEVELOPER_CHAT_ID = 208589966
+# The token you got from @botfather when you created the bot
+BOT_TOKEN = "TOKEN"
+
+# This can be your own ID, or one for a developer group/channel
+DEVELOPER_CHAT_ID = 123456789
 
 
 def error_handler(update: Update, context: CallbackContext):
@@ -64,7 +67,7 @@ def main():
     # Create the Updater and pass it your bot's token.
     # Make sure to set use_context=True to use the new context based callbacks
     # Post version 12 this will no longer be necessary
-    updater = Updater("TOKEN", use_context=True)
+    updater = Updater(BOT_TOKEN, use_context=True)
 
     # Get the dispatcher to register handlers
     dp = updater.dispatcher

--- a/examples/errorhandlerbot.py
+++ b/examples/errorhandlerbot.py
@@ -21,7 +21,8 @@ logger = logging.getLogger(__name__)
 # The token you got from @botfather when you created the bot
 BOT_TOKEN = "TOKEN"
 
-# This can be your own ID, or one for a developer group/channel
+# This can be your own ID, or one for a developer group/channel.
+# You can use the /start command of this bot to see your chat id.
 DEVELOPER_CHAT_ID = 123456789
 
 
@@ -60,7 +61,9 @@ def bad_command(update: Update, context: CallbackContext):
 
 
 def start(update: Update, context: CallbackContext):
-    update.effective_message.reply_text('Use /bad_command to cause an error.')
+    update.effective_message.reply_html('Use /bad_command to cause an error.\n'
+                                        'Your chat id is <code>{}</code>.'
+                                        .format(update.effective_chat.id))
 
 
 def main():

--- a/examples/errorhandlerbot.py
+++ b/examples/errorhandlerbot.py
@@ -18,12 +18,9 @@ logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s
 
 logger = logging.getLogger(__name__)
 
-# this can be your own ID, or one for a developer group/channel
-DEVELOPER_CHAT_ID = 208589966
-
 
 def error_handler(update: Update, context: CallbackContext):
-    """Log the error and send a telegram message to notify the developer."""
+    """Log the error and send a telegram message with error details."""
     # Log the error before we do anything else, so we can see it even if something breaks.
     logger.error(msg="Exception while handling an update:", exc_info=context.error)
 
@@ -47,8 +44,10 @@ def error_handler(update: Update, context: CallbackContext):
         html.escape(tb)
     )
 
-    # Finally, send the message
-    context.bot.send_message(chat_id=DEVELOPER_CHAT_ID, text=message, parse_mode=ParseMode.HTML)
+    # Finally, send the message. You can replace this with something like
+    # context.bot.send_message(chat_id=DEVELOPER_CHAT_ID, text=message, parse_mode=ParseMode.HTML)
+    # to send the message to the bot developer rather than the user.
+    update.effective_message.reply_text(text=message, parse_mode=ParseMode.HTML)
 
 
 def bad_command(update: Update, context: CallbackContext):

--- a/examples/errorhandlerbot.py
+++ b/examples/errorhandlerbot.py
@@ -18,9 +18,12 @@ logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s
 
 logger = logging.getLogger(__name__)
 
+# this can be your own ID, or one for a developer group/channel
+DEVELOPER_CHAT_ID = 208589966
+
 
 def error_handler(update: Update, context: CallbackContext):
-    """Log the error and send a telegram message with error details."""
+    """Log the error and send a telegram message to notify the developer."""
     # Log the error before we do anything else, so we can see it even if something breaks.
     logger.error(msg="Exception while handling an update:", exc_info=context.error)
 
@@ -44,10 +47,8 @@ def error_handler(update: Update, context: CallbackContext):
         html.escape(tb)
     )
 
-    # Finally, send the message. You can replace this with something like
-    # context.bot.send_message(chat_id=DEVELOPER_CHAT_ID, text=message, parse_mode=ParseMode.HTML)
-    # to send the message to the bot developer rather than the user.
-    update.effective_message.reply_text(text=message, parse_mode=ParseMode.HTML)
+    # Finally, send the message
+    context.bot.send_message(chat_id=DEVELOPER_CHAT_ID, text=message, parse_mode=ParseMode.HTML)
 
 
 def bad_command(update: Update, context: CallbackContext):

--- a/examples/inlinebot.py
+++ b/examples/inlinebot.py
@@ -64,11 +64,6 @@ def inlinequery(update, context):
     update.inline_query.answer(results)
 
 
-def error(update, context):
-    """Log Errors caused by Updates."""
-    logger.warning('Update "%s" caused error "%s"', update, context.error)
-
-
 def main():
     # Create the Updater and pass it your bot's token.
     # Make sure to set use_context=True to use the new context based callbacks
@@ -84,9 +79,6 @@ def main():
 
     # on noncommand i.e message - echo the message on Telegram
     dp.add_handler(InlineQueryHandler(inlinequery))
-
-    # log all errors
-    dp.add_error_handler(error)
 
     # Start the Bot
     updater.start_polling()

--- a/examples/inlinekeyboard.py
+++ b/examples/inlinekeyboard.py
@@ -40,11 +40,6 @@ def help(update, context):
     update.message.reply_text("Use /start to test this bot.")
 
 
-def error(update, context):
-    """Log Errors caused by Updates."""
-    logger.warning('Update "%s" caused error "%s"', update, context.error)
-
-
 def main():
     # Create the Updater and pass it your bot's token.
     # Make sure to set use_context=True to use the new context based callbacks
@@ -54,7 +49,6 @@ def main():
     updater.dispatcher.add_handler(CommandHandler('start', start))
     updater.dispatcher.add_handler(CallbackQueryHandler(button))
     updater.dispatcher.add_handler(CommandHandler('help', help))
-    updater.dispatcher.add_error_handler(error)
 
     # Start the Bot
     updater.start_polling()

--- a/examples/inlinekeyboard2.py
+++ b/examples/inlinekeyboard2.py
@@ -149,11 +149,6 @@ def end(update, context):
     return ConversationHandler.END
 
 
-def error(update, context):
-    """Log Errors caused by Updates."""
-    logger.warning('Update "%s" caused error "%s"', update, context.error)
-
-
 def main():
     # Create the Updater and pass it your bot's token.
     updater = Updater("TOKEN", use_context=True)
@@ -183,9 +178,6 @@ def main():
     # Add ConversationHandler to dispatcher that will be used for handling
     # updates
     dp.add_handler(conv_handler)
-
-    # log all errors
-    dp.add_error_handler(error)
 
     # Start the Bot
     updater.start_polling()

--- a/examples/nestedconversationbot.py
+++ b/examples/nestedconversationbot.py
@@ -267,12 +267,6 @@ def stop_nested(update, context):
     return STOPPING
 
 
-# Error handler
-def error(update, context):
-    """Log Errors caused by Updates."""
-    logger.warning('Update "%s" caused error "%s"', update, context.error)
-
-
 def main():
     # Create the Updater and pass it your bot's token.
     # Make sure to set use_context=True to use the new context based callbacks
@@ -358,9 +352,6 @@ def main():
     )
 
     dp.add_handler(conv_handler)
-
-    # log all errors
-    dp.add_error_handler(error)
 
     # Start the Bot
     updater.start_polling()

--- a/examples/passportbot.py
+++ b/examples/passportbot.py
@@ -77,11 +77,6 @@ def msg(update, context):
                     actual_file.download()
 
 
-def error(update, context):
-    """Log Errors caused by Updates."""
-    logger.warning('Update "%s" caused error "%s"', update, context.error)
-
-
 def main():
     """Start the bot."""
     # Create the Updater and pass it your token and private key
@@ -92,9 +87,6 @@ def main():
 
     # On messages that include passport data call msg
     dp.add_handler(MessageHandler(Filters.passport_data, msg))
-
-    # log all errors
-    dp.add_error_handler(error)
 
     # Start the Bot
     updater.start_polling()

--- a/examples/paymentbot.py
+++ b/examples/paymentbot.py
@@ -19,11 +19,6 @@ logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s
 logger = logging.getLogger(__name__)
 
 
-def error(update, context):
-    """Log Errors caused by Updates."""
-    logger.warning('Update "%s" caused error "%s"', update, context.error)
-
-
 def start_callback(update, context):
     msg = "Use /shipping to get an invoice for shipping-payment, "
     msg += "or /noshipping for an invoice without shipping."
@@ -133,9 +128,6 @@ def main():
 
     # Success! Notify your user!
     dp.add_handler(MessageHandler(Filters.successful_payment, successful_payment_callback))
-
-    # log all errors
-    dp.add_error_handler(error)
 
     # Start the Bot
     updater.start_polling()

--- a/examples/persistentconversationbot.py
+++ b/examples/persistentconversationbot.py
@@ -107,11 +107,6 @@ def done(update, context):
     return ConversationHandler.END
 
 
-def error(update, context):
-    """Log Errors caused by Updates."""
-    logger.warning('Update "%s" caused error "%s"', update, context.error)
-
-
 def main():
     # Create the Updater and pass it your bot's token.
     pp = PicklePersistence(filename='conversationbot')
@@ -149,8 +144,6 @@ def main():
 
     show_data_handler = CommandHandler('show_data', show_data)
     dp.add_handler(show_data_handler)
-    # log all errors
-    dp.add_error_handler(error)
 
     # Start the Bot
     updater.start_polling()

--- a/examples/timerbot.py
+++ b/examples/timerbot.py
@@ -77,11 +77,6 @@ def unset(update, context):
     update.message.reply_text('Timer successfully unset!')
 
 
-def error(update, context):
-    """Log Errors caused by Updates."""
-    logger.warning('Update "%s" caused error "%s"', update, context.error)
-
-
 def main():
     """Run bot."""
     # Create the Updater and pass it your bot's token.
@@ -100,9 +95,6 @@ def main():
                                   pass_job_queue=True,
                                   pass_chat_data=True))
     dp.add_handler(CommandHandler("unset", unset, pass_chat_data=True))
-
-    # log all errors
-    dp.add_error_handler(error)
 
     # Start the Bot
     updater.start_polling()


### PR DESCRIPTION
This should have been done a long time ago. A new example for a custom error handler can be added later.

Closes #1921
