### PR TITLE
Add missing shortcuts

### DIFF
--- a/telegram/callbackquery.py
+++ b/telegram/callbackquery.py
@@ -175,10 +175,10 @@ class CallbackQuery(TelegramObject):
     def edit_message_reply_markup(self, reply_markup, *args, **kwargs):
         """Shortcut for either::
 
-            bot.edit_message_replyMarkup(chat_id=update.callback_query.message.chat_id,
-                                       message_id=update.callback_query.message.message_id,
-                                       reply_markup=reply_markup,
-                                       *args, **kwargs)
+            bot.edit_message_reply_markup(chat_id=update.callback_query.message.chat_id,
+                                          message_id=update.callback_query.message.message_id,
+                                          reply_markup=reply_markup,
+                                          *args, **kwargs)
 
         or::
 
@@ -204,10 +204,10 @@ class CallbackQuery(TelegramObject):
     def edit_message_media(self, *args, **kwargs):
         """Shortcut for either::
 
-            bot.edit_message_replyMarkup(chat_id=update.callback_query.message.chat_id,
-                                         message_id=update.callback_query.message.message_id,
-                                         media=media,
-                                         *args, **kwargs)
+            bot.edit_message_media(chat_id=update.callback_query.message.chat_id,
+                                   message_id=update.callback_query.message.message_id,
+                                   media=media,
+                                   *args, **kwargs)
 
         or::
 

--- a/telegram/callbackquery.py
+++ b/telegram/callbackquery.py
@@ -309,19 +309,19 @@ class CallbackQuery(TelegramObject):
                                            message_id=self.message.message_id,
                                            *args, **kwargs)
 
-    def get_game_high_score(self, *args, **kwargs):
+    def get_game_high_scores(self, *args, **kwargs):
         """Shortcut for either::
 
-            bot.get_game_high_score(chat_id=update.callback_query.message.chat_id,
-                                    message_id=update.callback_query.message.message_id,
-                                    reply_markup=reply_markup,
-                                    *args, **kwargs)
+            bot.get_game_high_scores(chat_id=update.callback_query.message.chat_id,
+                                     message_id=update.callback_query.message.message_id,
+                                     reply_markup=reply_markup,
+                                     *args, **kwargs)
 
         or::
 
-            bot.get_game_high_score(inline_message_id=update.callback_query.inline_message_id,
-                                    reply_markup=reply_markup,
-                                    *args, **kwargs)
+            bot.get_game_high_scores(inline_message_id=update.callback_query.inline_message_id,
+                                     reply_markup=reply_markup,
+                                     *args, **kwargs)
 
         Returns:
             :class:`telegram.Message`: On success, if edited message is sent by the bot, the
@@ -329,9 +329,9 @@ class CallbackQuery(TelegramObject):
 
         """
         if self.inline_message_id:
-            return self.bot.get_game_high_score(inline_message_id=self.inline_message_id,
-                                                *args, **kwargs)
+            return self.bot.get_game_high_scores(inline_message_id=self.inline_message_id,
+                                                 *args, **kwargs)
         else:
-            return self.bot.get_game_high_score(chat_id=self.message.chat_id,
-                                                message_id=self.message.message_id,
-                                                *args, **kwargs)
+            return self.bot.get_game_high_scores(chat_id=self.message.chat_id,
+                                                 message_id=self.message.message_id,
+                                                 *args, **kwargs)

--- a/telegram/callbackquery.py
+++ b/telegram/callbackquery.py
@@ -200,3 +200,138 @@ class CallbackQuery(TelegramObject):
                                                       chat_id=self.message.chat_id,
                                                       message_id=self.message.message_id,
                                                       *args, **kwargs)
+
+    def edit_message_media(self, *args, **kwargs):
+        """Shortcut for either::
+
+            bot.edit_message_replyMarkup(chat_id=update.callback_query.message.chat_id,
+                                         message_id=update.callback_query.message.message_id,
+                                         media=media,
+                                         *args, **kwargs)
+
+        or::
+
+            bot.edit_message_media(inline_message_id=update.callback_query.inline_message_id,
+                                   media=media,
+                                   *args, **kwargs)
+
+        Returns:
+            :class:`telegram.Message`: On success, if edited message is sent by the bot, the
+            edited Message is returned, otherwise ``True`` is returned.
+
+        """
+        if self.inline_message_id:
+            return self.bot.edit_message_media(inline_message_id=self.inline_message_id,
+                                               *args, **kwargs)
+        else:
+            return self.bot.edit_message_media(chat_id=self.message.chat_id,
+                                               message_id=self.message.message_id,
+                                               *args, **kwargs)
+
+    def edit_message_live_location(self, *args, **kwargs):
+        """Shortcut for either::
+
+            bot.edit_message_live_location(chat_id=update.callback_query.message.chat_id,
+                                           message_id=update.callback_query.message.message_id,
+                                           reply_markup=reply_markup,
+                                           *args, **kwargs)
+
+        or::
+
+            bot.edit_message_live_location(inline_message_id=update.callback_query.inline_message_id,
+                                           reply_markup=reply_markup,
+                                           *args, **kwargs)
+
+        Returns:
+            :class:`telegram.Message`: On success, if edited message is sent by the bot, the
+            edited Message is returned, otherwise ``True`` is returned.
+
+        """
+        if self.inline_message_id:
+            return self.bot.edit_message_live_location(inline_message_id=self.inline_message_id,
+                                                       *args, **kwargs)
+        else:
+            return self.bot.edit_message_live_location(chat_id=self.message.chat_id,
+                                                       message_id=self.message.message_id,
+                                                       *args, **kwargs)
+
+    def stop_message_live_location(self, *args, **kwargs):
+        """Shortcut for either::
+
+            bot.stop_message_live_location(chat_id=update.callback_query.message.chat_id,
+                                           message_id=update.callback_query.message.message_id,
+                                           reply_markup=reply_markup,
+                                           *args, **kwargs)
+
+        or::
+
+            bot.stop_message_live_location(inline_message_id=update.callback_query.inline_message_id,
+                                           reply_markup=reply_markup,
+                                           *args, **kwargs)
+
+        Returns:
+            :class:`telegram.Message`: On success, if edited message is sent by the bot, the
+            edited Message is returned, otherwise ``True`` is returned.
+
+        """
+        if self.inline_message_id:
+            return self.bot.stop_message_live_location(inline_message_id=self.inline_message_id,
+                                                       *args, **kwargs)
+        else:
+            return self.bot.stop_message_live_location(chat_id=self.message.chat_id,
+                                                       message_id=self.message.message_id,
+                                                       *args, **kwargs)
+
+    def set_game_score(self, *args, **kwargs):
+        """Shortcut for either::
+
+            bot.set_game_score(chat_id=update.callback_query.message.chat_id,
+                               message_id=update.callback_query.message.message_id,
+                               reply_markup=reply_markup,
+                               *args, **kwargs)
+
+        or::
+
+            bot.set_game_score(inline_message_id=update.callback_query.inline_message_id,
+                               reply_markup=reply_markup,
+                               *args, **kwargs)
+
+        Returns:
+            :class:`telegram.Message`: On success, if edited message is sent by the bot, the
+            edited Message is returned, otherwise ``True`` is returned.
+
+        """
+        if self.inline_message_id:
+            return self.bot.set_game_score(inline_message_id=self.inline_message_id,
+                                           *args, **kwargs)
+        else:
+            return self.bot.set_game_score(chat_id=self.message.chat_id,
+                                           message_id=self.message.message_id,
+                                           *args, **kwargs)
+
+    def get_game_high_score(self, *args, **kwargs):
+        """Shortcut for either::
+
+            bot.get_game_high_score(chat_id=update.callback_query.message.chat_id,
+                                    message_id=update.callback_query.message.message_id,
+                                    reply_markup=reply_markup,
+                                    *args, **kwargs)
+
+        or::
+
+            bot.get_game_high_score(inline_message_id=update.callback_query.inline_message_id,
+                                    reply_markup=reply_markup,
+                                    *args, **kwargs)
+
+        Returns:
+            :class:`telegram.Message`: On success, if edited message is sent by the bot, the
+            edited Message is returned, otherwise ``True`` is returned.
+
+        """
+        if self.inline_message_id:
+            return self.bot.get_game_high_score(inline_message_id=self.inline_message_id,
+                                                *args, **kwargs)
+        else:
+            return self.bot.get_game_high_score(chat_id=self.message.chat_id,
+                                                message_id=self.message.message_id,
+                                                *args, **kwargs)

--- a/telegram/callbackquery.py
+++ b/telegram/callbackquery.py
@@ -238,9 +238,11 @@ class CallbackQuery(TelegramObject):
 
         or::
 
-            bot.edit_message_live_location(inline_message_id=update.callback_query.inline_message_id,
-                                           reply_markup=reply_markup,
-                                           *args, **kwargs)
+            bot.edit_message_live_location(
+                inline_message_id=update.callback_query.inline_message_id,
+                reply_markup=reply_markup,
+                *args, **kwargs
+            )
 
         Returns:
             :class:`telegram.Message`: On success, if edited message is sent by the bot, the
@@ -265,9 +267,11 @@ class CallbackQuery(TelegramObject):
 
         or::
 
-            bot.stop_message_live_location(inline_message_id=update.callback_query.inline_message_id,
-                                           reply_markup=reply_markup,
-                                           *args, **kwargs)
+            bot.stop_message_live_location(
+                inline_message_id=update.callback_query.inline_message_id,
+                reply_markup=reply_markup,
+                *args, **kwargs
+            )
 
         Returns:
             :class:`telegram.Message`: On success, if edited message is sent by the bot, the

--- a/telegram/chat.py
+++ b/telegram/chat.py
@@ -152,7 +152,7 @@ class Chat(TelegramObject):
     def leave(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.leave_chat(update.message.chat.id, *args, **kwargs)
+            bot.leave_chat(update.effective_chat.id, *args, **kwargs)
 
         Returns:
             :obj:`bool` If the action was sent successfully.
@@ -163,7 +163,7 @@ class Chat(TelegramObject):
     def get_administrators(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.get_chat_administrators(update.message.chat.id, *args, **kwargs)
+            bot.get_chat_administrators(update.effective_chat.id, *args, **kwargs)
 
         Returns:
             List[:class:`telegram.ChatMember`]: A list of administrators in a chat. An Array of
@@ -177,7 +177,7 @@ class Chat(TelegramObject):
     def get_members_count(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.get_chat_members_count(update.message.chat.id, *args, **kwargs)
+            bot.get_chat_members_count(update.effective_chat.id, *args, **kwargs)
 
         Returns:
             :obj:`int`
@@ -188,7 +188,7 @@ class Chat(TelegramObject):
     def get_member(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.get_chat_member(update.message.chat.id, *args, **kwargs)
+            bot.get_chat_member(update.effective_chat.id, *args, **kwargs)
 
         Returns:
             :class:`telegram.ChatMember`
@@ -199,10 +199,10 @@ class Chat(TelegramObject):
     def kick_member(self, *args, **kwargs):
         """Shortcut for::
 
-                bot.kick_chat_member(update.message.chat.id, *args, **kwargs)
+                bot.kick_chat_member(update.effective_chat.id, *args, **kwargs)
 
         Returns:
-            :obj:`bool`: If the action was sent succesfully.
+            :obj:`bool`: If the action was sent successfully.
 
         Note:
             This method will only work if the `All Members Are Admins` setting is off in the
@@ -215,7 +215,7 @@ class Chat(TelegramObject):
     def unban_member(self, *args, **kwargs):
         """Shortcut for::
 
-                bot.unban_chat_member(update.message.chat.id, *args, **kwargs)
+                bot.unban_chat_member(update.effective_chat.id, *args, **kwargs)
 
         Returns:
             :obj:`bool`: If the action was sent successfully.
@@ -226,7 +226,7 @@ class Chat(TelegramObject):
     def set_permissions(self, *args, **kwargs):
         """Shortcut for::
 
-                bot.set_chat_permissions(update.message.chat.id, *args, **kwargs)
+                bot.set_chat_permissions(update.effective_chat.id, *args, **kwargs)
 
         Returns:
         :obj:`bool`: If the action was sent successfully.
@@ -237,7 +237,7 @@ class Chat(TelegramObject):
     def set_administrator_custom_title(self, *args, **kwargs):
         """Shortcut for::
 
-                bot.set_chat_administrator_custom_title(update.message.chat.id, *args, **kwargs)
+                bot.set_chat_administrator_custom_title(update.effective_chat.id, *args, **kwargs)
 
         Returns:
         :obj:`bool`: If the action was sent successfully.
@@ -248,7 +248,7 @@ class Chat(TelegramObject):
     def send_message(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_message(Chat.id, *args, **kwargs)
+            bot.send_message(update.effective_chat.id, *args, **kwargs)
 
         Where Chat is the current instance.
 
@@ -261,7 +261,7 @@ class Chat(TelegramObject):
     def send_media_group(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_media_group(Chat.id, *args, **kwargs)
+            bot.send_media_group(update.effective_chat.id, *args, **kwargs)
 
         Where Chat is the current instance.
 
@@ -274,7 +274,7 @@ class Chat(TelegramObject):
     def send_chat_action(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_chat_action(Chat.id, *args, **kwargs)
+            bot.send_chat_action(update.effective_chat.id, *args, **kwargs)
 
         Where Chat is the current instance.
 
@@ -290,7 +290,7 @@ class Chat(TelegramObject):
     def send_photo(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_photo(Chat.id, *args, **kwargs)
+            bot.send_photo(update.effective_chat.id, *args, **kwargs)
 
         Where Chat is the current instance.
 
@@ -303,7 +303,7 @@ class Chat(TelegramObject):
     def send_contact(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_contact(Chat.id, *args, **kwargs)
+            bot.send_contact(update.effective_chat.id, *args, **kwargs)
 
         Where Chat is the current instance.
 
@@ -316,7 +316,7 @@ class Chat(TelegramObject):
     def send_audio(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_audio(Chat.id, *args, **kwargs)
+            bot.send_audio(update.effective_chat.id, *args, **kwargs)
 
         Where Chat is the current instance.
 
@@ -329,7 +329,7 @@ class Chat(TelegramObject):
     def send_document(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_document(Chat.id, *args, **kwargs)
+            bot.send_document(update.effective_chat.id, *args, **kwargs)
 
         Where Chat is the current instance.
 
@@ -342,7 +342,7 @@ class Chat(TelegramObject):
     def send_dice(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_dice(Chat.id, *args, **kwargs)
+            bot.send_dice(update.effective_chat.id, *args, **kwargs)
 
         Where Chat is the current instance.
 
@@ -355,7 +355,7 @@ class Chat(TelegramObject):
     def send_game(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_game(Chat.id, *args, **kwargs)
+            bot.send_game(update.effective_chat.id, *args, **kwargs)
 
         Where Chat is the current instance.
 
@@ -368,7 +368,7 @@ class Chat(TelegramObject):
     def send_invoice(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_invoice(Chat.id, *args, **kwargs)
+            bot.send_invoice(update.effective_chat.id, *args, **kwargs)
 
         Where Chat is the current instance.
 
@@ -381,7 +381,7 @@ class Chat(TelegramObject):
     def send_location(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_location(Chat.id, *args, **kwargs)
+            bot.send_location(update.effective_chat.id, *args, **kwargs)
 
         Where Chat is the current instance.
 
@@ -394,7 +394,7 @@ class Chat(TelegramObject):
     def send_animation(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_animation(Chat.id, *args, **kwargs)
+            bot.send_animation(update.effective_chat.id, *args, **kwargs)
 
         Where Chat is the current instance.
 
@@ -407,7 +407,7 @@ class Chat(TelegramObject):
     def send_sticker(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_sticker(Chat.id, *args, **kwargs)
+            bot.send_sticker(update.effective_chat.id, *args, **kwargs)
 
         Where Chat is the current instance.
 
@@ -420,7 +420,7 @@ class Chat(TelegramObject):
     def send_venue(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_venue(Chat.id, *args, **kwargs)
+            bot.send_venue(update.effective_chat.id, *args, **kwargs)
 
         Where Chat is the current instance.
 
@@ -433,7 +433,7 @@ class Chat(TelegramObject):
     def send_video(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_video(Chat.id, *args, **kwargs)
+            bot.send_video(update.effective_chat.id, *args, **kwargs)
 
         Where Chat is the current instance.
 
@@ -446,7 +446,7 @@ class Chat(TelegramObject):
     def send_video_note(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_video_note(Chat.id, *args, **kwargs)
+            bot.send_video_note(update.effective_chat.id, *args, **kwargs)
 
         Where Chat is the current instance.
 
@@ -459,7 +459,7 @@ class Chat(TelegramObject):
     def send_voice(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_voice(Chat.id, *args, **kwargs)
+            bot.send_voice(update.effective_chat.id, *args, **kwargs)
 
         Where Chat is the current instance.
 
@@ -472,7 +472,7 @@ class Chat(TelegramObject):
     def send_poll(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_poll(Chat.id, *args, **kwargs)
+            bot.send_poll(update.effective_chat.id, *args, **kwargs)
 
         Where Chat is the current instance.
 

--- a/telegram/chat.py
+++ b/telegram/chat.py
@@ -149,18 +149,6 @@ class Chat(TelegramObject):
 
         return cls(bot=bot, **data)
 
-    def send_action(self, *args, **kwargs):
-        """Shortcut for::
-
-            bot.send_chat_action(update.message.chat.id, *args, **kwargs)
-
-        Returns:
-            :obj:`bool`: If the action was sent successfully.
-
-        """
-
-        return self.bot.send_chat_action(self.id, *args, **kwargs)
-
     def leave(self, *args, **kwargs):
         """Shortcut for::
 
@@ -270,6 +258,35 @@ class Chat(TelegramObject):
         """
         return self.bot.send_message(self.id, *args, **kwargs)
 
+    def send_media_group(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_media_group(Chat.id, *args, **kwargs)
+
+        Where Chat is the current instance.
+
+        Returns:
+            List[:class:`telegram.Message`:] On success, instance representing the message posted.
+
+        """
+        return self.bot.send_media_group(self.id, *args, **kwargs)
+
+    def send_chat_action(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_chat_action(Chat.id, *args, **kwargs)
+
+        Where Chat is the current instance.
+
+        Returns:
+            :obj:`True`: On success.
+
+        """
+        return self.bot.send_chat_action(self.id, *args, **kwargs)
+
+    send_action = send_chat_action
+    """Alias for :attr:`send_chat_action`"""
+
     def send_photo(self, *args, **kwargs):
         """Shortcut for::
 
@@ -282,6 +299,19 @@ class Chat(TelegramObject):
 
         """
         return self.bot.send_photo(self.id, *args, **kwargs)
+
+    def send_contact(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_contact(Chat.id, *args, **kwargs)
+
+        Where Chat is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.bot.send_contact(self.id, *args, **kwargs)
 
     def send_audio(self, *args, **kwargs):
         """Shortcut for::
@@ -309,6 +339,58 @@ class Chat(TelegramObject):
         """
         return self.bot.send_document(self.id, *args, **kwargs)
 
+    def send_dice(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_dice(Chat.id, *args, **kwargs)
+
+        Where Chat is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.bot.send_dice(self.id, *args, **kwargs)
+
+    def send_game(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_game(Chat.id, *args, **kwargs)
+
+        Where Chat is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.bot.send_game(self.id, *args, **kwargs)
+
+    def send_invoice(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_invoice(Chat.id, *args, **kwargs)
+
+        Where Chat is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.bot.send_invoice(self.id, *args, **kwargs)
+
+    def send_location(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_location(Chat.id, *args, **kwargs)
+
+        Where Chat is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.bot.send_location(self.id, *args, **kwargs)
+
     def send_animation(self, *args, **kwargs):
         """Shortcut for::
 
@@ -334,6 +416,19 @@ class Chat(TelegramObject):
 
         """
         return self.bot.send_sticker(self.id, *args, **kwargs)
+
+    def send_venue(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_venue(Chat.id, *args, **kwargs)
+
+        Where Chat is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.bot.send_venue(self.id, *args, **kwargs)
 
     def send_video(self, *args, **kwargs):
         """Shortcut for::

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -995,13 +995,13 @@ class Message(TelegramObject):
         return self.bot.set_game_score(
             chat_id=self.chat_id, message_id=self.message_id, *args, **kwargs)
 
-    def get_game_high_score(self, *args, **kwargs):
+    def get_game_high_scores(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.get_game_high_score(chat_id=message.chat_id,
-                                    message_id=message.message_id,
-                                    *args,
-                                    **kwargs)
+            bot.get_game_high_scores(chat_id=message.chat_id,
+                                     message_id=message.message_id,
+                                     *args,
+                                     **kwargs)
 
         Note:
             You can only edit messages that the bot sent itself (i.e. of the ``bot.send_*`` family
@@ -1012,7 +1012,7 @@ class Message(TelegramObject):
             :class:`telegram.Message`: On success, if edited message is sent by the bot, the
             edited Message is returned, otherwise ``True`` is returned.
         """
-        return self.bot.get_game_high_score(
+        return self.bot.get_game_high_scores(
             chat_id=self.chat_id, message_id=self.message_id, *args, **kwargs)
 
     def delete(self, *args, **kwargs):

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -935,6 +935,86 @@ class Message(TelegramObject):
         return self.bot.edit_message_reply_markup(
             chat_id=self.chat_id, message_id=self.message_id, *args, **kwargs)
 
+    def edit_live_location(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.edit_message_live_location(chat_id=message.chat_id,
+                                           message_id=message.message_id,
+                                           *args,
+                                           **kwargs)
+
+        Note:
+            You can only edit messages that the bot sent itself (i.e. of the ``bot.send_*`` family
+            of methods) or channel posts, if the bot is an admin in that channel. However, this
+            behaviour is undocumented and might be changed by Telegram.
+
+        Returns:
+            :class:`telegram.Message`: On success, if edited message is sent by the bot, the
+            edited Message is returned, otherwise ``True`` is returned.
+        """
+        return self.bot.edit_message_live_location(
+            chat_id=self.chat_id, message_id=self.message_id, *args, **kwargs)
+
+    def stop_live_location(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.stop_message_live_location(chat_id=message.chat_id,
+                                           message_id=message.message_id,
+                                           *args,
+                                           **kwargs)
+
+        Note:
+            You can only edit messages that the bot sent itself (i.e. of the ``bot.send_*`` family
+            of methods) or channel posts, if the bot is an admin in that channel. However, this
+            behaviour is undocumented and might be changed by Telegram.
+
+        Returns:
+            :class:`telegram.Message`: On success, if edited message is sent by the bot, the
+            edited Message is returned, otherwise ``True`` is returned.
+        """
+        return self.bot.stop_message_live_location(
+            chat_id=self.chat_id, message_id=self.message_id, *args, **kwargs)
+
+    def set_game_score(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.set_game_score(chat_id=message.chat_id,
+                               message_id=message.message_id,
+                               *args,
+                               **kwargs)
+
+        Note:
+            You can only edit messages that the bot sent itself (i.e. of the ``bot.send_*`` family
+            of methods) or channel posts, if the bot is an admin in that channel. However, this
+            behaviour is undocumented and might be changed by Telegram.
+
+        Returns:
+            :class:`telegram.Message`: On success, if edited message is sent by the bot, the
+            edited Message is returned, otherwise ``True`` is returned.
+        """
+        return self.bot.set_game_score(
+            chat_id=self.chat_id, message_id=self.message_id, *args, **kwargs)
+
+    def get_game_high_score(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.get_game_high_score(chat_id=message.chat_id,
+                                    message_id=message.message_id,
+                                    *args,
+                                    **kwargs)
+
+        Note:
+            You can only edit messages that the bot sent itself (i.e. of the ``bot.send_*`` family
+            of methods) or channel posts, if the bot is an admin in that channel. However, this
+            behaviour is undocumented and might be changed by Telegram.
+
+        Returns:
+            :class:`telegram.Message`: On success, if edited message is sent by the bot, the
+            edited Message is returned, otherwise ``True`` is returned.
+        """
+        return self.bot.get_game_high_score(
+            chat_id=self.chat_id, message_id=self.message_id, *args, **kwargs)
+
     def delete(self, *args, **kwargs):
         """Shortcut for::
 
@@ -964,6 +1044,21 @@ class Message(TelegramObject):
 
         """
         return self.bot.stop_poll(
+            chat_id=self.chat_id, message_id=self.message_id, *args, **kwargs)
+
+    def pin(self, *args, **kwargs):
+        """Shortcut for::
+
+             bot.pin_chat_message(chat_id=message.chat_id,
+                                  message_id=message.message_id,
+                                  *args,
+                                  **kwargs)
+
+        Returns:
+            :obj:`True`: On success.
+
+        """
+        return self.bot.pin_chat_message(
             chat_id=self.chat_id, message_id=self.message_id, *args, **kwargs)
 
     def parse_entity(self, entity):

--- a/telegram/user.py
+++ b/telegram/user.py
@@ -124,7 +124,7 @@ class User(TelegramObject):
         """
         Shortcut for::
 
-                bot.get_user_profile_photos(update.message.from_user.id, *args, **kwargs)
+                bot.get_user_profile_photos(update.effective_user.id, *args, **kwargs)
 
         """
 
@@ -183,7 +183,7 @@ class User(TelegramObject):
     def send_message(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_message(User.id, *args, **kwargs)
+            bot.send_message(update.effective_user.id, *args, **kwargs)
 
         Where User is the current instance.
 
@@ -196,7 +196,7 @@ class User(TelegramObject):
     def send_photo(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_photo(User.id, *args, **kwargs)
+            bot.send_photo(update.effective_user.id, *args, **kwargs)
 
         Where User is the current instance.
 
@@ -209,7 +209,7 @@ class User(TelegramObject):
     def send_media_group(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_media_group(User.id, *args, **kwargs)
+            bot.send_media_group(update.effective_user.id, *args, **kwargs)
 
         Where User is the current instance.
 
@@ -222,7 +222,7 @@ class User(TelegramObject):
     def send_audio(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_audio(User.id, *args, **kwargs)
+            bot.send_audio(update.effective_user.id, *args, **kwargs)
 
         Where User is the current instance.
 
@@ -235,7 +235,7 @@ class User(TelegramObject):
     def send_chat_action(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_chat_action(User.id, *args, **kwargs)
+            bot.send_chat_action(update.effective_user.id, *args, **kwargs)
 
         Where User is the current instance.
 
@@ -251,7 +251,7 @@ class User(TelegramObject):
     def send_contact(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_contact(User.id, *args, **kwargs)
+            bot.send_contact(update.effective_user.id, *args, **kwargs)
 
         Where User is the current instance.
 
@@ -264,7 +264,7 @@ class User(TelegramObject):
     def send_dice(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_dice(User.id, *args, **kwargs)
+            bot.send_dice(update.effective_user.id, *args, **kwargs)
 
         Where User is the current instance.
 
@@ -277,7 +277,7 @@ class User(TelegramObject):
     def send_document(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_document(User.id, *args, **kwargs)
+            bot.send_document(update.effective_user.id, *args, **kwargs)
 
         Where User is the current instance.
 
@@ -290,7 +290,7 @@ class User(TelegramObject):
     def send_game(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_game(User.id, *args, **kwargs)
+            bot.send_game(update.effective_user.id, *args, **kwargs)
 
         Where User is the current instance.
 
@@ -303,7 +303,7 @@ class User(TelegramObject):
     def send_invoice(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_invoice(User.id, *args, **kwargs)
+            bot.send_invoice(update.effective_user.id, *args, **kwargs)
 
         Where User is the current instance.
 
@@ -316,7 +316,7 @@ class User(TelegramObject):
     def send_location(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_location(User.id, *args, **kwargs)
+            bot.send_location(update.effective_user.id, *args, **kwargs)
 
         Where User is the current instance.
 
@@ -329,7 +329,7 @@ class User(TelegramObject):
     def send_animation(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_animation(User.id, *args, **kwargs)
+            bot.send_animation(update.effective_user.id, *args, **kwargs)
 
         Where User is the current instance.
 
@@ -342,7 +342,7 @@ class User(TelegramObject):
     def send_sticker(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_sticker(User.id, *args, **kwargs)
+            bot.send_sticker(update.effective_user.id, *args, **kwargs)
 
         Where User is the current instance.
 
@@ -355,7 +355,7 @@ class User(TelegramObject):
     def send_video(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_video(User.id, *args, **kwargs)
+            bot.send_video(update.effective_user.id, *args, **kwargs)
 
         Where User is the current instance.
 
@@ -368,7 +368,7 @@ class User(TelegramObject):
     def send_venue(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_venue(User.id, *args, **kwargs)
+            bot.send_venue(update.effective_user.id, *args, **kwargs)
 
         Where User is the current instance.
 
@@ -381,7 +381,7 @@ class User(TelegramObject):
     def send_video_note(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_video_note(User.id, *args, **kwargs)
+            bot.send_video_note(update.effective_user.id, *args, **kwargs)
 
         Where User is the current instance.
 
@@ -394,7 +394,7 @@ class User(TelegramObject):
     def send_voice(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_voice(User.id, *args, **kwargs)
+            bot.send_voice(update.effective_user.id, *args, **kwargs)
 
         Where User is the current instance.
 
@@ -407,7 +407,7 @@ class User(TelegramObject):
     def send_poll(self, *args, **kwargs):
         """Shortcut for::
 
-            bot.send_poll(User.id, *args, **kwargs)
+            bot.send_poll(update.effective_user.id, *args, **kwargs)
 
         Where User is the current instance.
 

--- a/telegram/user.py
+++ b/telegram/user.py
@@ -206,6 +206,19 @@ class User(TelegramObject):
         """
         return self.bot.send_photo(self.id, *args, **kwargs)
 
+    def send_media_group(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_media_group(User.id, *args, **kwargs)
+
+        Where User is the current instance.
+
+        Returns:
+            List[:class:`telegram.Message`:] On success, instance representing the message posted.
+
+        """
+        return self.bot.send_media_group(self.id, *args, **kwargs)
+
     def send_audio(self, *args, **kwargs):
         """Shortcut for::
 
@@ -219,6 +232,48 @@ class User(TelegramObject):
         """
         return self.bot.send_audio(self.id, *args, **kwargs)
 
+    def send_chat_action(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_chat_action(User.id, *args, **kwargs)
+
+        Where User is the current instance.
+
+        Returns:
+            :obj:`True`: On success.
+
+        """
+        return self.bot.send_chat_action(self.id, *args, **kwargs)
+
+    send_action = send_chat_action
+    """Alias for :attr:`send_chat_action`"""
+
+    def send_contact(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_contact(User.id, *args, **kwargs)
+
+        Where User is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.bot.send_contact(self.id, *args, **kwargs)
+
+    def send_dice(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_dice(User.id, *args, **kwargs)
+
+        Where User is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.bot.send_dice(self.id, *args, **kwargs)
+
     def send_document(self, *args, **kwargs):
         """Shortcut for::
 
@@ -231,6 +286,45 @@ class User(TelegramObject):
 
         """
         return self.bot.send_document(self.id, *args, **kwargs)
+
+    def send_game(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_game(User.id, *args, **kwargs)
+
+        Where User is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.bot.send_game(self.id, *args, **kwargs)
+
+    def send_invoice(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_invoice(User.id, *args, **kwargs)
+
+        Where User is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.bot.send_invoice(self.id, *args, **kwargs)
+
+    def send_location(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_location(User.id, *args, **kwargs)
+
+        Where User is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.bot.send_location(self.id, *args, **kwargs)
 
     def send_animation(self, *args, **kwargs):
         """Shortcut for::
@@ -270,6 +364,19 @@ class User(TelegramObject):
 
         """
         return self.bot.send_video(self.id, *args, **kwargs)
+
+    def send_venue(self, *args, **kwargs):
+        """Shortcut for::
+
+            bot.send_venue(User.id, *args, **kwargs)
+
+        Where User is the current instance.
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return self.bot.send_venue(self.id, *args, **kwargs)
 
     def send_video_note(self, *args, **kwargs):
         """Shortcut for::

--- a/tests/test_callbackquery.py
+++ b/tests/test_callbackquery.py
@@ -133,6 +133,81 @@ class TestCallbackQuery:
         assert callback_query.edit_message_reply_markup(reply_markup=[['1', '2']])
         assert callback_query.edit_message_reply_markup([['1', '2']])
 
+    def test_edit_message_media(self, monkeypatch, callback_query):
+        def test(*args, **kwargs):
+            message_media = kwargs.get('media') == [['1', '2']] or args[0] == [['1', '2']]
+            try:
+                id_ = kwargs['inline_message_id'] == callback_query.inline_message_id
+                return id_ and message_media
+            except KeyError:
+                id_ = kwargs['chat_id'] == callback_query.message.chat_id
+                message = kwargs['message_id'] == callback_query.message.message_id
+                return id_ and message and message_media
+
+        monkeypatch.setattr(callback_query.bot, 'edit_message_media', test)
+        assert callback_query.edit_message_media(media=[['1', '2']])
+        assert callback_query.edit_message_media([['1', '2']])
+
+    def test_edit_message_live_location(self, monkeypatch, callback_query):
+        def test(*args, **kwargs):
+            latitude = kwargs.get('latitude') == 1 or args[0] == 1
+            longitude = kwargs.get('longitude') == 2 or args[1] == 2
+            try:
+                id_ = kwargs['inline_message_id'] == callback_query.inline_message_id
+                return id_ and latitude and longitude
+            except KeyError:
+                id_ = kwargs['chat_id'] == callback_query.message.chat_id
+                message = kwargs['message_id'] == callback_query.message.message_id
+                return id_ and message and latitude and longitude
+
+        monkeypatch.setattr(callback_query.bot, 'edit_message_live_location', test)
+        assert callback_query.edit_message_live_location(latitude=1, longitude=2)
+        assert callback_query.edit_message_live_location(1, 2)
+
+    def test_stop_message_live_location(self, monkeypatch, callback_query):
+        def test(*args, **kwargs):
+            try:
+                id_ = kwargs['inline_message_id'] == callback_query.inline_message_id
+                return id_
+            except KeyError:
+                id_ = kwargs['chat_id'] == callback_query.message.chat_id
+                message = kwargs['message_id'] == callback_query.message.message_id
+                return id_ and message
+
+        monkeypatch.setattr(callback_query.bot, 'stop_message_live_location', test)
+        assert callback_query.stop_message_live_location()
+
+    def test_set_game_score(self, monkeypatch, callback_query):
+        def test(*args, **kwargs):
+            user_id = kwargs.get('user_id') == 1 or args[0] == 1
+            score = kwargs.get('score') == 2 or args[1] == 2
+            try:
+                id_ = kwargs['inline_message_id'] == callback_query.inline_message_id
+                return id_ and user_id and score
+            except KeyError:
+                id_ = kwargs['chat_id'] == callback_query.message.chat_id
+                message = kwargs['message_id'] == callback_query.message.message_id
+                return id_ and message and user_id and score
+
+        monkeypatch.setattr(callback_query.bot, 'set_game_score', test)
+        assert callback_query.set_game_score(user_id=1, score=2)
+        assert callback_query.set_game_score(1, 2)
+
+    def test_get_game_high_scores(self, monkeypatch, callback_query):
+        def test(*args, **kwargs):
+            user_id = kwargs.get('user_id') == 1 or args[0] == 1
+            try:
+                id_ = kwargs['inline_message_id'] == callback_query.inline_message_id
+                return id_ and user_id
+            except KeyError:
+                id_ = kwargs['chat_id'] == callback_query.message.chat_id
+                message = kwargs['message_id'] == callback_query.message.message_id
+                return id_ and message and user_id
+
+        monkeypatch.setattr(callback_query.bot, 'get_game_high_scores', test)
+        assert callback_query.get_game_high_scores(user_id=1)
+        assert callback_query.get_game_high_scores(1)
+
     def test_equality(self):
         a = CallbackQuery(self.id_, self.from_user, 'chat')
         b = CallbackQuery(self.id_, self.from_user, 'chat')

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -113,6 +113,7 @@ class TestChat:
 
         monkeypatch.setattr(chat.bot, 'send_chat_action', test)
         assert chat.send_action(action=ChatAction.TYPING)
+        assert chat.send_chat_action(action=ChatAction.TYPING)
 
     def test_leave(self, monkeypatch, chat):
         def test(*args, **kwargs):
@@ -189,12 +190,26 @@ class TestChat:
         monkeypatch.setattr(chat.bot, 'send_message', test)
         assert chat.send_message('test')
 
+    def test_instance_method_send_media_group(self, monkeypatch, chat):
+        def test(*args, **kwargs):
+            return args[0] == chat.id and args[1] == 'test_media_group'
+
+        monkeypatch.setattr(chat.bot, 'send_media_group', test)
+        assert chat.send_media_group('test_media_group')
+
     def test_instance_method_send_photo(self, monkeypatch, chat):
         def test(*args, **kwargs):
             return args[0] == chat.id and args[1] == 'test_photo'
 
         monkeypatch.setattr(chat.bot, 'send_photo', test)
         assert chat.send_photo('test_photo')
+
+    def test_instance_method_send_contact(self, monkeypatch, chat):
+        def test(*args, **kwargs):
+            return args[0] == chat.id and args[1] == 'test_contact'
+
+        monkeypatch.setattr(chat.bot, 'send_contact', test)
+        assert chat.send_contact('test_contact')
 
     def test_instance_method_send_audio(self, monkeypatch, chat):
         def test(*args, **kwargs):
@@ -210,12 +225,47 @@ class TestChat:
         monkeypatch.setattr(chat.bot, 'send_document', test)
         assert chat.send_document('test_document')
 
+    def test_instance_method_send_dice(self, monkeypatch, chat):
+        def test(*args, **kwargs):
+            return args[0] == chat.id and args[1] == 'test_dice'
+
+        monkeypatch.setattr(chat.bot, 'send_dice', test)
+        assert chat.send_dice('test_dice')
+
+    def test_instance_method_send_game(self, monkeypatch, chat):
+        def test(*args, **kwargs):
+            return args[0] == chat.id and args[1] == 'test_game'
+
+        monkeypatch.setattr(chat.bot, 'send_game', test)
+        assert chat.send_game('test_game')
+
+    def test_instance_method_send_invoice(self, monkeypatch, chat):
+        def test(*args, **kwargs):
+            return args[0] == chat.id and args[1] == 'test_invoice'
+
+        monkeypatch.setattr(chat.bot, 'send_invoice', test)
+        assert chat.send_invoice('test_invoice')
+
+    def test_instance_method_send_location(self, monkeypatch, chat):
+        def test(*args, **kwargs):
+            return args[0] == chat.id and args[1] == 'test_location'
+
+        monkeypatch.setattr(chat.bot, 'send_location', test)
+        assert chat.send_location('test_location')
+
     def test_instance_method_send_sticker(self, monkeypatch, chat):
         def test(*args, **kwargs):
             return args[0] == chat.id and args[1] == 'test_sticker'
 
         monkeypatch.setattr(chat.bot, 'send_sticker', test)
         assert chat.send_sticker('test_sticker')
+
+    def test_instance_method_send_venue(self, monkeypatch, chat):
+        def test(*args, **kwargs):
+            return args[0] == chat.id and args[1] == 'test_venue'
+
+        monkeypatch.setattr(chat.bot, 'send_venue', test)
+        assert chat.send_venue('test_venue')
 
     def test_instance_method_send_video(self, monkeypatch, chat):
         def test(*args, **kwargs):

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -845,6 +845,24 @@ class TestMessage:
         monkeypatch.setattr(message.bot, 'delete_message', test)
         assert message.delete()
 
+    def test_stop_poll(self, monkeypatch, message):
+        def test(*args, **kwargs):
+            chat_id = kwargs['chat_id'] == message.chat_id
+            message_id = kwargs['message_id'] == message.message_id
+            return chat_id and message_id
+
+        monkeypatch.setattr(message.bot, 'stop_poll', test)
+        assert message.stop_poll()
+
+    def test_pin(self, monkeypatch, message):
+        def test(*args, **kwargs):
+            chat_id = kwargs['chat_id'] == message.chat_id
+            message_id = kwargs['message_id'] == message.message_id
+            return chat_id and message_id
+
+        monkeypatch.setattr(message.bot, 'pin_chat_message', test)
+        assert message.pin()
+
     def test_default_quote(self, message):
         kwargs = {}
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -795,6 +795,47 @@ class TestMessage:
         monkeypatch.setattr(message.bot, 'edit_message_reply_markup', test)
         assert message.edit_reply_markup(reply_markup=[['1', '2']])
 
+    def test_edit_live_location(self, monkeypatch, message):
+        def test(*args, **kwargs):
+            chat_id = kwargs['chat_id'] == message.chat_id
+            message_id = kwargs['message_id'] == message.message_id
+            latitude = kwargs['latitude'] == 1
+            longitude = kwargs['longitude'] == 2
+            return chat_id and message_id and longitude and latitude
+
+        monkeypatch.setattr(message.bot, 'edit_message_live_location', test)
+        assert message.edit_live_location(latitude=1, longitude=2)
+
+    def test_stop_live_location(self, monkeypatch, message):
+        def test(*args, **kwargs):
+            chat_id = kwargs['chat_id'] == message.chat_id
+            message_id = kwargs['message_id'] == message.message_id
+            return chat_id and message_id
+
+        monkeypatch.setattr(message.bot, 'stop_message_live_location', test)
+        assert message.stop_live_location()
+
+    def test_set_game_score(self, monkeypatch, message):
+        def test(*args, **kwargs):
+            chat_id = kwargs['chat_id'] == message.chat_id
+            message_id = kwargs['message_id'] == message.message_id
+            user_id = kwargs['user_id'] == 1
+            score = kwargs['score'] == 2
+            return chat_id and message_id and user_id and score
+
+        monkeypatch.setattr(message.bot, 'set_game_score', test)
+        assert message.set_game_score(user_id=1, score=2)
+
+    def test_get_game_high_scores(self, monkeypatch, message):
+        def test(*args, **kwargs):
+            chat_id = kwargs['chat_id'] == message.chat_id
+            message_id = kwargs['message_id'] == message.message_id
+            user_id = kwargs['user_id'] == 1
+            return chat_id and message_id and user_id
+
+        monkeypatch.setattr(message.bot, 'get_game_high_scores', test)
+        assert message.get_game_high_scores(user_id=1, score=2)
+
     def test_delete(self, monkeypatch, message):
         def test(*args, **kwargs):
             chat_id = kwargs['chat_id'] == message.chat_id

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -141,6 +141,13 @@ class TestUser:
         monkeypatch.setattr(user.bot, 'send_photo', test)
         assert user.send_photo('test_photo')
 
+    def test_instance_method_send_media_group(self, monkeypatch, user):
+        def test(*args, **kwargs):
+            return args[0] == user.id and args[1] == 'test_media_group'
+
+        monkeypatch.setattr(user.bot, 'send_media_group', test)
+        assert user.send_media_group('test_media_group')
+
     def test_instance_method_send_audio(self, monkeypatch, user):
         def test(*args, **kwargs):
             return args[0] == user.id and args[1] == 'test_audio'
@@ -148,12 +155,54 @@ class TestUser:
         monkeypatch.setattr(user.bot, 'send_audio', test)
         assert user.send_audio('test_audio')
 
+    def test_instance_method_send_chat_action(self, monkeypatch, user):
+        def test(*args, **kwargs):
+            return args[0] == user.id and args[1] == 'test_chat_action'
+
+        monkeypatch.setattr(user.bot, 'send_chat_action', test)
+        assert user.send_chat_action('test_chat_action')
+
+    def test_instance_method_send_contact(self, monkeypatch, user):
+        def test(*args, **kwargs):
+            return args[0] == user.id and args[1] == 'test_contact'
+
+        monkeypatch.setattr(user.bot, 'send_contact', test)
+        assert user.send_contact('test_contact')
+
+    def test_instance_method_send_dice(self, monkeypatch, user):
+        def test(*args, **kwargs):
+            return args[0] == user.id and args[1] == 'test_dice'
+
+        monkeypatch.setattr(user.bot, 'send_dice', test)
+        assert user.send_dice('test_dice')
+
     def test_instance_method_send_document(self, monkeypatch, user):
         def test(*args, **kwargs):
             return args[0] == user.id and args[1] == 'test_document'
 
         monkeypatch.setattr(user.bot, 'send_document', test)
         assert user.send_document('test_document')
+
+    def test_instance_method_send_game(self, monkeypatch, user):
+        def test(*args, **kwargs):
+            return args[0] == user.id and args[1] == 'test_game'
+
+        monkeypatch.setattr(user.bot, 'send_game', test)
+        assert user.send_game('test_game')
+
+    def test_instance_method_send_invoice(self, monkeypatch, user):
+        def test(*args, **kwargs):
+            return args[0] == user.id and args[1] == 'test_invoice'
+
+        monkeypatch.setattr(user.bot, 'send_invoice', test)
+        assert user.send_invoice('test_invoice')
+
+    def test_instance_method_send_location(self, monkeypatch, user):
+        def test(*args, **kwargs):
+            return args[0] == user.id and args[1] == 'test_location'
+
+        monkeypatch.setattr(user.bot, 'send_location', test)
+        assert user.send_location('test_location')
 
     def test_instance_method_send_sticker(self, monkeypatch, user):
         def test(*args, **kwargs):
@@ -168,6 +217,13 @@ class TestUser:
 
         monkeypatch.setattr(user.bot, 'send_video', test)
         assert user.send_video('test_video')
+
+    def test_instance_method_send_venue(self, monkeypatch, user):
+        def test(*args, **kwargs):
+            return args[0] == user.id and args[1] == 'test_venue'
+
+        monkeypatch.setattr(user.bot, 'send_venue', test)
+        assert user.send_venue('test_venue')
 
     def test_instance_method_send_video_note(self, monkeypatch, user):
         def test(*args, **kwargs):


### PR DESCRIPTION
Turns out, there where a lot more than I expected. 

`Chat` already has a method `send_action`. I added `send_chat_action` for completeness and both to `User`. 
**TL;DR:** Both. Both is good.
I guess the logic was to skip the `chat` similarly to `Message.edit_text` as shortcut for `Bot.edit_message_text`, but the `chat` in `send_chat_action` acutally comes from the class name `ChatAction` … But having both doesn't hurt.

Also, one *could* think of adding shortcuts to `ChosenInlineResult`, which has an `inline_message_id` attribute, but IMHO that doesn't really make sense. It would only be needed, if one would edit the message right after it's posted (why, though?). In all other cases one usually has only the `inline_message_id` and not the `CIR`.

Closes #2034