### PR TITLE
Check caption in Filters.regex

### DIFF
--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -506,11 +506,25 @@ class Filters:
                 match = self.pattern.search(message.text)
                 if match:
                     return {'matches': [match]}
-            elif message.caption:
+            return {}
+
+    class caption_regex (MessageFilter):
+        data_filter = True
+
+        def __init__(self, pattern: Union[str, Pattern]):
+            if isinstance(pattern, str):
+                pattern = re.compile(pattern)
+            pattern = cast(Pattern, pattern)
+            self.pattern: Pattern = pattern
+            self.name = 'Filters.caption_regex ({})'.format(self.pattern)
+
+        def filter(self, message: Message) -> Optional[Dict[str, List[Match]]]:
+            if message.caption:
                 match = self.pattern.search(message.caption)
                 if match:
                     return {'matches': [match]}
             return {}
+
 
     class _Reply(MessageFilter):
         name = 'Filters.reply'

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -506,6 +506,10 @@ class Filters:
                 match = self.pattern.search(message.text)
                 if match:
                     return {'matches': [match]}
+            elif message.caption:
+                match = self.pattern.search(message.caption)
+                if match:
+                    return {'matches': [match]}
             return {}
 
     class _Reply(MessageFilter):

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -509,6 +509,23 @@ class Filters:
             return {}
 
     class caption_regex(MessageFilter):
+        """
+        Filters updates by searching for an occurrence of ``pattern`` in the message caption.
+
+        This filter works similarly to :class:`Filters.regex`, with the only exception being that
+        it applies to the message caption instead of the text.
+
+        Examples:
+            Use ``MessageHandler(Filters.photo & Filters.caption_regex(r'help'), callback)``
+            to capture all photos with caption containing the word 'help'.
+
+        Note:
+            This filter will not work on simple text messages, but only on media with caption.
+
+        Args:
+            pattern (:obj:`str` | :obj:`Pattern`): The regex pattern.
+        """
+
         data_filter = True
 
         def __init__(self, pattern: Union[str, Pattern]):
@@ -519,6 +536,7 @@ class Filters:
             self.name = 'Filters.caption_regex ({})'.format(self.pattern)
 
         def filter(self, message: Message) -> Optional[Dict[str, List[Match]]]:
+            """"""  # remove method from docs
             if message.caption:
                 match = self.pattern.search(message.caption)
                 if match:

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -508,7 +508,7 @@ class Filters:
                     return {'matches': [match]}
             return {}
 
-    class caption_regex (MessageFilter):
+    class caption_regex(MessageFilter):
         data_filter = True
 
         def __init__(self, pattern: Union[str, Pattern]):

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -525,7 +525,6 @@ class Filters:
                     return {'matches': [match]}
             return {}
 
-
     class _Reply(MessageFilter):
         name = 'Filters.reply'
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -301,6 +301,209 @@ class TestFilters:
         result = filter(update)
         assert result
 
+    def test_filters_caption_regex(self, update):
+        SRE_TYPE = type(re.match("", ""))
+        update.message.caption = '/start deep-linked param'
+        result = Filters.caption_regex(r'deep-linked param')(update)
+        assert result
+        assert isinstance(result, dict)
+        matches = result['matches']
+        assert isinstance(matches, list)
+        assert type(matches[0]) is SRE_TYPE
+        update.message.caption = '/help'
+        assert Filters.caption_regex(r'help')(update)
+
+        update.message.caption = 'test'
+        assert not Filters.caption_regex(r'fail')(update)
+        assert Filters.caption_regex(r'test')(update)
+        assert Filters.caption_regex(re.compile(r'test'))(update)
+        assert Filters.caption_regex(re.compile(r'TEST', re.IGNORECASE))(update)
+
+        update.message.caption = 'i love python'
+        assert Filters.caption_regex(r'.\b[lo]{2}ve python')(update)
+
+        update.message.caption = None
+        assert not Filters.caption_regex(r'fail')(update)
+
+    def test_filters_caption_regex_multiple(self, update):
+        SRE_TYPE = type(re.match("", ""))
+        update.message.caption = '/start deep-linked param'
+        result = (Filters.caption_regex('deep') & Filters.caption_regex(r'linked param'))(update)
+        assert result
+        assert isinstance(result, dict)
+        matches = result['matches']
+        assert isinstance(matches, list)
+        assert all([type(res) == SRE_TYPE for res in matches])
+        result = (Filters.caption_regex('deep') | Filters.caption_regex(r'linked param'))(update)
+        assert result
+        assert isinstance(result, dict)
+        matches = result['matches']
+        assert isinstance(matches, list)
+        assert all([type(res) == SRE_TYPE for res in matches])
+        result = (Filters.caption_regex('not int') | Filters.caption_regex(r'linked param'))(update)
+        assert result
+        assert isinstance(result, dict)
+        matches = result['matches']
+        assert isinstance(matches, list)
+        assert all([type(res) == SRE_TYPE for res in matches])
+        result = (Filters.caption_regex('not int') & Filters.caption_regex(r'linked param'))(update)
+        assert not result
+
+    def test_filters_merged_with_caption_regex(self, update):
+        SRE_TYPE = type(re.match("", ""))
+        update.message.caption = '/start deep-linked param'
+        update.message.entities = [MessageEntity(MessageEntity.BOT_COMMAND, 0, 6)]
+        result = (Filters.command & Filters.caption_regex(r'linked param'))(update)
+        assert result
+        assert isinstance(result, dict)
+        matches = result['matches']
+        assert isinstance(matches, list)
+        assert all([type(res) == SRE_TYPE for res in matches])
+        result = (Filters.caption_regex(r'linked param') & Filters.command)(update)
+        assert result
+        assert isinstance(result, dict)
+        matches = result['matches']
+        assert isinstance(matches, list)
+        assert all([type(res) == SRE_TYPE for res in matches])
+        result = (Filters.caption_regex(r'linked param') | Filters.command)(update)
+        assert result
+        assert isinstance(result, dict)
+        matches = result['matches']
+        assert isinstance(matches, list)
+        assert all([type(res) == SRE_TYPE for res in matches])
+        # Should not give a match since it's a or filter and it short circuits
+        result = (Filters.command | Filters.caption_regex(r'linked param'))(update)
+        assert result is True
+
+    def test_caption_regex_complex_merges(self, update):
+        SRE_TYPE = type(re.match("", ""))
+        update.message.caption = 'test it out'
+        filter = Filters.caption_regex('test') & (
+            (Filters.status_update | Filters.forwarded) | Filters.caption_regex('out')
+        )
+        result = filter(update)
+        assert result
+        assert isinstance(result, dict)
+        matches = result['matches']
+        assert isinstance(matches, list)
+        assert len(matches) == 2
+        assert all([type(res) == SRE_TYPE for res in matches])
+        update.message.forward_date = datetime.datetime.utcnow()
+        result = filter(update)
+        assert result
+        assert isinstance(result, dict)
+        matches = result['matches']
+        assert isinstance(matches, list)
+        assert all([type(res) == SRE_TYPE for res in matches])
+        update.message.caption = 'test it'
+        result = filter(update)
+        assert result
+        assert isinstance(result, dict)
+        matches = result['matches']
+        assert isinstance(matches, list)
+        assert all([type(res) == SRE_TYPE for res in matches])
+        update.message.forward_date = None
+        result = filter(update)
+        assert not result
+        update.message.caption = 'test it out'
+        result = filter(update)
+        assert result
+        assert isinstance(result, dict)
+        matches = result['matches']
+        assert isinstance(matches, list)
+        assert all([type(res) == SRE_TYPE for res in matches])
+        update.message.pinned_message = True
+        result = filter(update)
+        assert result
+        assert isinstance(result, dict)
+        matches = result['matches']
+        assert isinstance(matches, list)
+        assert all([type(res) == SRE_TYPE for res in matches])
+        update.message.caption = 'it out'
+        result = filter(update)
+        assert not result
+
+        update.message.caption = 'test it out'
+        update.message.forward_date = None
+        update.message.pinned_message = None
+        filter = (Filters.caption_regex('test') | Filters.command) & (
+            Filters.caption_regex('it') | Filters.status_update
+        )
+        result = filter(update)
+        assert result
+        assert isinstance(result, dict)
+        matches = result['matches']
+        assert isinstance(matches, list)
+        assert len(matches) == 2
+        assert all([type(res) == SRE_TYPE for res in matches])
+        update.message.caption = 'test'
+        result = filter(update)
+        assert not result
+        update.message.pinned_message = True
+        result = filter(update)
+        assert result
+        assert isinstance(result, dict)
+        matches = result['matches']
+        assert isinstance(matches, list)
+        assert len(matches) == 1
+        assert all([type(res) == SRE_TYPE for res in matches])
+        update.message.caption = 'nothing'
+        result = filter(update)
+        assert not result
+        update.message.caption = '/start'
+        update.message.entities = [MessageEntity(MessageEntity.BOT_COMMAND, 0, 6)]
+        result = filter(update)
+        assert result
+        assert isinstance(result, bool)
+        update.message.caption = '/start it'
+        result = filter(update)
+        assert result
+        assert isinstance(result, dict)
+        matches = result['matches']
+        assert isinstance(matches, list)
+        assert len(matches) == 1
+        assert all([type(res) == SRE_TYPE for res in matches])
+
+    def test_caption_regex_inverted(self, update):
+        update.message.caption = '/start deep-linked param'
+        update.message.entities = [MessageEntity(MessageEntity.BOT_COMMAND, 0, 5)]
+        filter = ~Filters.caption_regex(r'deep-linked param')
+        result = filter(update)
+        assert not result
+        update.message.caption = 'not it'
+        result = filter(update)
+        assert result
+        assert isinstance(result, bool)
+
+        filter = ~Filters.caption_regex('linked') & Filters.command
+        update.message.caption = "it's linked"
+        result = filter(update)
+        assert not result
+        update.message.caption = '/start'
+        update.message.entities = [MessageEntity(MessageEntity.BOT_COMMAND, 0, 6)]
+        result = filter(update)
+        assert result
+        update.message.caption = '/linked'
+        result = filter(update)
+        assert not result
+
+        filter = ~Filters.caption_regex('linked') | Filters.command
+        update.message.caption = "it's linked"
+        update.message.entities = []
+        result = filter(update)
+        assert not result
+        update.message.caption = '/start linked'
+        update.message.entities = [MessageEntity(MessageEntity.BOT_COMMAND, 0, 6)]
+        result = filter(update)
+        assert result
+        update.message.caption = '/start'
+        result = filter(update)
+        assert result
+        update.message.caption = 'nothig'
+        update.message.entities = []
+        result = filter(update)
+        assert result
+
     def test_filters_reply(self, update):
         another_message = Message(
             1,

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -328,37 +328,29 @@ class TestFilters:
     def test_filters_caption_regex_multiple(self, update):
         SRE_TYPE = type(re.match("", ""))
         update.message.caption = '/start deep-linked param'
-        result = (
-            Filters.caption_regex('deep')
-            & Filters.caption_regex(r'linked param')
-        )(update)
+        result = (Filters.caption_regex('deep') & Filters.caption_regex(r'linked param'))(update)
         assert result
         assert isinstance(result, dict)
         matches = result['matches']
         assert isinstance(matches, list)
         assert all([type(res) == SRE_TYPE for res in matches])
-        result = (
-            Filters.caption_regex('deep')
-            | Filters.caption_regex(r'linked param')
-        )(update)
+        result = (Filters.caption_regex('deep') | Filters.caption_regex(r'linked param'))(update)
         assert result
         assert isinstance(result, dict)
         matches = result['matches']
         assert isinstance(matches, list)
         assert all([type(res) == SRE_TYPE for res in matches])
-        result = (
-            Filters.caption_regex('not int')
-            | Filters.caption_regex(r'linked param')
-        )(update)
+        result = (Filters.caption_regex('not int') | Filters.caption_regex(r'linked param'))(
+            update
+        )
         assert result
         assert isinstance(result, dict)
         matches = result['matches']
         assert isinstance(matches, list)
         assert all([type(res) == SRE_TYPE for res in matches])
-        result = (
-            Filters.caption_regex('not int')
-            & Filters.caption_regex(r'linked param')
-        )(update)
+        result = (Filters.caption_regex('not int') & Filters.caption_regex(r'linked param'))(
+            update
+        )
         assert not result
 
     def test_filters_merged_with_caption_regex(self, update):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -329,8 +329,8 @@ class TestFilters:
         SRE_TYPE = type(re.match("", ""))
         update.message.caption = '/start deep-linked param'
         result = (
-            Filters.caption_regex('deep') &
-            Filters.caption_regex(r'linked param')
+            Filters.caption_regex('deep')
+            & Filters.caption_regex(r'linked param')
         )(update)
         assert result
         assert isinstance(result, dict)
@@ -338,8 +338,8 @@ class TestFilters:
         assert isinstance(matches, list)
         assert all([type(res) == SRE_TYPE for res in matches])
         result = (
-            Filters.caption_regex('deep') |
-            Filters.caption_regex(r'linked param')
+            Filters.caption_regex('deep')
+            | Filters.caption_regex(r'linked param')
         )(update)
         assert result
         assert isinstance(result, dict)
@@ -347,8 +347,8 @@ class TestFilters:
         assert isinstance(matches, list)
         assert all([type(res) == SRE_TYPE for res in matches])
         result = (
-            Filters.caption_regex('not int') |
-            Filters.caption_regex(r'linked param')
+            Filters.caption_regex('not int')
+            | Filters.caption_regex(r'linked param')
         )(update)
         assert result
         assert isinstance(result, dict)
@@ -356,8 +356,8 @@ class TestFilters:
         assert isinstance(matches, list)
         assert all([type(res) == SRE_TYPE for res in matches])
         result = (
-            Filters.caption_regex('not int') &
-            Filters.caption_regex(r'linked param')
+            Filters.caption_regex('not int')
+            & Filters.caption_regex(r'linked param')
         )(update)
         assert not result
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -328,25 +328,37 @@ class TestFilters:
     def test_filters_caption_regex_multiple(self, update):
         SRE_TYPE = type(re.match("", ""))
         update.message.caption = '/start deep-linked param'
-        result = (Filters.caption_regex('deep') & Filters.caption_regex(r'linked param'))(update)
+        result = (
+            Filters.caption_regex('deep') &
+            Filters.caption_regex(r'linked param')
+        )(update)
         assert result
         assert isinstance(result, dict)
         matches = result['matches']
         assert isinstance(matches, list)
         assert all([type(res) == SRE_TYPE for res in matches])
-        result = (Filters.caption_regex('deep') | Filters.caption_regex(r'linked param'))(update)
+        result = (
+            Filters.caption_regex('deep') |
+            Filters.caption_regex(r'linked param')
+        )(update)
         assert result
         assert isinstance(result, dict)
         matches = result['matches']
         assert isinstance(matches, list)
         assert all([type(res) == SRE_TYPE for res in matches])
-        result = (Filters.caption_regex('not int') | Filters.caption_regex(r'linked param'))(update)
+        result = (
+            Filters.caption_regex('not int') |
+            Filters.caption_regex(r'linked param')
+        )(update)
         assert result
         assert isinstance(result, dict)
         matches = result['matches']
         assert isinstance(matches, list)
         assert all([type(res) == SRE_TYPE for res in matches])
-        result = (Filters.caption_regex('not int') & Filters.caption_regex(r'linked param'))(update)
+        result = (
+            Filters.caption_regex('not int') &
+            Filters.caption_regex(r'linked param')
+        )(update)
         assert not result
 
     def test_filters_merged_with_caption_regex(self, update):


### PR DESCRIPTION
Added regex matching for message caption in Filters.regex. 

I noticed that the regex filter only checks inside the message text, so if it's an image or a document it will be ignored, even if inside the caption the content could match.

Since we can already differentiate text messages and other contents using filters, I think the regex filter should work regardless of the type of message.