### PR TITLE
Make MessageHandler filter for Filters.update first

### DIFF
--- a/telegram/ext/messagehandler.py
+++ b/telegram/ext/messagehandler.py
@@ -126,9 +126,8 @@ class MessageHandler(Handler):
         if message_updates is False and channel_post_updates is False and edited_updates is False:
             raise ValueError(
                 'message_updates, channel_post_updates and edited_updates are all False')
-        self.filters = filters
-        if self.filters is not None:
-            self.filters &= Filters.update
+        if filters is not None:
+            self.filters = Filters.update & filters
         else:
             self.filters = Filters.update
         if message_updates is not None:

--- a/tests/test_messagehandler.py
+++ b/tests/test_messagehandler.py
@@ -24,7 +24,7 @@ from telegram.utils.deprecate import TelegramDeprecationWarning
 
 from telegram import (Message, Update, Chat, Bot, User, CallbackQuery, InlineQuery,
                       ChosenInlineResult, ShippingQuery, PreCheckoutQuery)
-from telegram.ext import Filters, MessageHandler, CallbackContext, JobQueue
+from telegram.ext import Filters, MessageHandler, CallbackContext, JobQueue, BaseFilter
 
 message = Message(1, User(1, '', False), None, Chat(1, ''), text='Text')
 
@@ -160,6 +160,23 @@ class TestMessageHandler:
 
         message.chat.type = 'private'
         assert not handler.check_update(Update(0, message))
+
+    def test_callback_query_with_filter(self):
+
+        class TestFilter(BaseFilter):
+            update_filter = True
+            flag = False
+
+            def filter(self, u):
+                self.flag = True
+
+        test_filter = TestFilter()
+        handler = MessageHandler(test_filter, self.callback_basic)
+
+        update = Update(1, callback_query=CallbackQuery(1, None, None))
+
+        assert not handler.check_update(update)
+        assert not test_filter.flag
 
     def test_specific_filters(self, message):
         f = (~Filters.update.messages

--- a/tests/test_messagehandler.py
+++ b/tests/test_messagehandler.py
@@ -161,7 +161,7 @@ class TestMessageHandler:
         message.chat.type = 'private'
         assert not handler.check_update(Update(0, message))
 
-    def test_callback_query_with_filter(self):
+    def test_callback_query_with_filter(self, message):
 
         class TestFilter(BaseFilter):
             update_filter = True
@@ -173,8 +173,9 @@ class TestMessageHandler:
         test_filter = TestFilter()
         handler = MessageHandler(test_filter, self.callback_basic)
 
-        update = Update(1, callback_query=CallbackQuery(1, None, None))
+        update = Update(1, callback_query=CallbackQuery(1, None, None, message=message))
 
+        assert update.effective_message
         assert not handler.check_update(update)
         assert not test_filter.flag
 


### PR DESCRIPTION
… so that the other filters don't need to be run, if the update is a CallbackQurey.
This is a minor tweak but checking all filters set by the user seems unnecessary, if the last one will fail anyway …