### PR TITLE
Refine codecov settings

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,10 @@
 comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        # We allow small coverage decreases in the project because we don't retry
+        # on hitting flood limits, which adds noise to the coverage
+        target: auto
+        threshold: 0.1%


### PR DESCRIPTION
Allows small coverage decreases in the project because in the tests we don't retry on hitting flood limits, which adds noise to the coverage.