### PR TITLE
Don't mark non-universal wheels as universal

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[wheel]
-universal = 1
-
 [metadata]
 license_file = LICENSE.dual
 


### PR DESCRIPTION
Wheels are only universal if they support both Python 2 and 3.