### PR TITLE
Do not override builtin method help()

### DIFF
--- a/examples/echobot2.py
+++ b/examples/echobot2.py
@@ -33,7 +33,7 @@ def start(update, context):
     update.message.reply_text('Hi!')
 
 
-def help(update, context):
+def help_command(update, context):
     """Send a message when the command /help is issued."""
     update.message.reply_text('Help!')
 
@@ -55,7 +55,7 @@ def main():
 
     # on different commands - answer in Telegram
     dp.add_handler(CommandHandler("start", start))
-    dp.add_handler(CommandHandler("help", help))
+    dp.add_handler(CommandHandler("help", help_command))
 
     # on noncommand i.e message - echo the message on Telegram
     dp.add_handler(MessageHandler(Filters.text, echo))

--- a/examples/inlinebot.py
+++ b/examples/inlinebot.py
@@ -34,7 +34,7 @@ def start(update, context):
     update.message.reply_text('Hi!')
 
 
-def help(update, context):
+def help_command(update, context):
     """Send a message when the command /help is issued."""
     update.message.reply_text('Help!')
 
@@ -75,7 +75,7 @@ def main():
 
     # on different commands - answer in Telegram
     dp.add_handler(CommandHandler("start", start))
-    dp.add_handler(CommandHandler("help", help))
+    dp.add_handler(CommandHandler("help", help_command))
 
     # on noncommand i.e message - echo the message on Telegram
     dp.add_handler(InlineQueryHandler(inlinequery))

--- a/examples/inlinekeyboard.py
+++ b/examples/inlinekeyboard.py
@@ -36,7 +36,7 @@ def button(update, context):
     query.edit_message_text(text="Selected option: {}".format(query.data))
 
 
-def help(update, context):
+def help_command(update, context):
     update.message.reply_text("Use /start to test this bot.")
 
 
@@ -48,7 +48,7 @@ def main():
 
     updater.dispatcher.add_handler(CommandHandler('start', start))
     updater.dispatcher.add_handler(CallbackQueryHandler(button))
-    updater.dispatcher.add_handler(CommandHandler('help', help))
+    updater.dispatcher.add_handler(CommandHandler('help', help_command))
 
     # Start the Bot
     updater.start_polling()


### PR DESCRIPTION
The echobot2 example overrides builtin method `help()`. This PR renames the `help(update, context)` function to `help_command(update, context)`. 

Perhaps change `start` to `start_command` too?