### PR TITLE
Add chain methods to improve keyboard markup creating experience

### DIFF
--- a/telegram/inline/inlinekeyboardmarkup.py
+++ b/telegram/inline/inlinekeyboardmarkup.py
@@ -92,7 +92,7 @@ class InlineKeyboardMarkup(ReplyMarkup):
 
     @classmethod
     def from_row(
-        cls, button_row: List[InlineKeyboardButton], **kwargs: Any
+            cls, button_row: List[InlineKeyboardButton], **kwargs: Any
     ) -> 'InlineKeyboardMarkup':
         """Shortcut for::
 
@@ -110,7 +110,7 @@ class InlineKeyboardMarkup(ReplyMarkup):
 
     @classmethod
     def from_column(
-        cls, button_column: List[InlineKeyboardButton], **kwargs: Any
+            cls, button_column: List[InlineKeyboardButton], **kwargs: Any
     ) -> 'InlineKeyboardMarkup':
         """Shortcut for::
 
@@ -129,50 +129,28 @@ class InlineKeyboardMarkup(ReplyMarkup):
 
     def add_button(self, button: InlineKeyboardButton,
                    from_row: int = None,
-                   insert_row: int = None,
-                   insert_column: int = None,
+                   column: int = None,
                    **kwargs: Any) -> 'InlineKeyboardMarkup':
 
-        def interval_value(lower: int, upper: int, value: int) -> int:
-            return min(max(lower, value), upper)
-
-        max_row = len(self.inline_keyboard) - 1
-        if from_row is not None and insert_row is None:
-            if from_row > max_row:
-                raise IndexError('row index out of range')
-            elif insert_column is not None:
-                self.inline_keyboard[
-                    interval_value(lower=0, upper=max_row, value=from_row)
-                ].insert(
-                    interval_value(lower=0, upper=len(self.inline_keyboard[from_row]),
-                                   value=insert_column),
-                    button
-                )
-            else:
-                self.inline_keyboard[
-                    interval_value(lower=0, upper=max_row, value=from_row)
-                ].append(button)
-
-        elif from_row is None and insert_row is not None:
-            self.inline_keyboard.insert(
-                interval_value(lower=0, upper=max_row + 1, value=insert_row),
-                [button]
-            )
-
-        elif from_row is None and insert_row is None:
-            if insert_column is not None:
-                self.inline_keyboard[-1].insert(
-                    interval_value(lower=0, upper=len(self.inline_keyboard[-1]),
-                                   value=insert_column),
-                    button
-                )
-            else:
-                self.inline_keyboard[-1].append(button)
+        row = len(self.inline_keyboard) - 1 if from_row is None else from_row
+        if row >= len(self.inline_keyboard) or row < -len(self.inline_keyboard):
+            raise IndexError('row index out of range')
+        if column is None:
+            self.inline_keyboard[row].append(button)
         else:
-            raise AttributeError(
-                "Arguments 'from_row' and 'row' are not allowed to be passed in at the same time"
-            )
+            if column >= len(self.inline_keyboard[row]):
+                self.inline_keyboard[row].append(button)
+            elif column < -len(self.inline_keyboard[row]):
+                self.inline_keyboard[row].insert(0, button)
+            else:
+                self.inline_keyboard[row].insert(column, button)
+        return self
 
+    def add_row(self, index: int = None, **kwargs: Any) -> 'InlineKeyboardMarkup':
+        if index is None:
+            self.inline_keyboard.append([])
+        else:
+            self.inline_keyboard.insert(min(max(0, index), len(self.inline_keyboard)), [])
         return self
 
     def __eq__(self, other: object) -> bool:

--- a/telegram/inline/inlinekeyboardmarkup.py
+++ b/telegram/inline/inlinekeyboardmarkup.py
@@ -179,7 +179,12 @@ class InlineKeyboardMarkup(ReplyMarkup):
         if index is None:
             self.inline_keyboard.append([])
         else:
-            self.inline_keyboard.insert(min(max(0, index), len(self.inline_keyboard)), [])
+            if index >= len(self.inline_keyboard):
+                self.inline_keyboard.append([])
+            elif index < -len(self.inline_keyboard):
+                self.inline_keyboard.insert(0, [])
+            else:
+                self.inline_keyboard.insert(index, [])
         return self
 
     def __eq__(self, other: object) -> bool:

--- a/telegram/inline/inlinekeyboardmarkup.py
+++ b/telegram/inline/inlinekeyboardmarkup.py
@@ -171,8 +171,8 @@ class InlineKeyboardMarkup(ReplyMarkup):
         a specified location.
 
         Args:
-            button_row: (List[:class:`telegram.InlineKeyboardButton`]): The button to add to the
-                markup
+            button_row: (List[:class:`telegram.InlineKeyboardButton`], optional): The button to
+                add to the markup
             index (:obj:`int`, optional): Set index for the row insert location of the markup.
                 Leave `None`, to append the row to the end of markup.
             **kwargs (:obj:`dict`): Arbitrary keyword arguments.
@@ -190,6 +190,38 @@ class InlineKeyboardMarkup(ReplyMarkup):
                 self.inline_keyboard.insert(0, row)
             else:
                 self.inline_keyboard.insert(index, row)
+        return self
+
+    def add_from_markup(
+            self,
+            markup: 'InlineKeyboardMarkup',
+            index: int = None,
+            **kwargs: Any
+    ) -> 'InlineKeyboardMarkup':
+        """Convenient method to add :class:`telegram.InlineKeyboardMarkup` to current markup
+
+        Args:
+            markup (:class:`telegram.InlineKeyboardMarkup`): Add InlineKeyboardMarkup to current
+                markup
+            index (:obj:`int`, optional):  Set index for the markup insert location of the
+                current markup. Leave `None`, to append the markup to the end.
+            **kwargs (:obj:`dict`): Arbitrary keyword arguments.
+
+        Returns:
+            :class:`telegram.InlineKeyboardMarkup`
+        """
+        if index is None:
+            self.inline_keyboard += markup.inline_keyboard
+        else:
+            if index >= len(self.inline_keyboard):
+                self.inline_keyboard += markup.inline_keyboard
+            elif index < -len(self.inline_keyboard):
+                self.inline_keyboard = markup.inline_keyboard + self.inline_keyboard
+            else:
+                self.inline_keyboard = \
+                    self.inline_keyboard[0:index] \
+                    + markup.inline_keyboard \
+                    + self.inline_keyboard[index:len(self.inline_keyboard)]
         return self
 
     def __eq__(self, other: object) -> bool:

--- a/telegram/inline/inlinekeyboardmarkup.py
+++ b/telegram/inline/inlinekeyboardmarkup.py
@@ -131,7 +131,25 @@ class InlineKeyboardMarkup(ReplyMarkup):
                    from_row: int = None,
                    column: int = None,
                    **kwargs: Any) -> 'InlineKeyboardMarkup':
+        """Convenient method to add :class:`telegram.InlineKeyboardButton` to the specified
+        row and column.
 
+        Args:
+            button (:class:`telegram.InlineKeyboardButton`): The button to be added to the markup
+            from_row (:obj:`int`, optional): Set index to specify the row to add the button.
+                The value should be less than the number of rows. Leave `None` to set the last row
+                as default.
+            column (:obj:`int`, optional): Set index for the button insert location of the row.
+                Leave `None`, to append the button to the row by default.
+            **kwargs (:obj:`dict`): Arbitrary keyword arguments.
+
+        Returns:
+            :class:`telegram.InlineKeyboardButton`
+
+        Raises:
+            :class:`IndexError`
+
+        """
         row = len(self.inline_keyboard) - 1 if from_row is None else from_row
         if row >= len(self.inline_keyboard) or row < -len(self.inline_keyboard):
             raise IndexError('row index out of range')
@@ -147,6 +165,17 @@ class InlineKeyboardMarkup(ReplyMarkup):
         return self
 
     def add_row(self, index: int = None, **kwargs: Any) -> 'InlineKeyboardMarkup':
+        """Convenient method to add List[:class:`telegram.InlineKeyboardButton`] into
+        a specified location.
+
+        Args:
+            index (:obj:`int`, optional): Set index for the row insert location of the markup.
+                Leave `None`, to append the row to the end of markup.
+            **kwargs (:obj:`dict`): Arbitrary keyword arguments.
+
+        Returns:
+            :class:`telegram.InlineKeyboardButton`
+        """
         if index is None:
             self.inline_keyboard.append([])
         else:

--- a/telegram/inline/inlinekeyboardmarkup.py
+++ b/telegram/inline/inlinekeyboardmarkup.py
@@ -164,11 +164,15 @@ class InlineKeyboardMarkup(ReplyMarkup):
                 self.inline_keyboard[row].insert(column, button)
         return self
 
-    def add_row(self, index: int = None, **kwargs: Any) -> 'InlineKeyboardMarkup':
+    def add_row(
+            self, button_row: List[InlineKeyboardButton] = None, index: int = None, **kwargs: Any
+    ) -> 'InlineKeyboardMarkup':
         """Convenient method to add List[:class:`telegram.InlineKeyboardButton`] into
         a specified location.
 
         Args:
+            button_row: (List[:class:`telegram.InlineKeyboardButton`]): The button to add to the
+                markup
             index (:obj:`int`, optional): Set index for the row insert location of the markup.
                 Leave `None`, to append the row to the end of markup.
             **kwargs (:obj:`dict`): Arbitrary keyword arguments.
@@ -176,15 +180,16 @@ class InlineKeyboardMarkup(ReplyMarkup):
         Returns:
             :class:`telegram.InlineKeyboardButton`
         """
+        row = [] if button_row is None else button_row
         if index is None:
-            self.inline_keyboard.append([])
+            self.inline_keyboard.append(row)
         else:
             if index >= len(self.inline_keyboard):
-                self.inline_keyboard.append([])
+                self.inline_keyboard.append(row)
             elif index < -len(self.inline_keyboard):
-                self.inline_keyboard.insert(0, [])
+                self.inline_keyboard.insert(0, row)
             else:
-                self.inline_keyboard.insert(index, [])
+                self.inline_keyboard.insert(index, row)
         return self
 
     def __eq__(self, other: object) -> bool:

--- a/telegram/inline/inlinekeyboardmarkup.py
+++ b/telegram/inline/inlinekeyboardmarkup.py
@@ -144,7 +144,7 @@ class InlineKeyboardMarkup(ReplyMarkup):
             **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
         Returns:
-            :class:`telegram.InlineKeyboardButton`
+            :class:`telegram.InlineKeyboardMarkup`
 
         Raises:
             :class:`IndexError`
@@ -178,7 +178,7 @@ class InlineKeyboardMarkup(ReplyMarkup):
             **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
         Returns:
-            :class:`telegram.InlineKeyboardButton`
+            :class:`telegram.InlineKeyboardMarkup`
         """
         row = [] if button_row is None else button_row
         if index is None:

--- a/telegram/replykeyboardmarkup.py
+++ b/telegram/replykeyboardmarkup.py
@@ -294,8 +294,8 @@ class ReplyKeyboardMarkup(ReplyMarkup):
         a specified location.
 
         Args:
-            button_row: (List[:class:`telegram.KeyboardButton` | :obj:`str`]): The button to
-                add to the markup
+            button_row: (List[:class:`telegram.KeyboardButton` | :obj:`str`], optional): The
+                button to add to the markup
             index (:obj:`int`, optional): Set index for the row insert location of the markup.
                 Leave `None`, to append the row to the end of markup.
             **kwargs (:obj:`dict`): Arbitrary keyword arguments.
@@ -320,6 +320,39 @@ class ReplyKeyboardMarkup(ReplyMarkup):
                 self.keyboard.insert(0, row)
             else:
                 self.keyboard.insert(index, row)
+        return self
+
+    def add_from_markup(
+            self,
+            markup: 'ReplyKeyboardMarkup',
+            index: int = None,
+            **kwargs: Any
+    ) -> 'ReplyKeyboardMarkup':
+        """Convenient method to add :class:`telegram.ReplyKeyboardMarkup` to current markup
+
+        Args:
+            markup (:class:`telegram.InlineKeyboardMarkup`): Add :class:`ReplyKeyboardMarkup`
+                to current markup.
+            index (:obj:`int`, optional):  Set index for the markup insert location of the
+                current markup. Leave `None`, to append the markup to the end.
+            **kwargs (:obj:`dict`): Arbitrary keyword arguments.
+
+        Returns:
+            :class:`telegram.ReplyKeyboardMarkup`
+        """
+        if index is None:
+            self.keyboard += markup.keyboard
+        else:
+            if index >= len(self.keyboard):
+                self.keyboard += markup.keyboard
+            elif index < -len(self.keyboard):
+                self.keyboard = \
+                    markup.keyboard + self.keyboard
+            else:
+                self.keyboard = \
+                    self.keyboard[0:index] \
+                    + markup.keyboard \
+                    + self.keyboard[index:len(self.keyboard)]
         return self
 
     def __eq__(self, other: object) -> bool:

--- a/telegram/replykeyboardmarkup.py
+++ b/telegram/replykeyboardmarkup.py
@@ -66,7 +66,7 @@ class ReplyKeyboardMarkup(ReplyMarkup):
 
     def __init__(
         self,
-        keyboard: List[List[Union[str, KeyboardButton]]],
+        keyboard: List[List[Union[str, KeyboardButton]]] = None,
         resize_keyboard: bool = False,
         one_time_keyboard: bool = False,
         selective: bool = False,
@@ -74,14 +74,15 @@ class ReplyKeyboardMarkup(ReplyMarkup):
     ):
         # Required
         self.keyboard = []
-        for row in keyboard:
-            r = []
-            for button in row:
-                if isinstance(button, KeyboardButton):
-                    r.append(button)  # telegram.KeyboardButton
-                else:
-                    r.append(KeyboardButton(button))  # str
-            self.keyboard.append(r)
+        if keyboard is not None:
+            for row in keyboard:
+                r = []
+                for button in row:
+                    if isinstance(button, KeyboardButton):
+                        r.append(button)  # telegram.KeyboardButton
+                    else:
+                        r.append(KeyboardButton(button))  # str
+                self.keyboard.append(r)
 
         # Optionals
         self.resize_keyboard = bool(resize_keyboard)
@@ -239,6 +240,86 @@ class ReplyKeyboardMarkup(ReplyMarkup):
             selective=selective,
             **kwargs,
         )
+
+    def add_button(
+            self,
+            button: Union[KeyboardButton, str],
+            from_row: int = None,
+            column: int = None,
+            **kwargs: Any,
+    ) -> 'ReplyKeyboardMarkup':
+        """Convenient method to add :class:`telegram.KeyboardButton` to the specified
+        row and column.
+
+        Args:
+            button (:class:`telegram.KeyboardButton` | :obj:`str`): The button to be added to
+                the markup
+            from_row (:obj:`int`, optional): Set index to specify the row to add the button.
+                The value should be included in the row indexes. Leave `None` to set the last row
+                as default.
+            column (:obj:`int`, optional): Set index for the button insert location of the row.
+                Leave `None`, to append the button to the row by default.
+            **kwargs (:obj:`dict`): Arbitrary keyword arguments.
+
+        Returns:
+            :class:`telegram.ReplyKeyboardMarkup`
+
+        Raises:
+            :class:`IndexError`
+
+        """
+        button = button if isinstance(button, KeyboardButton) else KeyboardButton(button)
+        row = len(self.keyboard) - 1 if from_row is None else from_row
+        if row >= len(self.keyboard) or row < -len(self.keyboard):
+            raise IndexError('row index out of range')
+        if column is None:
+            self.keyboard[row].append(button)
+        else:
+            if column >= len(self.keyboard[row]):
+                self.keyboard[row].append(button)
+            elif column < -len(self.keyboard[row]):
+                self.keyboard[row].insert(0, button)
+            else:
+                self.keyboard[row].insert(column, button)
+        return self
+
+    def add_row(
+            self,
+            button_row: List[Union[str, KeyboardButton]] = None,
+            index: int = None,
+            **kwargs: Any
+    ) -> 'ReplyKeyboardMarkup':
+        """Convenient method to add List[:class:`telegram.KeyboardButton` | :obj:`str`] into
+        a specified location.
+
+        Args:
+            button_row: (List[:class:`telegram.KeyboardButton` | :obj:`str`]): The button to
+                add to the markup
+            index (:obj:`int`, optional): Set index for the row insert location of the markup.
+                Leave `None`, to append the row to the end of markup.
+            **kwargs (:obj:`dict`): Arbitrary keyword arguments.
+
+        Returns:
+            :class:`telegram.ReplyKeyboardMarkup`
+        """
+        row = []
+        if button_row is not None:
+            for button in button_row:
+                if isinstance(button, KeyboardButton):
+                    row.append(button)
+                else:
+                    row.append(KeyboardButton(button))
+
+        if index is None:
+            self.keyboard.append(row)
+        else:
+            if index >= len(self.keyboard):
+                self.keyboard.append(row)
+            elif index < -len(self.keyboard):
+                self.keyboard.insert(0, row)
+            else:
+                self.keyboard.insert(index, row)
+        return self
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, self.__class__):

--- a/telegram/replykeyboardmarkup.py
+++ b/telegram/replykeyboardmarkup.py
@@ -73,7 +73,7 @@ class ReplyKeyboardMarkup(ReplyMarkup):
         **kwargs: Any,
     ):
         # Required
-        self.keyboard = []
+        k = []
         if keyboard is not None:
             for row in keyboard:
                 r = []
@@ -82,7 +82,8 @@ class ReplyKeyboardMarkup(ReplyMarkup):
                         r.append(button)  # telegram.KeyboardButton
                     else:
                         r.append(KeyboardButton(button))  # str
-                self.keyboard.append(r)
+                k.append(r)
+        self.keyboard = [[]] if len(k) == 0 else k
 
         # Optionals
         self.resize_keyboard = bool(resize_keyboard)

--- a/tests/test_inlinekeyboardmarkup.py
+++ b/tests/test_inlinekeyboardmarkup.py
@@ -73,18 +73,90 @@ class TestInlineKeyboardMarkup:
         assert len(inline_keyboard_markup[0]) == 1
         assert len(inline_keyboard_markup[1]) == 1
 
+    def test_add_button(self):
+        inline_keyboard_markup = InlineKeyboardMarkup().add_button(
+            InlineKeyboardButton(text='button1', callback_data='data1')
+        ).inline_keyboard
+        assert len(inline_keyboard_markup) == 1
+        assert len(inline_keyboard_markup[0]) == 1
+        inline_keyboard_markup = InlineKeyboardMarkup(
+            [
+                [
+                    InlineKeyboardButton(text='button2', callback_data='data2'),
+                    InlineKeyboardButton(text='button3', callback_data='data3'),
+                ],
+                [
+                    InlineKeyboardButton(text='button4', callback_data='data4'),
+                    InlineKeyboardButton(text='button5', callback_data='data5'),
+                ],
+                [
+                    InlineKeyboardButton(text='button6', callback_data='data6'),
+                ]
+            ]
+        ).add_button(
+            InlineKeyboardButton(text='button7', callback_data='data7')
+        ).add_button(
+            InlineKeyboardButton(text='button8', callback_data='data8'),
+            from_row=0,
+            column=1
+        ).add_button(
+            InlineKeyboardButton(text='button9', callback_data='data9'),
+            from_row=1,
+            column=-2
+        ).add_button(
+            InlineKeyboardButton(text='button10', callback_data='data10'),
+            from_row=2,
+            column=-100
+        ).add_button(
+            InlineKeyboardButton(text='button11', callback_data='data11'),
+            from_row=2,
+            column=100
+        ).inline_keyboard
+        assert len(inline_keyboard_markup) == 3
+        assert len(inline_keyboard_markup[0]) == 3
+        assert len(inline_keyboard_markup[1]) == 3
+        assert len(inline_keyboard_markup[2]) == 4
+        assert inline_keyboard_markup[2][2].text == 'button7'
+        assert inline_keyboard_markup[0][1].text == 'button8'
+        assert inline_keyboard_markup[1][-3].text == 'button9'
+        assert inline_keyboard_markup[2][0].text == 'button10'
+        assert inline_keyboard_markup[2][-1].text == 'button11'
+
+    def test_add_row(self):
+        inline_keyboard_markup = InlineKeyboardMarkup().add_row().inline_keyboard
+        assert len(inline_keyboard_markup) == 2
+        assert len(inline_keyboard_markup[0]) == 0
+        assert len(inline_keyboard_markup[1]) == 0
+        inline_keyboard_markup = InlineKeyboardMarkup(
+            [
+                [
+                    InlineKeyboardButton(text='button1', callback_data='data1'),
+                    InlineKeyboardButton(text='button2', callback_data='data2'),
+                ],
+                [
+                    InlineKeyboardButton(text='button3', callback_data='data3'),
+                    InlineKeyboardButton(text='button4', callback_data='data4'),
+                ]
+            ]
+        ).add_row(
+            button_row=[InlineKeyboardButton(text='button5', callback_data='data5')],
+            index=1
+        ).inline_keyboard
+        assert len(inline_keyboard_markup) == 3
+        assert inline_keyboard_markup[1][0].text == 'button5'
+
     def test_expected_values(self, inline_keyboard_markup):
         assert inline_keyboard_markup.inline_keyboard == self.inline_keyboard
 
     def test_expected_values_empty_switch(self, inline_keyboard_markup, bot, monkeypatch):
         def test(
-            url,
-            data,
-            reply_to_message_id=None,
-            disable_notification=None,
-            reply_markup=None,
-            timeout=None,
-            **kwargs,
+                url,
+                data,
+                reply_to_message_id=None,
+                disable_notification=None,
+                reply_markup=None,
+                timeout=None,
+                **kwargs,
         ):
             if reply_markup is not None:
                 if isinstance(reply_markup, ReplyMarkup):

--- a/tests/test_inlinekeyboardmarkup.py
+++ b/tests/test_inlinekeyboardmarkup.py
@@ -145,6 +145,44 @@ class TestInlineKeyboardMarkup:
         assert len(inline_keyboard_markup) == 3
         assert inline_keyboard_markup[1][0].text == 'button5'
 
+    def test_add_from_markup(self):
+        inline_keyboard_markup = InlineKeyboardMarkup(
+            [
+                [
+                    InlineKeyboardButton(text='button1', callback_data='data1'),
+                    InlineKeyboardButton(text='button2', callback_data='data2'),
+                ],
+                [
+                    InlineKeyboardButton(text='button3', callback_data='data3')
+                ]
+            ]
+        ).add_from_markup(
+            InlineKeyboardMarkup(
+                [
+                    [
+                        InlineKeyboardButton(text='button4', callback_data='data4'),
+                        InlineKeyboardButton(text='button5', callback_data='data5'),
+                    ]
+                ]
+            )
+        ).add_from_markup(
+            InlineKeyboardMarkup(
+                [
+                    [
+                        InlineKeyboardButton(text='button6', callback_data='data6'),
+                        InlineKeyboardButton(text='button7', callback_data='data7'),
+                    ],
+                    [
+                        InlineKeyboardButton(text='button8', callback_data='data8'),
+                    ]
+                ]
+            ),
+            index=0
+        ).inline_keyboard
+        assert len(inline_keyboard_markup) == 5
+        assert inline_keyboard_markup[0][0].text == 'button6'
+        assert inline_keyboard_markup[-1][0].text == 'button4'
+
     def test_expected_values(self, inline_keyboard_markup):
         assert inline_keyboard_markup.inline_keyboard == self.inline_keyboard
 

--- a/tests/test_replykeyboardmarkup.py
+++ b/tests/test_replykeyboardmarkup.py
@@ -137,6 +137,31 @@ class TestReplyKeyboardMarkup:
         assert len(reply_keyboard_markup) == 3
         assert reply_keyboard_markup[1][0].text == 'button5'
 
+    def test_add_from_markup(self):
+        reply_keyboard_markup = ReplyKeyboardMarkup(
+            [
+                [KeyboardButton(text='button1'), KeyboardButton(text='button2')],
+                [KeyboardButton(text='button3')]
+            ]
+        ).add_from_markup(
+            ReplyKeyboardMarkup(
+                [
+                    [KeyboardButton(text='button4'), KeyboardButton(text='button5')]
+                ]
+            )
+        ).add_from_markup(
+            ReplyKeyboardMarkup(
+                [
+                    [KeyboardButton(text='button6'), KeyboardButton(text='button7')],
+                    [KeyboardButton(text='button8')]
+                ]
+            ),
+            index=0
+        ).keyboard
+        assert len(reply_keyboard_markup) == 5
+        assert reply_keyboard_markup[0][0].text == 'button6'
+        assert reply_keyboard_markup[-1][0].text == 'button4'
+
     def test_expected_values(self, reply_keyboard_markup):
         assert isinstance(reply_keyboard_markup.keyboard, list)
         assert isinstance(reply_keyboard_markup.keyboard[0][0], KeyboardButton)

--- a/tests/test_replykeyboardmarkup.py
+++ b/tests/test_replykeyboardmarkup.py
@@ -88,6 +88,55 @@ class TestReplyKeyboardMarkup:
         assert len(reply_keyboard_markup[0]) == 1
         assert len(reply_keyboard_markup[1]) == 1
 
+    def test_add_button(self):
+        reply_keyboard_markup = ReplyKeyboardMarkup().add_button(
+            KeyboardButton(text='button1')
+        ).keyboard
+        assert len(reply_keyboard_markup) == 1
+        assert len(reply_keyboard_markup[0]) == 1
+        reply_keyboard_markup = ReplyKeyboardMarkup(
+            [
+                [KeyboardButton(text='button2'), KeyboardButton(text='button3')],
+                [KeyboardButton(text='button4'), KeyboardButton(text='button5')],
+                [KeyboardButton(text='button6')]
+            ]
+        ).add_button(
+            KeyboardButton(text='button7')
+        ).add_button(
+            KeyboardButton(text='button8'), from_row=0, column=1
+        ).add_button(
+            KeyboardButton(text='button9'), from_row=1, column=-2
+        ).add_button(
+            KeyboardButton(text='button10'), from_row=2, column=-100
+        ).add_button(
+            KeyboardButton(text='button11'), column=100
+        ).keyboard
+        assert len(reply_keyboard_markup) == 3
+        assert len(reply_keyboard_markup[0]) == 3
+        assert len(reply_keyboard_markup[1]) == 3
+        assert len(reply_keyboard_markup[2]) == 4
+        assert reply_keyboard_markup[2][2].text == 'button7'
+        assert reply_keyboard_markup[0][1].text == 'button8'
+        assert reply_keyboard_markup[1][-3].text == 'button9'
+        assert reply_keyboard_markup[2][0].text == 'button10'
+        assert reply_keyboard_markup[2][-1].text == 'button11'
+
+    def test_add_row(self):
+        reply_keyboard_markup = ReplyKeyboardMarkup().add_row().keyboard
+        assert len(reply_keyboard_markup) == 2
+        assert len(reply_keyboard_markup[0]) == 0
+        assert len(reply_keyboard_markup[1]) == 0
+        reply_keyboard_markup = ReplyKeyboardMarkup(
+            [
+                [KeyboardButton(text='button1'), KeyboardButton(text='button2')],
+                [KeyboardButton(text='button3'), KeyboardButton(text='button4')]
+            ]
+        ).add_row(
+            button_row=[KeyboardButton(text='button5')], index=1
+        ).keyboard
+        assert len(reply_keyboard_markup) == 3
+        assert reply_keyboard_markup[1][0].text == 'button5'
+
     def test_expected_values(self, reply_keyboard_markup):
         assert isinstance(reply_keyboard_markup.keyboard, list)
         assert isinstance(reply_keyboard_markup.keyboard[0][0], KeyboardButton)


### PR DESCRIPTION
Function of keyboard markup has been enhanced by classmethods, yet it still needs creation of list-of-button-list in advance dealing with multiple rows of buttons. 

Methods `add_button`, `add_row`, `add_from_markup` added to `InlineKeyboardMarkup` and `ReplyKeyboardMarkup` can be called by chain to add button to the markup. `add_from_markup` method permits modularization of buttons to plug in as an existing markup.

* To support method chaining, I changed `inline_keyboard` to a optional argument. It seems having no adverse effect by now.