### PR TITLE
Fix Webhook not working on windows with py38+

### DIFF
--- a/telegram/ext/updater.py
+++ b/telegram/ext/updater.py
@@ -332,7 +332,7 @@ class Updater:
                 webhook_ready = Event()
                 dispatcher_ready = Event()
                 self.job_queue.start()
-                self._init_thread(self.dispatcher.start, "dispatcher", dispatcher_ready),
+                self._init_thread(self.dispatcher.start, "dispatcher", dispatcher_ready)
                 self._init_thread(self._start_webhook, "updater", listen, port, url_path, cert,
                                   key, bootstrap_retries, clean, webhook_url, allowed_updates,
                                   ready=webhook_ready, force_event_loop=force_event_loop)

--- a/telegram/ext/updater.py
+++ b/telegram/ext/updater.py
@@ -258,11 +258,15 @@ class Updater:
                 # Create & start threads
                 self.job_queue.start()
                 dispatcher_ready = Event()
+                polling_ready = Event()
                 self._init_thread(self.dispatcher.start, "dispatcher", ready=dispatcher_ready)
                 self._init_thread(self._start_polling, "updater", poll_interval, timeout,
-                                  read_latency, bootstrap_retries, clean, allowed_updates)
+                                  read_latency, bootstrap_retries, clean, allowed_updates,
+                                  ready=polling_ready)
 
+                self.logger.debug('Waiting for Dispatcher and polling to start')
                 dispatcher_ready.wait()
+                polling_ready.wait()
 
                 # Return the update queue so the main thread can insert updates
                 return self.update_queue
@@ -276,13 +280,23 @@ class Updater:
                       clean=False,
                       bootstrap_retries=0,
                       webhook_url=None,
-                      allowed_updates=None):
+                      allowed_updates=None,
+                      force_event_loop=False):
         """
         Starts a small http server to listen for updates via webhook. If cert
         and key are not provided, the webhook will be started directly on
         http://listen:port/url_path, so SSL can be handled by another
         application. Else, the webhook will be started on
         https://listen:port/url_path
+
+        Note:
+            Due to an incompatibility of the Tornado library PTB uses for the webhook with Python
+            3.8+ on Windows machines, PTB will attempt to set the event loop to
+            :attr:`asyncio.SelectorEventLoop` and raise an exception, if an incompatible event loop
+            has already been specified. See this `thread`_ for more details. To suppress the
+            exception, set :attr:`force_event_loop` to :obj:`True`.
+
+            .. _thread: https://github.com/tornadoweb/tornado/issues/2608
 
         Args:
             listen (:obj:`str`, optional): IP-Address to listen on. Default ``127.0.0.1``.
@@ -303,6 +317,8 @@ class Updater:
                 NAT, reverse proxy, etc. Default is derived from `listen`, `port` & `url_path`.
             allowed_updates (List[:obj:`str`], optional): Passed to
                 :attr:`telegram.Bot.set_webhook`.
+            force_event_loop (:obj:`bool`, optional): Force using the current event loop. See above
+                note for details. Defaults to :obj:`False`
 
         Returns:
             :obj:`Queue`: The update queue that can be filled from the main thread.
@@ -313,16 +329,23 @@ class Updater:
                 self.running = True
 
                 # Create & start threads
+                webhook_ready = Event()
+                dispatcher_ready = Event()
                 self.job_queue.start()
-                self._init_thread(self.dispatcher.start, "dispatcher"),
+                self._init_thread(self.dispatcher.start, "dispatcher", dispatcher_ready),
                 self._init_thread(self._start_webhook, "updater", listen, port, url_path, cert,
-                                  key, bootstrap_retries, clean, webhook_url, allowed_updates)
+                                  key, bootstrap_retries, clean, webhook_url, allowed_updates,
+                                  ready=webhook_ready, force_event_loop=force_event_loop)
+
+                self.logger.debug('Waiting for Dispatcher and Webhook to start')
+                webhook_ready.wait()
+                dispatcher_ready.wait()
 
                 # Return the update queue so the main thread can insert updates
                 return self.update_queue
 
     def _start_polling(self, poll_interval, timeout, read_latency, bootstrap_retries, clean,
-                       allowed_updates):  # pragma: no cover
+                       allowed_updates, ready=None):  # pragma: no cover
         # Thread target of thread 'updater'. Runs in background, pulls
         # updates from Telegram and inserts them in the update queue of the
         # Dispatcher.
@@ -353,6 +376,9 @@ class Updater:
             # Put the error into the update queue and let the Dispatcher
             # broadcast it
             self.update_queue.put(exc)
+
+        if ready is not None:
+            ready.set()
 
         self._network_loop_retry(polling_action_cb, polling_onerr_cb, 'getting Updates',
                                  poll_interval)
@@ -410,7 +436,7 @@ class Updater:
         return current_interval
 
     def _start_webhook(self, listen, port, url_path, cert, key, bootstrap_retries, clean,
-                       webhook_url, allowed_updates):
+                       webhook_url, allowed_updates, ready=None, force_event_loop=False):
         self.logger.debug('Updater thread started (webhook)')
         use_ssl = cert is not None and key is not None
         if not url_path.startswith('/'):
@@ -448,7 +474,7 @@ class Updater:
             self.logger.warning("cleaning updates is not supported if "
                                 "SSL-termination happens elsewhere; skipping")
 
-        self.httpd.serve_forever()
+        self.httpd.serve_forever(force_event_loop=force_event_loop, ready=ready)
 
     @staticmethod
     def _gen_webhook_url(listen, port, url_path):

--- a/telegram/utils/webhookhandler.py
+++ b/telegram/utils/webhookhandler.py
@@ -73,12 +73,12 @@ class WebhookServer:
                           client_address, exc_info=True)
 
     def _ensure_event_loop(self, force_event_loop=False):
-        """If there's no asyncio event loop set for the current thread - create one"""
+        """If there's no asyncio event loop set for the current thread - create one."""
         try:
             loop = asyncio.get_event_loop()
             if (not force_event_loop and os.name == 'nt' and sys.version_info >= (3, 8)
                     and isinstance(loop, asyncio.ProactorEventLoop)):
-                raise TypeError('`ProactorEventLoop` is incompatible is incompatible with '
+                raise TypeError('`ProactorEventLoop` is incompatible with '
                                 'Tornado. Please switch to `SelectorEventLoop`.')
         except RuntimeError:
             # Python 3.8 changed default asyncio event loop implementation on windows

--- a/telegram/utils/webhookhandler.py
+++ b/telegram/utils/webhookhandler.py
@@ -98,8 +98,9 @@ class WebhookServer:
                     and sys.version_info >= (3, 8)
                     # OS+version check makes hasattr check redundant, but just to be sure
                     and hasattr(asyncio, 'WindowsProactorEventLoopPolicy')
-                    and (type(asyncio.get_event_loop_policy())
-                         is asyncio.WindowsProactorEventLoopPolicy)):  # pylint: disable=E1101
+                    and (isinstance(
+                         asyncio.get_event_loop_policy(),
+                         asyncio.WindowsProactorEventLoopPolicy))):  # pylint: disable=E1101
                 self.logger.debug(
                     'Applying Tornado asyncio event loop fix for Python 3.8+ on Windows')
                 loop = asyncio.SelectorEventLoop()

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -211,7 +211,7 @@ class TestUpdater:
             updater.stop()
         assert not caplog.records
 
-    @pytest.mark.skipif(os.name == 'nt' and sys.version_info < (3, 8),
+    @pytest.mark.skipif(os.name != 'nt' or sys.version_info < (3, 8),
                         reason='Workaround only relevant on windows with py3.8+')
     def test_start_webhook_ensure_event_loop(self, updater, monkeypatch):
         def serve_forever(self, force_event_loop=False, ready=None):
@@ -243,7 +243,7 @@ class TestUpdater:
 
             assert isinstance(asyncio.get_event_loop(), asyncio.SelectorEventLoop)
 
-    @pytest.mark.skipif(os.name == 'nt' and sys.version_info < (3, 8),
+    @pytest.mark.skipif(os.name != 'nt' or sys.version_info < (3, 8),
                         reason='Workaround only relevant on windows with py3.8+')
     def test_start_webhook_force_event_loop_false(self, updater, monkeypatch):
         monkeypatch.setattr(updater.bot, 'set_webhook', lambda *args, **kwargs: True)
@@ -265,7 +265,7 @@ class TestUpdater:
                     webhook_url=None,
                     allowed_updates=None)
 
-    @pytest.mark.skipif(os.name == 'nt' and sys.version_info < (3, 8),
+    @pytest.mark.skipif(os.name != 'nt' or sys.version_info < (3, 8),
                         reason='Workaround only relevant on windows with py3.8+')
     def test_start_webhook_force_event_loop_true(self, updater, monkeypatch):
         def serve_forever(self, force_event_loop=False, ready=None):


### PR DESCRIPTION
As discussed with @tsnoam. Thanks @n5y for getting started with this.

I moved the `webhook_ready.set()` to `WebhookServer.serve_forever()` as setting it in `Updater._start_webhook` didn't seem to suffice for the tests not to need `sleep(0.1)`

I hope the description of `force_event_loop` is descriptive enough

Closes #1977