### PR TITLE
Bug fixes for insert/replace_bot

### DIFF
--- a/telegram/ext/basepersistence.py
+++ b/telegram/ext/basepersistence.py
@@ -133,7 +133,7 @@ class BasePersistence(ABC):
         Replaces all instances of :class:`telegram.Bot` that occur within the passed object with
         :attr:`REPLACED_BOT`. Currently, this handles objects of type ``list``, ``tuple``, ``set``,
         ``frozenset``, ``dict``, ``defaultdict`` and objects that have a ``__dict__`` or
-        ``__slot__`` attribute.
+        ``__slot__`` attribute, excluding objects that can't be copied with `copy.copy`.
 
         Args:
             obj (:obj:`object`): The object
@@ -205,7 +205,7 @@ class BasePersistence(ABC):
         Replaces all instances of :attr:`REPLACED_BOT` that occur within the passed object with
         :attr:`bot`. Currently, this handles objects of type ``list``, ``tuple``, ``set``,
         ``frozenset``, ``dict``, ``defaultdict`` and objects that have a ``__dict__`` or
-        ``__slot__`` attribute.
+        ``__slot__`` attribute, excluding objects that can't be copied with `copy.copy`.
 
         Args:
             obj (:obj:`object`): The object

--- a/telegram/ext/basepersistence.py
+++ b/telegram/ext/basepersistence.py
@@ -171,8 +171,14 @@ class BasePersistence(ABC):
             memo[id(obj)] = new_immutable
             return new_immutable
 
-        new_obj = copy(obj)
-        memo[id(obj)] = new_obj
+        try:
+            new_obj = copy(obj)
+            memo[id(obj)] = new_obj
+        except TypeError as exc:
+            if 'cannot pickle' in str(exc):
+                memo[id(obj)] = obj
+                return obj
+
         if isinstance(obj, (dict, defaultdict)):
             new_obj = cast(dict, new_obj)
             new_obj.clear()
@@ -239,8 +245,14 @@ class BasePersistence(ABC):
             memo[id(obj)] = new_immutable
             return new_immutable
 
-        new_obj = copy(obj)
-        memo[id(obj)] = new_obj
+        try:
+            new_obj = copy(obj)
+            memo[id(obj)] = new_obj
+        except TypeError as exc:
+            if 'cannot pickle' in str(exc):
+                memo[id(obj)] = obj
+                return obj
+
         if isinstance(obj, (dict, defaultdict)):
             new_obj = cast(dict, new_obj)
             new_obj.clear()


### PR DESCRIPTION
this does two things:

* pass a `memo` dict to handle recursion, closes #2145 
* if an object can't be copied, they're probably something special and don't contain a `Bot` instance. Therefore, those will now just be skipped.

Note: I noticed the latter while testing the changes on a personal project, where I have `locks` in some objects that have a custom pickle behaviour but not a custom `copy` behaivour