### PR TITLE
Account for DST thingies in JobQueue tests

### DIFF
--- a/tests/test_jobqueue.py
+++ b/tests/test_jobqueue.py
@@ -311,6 +311,10 @@ class TestJobQueue:
 
         expected_reschedule_time += (dtm.timedelta(calendar.monthrange(now.year, now.month)[1])
                                      - dtm.timedelta(days=now.day))
+        # Adjust the hour for the special case that between now & end of month a DST switch happens
+        expected_reschedule_time = timezone.normalize(expected_reschedule_time)
+        expected_reschedule_time += dtm.timedelta(
+            hours=time_of_day.hour - expected_reschedule_time.hour)
         expected_reschedule_time = expected_reschedule_time.timestamp()
 
         job_queue.run_monthly(self.job_run_once, time_of_day, 31, day_is_strict=False)


### PR DESCRIPTION
Noticed in the latest test runs of #1920 . It's really no issue of `JobQueue` but only of the test not accounting for DST switches.

Will merge int v13 and squash the commit into the JobQueue commit on the next rebase of v13