### PR TITLE
Add `Tuple` option to arguments type hints

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -77,6 +77,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Paul Larsen <https://github.com/PaulSonOfLars>`_
 - `Pieter Schutz <https://github.com/eldinnie>`_
 - `Poolitzer <https://github.com/Poolitzer>`_
+- `Pranjalya Tiwari <https://github.com/Pranjalya>`_
 - `Rahiel Kasim <https://github.com/rahiel>`_
 - `Riko Naka <https://github.com/rikonaka>`_
 - `Rizlas <https://github.com/rizlas>`_

--- a/telegram/ext/commandhandler.py
+++ b/telegram/ext/commandhandler.py
@@ -132,7 +132,7 @@ class CommandHandler(Handler):
 
     def __init__(
         self,
-        command: Union[str, List[str]],
+        command: Union[str, List[str], Tuple[str]],
         callback: Callable[[HandlerArg, 'CallbackContext'], RT],
         filters: BaseFilter = None,
         allow_edited: bool = None,
@@ -340,8 +340,8 @@ class PrefixHandler(CommandHandler):
 
     def __init__(
         self,
-        prefix: Union[str, List[str]],
-        command: Union[str, List[str]],
+        prefix: Union[str, List[str], Tuple[str]],
+        command: Union[str, List[str], Tuple[str]],
         callback: Callable[[HandlerArg, 'CallbackContext'], RT],
         filters: BaseFilter = None,
         pass_args: bool = False,
@@ -384,7 +384,7 @@ class PrefixHandler(CommandHandler):
         return self._prefix
 
     @prefix.setter
-    def prefix(self, prefix: Union[str, List[str]]) -> None:
+    def prefix(self, prefix: Union[str, List[str], Tuple[str]]) -> None:
         if isinstance(prefix, str):
             self._prefix = [prefix.lower()]
         else:
@@ -402,7 +402,7 @@ class PrefixHandler(CommandHandler):
         return self._command
 
     @command.setter
-    def command(self, command: Union[str, List[str]]) -> None:
+    def command(self, command: Union[str, List[str], Tuple[str]]) -> None:
         if isinstance(command, str):
             self._command = [command.lower()]
         else:

--- a/telegram/ext/commandhandler.py
+++ b/telegram/ext/commandhandler.py
@@ -385,13 +385,11 @@ class PrefixHandler(CommandHandler):
         return self._prefix
 
     @prefix.setter
-    def prefix(self, prefix: SLT[str]) -> None:
+    def prefix(self, prefix: Union[str, List[str]]) -> None:
         if isinstance(prefix, str):
             self._prefix = [prefix.lower()]
-        elif isinstance(prefix, list):
-            self._prefix = prefix
         else:
-            self._prefix = list(prefix)
+            self._prefix = prefix
         self._build_commands()
 
     @property  # type: ignore[override]
@@ -405,13 +403,11 @@ class PrefixHandler(CommandHandler):
         return self._command
 
     @command.setter
-    def command(self, command: SLT[str]) -> None:
+    def command(self, command: Union[str, List[str]]) -> None:
         if isinstance(command, str):
             self._command = [command.lower()]
-        elif isinstance(command, list):
-            self._command = command
         else:
-            self._command = list(command)
+            self._command = command
         self._build_commands()
 
     def _build_commands(self) -> None:

--- a/telegram/ext/commandhandler.py
+++ b/telegram/ext/commandhandler.py
@@ -49,7 +49,7 @@ class CommandHandler(Handler):
         :class:`telegram.ext.CommandHandler` does *not* handle (edited) channel posts.
 
     Attributes:
-        command (:class:`telegram.utils.types.SLT`[:obj:`str`]):
+        command (:class:`telegram.utils.types.SLT[str]`):
             The command or list of commands this handler should listen for.
             Limitations are the same as described here https://core.telegram.org/bots#commands
         callback (:obj:`callable`): The callback function for this handler.
@@ -83,7 +83,7 @@ class CommandHandler(Handler):
         attributes to :class:`telegram.ext.CallbackContext`. See its docs for more info.
 
     Args:
-        command (:class:`telegram.utils.types.SLT`[:obj:`str`]):
+        command (:class:`telegram.utils.types.SLT[str]`):
             The command or list of commands this handler should listen for.
             Limitations are the same as described here https://core.telegram.org/bots#commands
         callback (:obj:`callable`): The callback function for this handler. Will be called when
@@ -297,9 +297,9 @@ class PrefixHandler(CommandHandler):
         attributes to :class:`telegram.ext.CallbackContext`. See its docs for more info.
 
     Args:
-        prefix (:class:`telegram.utils.types.SLT`[:obj:`str`]):
+        prefix (:class:`telegram.utils.types.SLT[str]`):
             The prefix(es) that will precede :attr:`command`.
-        command (:class:`telegram.utils.types.SLT`[:obj:`str`]):
+        command (:class:`telegram.utils.types.SLT[str]`):
             The command or list of commands this handler should listen for.
         callback (:obj:`callable`): The callback function for this handler. Will be called when
             :attr:`check_update` has determined that an update should be processed by this handler.

--- a/telegram/ext/commandhandler.py
+++ b/telegram/ext/commandhandler.py
@@ -49,9 +49,9 @@ class CommandHandler(Handler):
         :class:`telegram.ext.CommandHandler` does *not* handle (edited) channel posts.
 
     Attributes:
-        command (SLT[:obj:`str`]): The command or list of commands this handler
-            should listen for. Limitations are the same as described here
-            https://core.telegram.org/bots#commands
+        command (:class:`telegram.utils.types.SLT`[:obj:`str`]):
+            The command or list of commands this handler should listen for.
+            Limitations are the same as described here https://core.telegram.org/bots#commands
         callback (:obj:`callable`): The callback function for this handler.
         filters (:class:`telegram.ext.BaseFilter`): Optional. Only allow updates with these
             Filters.
@@ -83,9 +83,9 @@ class CommandHandler(Handler):
         attributes to :class:`telegram.ext.CallbackContext`. See its docs for more info.
 
     Args:
-        command (SLT[:obj:`str`]): The command or list of commands this handler
-            should listen for. Limitations are the same as described here
-            https://core.telegram.org/bots#commands
+        command (:class:`telegram.utils.types.SLT`[:obj:`str`]):
+            The command or list of commands this handler should listen for.
+            Limitations are the same as described here https://core.telegram.org/bots#commands
         callback (:obj:`callable`): The callback function for this handler. Will be called when
             :attr:`check_update` has determined that an update should be processed by this handler.
             Callback signature for context based API:
@@ -297,9 +297,10 @@ class PrefixHandler(CommandHandler):
         attributes to :class:`telegram.ext.CallbackContext`. See its docs for more info.
 
     Args:
-        prefix (SLT[:obj:`str`]): The prefix(es) that will precede :attr:`command`.
-        command (SLT[:obj:`str`]): The command or list of commands this handler
-            should listen for.
+        prefix (:class:`telegram.utils.types.SLT`[:obj:`str`]):
+            The prefix(es) that will precede :attr:`command`.
+        command (:class:`telegram.utils.types.SLT`[:obj:`str`]):
+            The command or list of commands this handler should listen for.
         callback (:obj:`callable`): The callback function for this handler. Will be called when
             :attr:`check_update` has determined that an update should be processed by this handler.
             Callback signature for context based API:

--- a/telegram/ext/commandhandler.py
+++ b/telegram/ext/commandhandler.py
@@ -387,8 +387,10 @@ class PrefixHandler(CommandHandler):
     def prefix(self, prefix: Union[str, List[str], Tuple[str]]) -> None:
         if isinstance(prefix, str):
             self._prefix = [prefix.lower()]
-        else:
+        elif isinstance(prefix, list):
             self._prefix = prefix
+        else:
+            self._prefix = list(prefix)
         self._build_commands()
 
     @property  # type: ignore[override]
@@ -405,8 +407,10 @@ class PrefixHandler(CommandHandler):
     def command(self, command: Union[str, List[str], Tuple[str]]) -> None:
         if isinstance(command, str):
             self._command = [command.lower()]
-        else:
+        elif isinstance(command, list):
             self._command = command
+        else:
+            self._command = list(command)
         self._build_commands()
 
     def _build_commands(self) -> None:

--- a/telegram/ext/commandhandler.py
+++ b/telegram/ext/commandhandler.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Ty
 from telegram import MessageEntity, Update
 from telegram.ext import BaseFilter, Filters
 from telegram.utils.deprecate import TelegramDeprecationWarning
-from telegram.utils.types import HandlerArg
+from telegram.utils.types import HandlerArg, SLT
 
 from .handler import Handler
 
@@ -49,7 +49,7 @@ class CommandHandler(Handler):
         :class:`telegram.ext.CommandHandler` does *not* handle (edited) channel posts.
 
     Attributes:
-        command (:obj:`str` | List[:obj:`str`]): The command or list of commands this handler
+        command (SLT[:obj:`str`]): The command or list of commands this handler
             should listen for. Limitations are the same as described here
             https://core.telegram.org/bots#commands
         callback (:obj:`callable`): The callback function for this handler.
@@ -83,7 +83,7 @@ class CommandHandler(Handler):
         attributes to :class:`telegram.ext.CallbackContext`. See its docs for more info.
 
     Args:
-        command (:obj:`str` | List[:obj:`str`]): The command or list of commands this handler
+        command (SLT[:obj:`str`]): The command or list of commands this handler
             should listen for. Limitations are the same as described here
             https://core.telegram.org/bots#commands
         callback (:obj:`callable`): The callback function for this handler. Will be called when
@@ -132,7 +132,7 @@ class CommandHandler(Handler):
 
     def __init__(
         self,
-        command: Union[str, List[str], Tuple[str]],
+        command: SLT[str],
         callback: Callable[[HandlerArg, 'CallbackContext'], RT],
         filters: BaseFilter = None,
         allow_edited: bool = None,
@@ -297,8 +297,8 @@ class PrefixHandler(CommandHandler):
         attributes to :class:`telegram.ext.CallbackContext`. See its docs for more info.
 
     Args:
-        prefix (:obj:`str` | List[:obj:`str`]): The prefix(es) that will precede :attr:`command`.
-        command (:obj:`str` | List[:obj:`str`]): The command or list of commands this handler
+        prefix (SLT[:obj:`str`]): The prefix(es) that will precede :attr:`command`.
+        command (SLT[:obj:`str`]): The command or list of commands this handler
             should listen for.
         callback (:obj:`callable`): The callback function for this handler. Will be called when
             :attr:`check_update` has determined that an update should be processed by this handler.
@@ -340,8 +340,8 @@ class PrefixHandler(CommandHandler):
 
     def __init__(
         self,
-        prefix: Union[str, List[str], Tuple[str]],
-        command: Union[str, List[str], Tuple[str]],
+        prefix: SLT[str],
+        command: SLT[str],
         callback: Callable[[HandlerArg, 'CallbackContext'], RT],
         filters: BaseFilter = None,
         pass_args: bool = False,
@@ -384,7 +384,7 @@ class PrefixHandler(CommandHandler):
         return self._prefix
 
     @prefix.setter
-    def prefix(self, prefix: Union[str, List[str], Tuple[str]]) -> None:
+    def prefix(self, prefix: SLT[str]) -> None:
         if isinstance(prefix, str):
             self._prefix = [prefix.lower()]
         elif isinstance(prefix, list):
@@ -404,7 +404,7 @@ class PrefixHandler(CommandHandler):
         return self._command
 
     @command.setter
-    def command(self, command: Union[str, List[str], Tuple[str]]) -> None:
+    def command(self, command: SLT[str]) -> None:
         if isinstance(command, str):
             self._command = [command.lower()]
         elif isinstance(command, list):

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -24,19 +24,7 @@ import warnings
 
 from abc import ABC, abstractmethod
 from threading import Lock
-from typing import (
-    Dict,
-    FrozenSet,
-    Iterable,
-    List,
-    Match,
-    Optional,
-    Pattern,
-    Set,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import Dict, FrozenSet, List, Match, Optional, Pattern, Set, Tuple, Union, cast
 
 from telegram import Chat, Message, MessageEntity, Update
 
@@ -348,7 +336,7 @@ class Filters:
         name = 'Filters.text'
 
         class _TextStrings(MessageFilter):
-            def __init__(self, strings: Iterable[str]):
+            def __init__(self, strings: Union[List[str], Tuple[str]]):
                 self.strings = list(strings)
                 self.name = 'Filters.text({})'.format(strings)
 
@@ -1088,10 +1076,10 @@ officedocument.wordprocessingml.document")``-
                 is specified in :attr:`user_ids` and :attr:`usernames`.
 
         Args:
-            user_id(SLT[:obj:`int`], optional): Which user ID(s) to allow
-                through.
-            username(SLT[:obj:`str`], optional): Which username(s) to allow
-                through. Leading '@'s in usernames will be discarded.
+            user_id(:class:`telegram.utils.types.SLT`[:obj:`int`], optional):
+                Which user ID(s) to allow through.
+            username(:class:`telegram.utils.types.SLT`[:obj:`str`], optional):
+                Which username(s) to allow through. Leading '@'s in usernames will be discarded.
             allow_empty(:obj:`bool`, optional): Whether updates should be processed, if no user
                 is specified in :attr:`user_ids` and :attr:`usernames`. Defaults to :obj:`False`
 
@@ -1170,8 +1158,9 @@ officedocument.wordprocessingml.document")``-
             Add one or more users to the allowed usernames.
 
             Args:
-                username(SLT[:obj:`str`], optional): Which username(s) to allow
-                    through. Leading '@'s in usernames will be discarded.
+                username(:class:`telegram.utils.types.SLT`[:obj:`str`], optional):
+                    Which username(s) to allow through.
+                    Leading '@'s in usernames will be discarded.
             """
             with self.__lock:
                 if self._user_ids:
@@ -1187,8 +1176,8 @@ officedocument.wordprocessingml.document")``-
             Add one or more users to the allowed user ids.
 
             Args:
-                user_id(SLT[:obj:`int`], optional): Which user ID(s) to allow
-                    through.
+                user_id(:class:`telegram.utils.types.SLT`[:obj:`int`], optional):
+                    Which user ID(s) to allow through.
             """
             with self.__lock:
                 if self._usernames:
@@ -1205,8 +1194,9 @@ officedocument.wordprocessingml.document")``-
             Remove one or more users from allowed usernames.
 
             Args:
-                username(SLT[:obj:`str`], optional): Which username(s) to disallow
-                    through. Leading '@'s in usernames will be discarded.
+                username(:class:`telegram.utils.types.SLT`[:obj:`str`], optional):
+                    Which username(s) to disallow through.
+                    Leading '@'s in usernames will be discarded.
             """
             with self.__lock:
                 if self._user_ids:
@@ -1222,8 +1212,8 @@ officedocument.wordprocessingml.document")``-
             Remove one or more users from allowed user ids.
 
             Args:
-                user_id(SLT[:obj:`int`], optional): Which user ID(s) to disallow
-                    through.
+                user_id(:class:`telegram.utils.types.SLT`[:obj:`int`], optional):
+                    Which user ID(s) to disallow through.
             """
             with self.__lock:
                 if self._usernames:
@@ -1268,10 +1258,10 @@ officedocument.wordprocessingml.document")``-
                 is specified in :attr:`bot_ids` and :attr:`usernames`.
 
         Args:
-            bot_id(SLT[:obj:`int`], optional): Which bot ID(s) to allow
-                through.
-            username(SLT[:obj:`str`], optional): Which username(s) to allow
-                through. Leading '@'s in usernames will be discarded.
+            bot_id(:class:`telegram.utils.types.SLT`[:obj:`int`], optional):
+                Which bot ID(s) to allow through.
+            username(:class:`telegram.utils.types.SLT`[:obj:`str`], optional):
+                Which username(s) to allow through. Leading '@'s in usernames will be discarded.
             allow_empty(:obj:`bool`, optional): Whether updates should be processed, if no user
                 is specified in :attr:`bot_ids` and :attr:`usernames`. Defaults to :obj:`False`
 
@@ -1349,8 +1339,9 @@ officedocument.wordprocessingml.document")``-
             Add one or more users to the allowed usernames.
 
             Args:
-                username(SLT[:obj:`str`], optional): Which username(s) to allow
-                    through. Leading '@'s in usernames will be discarded.
+                username(:class:`telegram.utils.types.SLT`[:obj:`str`], optional):
+                    Which username(s) to allow through.
+                    Leading '@'s in usernames will be discarded.
             """
             with self.__lock:
                 if self._bot_ids:
@@ -1367,8 +1358,8 @@ officedocument.wordprocessingml.document")``-
             Add one or more users to the allowed user ids.
 
             Args:
-                bot_id(SLT[:obj:`int`], optional): Which bot ID(s) to allow
-                    through.
+                bot_id(:class:`telegram.utils.types.SLT`[:obj:`int`], optional):
+                    Which bot ID(s) to allow through.
             """
             with self.__lock:
                 if self._usernames:
@@ -1385,8 +1376,9 @@ officedocument.wordprocessingml.document")``-
             Remove one or more users from allowed usernames.
 
             Args:
-                username(SLT[:obj:`str`], optional): Which username(s) to disallow
-                    through. Leading '@'s in usernames will be discarded.
+                username(:class:`telegram.utils.types.SLT`[:obj:`str`], optional):
+                    Which username(s) to disallow through.
+                    Leading '@'s in usernames will be discarded.
             """
             with self.__lock:
                 if self._bot_ids:
@@ -1402,8 +1394,8 @@ officedocument.wordprocessingml.document")``-
             Remove one or more users from allowed user ids.
 
             Args:
-                bot_id(SLT[:obj:`int`], optional): Which bot ID(s) to disallow
-                    through.
+                bot_id(:class:`telegram.utils.types.SLT`[:obj:`int`], optional):
+                    Which bot ID(s) to disallow through.
             """
             with self.__lock:
                 if self._usernames:
@@ -1447,10 +1439,11 @@ officedocument.wordprocessingml.document")``-
                 is specified in :attr:`chat_ids` and :attr:`usernames`.
 
         Args:
-            chat_id(SLT[:obj:`int`], optional): Which chat ID(s) to allow
-                through.
-            username(SLT[:obj:`str`], optional): Which username(s) to allow
-                through. Leading `'@'` s in usernames will be discarded.
+            chat_id(:class:`telegram.utils.types.SLT`[:obj:`int`], optional):
+                Which chat ID(s) to allow through.
+            username(:class:`telegram.utils.types.SLT`[:obj:`str`], optional):
+                Which username(s) to allow through.
+                Leading `'@'` s in usernames will be discarded.
             allow_empty(:obj:`bool`, optional): Whether updates should be processed, if no chat
                 is specified in :attr:`chat_ids` and :attr:`usernames`. Defaults to :obj:`False`
 
@@ -1529,8 +1522,9 @@ officedocument.wordprocessingml.document")``-
             Add one or more chats to the allowed usernames.
 
             Args:
-                username(SLT[:obj:`str`], optional): Which username(s) to allow
-                    through. Leading `'@'` s in usernames will be discarded.
+                username(:class:`telegram.utils.types.SLT`[:obj:`str`], optional):
+                    Which username(s) to allow through.
+                    Leading `'@'` s in usernames will be discarded.
             """
             with self.__lock:
                 if self._chat_ids:
@@ -1546,8 +1540,8 @@ officedocument.wordprocessingml.document")``-
             Add one or more chats to the allowed chat ids.
 
             Args:
-                chat_id(SLT[:obj:`int`], optional): Which chat ID(s) to allow
-                    through.
+                chat_id(:class:`telegram.utils.types.SLT`[:obj:`int`], optional):
+                    Which chat ID(s) to allow through.
             """
             with self.__lock:
                 if self._usernames:
@@ -1564,8 +1558,9 @@ officedocument.wordprocessingml.document")``-
             Remove one or more chats from allowed usernames.
 
             Args:
-                username(SLT[:obj:`str`], optional): Which username(s) to disallow
-                    through. Leading '@'s in usernames will be discarded.
+                username(:class:`telegram.utils.types.SLT`[:obj:`str`], optional):
+                    Which username(s) to disallow through.
+                    Leading '@'s in usernames will be discarded.
             """
             with self.__lock:
                 if self._chat_ids:
@@ -1581,8 +1576,8 @@ officedocument.wordprocessingml.document")``-
             Remove one or more chats from allowed chat ids.
 
             Args:
-                chat_id(SLT[:obj:`int`], optional): Which chat ID(s) to disallow
-                    through.
+                chat_id(:class:`telegram.utils.types.SLT`[:obj:`int`], optional):
+                    Which chat ID(s) to disallow through.
             """
             with self.__lock:
                 if self._usernames:
@@ -1656,8 +1651,8 @@ officedocument.wordprocessingml.document")``-
         ``MessageHandler(Filters.dice([5, 6]), callback_method)``.
 
     Args:
-        update (SLT[:obj:`int`], optional): Which values to allow. If not
-            specified, will allow any dice message.
+        update (:class:`telegram.utils.types.SLT`[:obj:`int`], optional):
+            Which values to allow. If not specified, will allow any dice message.
 
     Note:
         Dice messages don't have text. If you want to filter either text or dice messages, use
@@ -1683,9 +1678,10 @@ officedocument.wordprocessingml.document")``-
             ``MessageHandler(Filters.language("en"), callback_method)``
 
         Args:
-            lang (SLT[:obj:`str`]): Which language code(s) to allow through. This
-                will be matched using ``.startswith`` meaning that 'en' will match both 'en_US'
-                and 'en_GB'.
+            lang (:class:`telegram.utils.types.SLT`[:obj:`str`]):
+                Which language code(s) to allow through.
+                This will be matched using ``.startswith`` meaning that
+                'en' will match both 'en_US' and 'en_GB'.
 
         """
 
@@ -1700,7 +1696,7 @@ officedocument.wordprocessingml.document")``-
             """"""  # remove method from docs
             return bool(
                 message.from_user.language_code
-                and any(message.from_user.language_code.startswith(x) for x in self.lang)
+                and any([message.from_user.language_code.startswith(x) for x in self.lang])
             )
 
     class _UpdateType(UpdateFilter):

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -1076,9 +1076,9 @@ officedocument.wordprocessingml.document")``-
                 is specified in :attr:`user_ids` and :attr:`usernames`.
 
         Args:
-            user_id(:class:`telegram.utils.types.SLT`[:obj:`int`], optional):
+            user_id(:class:`telegram.utils.types.SLT[int]`, optional):
                 Which user ID(s) to allow through.
-            username(:class:`telegram.utils.types.SLT`[:obj:`str`], optional):
+            username(:class:`telegram.utils.types.SLT[str]`, optional):
                 Which username(s) to allow through. Leading '@'s in usernames will be discarded.
             allow_empty(:obj:`bool`, optional): Whether updates should be processed, if no user
                 is specified in :attr:`user_ids` and :attr:`usernames`. Defaults to :obj:`False`
@@ -1158,7 +1158,7 @@ officedocument.wordprocessingml.document")``-
             Add one or more users to the allowed usernames.
 
             Args:
-                username(:class:`telegram.utils.types.SLT`[:obj:`str`], optional):
+                username(:class:`telegram.utils.types.SLT[str]`, optional):
                     Which username(s) to allow through.
                     Leading '@'s in usernames will be discarded.
             """
@@ -1176,7 +1176,7 @@ officedocument.wordprocessingml.document")``-
             Add one or more users to the allowed user ids.
 
             Args:
-                user_id(:class:`telegram.utils.types.SLT`[:obj:`int`], optional):
+                user_id(:class:`telegram.utils.types.SLT[int]`, optional):
                     Which user ID(s) to allow through.
             """
             with self.__lock:
@@ -1194,7 +1194,7 @@ officedocument.wordprocessingml.document")``-
             Remove one or more users from allowed usernames.
 
             Args:
-                username(:class:`telegram.utils.types.SLT`[:obj:`str`], optional):
+                username(:class:`telegram.utils.types.SLT[str]`, optional):
                     Which username(s) to disallow through.
                     Leading '@'s in usernames will be discarded.
             """
@@ -1212,7 +1212,7 @@ officedocument.wordprocessingml.document")``-
             Remove one or more users from allowed user ids.
 
             Args:
-                user_id(:class:`telegram.utils.types.SLT`[:obj:`int`], optional):
+                user_id(:class:`telegram.utils.types.SLT[int]`, optional):
                     Which user ID(s) to disallow through.
             """
             with self.__lock:
@@ -1258,9 +1258,9 @@ officedocument.wordprocessingml.document")``-
                 is specified in :attr:`bot_ids` and :attr:`usernames`.
 
         Args:
-            bot_id(:class:`telegram.utils.types.SLT`[:obj:`int`], optional):
+            bot_id(:class:`telegram.utils.types.SLT[int]`, optional):
                 Which bot ID(s) to allow through.
-            username(:class:`telegram.utils.types.SLT`[:obj:`str`], optional):
+            username(:class:`telegram.utils.types.SLT[str]`, optional):
                 Which username(s) to allow through. Leading '@'s in usernames will be discarded.
             allow_empty(:obj:`bool`, optional): Whether updates should be processed, if no user
                 is specified in :attr:`bot_ids` and :attr:`usernames`. Defaults to :obj:`False`
@@ -1339,7 +1339,7 @@ officedocument.wordprocessingml.document")``-
             Add one or more users to the allowed usernames.
 
             Args:
-                username(:class:`telegram.utils.types.SLT`[:obj:`str`], optional):
+                username(:class:`telegram.utils.types.SLT[str]`, optional):
                     Which username(s) to allow through.
                     Leading '@'s in usernames will be discarded.
             """
@@ -1358,7 +1358,7 @@ officedocument.wordprocessingml.document")``-
             Add one or more users to the allowed user ids.
 
             Args:
-                bot_id(:class:`telegram.utils.types.SLT`[:obj:`int`], optional):
+                bot_id(:class:`telegram.utils.types.SLT[int]`, optional):
                     Which bot ID(s) to allow through.
             """
             with self.__lock:
@@ -1376,7 +1376,7 @@ officedocument.wordprocessingml.document")``-
             Remove one or more users from allowed usernames.
 
             Args:
-                username(:class:`telegram.utils.types.SLT`[:obj:`str`], optional):
+                username(:class:`telegram.utils.types.SLT[str]`, optional):
                     Which username(s) to disallow through.
                     Leading '@'s in usernames will be discarded.
             """
@@ -1394,7 +1394,7 @@ officedocument.wordprocessingml.document")``-
             Remove one or more users from allowed user ids.
 
             Args:
-                bot_id(:class:`telegram.utils.types.SLT`[:obj:`int`], optional):
+                bot_id(:class:`telegram.utils.types.SLT[int]`, optional):
                     Which bot ID(s) to disallow through.
             """
             with self.__lock:
@@ -1439,9 +1439,9 @@ officedocument.wordprocessingml.document")``-
                 is specified in :attr:`chat_ids` and :attr:`usernames`.
 
         Args:
-            chat_id(:class:`telegram.utils.types.SLT`[:obj:`int`], optional):
+            chat_id(:class:`telegram.utils.types.SLT[int]`, optional):
                 Which chat ID(s) to allow through.
-            username(:class:`telegram.utils.types.SLT`[:obj:`str`], optional):
+            username(:class:`telegram.utils.types.SLT[str]`, optional):
                 Which username(s) to allow through.
                 Leading `'@'` s in usernames will be discarded.
             allow_empty(:obj:`bool`, optional): Whether updates should be processed, if no chat
@@ -1522,7 +1522,7 @@ officedocument.wordprocessingml.document")``-
             Add one or more chats to the allowed usernames.
 
             Args:
-                username(:class:`telegram.utils.types.SLT`[:obj:`str`], optional):
+                username(:class:`telegram.utils.types.SLT[str]`, optional):
                     Which username(s) to allow through.
                     Leading `'@'` s in usernames will be discarded.
             """
@@ -1540,7 +1540,7 @@ officedocument.wordprocessingml.document")``-
             Add one or more chats to the allowed chat ids.
 
             Args:
-                chat_id(:class:`telegram.utils.types.SLT`[:obj:`int`], optional):
+                chat_id(:class:`telegram.utils.types.SLT[int]`, optional):
                     Which chat ID(s) to allow through.
             """
             with self.__lock:
@@ -1558,7 +1558,7 @@ officedocument.wordprocessingml.document")``-
             Remove one or more chats from allowed usernames.
 
             Args:
-                username(:class:`telegram.utils.types.SLT`[:obj:`str`], optional):
+                username(:class:`telegram.utils.types.SLT[str]`, optional):
                     Which username(s) to disallow through.
                     Leading '@'s in usernames will be discarded.
             """
@@ -1576,7 +1576,7 @@ officedocument.wordprocessingml.document")``-
             Remove one or more chats from allowed chat ids.
 
             Args:
-                chat_id(:class:`telegram.utils.types.SLT`[:obj:`int`], optional):
+                chat_id(:class:`telegram.utils.types.SLT[int]`, optional):
                     Which chat ID(s) to disallow through.
             """
             with self.__lock:
@@ -1651,7 +1651,7 @@ officedocument.wordprocessingml.document")``-
         ``MessageHandler(Filters.dice([5, 6]), callback_method)``.
 
     Args:
-        update (:class:`telegram.utils.types.SLT`[:obj:`int`], optional):
+        update (:class:`telegram.utils.types.SLT[int]`, optional):
             Which values to allow. If not specified, will allow any dice message.
 
     Note:
@@ -1678,7 +1678,7 @@ officedocument.wordprocessingml.document")``-
             ``MessageHandler(Filters.language("en"), callback_method)``
 
         Args:
-            lang (:class:`telegram.utils.types.SLT`[:obj:`str`]):
+            lang (:class:`telegram.utils.types.SLT[str]`):
                 Which language code(s) to allow through.
                 This will be matched using ``.startswith`` meaning that
                 'en' will match both 'en_US' and 'en_GB'.

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -24,7 +24,7 @@ import warnings
 
 from abc import ABC, abstractmethod
 from threading import Lock
-from typing import Dict, FrozenSet, List, Match, Optional, Pattern, Set, Union, cast
+from typing import Dict, FrozenSet, List, Match, Optional, Pattern, Set, Tuple, Union, cast
 
 from telegram import Chat, Message, MessageEntity, Update
 
@@ -280,7 +280,7 @@ class _DiceEmoji(MessageFilter):
         self.emoji = emoji
 
     class _DiceValues(MessageFilter):
-        def __init__(self, values: Union[int, List[int]], name: str, emoji: str = None):
+        def __init__(self, values: Union[int, List[int], Tuple[int]], name: str, emoji: str = None):
             self.values = [values] if isinstance(values, int) else values
             self.emoji = emoji
             self.name = '{}({})'.format(name, values)
@@ -293,7 +293,7 @@ class _DiceEmoji(MessageFilter):
             return False
 
     def __call__(  # type: ignore[override]
-        self, update: Union[Update, List[int]]
+        self, update: Union[Update, List[int], Tuple[int]]
     ) -> Union[bool, '_DiceValues']:
         if isinstance(update, Update):
             return self.filter(update.effective_message)
@@ -340,7 +340,7 @@ class Filters:
                 return False
 
         def __call__(  # type: ignore[override]
-            self, update: Union[Update, List[str]]
+            self, update: Union[Update, List[str], Tuple[str]]
         ) -> Union[bool, '_TextStrings']:
             if isinstance(update, Update):
                 return self.filter(update.effective_message)
@@ -391,7 +391,7 @@ class Filters:
                 return False
 
         def __call__(  # type: ignore[override]
-            self, update: Union[Update, List[str]]
+            self, update: Union[Update, List[str], Tuple[str]]
         ) -> Union[bool, '_CaptionStrings']:
             if isinstance(update, Update):
                 return self.filter(update.effective_message)
@@ -1084,8 +1084,8 @@ officedocument.wordprocessingml.document")``-
 
         def __init__(
             self,
-            user_id: Union[int, List[int]] = None,
-            username: Union[str, List[str]] = None,
+            user_id: Union[int, List[int], Tuple[int]] = None,
+            username: Union[str, List[str], Tuple[str]] = None,
             allow_empty: bool = False,
         ):
             self.allow_empty = allow_empty
@@ -1098,7 +1098,7 @@ officedocument.wordprocessingml.document")``-
             self._set_usernames(username)
 
         @staticmethod
-        def _parse_user_id(user_id: Union[int, List[int]]) -> Set[int]:
+        def _parse_user_id(user_id: Union[int, List[int], Tuple[int]]) -> Set[int]:
             if user_id is None:
                 return set()
             if isinstance(user_id, int):
@@ -1106,14 +1106,14 @@ officedocument.wordprocessingml.document")``-
             return set(user_id)
 
         @staticmethod
-        def _parse_username(username: Union[str, List[str]]) -> Set[str]:
+        def _parse_username(username: Union[str, List[str], Tuple[str]]) -> Set[str]:
             if username is None:
                 return set()
             if isinstance(username, str):
                 return {username[1:] if username.startswith('@') else username}
             return {user[1:] if user.startswith('@') else user for user in username}
 
-        def _set_user_ids(self, user_id: Union[int, List[int]]) -> None:
+        def _set_user_ids(self, user_id: Union[int, List[int], Tuple[int]]) -> None:
             with self.__lock:
                 if user_id and self._usernames:
                     raise RuntimeError(
@@ -1121,7 +1121,7 @@ officedocument.wordprocessingml.document")``-
                     )
                 self._user_ids = self._parse_user_id(user_id)
 
-        def _set_usernames(self, username: Union[str, List[str]]) -> None:
+        def _set_usernames(self, username: Union[str, List[str], Tuple[str]]) -> None:
             with self.__lock:
                 if username and self._user_ids:
                     raise RuntimeError(
@@ -1135,7 +1135,7 @@ officedocument.wordprocessingml.document")``-
                 return frozenset(self._user_ids)
 
         @user_ids.setter
-        def user_ids(self, user_id: Union[int, List[int]]) -> None:
+        def user_ids(self, user_id: Union[int, List[int], Tuple[int]]) -> None:
             self._set_user_ids(user_id)
 
         @property
@@ -1144,10 +1144,10 @@ officedocument.wordprocessingml.document")``-
                 return frozenset(self._usernames)
 
         @usernames.setter
-        def usernames(self, username: Union[str, List[str]]) -> None:
+        def usernames(self, username: Union[str, List[str], Tuple[str]]) -> None:
             self._set_usernames(username)
 
-        def add_usernames(self, username: Union[str, List[str]]) -> None:
+        def add_usernames(self, username: Union[str, List[str], Tuple[str]]) -> None:
             """
             Add one or more users to the allowed usernames.
 
@@ -1164,7 +1164,7 @@ officedocument.wordprocessingml.document")``-
                 parsed_username = self._parse_username(username)
                 self._usernames |= parsed_username
 
-        def add_user_ids(self, user_id: Union[int, List[int]]) -> None:
+        def add_user_ids(self, user_id: Union[int, List[int], Tuple[int]]) -> None:
             """
             Add one or more users to the allowed user ids.
 
@@ -1182,7 +1182,7 @@ officedocument.wordprocessingml.document")``-
 
                 self._user_ids |= parsed_user_id
 
-        def remove_usernames(self, username: Union[str, List[str]]) -> None:
+        def remove_usernames(self, username: Union[str, List[str], Tuple[str]]) -> None:
             """
             Remove one or more users from allowed usernames.
 
@@ -1199,7 +1199,7 @@ officedocument.wordprocessingml.document")``-
                 parsed_username = self._parse_username(username)
                 self._usernames -= parsed_username
 
-        def remove_user_ids(self, user_id: Union[int, List[int]]) -> None:
+        def remove_user_ids(self, user_id: Union[int, List[int], Tuple[int]]) -> None:
             """
             Remove one or more users from allowed user ids.
 
@@ -1263,8 +1263,8 @@ officedocument.wordprocessingml.document")``-
 
         def __init__(
             self,
-            bot_id: Union[int, List[int]] = None,
-            username: Union[str, List[str]] = None,
+            bot_id: Union[int, List[int], Tuple[int]] = None,
+            username: Union[str, List[str], Tuple[str]] = None,
             allow_empty: bool = False,
         ):
             self.allow_empty = allow_empty
@@ -1277,7 +1277,7 @@ officedocument.wordprocessingml.document")``-
             self._set_usernames(username)
 
         @staticmethod
-        def _parse_bot_id(bot_id: Union[int, List[int]]) -> Set[int]:
+        def _parse_bot_id(bot_id: Union[int, List[int], Tuple[int]]) -> Set[int]:
             if bot_id is None:
                 return set()
             if isinstance(bot_id, int):
@@ -1285,14 +1285,14 @@ officedocument.wordprocessingml.document")``-
             return set(bot_id)
 
         @staticmethod
-        def _parse_username(username: Union[str, List[str]]) -> Set[str]:
+        def _parse_username(username: Union[str, List[str], Tuple[str]]) -> Set[str]:
             if username is None:
                 return set()
             if isinstance(username, str):
                 return {username[1:] if username.startswith('@') else username}
             return {bot[1:] if bot.startswith('@') else bot for bot in username}
 
-        def _set_bot_ids(self, bot_id: Union[int, List[int]]) -> None:
+        def _set_bot_ids(self, bot_id: Union[int, List[int], Tuple[int]]) -> None:
             with self.__lock:
                 if bot_id and self._usernames:
                     raise RuntimeError(
@@ -1300,7 +1300,7 @@ officedocument.wordprocessingml.document")``-
                     )
                 self._bot_ids = self._parse_bot_id(bot_id)
 
-        def _set_usernames(self, username: Union[str, List[str]]) -> None:
+        def _set_usernames(self, username: Union[str, List[str], Tuple[str]]) -> None:
             with self.__lock:
                 if username and self._bot_ids:
                     raise RuntimeError(
@@ -1314,7 +1314,7 @@ officedocument.wordprocessingml.document")``-
                 return frozenset(self._bot_ids)
 
         @bot_ids.setter
-        def bot_ids(self, bot_id: Union[int, List[int]]) -> None:
+        def bot_ids(self, bot_id: Union[int, List[int], Tuple[int]]) -> None:
             self._set_bot_ids(bot_id)
 
         @property
@@ -1323,10 +1323,10 @@ officedocument.wordprocessingml.document")``-
                 return frozenset(self._usernames)
 
         @usernames.setter
-        def usernames(self, username: Union[str, List[str]]) -> None:
+        def usernames(self, username: Union[str, List[str], Tuple[str]]) -> None:
             self._set_usernames(username)
 
-        def add_usernames(self, username: Union[str, List[str]]) -> None:
+        def add_usernames(self, username: Union[str, List[str], Tuple[str]]) -> None:
             """
             Add one or more users to the allowed usernames.
 
@@ -1343,7 +1343,7 @@ officedocument.wordprocessingml.document")``-
                 parsed_username = self._parse_username(username)
                 self._usernames |= parsed_username
 
-        def add_bot_ids(self, bot_id: Union[int, List[int]]) -> None:
+        def add_bot_ids(self, bot_id: Union[int, List[int], Tuple[int]]) -> None:
             """
 
             Add one or more users to the allowed user ids.
@@ -1362,7 +1362,7 @@ officedocument.wordprocessingml.document")``-
 
                 self._bot_ids |= parsed_bot_id
 
-        def remove_usernames(self, username: Union[str, List[str]]) -> None:
+        def remove_usernames(self, username: Union[str, List[str], Tuple[str]]) -> None:
             """
             Remove one or more users from allowed usernames.
 
@@ -1379,7 +1379,7 @@ officedocument.wordprocessingml.document")``-
                 parsed_username = self._parse_username(username)
                 self._usernames -= parsed_username
 
-        def remove_bot_ids(self, bot_id: Union[int, List[int]]) -> None:
+        def remove_bot_ids(self, bot_id: Union[int, List[int], Tuple[int]]) -> None:
             """
             Remove one or more users from allowed user ids.
 
@@ -1443,8 +1443,8 @@ officedocument.wordprocessingml.document")``-
 
         def __init__(
             self,
-            chat_id: Union[int, List[int]] = None,
-            username: Union[str, List[str]] = None,
+            chat_id: Union[int, List[int], Tuple[int]] = None,
+            username: Union[str, List[str], Tuple[str]] = None,
             allow_empty: bool = False,
         ):
             self.allow_empty = allow_empty
@@ -1457,7 +1457,7 @@ officedocument.wordprocessingml.document")``-
             self._set_usernames(username)
 
         @staticmethod
-        def _parse_chat_id(chat_id: Union[int, List[int]]) -> Set[int]:
+        def _parse_chat_id(chat_id: Union[int, List[int], Tuple[int]]) -> Set[int]:
             if chat_id is None:
                 return set()
             if isinstance(chat_id, int):
@@ -1465,14 +1465,14 @@ officedocument.wordprocessingml.document")``-
             return set(chat_id)
 
         @staticmethod
-        def _parse_username(username: Union[str, List[str]]) -> Set[str]:
+        def _parse_username(username: Union[str, List[str], Tuple[str]]) -> Set[str]:
             if username is None:
                 return set()
             if isinstance(username, str):
                 return {username[1:] if username.startswith('@') else username}
             return {chat[1:] if chat.startswith('@') else chat for chat in username}
 
-        def _set_chat_ids(self, chat_id: Union[int, List[int]]) -> None:
+        def _set_chat_ids(self, chat_id: Union[int, List[int], Tuple[int]]) -> None:
             with self.__lock:
                 if chat_id and self._usernames:
                     raise RuntimeError(
@@ -1480,7 +1480,7 @@ officedocument.wordprocessingml.document")``-
                     )
                 self._chat_ids = self._parse_chat_id(chat_id)
 
-        def _set_usernames(self, username: Union[str, List[str]]) -> None:
+        def _set_usernames(self, username: Union[str, List[str], Tuple[str]]) -> None:
             with self.__lock:
                 if username and self._chat_ids:
                     raise RuntimeError(
@@ -1494,7 +1494,7 @@ officedocument.wordprocessingml.document")``-
                 return frozenset(self._chat_ids)
 
         @chat_ids.setter
-        def chat_ids(self, chat_id: Union[int, List[int]]) -> None:
+        def chat_ids(self, chat_id: Union[int, List[int], Tuple[int]]) -> None:
             self._set_chat_ids(chat_id)
 
         @property
@@ -1503,10 +1503,10 @@ officedocument.wordprocessingml.document")``-
                 return frozenset(self._usernames)
 
         @usernames.setter
-        def usernames(self, username: Union[str, List[str]]) -> None:
+        def usernames(self, username: Union[str, List[str], Tuple[str]]) -> None:
             self._set_usernames(username)
 
-        def add_usernames(self, username: Union[str, List[str]]) -> None:
+        def add_usernames(self, username: Union[str, List[str], Tuple[str]]) -> None:
             """
             Add one or more chats to the allowed usernames.
 
@@ -1523,7 +1523,7 @@ officedocument.wordprocessingml.document")``-
                 parsed_username = self._parse_username(username)
                 self._usernames |= parsed_username
 
-        def add_chat_ids(self, chat_id: Union[int, List[int]]) -> None:
+        def add_chat_ids(self, chat_id: Union[int, List[int], Tuple[int]]) -> None:
             """
             Add one or more chats to the allowed chat ids.
 
@@ -1541,7 +1541,7 @@ officedocument.wordprocessingml.document")``-
 
                 self._chat_ids |= parsed_chat_id
 
-        def remove_usernames(self, username: Union[str, List[str]]) -> None:
+        def remove_usernames(self, username: Union[str, List[str], Tuple[str]]) -> None:
             """
             Remove one or more chats from allowed usernames.
 
@@ -1558,7 +1558,7 @@ officedocument.wordprocessingml.document")``-
                 parsed_username = self._parse_username(username)
                 self._usernames -= parsed_username
 
-        def remove_chat_ids(self, chat_id: Union[int, List[int]]) -> None:
+        def remove_chat_ids(self, chat_id: Union[int, List[int], Tuple[int]]) -> None:
             """
             Remove one or more chats from allowed chat ids.
 
@@ -1671,12 +1671,15 @@ officedocument.wordprocessingml.document")``-
 
         """
 
-        def __init__(self, lang: Union[str, List[str]]):
+        def __init__(self, lang: Union[str, List[str], Tuple[str]]):
             if isinstance(lang, str):
                 lang = cast(str, lang)
                 self.lang = [lang]
-            else:
+            elif isinstance(lang, List[str]):
                 lang = cast(List[str], lang)
+                self.lang = lang
+            else:
+                lang = cast(Tuple[str], lang)
                 self.lang = lang
             self.name = 'Filters.language({})'.format(self.lang)
 

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -24,7 +24,19 @@ import warnings
 
 from abc import ABC, abstractmethod
 from threading import Lock
-from typing import Dict, FrozenSet, List, Match, Optional, Pattern, Set, Tuple, Union, cast
+from typing import (
+    Dict,
+    FrozenSet,
+    Iterable,
+    List,
+    Match,
+    Optional,
+    Pattern,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
 
 from telegram import Chat, Message, MessageEntity, Update
 
@@ -280,7 +292,12 @@ class _DiceEmoji(MessageFilter):
         self.emoji = emoji
 
     class _DiceValues(MessageFilter):
-        def __init__(self, values: Union[int, List[int], Tuple[int]], name: str, emoji: str = None):
+        def __init__(
+            self,
+            values: Union[int, List[int], Tuple[int]],
+            name: str,
+            emoji: str = None,
+        ):
             self.values = [values] if isinstance(values, int) else values
             self.emoji = emoji
             self.name = '{}({})'.format(name, values)
@@ -330,8 +347,8 @@ class Filters:
         name = 'Filters.text'
 
         class _TextStrings(MessageFilter):
-            def __init__(self, strings: List[str]):
-                self.strings = strings
+            def __init__(self, strings: Iterable[str]):
+                self.strings = list(strings)
                 self.name = 'Filters.text({})'.format(strings)
 
             def filter(self, message: Message) -> bool:
@@ -381,8 +398,8 @@ class Filters:
         name = 'Filters.caption'
 
         class _CaptionStrings(MessageFilter):
-            def __init__(self, strings: List[str]):
-                self.strings = strings
+            def __init__(self, strings: Union[List[str], Tuple[str]]):
+                self.strings = list(strings)
                 self.name = 'Filters.caption({})'.format(strings)
 
             def filter(self, message: Message) -> bool:
@@ -1665,29 +1682,25 @@ officedocument.wordprocessingml.document")``-
             ``MessageHandler(Filters.language("en"), callback_method)``
 
         Args:
-            lang (:obj:`str` | List[:obj:`str`]): Which language code(s) to allow through. This
+            lang (:obj:`str` | Iterable[:obj:`str`]): Which language code(s) to allow through. This
                 will be matched using ``.startswith`` meaning that 'en' will match both 'en_US'
                 and 'en_GB'.
 
         """
 
-        def __init__(self, lang: Union[str, List[str], Tuple[str]]):
+        def __init__(self, lang: Union[str, Iterable[str]]):
             if isinstance(lang, str):
-                lang = cast(str, lang)
                 self.lang = [lang]
-            elif isinstance(lang, List[str]):
-                lang = cast(List[str], lang)
-                self.lang = lang
             else:
-                lang = cast(Tuple[str], lang)
+                lang = list(lang)
                 self.lang = lang
-            self.name = 'Filters.language({})'.format(self.lang)
+            self.name = 'Filters.language({})'.format(lang)
 
         def filter(self, message: Message) -> bool:
             """"""  # remove method from docs
             return bool(
                 message.from_user.language_code
-                and any([message.from_user.language_code.startswith(x) for x in self.lang])
+                and any(message.from_user.language_code.startswith(x) for x in self.lang)
             )
 
     class _UpdateType(UpdateFilter):

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -50,6 +50,7 @@ __all__ = [
 ]
 
 from telegram.utils.deprecate import TelegramDeprecationWarning
+from telegram.utils.types import SLT
 
 
 class BaseFilter(ABC):
@@ -294,11 +295,11 @@ class _DiceEmoji(MessageFilter):
     class _DiceValues(MessageFilter):
         def __init__(
             self,
-            values: Union[int, List[int], Tuple[int]],
+            values: SLT[int],
             name: str,
             emoji: str = None,
         ):
-            self.values = [values] if isinstance(values, int) else values
+            self.values = [values] if isinstance(values, int) else list(values)
             self.emoji = emoji
             self.name = '{}({})'.format(name, values)
 
@@ -1087,9 +1088,9 @@ officedocument.wordprocessingml.document")``-
                 is specified in :attr:`user_ids` and :attr:`usernames`.
 
         Args:
-            user_id(:obj:`int` | List[:obj:`int`], optional): Which user ID(s) to allow
+            user_id(SLT[:obj:`int`], optional): Which user ID(s) to allow
                 through.
-            username(:obj:`str` | List[:obj:`str`], optional): Which username(s) to allow
+            username(SLT[:obj:`str`], optional): Which username(s) to allow
                 through. Leading '@'s in usernames will be discarded.
             allow_empty(:obj:`bool`, optional): Whether updates should be processed, if no user
                 is specified in :attr:`user_ids` and :attr:`usernames`. Defaults to :obj:`False`
@@ -1101,8 +1102,8 @@ officedocument.wordprocessingml.document")``-
 
         def __init__(
             self,
-            user_id: Union[int, List[int], Tuple[int]] = None,
-            username: Union[str, List[str], Tuple[str]] = None,
+            user_id: SLT[int] = None,
+            username: SLT[str] = None,
             allow_empty: bool = False,
         ):
             self.allow_empty = allow_empty
@@ -1115,7 +1116,7 @@ officedocument.wordprocessingml.document")``-
             self._set_usernames(username)
 
         @staticmethod
-        def _parse_user_id(user_id: Union[int, List[int], Tuple[int]]) -> Set[int]:
+        def _parse_user_id(user_id: SLT[int]) -> Set[int]:
             if user_id is None:
                 return set()
             if isinstance(user_id, int):
@@ -1123,14 +1124,14 @@ officedocument.wordprocessingml.document")``-
             return set(user_id)
 
         @staticmethod
-        def _parse_username(username: Union[str, List[str], Tuple[str]]) -> Set[str]:
+        def _parse_username(username: SLT[str]) -> Set[str]:
             if username is None:
                 return set()
             if isinstance(username, str):
                 return {username[1:] if username.startswith('@') else username}
             return {user[1:] if user.startswith('@') else user for user in username}
 
-        def _set_user_ids(self, user_id: Union[int, List[int], Tuple[int]]) -> None:
+        def _set_user_ids(self, user_id: SLT[int]) -> None:
             with self.__lock:
                 if user_id and self._usernames:
                     raise RuntimeError(
@@ -1138,7 +1139,7 @@ officedocument.wordprocessingml.document")``-
                     )
                 self._user_ids = self._parse_user_id(user_id)
 
-        def _set_usernames(self, username: Union[str, List[str], Tuple[str]]) -> None:
+        def _set_usernames(self, username: SLT[str]) -> None:
             with self.__lock:
                 if username and self._user_ids:
                     raise RuntimeError(
@@ -1152,7 +1153,7 @@ officedocument.wordprocessingml.document")``-
                 return frozenset(self._user_ids)
 
         @user_ids.setter
-        def user_ids(self, user_id: Union[int, List[int], Tuple[int]]) -> None:
+        def user_ids(self, user_id: SLT[int]) -> None:
             self._set_user_ids(user_id)
 
         @property
@@ -1161,15 +1162,15 @@ officedocument.wordprocessingml.document")``-
                 return frozenset(self._usernames)
 
         @usernames.setter
-        def usernames(self, username: Union[str, List[str], Tuple[str]]) -> None:
+        def usernames(self, username: SLT[str]) -> None:
             self._set_usernames(username)
 
-        def add_usernames(self, username: Union[str, List[str], Tuple[str]]) -> None:
+        def add_usernames(self, username: SLT[str]) -> None:
             """
             Add one or more users to the allowed usernames.
 
             Args:
-                username(:obj:`str` | List[:obj:`str`], optional): Which username(s) to allow
+                username(SLT[:obj:`str`], optional): Which username(s) to allow
                     through. Leading '@'s in usernames will be discarded.
             """
             with self.__lock:
@@ -1181,12 +1182,12 @@ officedocument.wordprocessingml.document")``-
                 parsed_username = self._parse_username(username)
                 self._usernames |= parsed_username
 
-        def add_user_ids(self, user_id: Union[int, List[int], Tuple[int]]) -> None:
+        def add_user_ids(self, user_id: SLT[int]) -> None:
             """
             Add one or more users to the allowed user ids.
 
             Args:
-                user_id(:obj:`int` | List[:obj:`int`], optional): Which user ID(s) to allow
+                user_id(SLT[:obj:`int`], optional): Which user ID(s) to allow
                     through.
             """
             with self.__lock:
@@ -1199,12 +1200,12 @@ officedocument.wordprocessingml.document")``-
 
                 self._user_ids |= parsed_user_id
 
-        def remove_usernames(self, username: Union[str, List[str], Tuple[str]]) -> None:
+        def remove_usernames(self, username: SLT[str]) -> None:
             """
             Remove one or more users from allowed usernames.
 
             Args:
-                username(:obj:`str` | List[:obj:`str`], optional): Which username(s) to disallow
+                username(SLT[:obj:`str`], optional): Which username(s) to disallow
                     through. Leading '@'s in usernames will be discarded.
             """
             with self.__lock:
@@ -1216,12 +1217,12 @@ officedocument.wordprocessingml.document")``-
                 parsed_username = self._parse_username(username)
                 self._usernames -= parsed_username
 
-        def remove_user_ids(self, user_id: Union[int, List[int], Tuple[int]]) -> None:
+        def remove_user_ids(self, user_id: SLT[int]) -> None:
             """
             Remove one or more users from allowed user ids.
 
             Args:
-                user_id(:obj:`int` | List[:obj:`int`], optional): Which user ID(s) to disallow
+                user_id(SLT[:obj:`int`], optional): Which user ID(s) to disallow
                     through.
             """
             with self.__lock:
@@ -1267,9 +1268,9 @@ officedocument.wordprocessingml.document")``-
                 is specified in :attr:`bot_ids` and :attr:`usernames`.
 
         Args:
-            bot_id(:obj:`int` | List[:obj:`int`], optional): Which bot ID(s) to allow
+            bot_id(SLT[:obj:`int`], optional): Which bot ID(s) to allow
                 through.
-            username(:obj:`str` | List[:obj:`str`], optional): Which username(s) to allow
+            username(SLT[:obj:`str`], optional): Which username(s) to allow
                 through. Leading '@'s in usernames will be discarded.
             allow_empty(:obj:`bool`, optional): Whether updates should be processed, if no user
                 is specified in :attr:`bot_ids` and :attr:`usernames`. Defaults to :obj:`False`
@@ -1280,8 +1281,8 @@ officedocument.wordprocessingml.document")``-
 
         def __init__(
             self,
-            bot_id: Union[int, List[int], Tuple[int]] = None,
-            username: Union[str, List[str], Tuple[str]] = None,
+            bot_id: SLT[int] = None,
+            username: SLT[str] = None,
             allow_empty: bool = False,
         ):
             self.allow_empty = allow_empty
@@ -1294,7 +1295,7 @@ officedocument.wordprocessingml.document")``-
             self._set_usernames(username)
 
         @staticmethod
-        def _parse_bot_id(bot_id: Union[int, List[int], Tuple[int]]) -> Set[int]:
+        def _parse_bot_id(bot_id: SLT[int]) -> Set[int]:
             if bot_id is None:
                 return set()
             if isinstance(bot_id, int):
@@ -1302,14 +1303,14 @@ officedocument.wordprocessingml.document")``-
             return set(bot_id)
 
         @staticmethod
-        def _parse_username(username: Union[str, List[str], Tuple[str]]) -> Set[str]:
+        def _parse_username(username: SLT[str]) -> Set[str]:
             if username is None:
                 return set()
             if isinstance(username, str):
                 return {username[1:] if username.startswith('@') else username}
             return {bot[1:] if bot.startswith('@') else bot for bot in username}
 
-        def _set_bot_ids(self, bot_id: Union[int, List[int], Tuple[int]]) -> None:
+        def _set_bot_ids(self, bot_id: SLT[int]) -> None:
             with self.__lock:
                 if bot_id and self._usernames:
                     raise RuntimeError(
@@ -1317,7 +1318,7 @@ officedocument.wordprocessingml.document")``-
                     )
                 self._bot_ids = self._parse_bot_id(bot_id)
 
-        def _set_usernames(self, username: Union[str, List[str], Tuple[str]]) -> None:
+        def _set_usernames(self, username: SLT[str]) -> None:
             with self.__lock:
                 if username and self._bot_ids:
                     raise RuntimeError(
@@ -1331,7 +1332,7 @@ officedocument.wordprocessingml.document")``-
                 return frozenset(self._bot_ids)
 
         @bot_ids.setter
-        def bot_ids(self, bot_id: Union[int, List[int], Tuple[int]]) -> None:
+        def bot_ids(self, bot_id: SLT[int]) -> None:
             self._set_bot_ids(bot_id)
 
         @property
@@ -1340,15 +1341,15 @@ officedocument.wordprocessingml.document")``-
                 return frozenset(self._usernames)
 
         @usernames.setter
-        def usernames(self, username: Union[str, List[str], Tuple[str]]) -> None:
+        def usernames(self, username: SLT[str]) -> None:
             self._set_usernames(username)
 
-        def add_usernames(self, username: Union[str, List[str], Tuple[str]]) -> None:
+        def add_usernames(self, username: SLT[str]) -> None:
             """
             Add one or more users to the allowed usernames.
 
             Args:
-                username(:obj:`str` | List[:obj:`str`], optional): Which username(s) to allow
+                username(SLT[:obj:`str`], optional): Which username(s) to allow
                     through. Leading '@'s in usernames will be discarded.
             """
             with self.__lock:
@@ -1360,13 +1361,13 @@ officedocument.wordprocessingml.document")``-
                 parsed_username = self._parse_username(username)
                 self._usernames |= parsed_username
 
-        def add_bot_ids(self, bot_id: Union[int, List[int], Tuple[int]]) -> None:
+        def add_bot_ids(self, bot_id: SLT[int]) -> None:
             """
 
             Add one or more users to the allowed user ids.
 
             Args:
-                bot_id(:obj:`int` | List[:obj:`int`], optional): Which bot ID(s) to allow
+                bot_id(SLT[:obj:`int`], optional): Which bot ID(s) to allow
                     through.
             """
             with self.__lock:
@@ -1379,12 +1380,12 @@ officedocument.wordprocessingml.document")``-
 
                 self._bot_ids |= parsed_bot_id
 
-        def remove_usernames(self, username: Union[str, List[str], Tuple[str]]) -> None:
+        def remove_usernames(self, username: SLT[str]) -> None:
             """
             Remove one or more users from allowed usernames.
 
             Args:
-                username(:obj:`str` | List[:obj:`str`], optional): Which username(s) to disallow
+                username(SLT[:obj:`str`], optional): Which username(s) to disallow
                     through. Leading '@'s in usernames will be discarded.
             """
             with self.__lock:
@@ -1396,12 +1397,12 @@ officedocument.wordprocessingml.document")``-
                 parsed_username = self._parse_username(username)
                 self._usernames -= parsed_username
 
-        def remove_bot_ids(self, bot_id: Union[int, List[int], Tuple[int]]) -> None:
+        def remove_bot_ids(self, bot_id: SLT[int]) -> None:
             """
             Remove one or more users from allowed user ids.
 
             Args:
-                bot_id(:obj:`int` | List[:obj:`int`], optional): Which bot ID(s) to disallow
+                bot_id(SLT[:obj:`int`], optional): Which bot ID(s) to disallow
                     through.
             """
             with self.__lock:
@@ -1446,9 +1447,9 @@ officedocument.wordprocessingml.document")``-
                 is specified in :attr:`chat_ids` and :attr:`usernames`.
 
         Args:
-            chat_id(:obj:`int` | List[:obj:`int`], optional): Which chat ID(s) to allow
+            chat_id(SLT[:obj:`int`], optional): Which chat ID(s) to allow
                 through.
-            username(:obj:`str` | List[:obj:`str`], optional): Which username(s) to allow
+            username(SLT[:obj:`str`], optional): Which username(s) to allow
                 through. Leading `'@'` s in usernames will be discarded.
             allow_empty(:obj:`bool`, optional): Whether updates should be processed, if no chat
                 is specified in :attr:`chat_ids` and :attr:`usernames`. Defaults to :obj:`False`
@@ -1460,8 +1461,8 @@ officedocument.wordprocessingml.document")``-
 
         def __init__(
             self,
-            chat_id: Union[int, List[int], Tuple[int]] = None,
-            username: Union[str, List[str], Tuple[str]] = None,
+            chat_id: SLT[int] = None,
+            username: SLT[str] = None,
             allow_empty: bool = False,
         ):
             self.allow_empty = allow_empty
@@ -1474,7 +1475,7 @@ officedocument.wordprocessingml.document")``-
             self._set_usernames(username)
 
         @staticmethod
-        def _parse_chat_id(chat_id: Union[int, List[int], Tuple[int]]) -> Set[int]:
+        def _parse_chat_id(chat_id: SLT[int]) -> Set[int]:
             if chat_id is None:
                 return set()
             if isinstance(chat_id, int):
@@ -1482,14 +1483,14 @@ officedocument.wordprocessingml.document")``-
             return set(chat_id)
 
         @staticmethod
-        def _parse_username(username: Union[str, List[str], Tuple[str]]) -> Set[str]:
+        def _parse_username(username: SLT[str]) -> Set[str]:
             if username is None:
                 return set()
             if isinstance(username, str):
                 return {username[1:] if username.startswith('@') else username}
             return {chat[1:] if chat.startswith('@') else chat for chat in username}
 
-        def _set_chat_ids(self, chat_id: Union[int, List[int], Tuple[int]]) -> None:
+        def _set_chat_ids(self, chat_id: SLT[int]) -> None:
             with self.__lock:
                 if chat_id and self._usernames:
                     raise RuntimeError(
@@ -1497,7 +1498,7 @@ officedocument.wordprocessingml.document")``-
                     )
                 self._chat_ids = self._parse_chat_id(chat_id)
 
-        def _set_usernames(self, username: Union[str, List[str], Tuple[str]]) -> None:
+        def _set_usernames(self, username: SLT[str]) -> None:
             with self.__lock:
                 if username and self._chat_ids:
                     raise RuntimeError(
@@ -1511,7 +1512,7 @@ officedocument.wordprocessingml.document")``-
                 return frozenset(self._chat_ids)
 
         @chat_ids.setter
-        def chat_ids(self, chat_id: Union[int, List[int], Tuple[int]]) -> None:
+        def chat_ids(self, chat_id: SLT[int]) -> None:
             self._set_chat_ids(chat_id)
 
         @property
@@ -1520,15 +1521,15 @@ officedocument.wordprocessingml.document")``-
                 return frozenset(self._usernames)
 
         @usernames.setter
-        def usernames(self, username: Union[str, List[str], Tuple[str]]) -> None:
+        def usernames(self, username: SLT[str]) -> None:
             self._set_usernames(username)
 
-        def add_usernames(self, username: Union[str, List[str], Tuple[str]]) -> None:
+        def add_usernames(self, username: SLT[str]) -> None:
             """
             Add one or more chats to the allowed usernames.
 
             Args:
-                username(:obj:`str` | List[:obj:`str`], optional): Which username(s) to allow
+                username(SLT[:obj:`str`], optional): Which username(s) to allow
                     through. Leading `'@'` s in usernames will be discarded.
             """
             with self.__lock:
@@ -1540,12 +1541,12 @@ officedocument.wordprocessingml.document")``-
                 parsed_username = self._parse_username(username)
                 self._usernames |= parsed_username
 
-        def add_chat_ids(self, chat_id: Union[int, List[int], Tuple[int]]) -> None:
+        def add_chat_ids(self, chat_id: SLT[int]) -> None:
             """
             Add one or more chats to the allowed chat ids.
 
             Args:
-                chat_id(:obj:`int` | List[:obj:`int`], optional): Which chat ID(s) to allow
+                chat_id(SLT[:obj:`int`], optional): Which chat ID(s) to allow
                     through.
             """
             with self.__lock:
@@ -1558,12 +1559,12 @@ officedocument.wordprocessingml.document")``-
 
                 self._chat_ids |= parsed_chat_id
 
-        def remove_usernames(self, username: Union[str, List[str], Tuple[str]]) -> None:
+        def remove_usernames(self, username: SLT[str]) -> None:
             """
             Remove one or more chats from allowed usernames.
 
             Args:
-                username(:obj:`str` | List[:obj:`str`], optional): Which username(s) to disallow
+                username(SLT[:obj:`str`], optional): Which username(s) to disallow
                     through. Leading '@'s in usernames will be discarded.
             """
             with self.__lock:
@@ -1575,12 +1576,12 @@ officedocument.wordprocessingml.document")``-
                 parsed_username = self._parse_username(username)
                 self._usernames -= parsed_username
 
-        def remove_chat_ids(self, chat_id: Union[int, List[int], Tuple[int]]) -> None:
+        def remove_chat_ids(self, chat_id: SLT[int]) -> None:
             """
             Remove one or more chats from allowed chat ids.
 
             Args:
-                chat_id(:obj:`int` | List[:obj:`int`], optional): Which chat ID(s) to disallow
+                chat_id(SLT[:obj:`int`], optional): Which chat ID(s) to disallow
                     through.
             """
             with self.__lock:
@@ -1655,7 +1656,7 @@ officedocument.wordprocessingml.document")``-
         ``MessageHandler(Filters.dice([5, 6]), callback_method)``.
 
     Args:
-        update (:obj:`int` | List[:obj:`int`], optional): Which values to allow. If not
+        update (SLT[:obj:`int`], optional): Which values to allow. If not
             specified, will allow any dice message.
 
     Note:
@@ -1682,19 +1683,18 @@ officedocument.wordprocessingml.document")``-
             ``MessageHandler(Filters.language("en"), callback_method)``
 
         Args:
-            lang (:obj:`str` | Iterable[:obj:`str`]): Which language code(s) to allow through. This
+            lang (SLT[:obj:`str`]): Which language code(s) to allow through. This
                 will be matched using ``.startswith`` meaning that 'en' will match both 'en_US'
                 and 'en_GB'.
 
         """
 
-        def __init__(self, lang: Union[str, Iterable[str]]):
+        def __init__(self, lang: SLT[str]):
             if isinstance(lang, str):
                 self.lang = [lang]
             else:
-                lang = list(lang)
-                self.lang = lang
-            self.name = 'Filters.language({})'.format(lang)
+                self.lang = list(lang)
+            self.name = 'Filters.language({})'.format(self.lang)
 
         def filter(self, message: Message) -> bool:
             """"""  # remove method from docs

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -287,7 +287,7 @@ class _DiceEmoji(MessageFilter):
             name: str,
             emoji: str = None,
         ):
-            self.values = [values] if isinstance(values, int) else list(values)
+            self.values = [values] if isinstance(values, int) else values
             self.emoji = emoji
             self.name = '{}({})'.format(name, values)
 
@@ -337,7 +337,7 @@ class Filters:
 
         class _TextStrings(MessageFilter):
             def __init__(self, strings: Union[List[str], Tuple[str]]):
-                self.strings = list(strings)
+                self.strings = strings
                 self.name = 'Filters.text({})'.format(strings)
 
             def filter(self, message: Message) -> bool:
@@ -388,7 +388,7 @@ class Filters:
 
         class _CaptionStrings(MessageFilter):
             def __init__(self, strings: Union[List[str], Tuple[str]]):
-                self.strings = list(strings)
+                self.strings = strings
                 self.name = 'Filters.caption({})'.format(strings)
 
             def filter(self, message: Message) -> bool:
@@ -1687,9 +1687,11 @@ officedocument.wordprocessingml.document")``-
 
         def __init__(self, lang: SLT[str]):
             if isinstance(lang, str):
+                lang = cast(str, lang)
                 self.lang = [lang]
             else:
-                self.lang = list(lang)
+                lang = cast(List[str], lang)
+                self.lang = lang
             self.name = 'Filters.language({})'.format(self.lang)
 
         def filter(self, message: Message) -> bool:

--- a/telegram/utils/types.py
+++ b/telegram/utils/types.py
@@ -22,8 +22,6 @@ from typing import IO, TYPE_CHECKING, Any, Dict, List, Optional, Tuple, TypeVar,
 if TYPE_CHECKING:
     from telegram import InputFile, Update
 
-RT = TypeVar("RT")
-
 FileLike = Union[IO, 'InputFile']
 """Either an open file handler or in :class:`telegram.InputFile`."""
 
@@ -36,5 +34,6 @@ HandlerArg = Union[str, 'Update']
 ConversationDict = Dict[Tuple[int, ...], Optional[object]]
 """Dicts as maintained by the :class:`telegram.ext.ConversationHandler`."""
 
+RT = TypeVar("RT")
 SLT = Union[RT, List[RT], Tuple[RT, ...]]
 """Single instance or list/tuple of instances."""

--- a/telegram/utils/types.py
+++ b/telegram/utils/types.py
@@ -17,10 +17,12 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains custom typing aliases."""
-from typing import IO, TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
+from typing import IO, TYPE_CHECKING, Any, Dict, List, Optional, Tuple, TypeVar, Union
 
 if TYPE_CHECKING:
     from telegram import InputFile, Update
+
+RT = TypeVar("RT")
 
 FileLike = Union[IO, 'InputFile']
 """Either an open file handler or in :class:`telegram.InputFile`."""
@@ -33,3 +35,6 @@ HandlerArg = Union[str, 'Update']
 
 ConversationDict = Dict[Tuple[int, ...], Optional[object]]
 """Dicts as maintained by the :class:`telegram.ext.ConversationHandler`."""
+
+SLT = Union[RT, List[RT], Tuple[RT, ...]]
+"""Single instance or list/tuple of instances."""

--- a/tests/test_commandhandler.py
+++ b/tests/test_commandhandler.py
@@ -397,8 +397,6 @@ class TestPrefixHandler(BaseTest):
         handler = self.make_default_handler()
         handler.prefix = ['?', '§']
         assert handler._commands == list(combinations(['?', '§'], self.COMMANDS))
-        handler.prefix = ('!', '^')
-        assert handler._commands == list(combinations(['!', '^'], self.COMMANDS))
         handler.prefix = '+'
         assert handler._commands == list(combinations(['+'], self.COMMANDS))
 
@@ -406,10 +404,6 @@ class TestPrefixHandler(BaseTest):
         handler = self.make_default_handler()
         handler.command = 'foo'
         assert handler._commands == list(combinations(self.PREFIXES, ['foo']))
-        handler.command = ['foo', 'bar']
-        assert handler._commands == list(combinations(self.PREFIXES, ['foo', 'bar']))
-        handler.command = ('baz', 'fiz')
-        assert handler._commands == list(combinations(self.PREFIXES, ['baz', 'fiz']))
 
     def test_basic_after_editing(self, dp, prefix, command):
         """Test the basic expected response from a prefix handler"""

--- a/tests/test_commandhandler.py
+++ b/tests/test_commandhandler.py
@@ -397,6 +397,8 @@ class TestPrefixHandler(BaseTest):
         handler = self.make_default_handler()
         handler.prefix = ['?', '§']
         assert handler._commands == list(combinations(['?', '§'], self.COMMANDS))
+        handler.prefix = ('!', '^')
+        assert handler._commands == list(combinations(['!', '^'], self.COMMANDS))
         handler.prefix = '+'
         assert handler._commands == list(combinations(['+'], self.COMMANDS))
 
@@ -404,6 +406,10 @@ class TestPrefixHandler(BaseTest):
         handler = self.make_default_handler()
         handler.command = 'foo'
         assert handler._commands == list(combinations(self.PREFIXES, ['foo']))
+        handler.command = ['foo', 'bar']
+        assert handler._commands == list(combinations(self.PREFIXES, ['foo', 'bar']))
+        handler.command = ('baz', 'fiz')
+        assert handler._commands == list(combinations(self.PREFIXES, ['baz', 'fiz']))
 
     def test_basic_after_editing(self, dp, prefix, command):
         """Test the basic expected response from a prefix handler"""


### PR DESCRIPTION
closes #2125.

Based on https://github.com/python-telegram-bot/python-telegram-bot/pull/2152 with a little fix. closes #2152 