### PR TITLE
Added: Filter for file ending/extension

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -58,6 +58,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Loo Zheng Yuan <https://github.com/loozhengyuan>`_
 - `LRezende <https://github.com/lrezende>`_
 - `macrojames <https://github.com/macrojames>`_
+- `Matheus Lemos <https://github.com/mlemosf>`_
 - `Michael Elovskikh <https://github.com/wronglink>`_
 - `Mischa Krüger <https://github.com/Makman2>`_
 - `naveenvhegde <https://github.com/naveenvhegde>`_

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -603,31 +603,31 @@ class Filters:
         xml = mime_type('application/xml')
         zip = mime_type('application/zip')
 
-        class file_ending(MessageFilter):
+        class file_extension(MessageFilter):
             """ This filter filters documents by their file ending/extension
 
             Note:
                 This Filter only filters by the file ending/extension of the document,
                     it doesn't check the validity of document.
-                The user can manipulate the mime-type of a message and
+                The user can manipulate the file extension of a document and
                     send media with wrong types that don't fit to this handler.
 
             Example:
-                ``Filters.document.file_ending('jpg')`` filters all files with extension .jpg
+                ``Filters.document.file_extension('jpg')`` filters all files with extension ``.jpg``
             """
 
-            def __init__(self, file_ending: Optional[str]):
-                """Initialize the category you want to filter
+            def __init__(self, file_extension: Optional[str]):
+                """Initialize the extension you want to filter
 
                 Args:
-                    file_ending (str, optional): file ending of the media you want to filter"""
-                self.file_ending = file_ending
-                self.name = "Filters.document.file_ending('{}')".format(self.file_ending)
+                    file_extension (str, optional): file extension of the media you want to filter"""
+                self.file_extension = file_extension
+                self.name = f"Filters.document.file_extenision('{self.file_extension}')"
 
             def filter(self, message : Message) -> bool:
                 """"""  # remove method from docs
                 if message.document:
-                    return message.document.file_name.endswith(self.file_ending)
+                    return message.document.file_name.endswith(self.file_extension)
                 return False
 
         def filter(self, message: Message) -> bool:

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -603,6 +603,33 @@ class Filters:
         xml = mime_type('application/xml')
         zip = mime_type('application/zip')
 
+        class file_ending(MessageFilter):
+            """ This filter filters documents by their file ending/extension
+
+            Note:
+                This Filter only filters by the file ending/extension of the document,
+                    it doesn't check the validity of document.
+                The user can manipulate the mime-type of a message and
+                    send media with wrong types that don't fit to this handler.
+
+            Example:
+                ``Filters.document.file_ending('jpg')`` filters all files with extension .jpg
+            """
+
+            def __init__(self, file_ending: Optional[str]):
+                """Initialize the category you want to filter
+
+                Args:
+                    file_ending (str, optional): file ending of the media you want to filter"""
+                self.file_ending = file_ending
+                self.name = "Filters.document.file_ending('{}')".format(self.file_ending)
+
+            def filter(self, message : Message) -> bool:
+                """"""  # remove method from docs
+                if message.document:
+                    return message.document.file_name.endswith(self.file_ending)
+                return False
+
         def filter(self, message: Message) -> bool:
             return bool(message.document)
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -422,7 +422,19 @@ class TestFilters:
         update.message.document.mime_type = "application/x-sh"
         assert Filters.document.category("application/")(update)
         assert Filters.document.mime_type("application/x-sh")(update)
-
+ 
+        update.message.document.file_name = "file.docx"
+        assert Filters.document.file_extension('docx')(update)
+        assert not Filters.document.file_extension('pdf')(update)
+        
+        update.message.document.file_name = "file.tar.gz"
+        assert Filters.document.file_extension('tar.gz')(update)
+        assert not Filters.document.file_extension('zip')(update)
+        
+        update.message.document.file_name = "file.png"
+        assert Filters.document.file_extension('png')(update)
+        assert not Filters.document.file_extension('jpeg')(update)
+        
     def test_filters_animation(self, update):
         assert not Filters.animation(update)
         update.message.animation = 'test'


### PR DESCRIPTION
# Feature: Added filter for file endings / file extensions on documents

Added class 'file_ending' that filter documents which end in the
extension passed by the user to Filters.document.file_ending;  
Also added name to AUTHORS.rst.

This pull request solves issue #2140
