### PR TITLE
Improve handling of custom objects in BP.insert/replace_bot

### DIFF
--- a/telegram/ext/basepersistence.py
+++ b/telegram/ext/basepersistence.py
@@ -194,7 +194,7 @@ class BasePersistence(ABC):
         """
         if isinstance(obj, Bot):
             return self.bot
-        if obj == self.REPLACED_BOT:
+        if isinstance(obj, str) and obj == self.REPLACED_BOT:
             return self.bot
         if isinstance(obj, (list, tuple, set, frozenset)):
             return obj.__class__(self.insert_bot(item) for item in obj)

--- a/telegram/ext/basepersistence.py
+++ b/telegram/ext/basepersistence.py
@@ -149,7 +149,7 @@ class BasePersistence(ABC):
         try:
             new_obj = copy(obj)
         except TypeError as exc:
-            if 'cannot pickle' in str(exc):
+            if 'pickle' in str(exc):
                 return obj
             raise exc
 
@@ -197,7 +197,7 @@ class BasePersistence(ABC):
         try:
             new_obj = copy(obj)
         except TypeError as exc:
-            if 'cannot pickle' in str(exc):
+            if 'pickle' in str(exc):
                 return obj
             raise exc
 

--- a/telegram/ext/basepersistence.py
+++ b/telegram/ext/basepersistence.py
@@ -133,7 +133,7 @@ class BasePersistence(ABC):
         Replaces all instances of :class:`telegram.Bot` that occur within the passed object with
         :attr:`REPLACED_BOT`. Currently, this handles objects of type ``list``, ``tuple``, ``set``,
         ``frozenset``, ``dict``, ``defaultdict`` and objects that have a ``__dict__`` or
-        ``__slot__`` attribute.
+        ``__slot__`` attribute, excluding objects that can't be copied with `copy.copy`.
 
         Args:
             obj (:obj:`object`): The object
@@ -146,7 +146,13 @@ class BasePersistence(ABC):
         if isinstance(obj, (list, tuple, set, frozenset)):
             return obj.__class__(cls.replace_bot(item) for item in obj)
 
-        new_obj = copy(obj)
+        try:
+            new_obj = copy(obj)
+        except TypeError as exc:
+            if 'cannot pickle' in str(exc):
+                return obj
+            raise exc
+
         if isinstance(obj, (dict, defaultdict)):
             new_obj = cast(dict, new_obj)
             new_obj.clear()
@@ -173,7 +179,7 @@ class BasePersistence(ABC):
         Replaces all instances of :attr:`REPLACED_BOT` that occur within the passed object with
         :attr:`bot`. Currently, this handles objects of type ``list``, ``tuple``, ``set``,
         ``frozenset``, ``dict``, ``defaultdict`` and objects that have a ``__dict__`` or
-        ``__slot__`` attribute.
+        ``__slot__`` attribute, excluding objects that can't be copied with `copy.copy`.
 
         Args:
             obj (:obj:`object`): The object
@@ -188,7 +194,13 @@ class BasePersistence(ABC):
         if isinstance(obj, (list, tuple, set, frozenset)):
             return obj.__class__(self.insert_bot(item) for item in obj)
 
-        new_obj = copy(obj)
+        try:
+            new_obj = copy(obj)
+        except TypeError as exc:
+            if 'cannot pickle' in str(exc):
+                return obj
+            raise exc
+
         if isinstance(obj, (dict, defaultdict)):
             new_obj = cast(dict, new_obj)
             new_obj.clear()

--- a/telegram/ext/basepersistence.py
+++ b/telegram/ext/basepersistence.py
@@ -128,7 +128,7 @@ class BasePersistence(ABC):
         self.bot = bot
 
     @classmethod
-    def replace_bot(cls, obj: object) -> object:
+    def replace_bot(cls, obj: object) -> object:  # pylint: disable=R0911
         """
         Replaces all instances of :class:`telegram.Bot` that occur within the passed object with
         :attr:`REPLACED_BOT`. Currently, this handles objects of type ``list``, ``tuple``, ``set``,

--- a/telegram/ext/basepersistence.py
+++ b/telegram/ext/basepersistence.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains the BasePersistence class."""
-
+import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from copy import copy
@@ -148,10 +148,15 @@ class BasePersistence(ABC):
 
         try:
             new_obj = copy(obj)
-        except TypeError as exc:
-            if 'pickle' in str(exc):
-                return obj
-            raise exc
+        except Exception:
+            warnings.warn(
+                'BasePersistence.replace_bot caught an error while trying to copy an object. '
+                'Objects that can not be copied will be assumed to not contain a telegram.Bot '
+                'instance and will not be handled further. See the docs of '
+                'BasePersistence.replace_bot for more information.',
+                RuntimeWarning,
+            )
+            return obj
 
         if isinstance(obj, (dict, defaultdict)):
             new_obj = cast(dict, new_obj)
@@ -196,10 +201,15 @@ class BasePersistence(ABC):
 
         try:
             new_obj = copy(obj)
-        except TypeError as exc:
-            if 'pickle' in str(exc):
-                return obj
-            raise exc
+        except Exception:
+            warnings.warn(
+                'BasePersistence.insert_bot caught an error while trying to copy an object. '
+                'Objects that can not be copied will be assumed to not contain a telegram.Bot '
+                'instance and will not be handled further. See the docs of '
+                'BasePersistence.insert_bot for more information.',
+                RuntimeWarning,
+            )
+            return obj
 
         if isinstance(obj, (dict, defaultdict)):
             new_obj = cast(dict, new_obj)
@@ -219,6 +229,7 @@ class BasePersistence(ABC):
                     self.insert_bot(self.insert_bot(getattr(new_obj, attr_name))),
                 )
             return new_obj
+
         return obj
 
     @abstractmethod

--- a/telegram/ext/basepersistence.py
+++ b/telegram/ext/basepersistence.py
@@ -150,10 +150,8 @@ class BasePersistence(ABC):
             new_obj = copy(obj)
         except Exception:
             warnings.warn(
-                'BasePersistence.replace_bot caught an error while trying to copy an object. '
-                'Objects that can not be copied will be assumed to not contain a telegram.Bot '
-                'instance and will not be handled further. See the docs of '
-                'BasePersistence.replace_bot for more information.',
+                'BasePersistence.replace_bot does not handle objects that can not be copied. See '
+                'the docs of BasePersistence.replace_bot for more information.',
                 RuntimeWarning,
             )
             return obj
@@ -203,10 +201,8 @@ class BasePersistence(ABC):
             new_obj = copy(obj)
         except Exception:
             warnings.warn(
-                'BasePersistence.insert_bot caught an error while trying to copy an object. '
-                'Objects that can not be copied will be assumed to not contain a telegram.Bot '
-                'instance and will not be handled further. See the docs of '
-                'BasePersistence.insert_bot for more information.',
+                'BasePersistence.insert_bot does not handle objects that can not be copied. See '
+                'the docs of BasePersistence.insert_bot for more information.',
                 RuntimeWarning,
             )
             return obj

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -555,6 +555,10 @@ class TestBasePersistence:
         persistence = bot_persistence
         persistence.set_bot(bot)
 
+        class CustomClass:
+            def __copy__(self):
+                raise TypeError('UnhandledException')
+
         lock = Lock()
 
         persistence.update_bot_data({1: lock})
@@ -567,6 +571,23 @@ class TestBasePersistence:
         assert persistence.get_bot_data()[1] is lock
         assert persistence.get_chat_data()[123][1] is lock
         assert persistence.get_user_data()[123][1] is lock
+
+        with pytest.raises(TypeError, match='UnhandledException'):
+            persistence.update_bot_data({2: CustomClass()})
+        with pytest.raises(TypeError, match='UnhandledException'):
+            persistence.update_chat_data(456, {2: CustomClass()})
+        with pytest.raises(TypeError, match='UnhandledException'):
+            persistence.update_user_data(456, {2: CustomClass()})
+
+        persistence.bot_data[2] = CustomClass()
+        persistence.chat_data[456][2] = CustomClass()
+        persistence.user_data[456][2] = CustomClass()
+        with pytest.raises(TypeError, match='UnhandledException'):
+            persistence.get_bot_data()
+        with pytest.raises(TypeError, match='UnhandledException'):
+            persistence.get_user_data()
+        with pytest.raises(TypeError, match='UnhandledException'):
+            persistence.get_chat_data()
 
 
 @pytest.fixture(scope='function')

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -584,10 +584,10 @@ class TestBasePersistence:
 
         assert len(recwarn) == 2
         assert str(recwarn[0].message).startswith(
-            "BasePersistence.replace_bot caught an error while trying to copy an object."
+            "BasePersistence.replace_bot does not handle objects that can not be copied."
         )
         assert str(recwarn[1].message).startswith(
-            "BasePersistence.insert_bot caught an error while trying to copy an object."
+            "BasePersistence.insert_bot does not handle objects that can not be copied."
         )
 
     def test_bot_replace_insert_bot_objects_with_faulty_equality(self, bot, bot_persistence):

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 import signal
+from threading import Lock
 
 from telegram.utils.helpers import encode_conversations_to_json
 
@@ -86,6 +87,42 @@ def base_persistence():
             raise NotImplementedError
 
     return OwnPersistence(store_chat_data=True, store_user_data=True, store_bot_data=True)
+
+
+@pytest.fixture(scope="function")
+def bot_persistence():
+    class BotPersistence(BasePersistence):
+        def __init__(self):
+            super().__init__()
+            self.bot_data = None
+            self.chat_data = defaultdict(dict)
+            self.user_data = defaultdict(dict)
+
+        def get_bot_data(self):
+            return self.bot_data
+
+        def get_chat_data(self):
+            return self.chat_data
+
+        def get_user_data(self):
+            return self.user_data
+
+        def get_conversations(self, name):
+            raise NotImplementedError
+
+        def update_bot_data(self, data):
+            self.bot_data = data
+
+        def update_chat_data(self, chat_id, data):
+            self.chat_data[chat_id] = data
+
+        def update_user_data(self, user_id, data):
+            self.user_data[user_id] = data
+
+        def update_conversation(self, name, key, new_state):
+            raise NotImplementedError
+
+    return BotPersistence()
 
 
 @pytest.fixture(scope="function")
@@ -437,37 +474,7 @@ class TestBasePersistence:
             dp.process_update(MyUpdate())
         assert 'An uncaught error was raised while processing the update' not in caplog.text
 
-    def test_bot_replace_insert_bot(self, bot):
-        class BotPersistence(BasePersistence):
-            def __init__(self):
-                super().__init__()
-                self.bot_data = None
-                self.chat_data = defaultdict(dict)
-                self.user_data = defaultdict(dict)
-
-            def get_bot_data(self):
-                return self.bot_data
-
-            def get_chat_data(self):
-                return self.chat_data
-
-            def get_user_data(self):
-                return self.user_data
-
-            def get_conversations(self, name):
-                raise NotImplementedError
-
-            def update_bot_data(self, data):
-                self.bot_data = data
-
-            def update_chat_data(self, chat_id, data):
-                self.chat_data[chat_id] = data
-
-            def update_user_data(self, user_id, data):
-                self.user_data[user_id] = data
-
-            def update_conversation(self, name, key, new_state):
-                raise NotImplementedError
+    def test_bot_replace_insert_bot(self, bot, bot_persistence):
 
         class CustomSlottedClass:
             __slots__ = ('bot',)
@@ -520,7 +527,7 @@ class TestBasePersistence:
                     )
                 return False
 
-        persistence = BotPersistence()
+        persistence = bot_persistence
         persistence.set_bot(bot)
         cc = CustomClass()
 
@@ -542,6 +549,24 @@ class TestBasePersistence:
         assert persistence.get_chat_data()[123][1].bot is bot
         assert persistence.get_user_data()[123][1] == cc
         assert persistence.get_user_data()[123][1].bot is bot
+
+    def test_bot_replace_insert_bot_unpickable_objects(self, bot, bot_persistence):
+        """Here check that unpickable objects are just returned verbatim."""
+        persistence = bot_persistence
+        persistence.set_bot(bot)
+
+        lock = Lock()
+
+        persistence.update_bot_data({1: lock})
+        assert persistence.bot_data[1] is lock
+        persistence.update_chat_data(123, {1: lock})
+        assert persistence.chat_data[123][1] is lock
+        persistence.update_user_data(123, {1: lock})
+        assert persistence.user_data[123][1] is lock
+
+        assert persistence.get_bot_data()[1] is lock
+        assert persistence.get_chat_data()[123][1] is lock
+        assert persistence.get_user_data()[123][1] is lock
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
if an object can't be copied, they're probably something special and don't contain a Bot instance. Therefore, those will now just be skipped.

Note: I noticed the latter while testing the changes on a personal project, where I have locks in some objects that have a custom pickle behaviour but not a custom copy behaivour