### PR TITLE
Improve Filtering in examples

### DIFF
--- a/examples/conversationbot.py
+++ b/examples/conversationbot.py
@@ -130,7 +130,7 @@ def main():
             LOCATION: [MessageHandler(Filters.location, location),
                        CommandHandler('skip', skip_location)],
 
-            BIO: [MessageHandler(Filters.text, bio)]
+            BIO: [MessageHandler(Filters.text & ~Filters.command, bio)]
         },
 
         fallbacks=[CommandHandler('cancel', cancel)]

--- a/examples/conversationbot2.py
+++ b/examples/conversationbot2.py
@@ -116,13 +116,13 @@ def main():
                                       custom_choice)
                        ],
 
-            TYPING_CHOICE: [MessageHandler(Filters.text,
-                                           regular_choice)
-                            ],
+            TYPING_CHOICE: [
+                MessageHandler(Filters.text & ~(Filters.command | Filters.regex('^Done$')),
+                               regular_choice)],
 
-            TYPING_REPLY: [MessageHandler(Filters.text,
-                                          received_information),
-                           ],
+            TYPING_REPLY: [
+                MessageHandler(Filters.text & ~(Filters.command | Filters.regex('^Done$')),
+                               received_information)],
         },
 
         fallbacks=[MessageHandler(Filters.regex('^Done$'), done)]

--- a/examples/echobot.py
+++ b/examples/echobot.py
@@ -58,7 +58,7 @@ def main():
     dp.add_handler(CommandHandler("help", help_command))
 
     # on noncommand i.e message - echo the message on Telegram
-    dp.add_handler(MessageHandler(Filters.text, echo))
+    dp.add_handler(MessageHandler(Filters.text & ~Filters.command, echo))
 
     # Start the Bot
     updater.start_polling()

--- a/examples/nestedconversationbot.py
+++ b/examples/nestedconversationbot.py
@@ -284,7 +284,7 @@ def main():
         states={
             SELECTING_FEATURE: [CallbackQueryHandler(ask_for_input,
                                                      pattern='^(?!' + str(END) + ').*$')],
-            TYPING: [MessageHandler(Filters.text, save_input)],
+            TYPING: [MessageHandler(Filters.text & ~Filters.command, save_input)],
         },
 
         fallbacks=[

--- a/examples/persistentconversationbot.py
+++ b/examples/persistentconversationbot.py
@@ -126,13 +126,13 @@ def main():
                                       custom_choice),
                        ],
 
-            TYPING_CHOICE: [MessageHandler(Filters.text,
-                                           regular_choice),
-                            ],
+            TYPING_CHOICE: [
+                MessageHandler(Filters.text & ~(Filters.command | Filters.regex('^Done$')),
+                               regular_choice)],
 
-            TYPING_REPLY: [MessageHandler(Filters.text,
-                                          received_information),
-                           ],
+            TYPING_REPLY: [
+                MessageHandler(Filters.text & ~(Filters.command | Filters.regex('^Done$')),
+                               received_information)],
         },
 
         fallbacks=[MessageHandler(Filters.regex('^Done$'), done)],


### PR DESCRIPTION
* Since v12.4 `Filters.text` accepts commands, so some `& ~Filters.command` where added
* `conversationbot2` and `persistentconversationbot` also got an upgrade making sure that the fallback works from every stage.