### PR TITLE
API 5.0 WP5 - Pinned messages

### DIFF
--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -3711,7 +3711,7 @@ class Bot(TelegramObject):
         api_kwargs: JSONDict = None,
     ) -> bool:
         """
-        Use this method to remove a message from the list of pinned messages in a chat. If the
+        Use this method to clear the list of pinned messages in a chat. If the
         chat is not a private chat, the bot must be an administrator in the chat for this
         to work and must have the ``can_pin_messages`` admin right in a supergroup or
         ``can_edit_messages`` admin right in a channel.

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -3628,10 +3628,10 @@ class Bot(TelegramObject):
         api_kwargs: JSONDict = None,
     ) -> bool:
         """
-        Use this method to pin a message in a group, a supergroup, or a channel.
-        The bot must be an administrator in the chat for this to work and must have the
-        ‘can_pin_messages’ admin right in the supergroup or ‘can_edit_messages’ admin right
-        in the channel.
+        Use this method to add a message to the list of pinned messages in a chat. If the
+        chat is not a private chat, the bot must be an administrator in the chat for this to work
+        and must have the ``can_pin_messages`` admin right in a supergroup or ``can_edit_messages``
+        admin right in a channel.
 
         Args:
             chat_id (:obj:`int` | :obj:`str`): Unique identifier for the target chat or username
@@ -3664,13 +3664,57 @@ class Bot(TelegramObject):
 
     @log
     def unpin_chat_message(
-        self, chat_id: Union[str, int], timeout: float = None, api_kwargs: JSONDict = None
+        self,
+        chat_id: Union[str, int],
+        message_id: Union[str, int] = None,
+        timeout: float = None,
+        api_kwargs: JSONDict = None,
     ) -> bool:
         """
-        Use this method to unpin a message in a group, a supergroup, or a channel.
-        The bot must be an administrator in the chat for this to work and must have the
-        ``can_pin_messages`` admin right in the supergroup or ``can_edit_messages`` admin right
-        in the channel.
+        Use this method to remove a message from the list of pinned messages in a chat. If the
+        chat is not a private chat, the bot must be an administrator in the chat for this to work
+        and must have the ``can_pin_messages`` admin right in a supergroup or ``can_edit_messages``
+        admin right in a channel.
+
+        Args:
+            chat_id (:obj:`int` | :obj:`str`): Unique identifier for the target chat or username
+                of the target channel (in the format @channelusername).
+            message_id (:obj:`int`, optional): Identifier of a message to unpin. If not specified,
+                the most recent pinned message (by sending date) will be unpinned.
+            timeout (:obj:`int` | :obj:`float`, optional): If this value is specified, use it as
+                the read timeout from the server (instead of the one specified during creation of
+                the connection pool).
+            api_kwargs (:obj:`dict`, optional): Arbitrary keyword arguments to be passed to the
+                Telegram API.
+
+        Returns:
+            :obj:`bool`: On success, :obj:`True` is returned.
+
+        Raises:
+            :class:`telegram.TelegramError`
+
+        """
+        data: JSONDict = {'chat_id': chat_id}
+
+        if message_id is not None:
+            data['message_id'] = message_id
+
+        result = self._post('unpinChatMessage', data, timeout=timeout, api_kwargs=api_kwargs)
+
+        return result  # type: ignore[return-value]
+
+    @log
+    def unpin_all_chat_messages(
+        self,
+        chat_id: Union[str, int],
+        timeout: float = None,
+        api_kwargs: JSONDict = None,
+    ) -> bool:
+        """
+        Use this method to remove a message from the list of pinned messages in a chat. If the
+        chat is not a private chat, the bot must be an administrator in the chat for this
+        to work and must have the ``can_pin_messages`` admin right in a supergroup or
+        ``can_edit_messages`` admin right in a channel.
 
         Args:
             chat_id (:obj:`int` | :obj:`str`): Unique identifier for the target chat or username
@@ -3688,9 +3732,10 @@ class Bot(TelegramObject):
             :class:`telegram.TelegramError`
 
         """
+
         data: JSONDict = {'chat_id': chat_id}
 
-        result = self._post('unpinChatMessage', data, timeout=timeout, api_kwargs=api_kwargs)
+        result = self._post('unpinAllChatMessages', data, timeout=timeout, api_kwargs=api_kwargs)
 
         return result  # type: ignore[return-value]
 
@@ -4483,6 +4528,8 @@ class Bot(TelegramObject):
     """Alias for :attr:`pin_chat_message`"""
     unpinChatMessage = unpin_chat_message
     """Alias for :attr:`unpin_chat_message`"""
+    unpinAllChatMessages = unpin_all_chat_messages
+    """Alias for :attr:`unpin_all_chat_messages`"""
     getStickerSet = get_sticker_set
     """Alias for :attr:`get_sticker_set`"""
     uploadStickerFile = upload_sticker_file

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -3638,8 +3638,8 @@ class Bot(TelegramObject):
                 of the target channel (in the format @channelusername).
             message_id (:obj:`int`): Identifier of a message to pin.
             disable_notification (:obj:`bool`, optional): Pass :obj:`True`, if it is not necessary
-                to send a notification to all group members about the new pinned message.
-                Notifications are always disabled in channels.
+                to send a notification to all chat members about the new pinned message.
+                Notifications are always disabled in channels and private chats.
             timeout (:obj:`int` | :obj:`float`, optional): If this value is specified, use it as
                 the read timeout from the server (instead of the one specified during creation of
                 the connection pool).
@@ -3658,17 +3658,17 @@ class Bot(TelegramObject):
         if disable_notification is not None:
             data['disable_notification'] = disable_notification
 
-        result = self._post('pinChatMessage', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'pinChatMessage', data, timeout=timeout, api_kwargs=api_kwargs
+        )  # type: ignore[return-value]
 
     @log
     def unpin_chat_message(
         self,
         chat_id: Union[str, int],
-        message_id: Union[str, int] = None,
         timeout: float = None,
         api_kwargs: JSONDict = None,
+        message_id: Union[str, int] = None,
     ) -> bool:
         """
         Use this method to remove a message from the list of pinned messages in a chat. If the
@@ -3699,9 +3699,9 @@ class Bot(TelegramObject):
         if message_id is not None:
             data['message_id'] = message_id
 
-        result = self._post('unpinChatMessage', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'unpinChatMessage', data, timeout=timeout, api_kwargs=api_kwargs
+        )  # type: ignore[return-value]
 
     @log
     def unpin_all_chat_messages(
@@ -3735,9 +3735,9 @@ class Bot(TelegramObject):
 
         data: JSONDict = {'chat_id': chat_id}
 
-        result = self._post('unpinAllChatMessages', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'unpinAllChatMessages', data, timeout=timeout, api_kwargs=api_kwargs
+        )  # type: ignore[return-value]
 
     @log
     def get_sticker_set(

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -3658,9 +3658,9 @@ class Bot(TelegramObject):
         if disable_notification is not None:
             data['disable_notification'] = disable_notification
 
-        return self._post(
+        return self._post(  # type: ignore[return-value]
             'pinChatMessage', data, timeout=timeout, api_kwargs=api_kwargs
-        )  # type: ignore[return-value]
+        )
 
     @log
     def unpin_chat_message(
@@ -3699,9 +3699,9 @@ class Bot(TelegramObject):
         if message_id is not None:
             data['message_id'] = message_id
 
-        return self._post(
+        return self._post(  # type: ignore[return-value]
             'unpinChatMessage', data, timeout=timeout, api_kwargs=api_kwargs
-        )  # type: ignore[return-value]
+        )
 
     @log
     def unpin_all_chat_messages(
@@ -3735,9 +3735,9 @@ class Bot(TelegramObject):
 
         data: JSONDict = {'chat_id': chat_id}
 
-        return self._post(
+        return self._post(  # type: ignore[return-value]
             'unpinAllChatMessages', data, timeout=timeout, api_kwargs=api_kwargs
-        )  # type: ignore[return-value]
+        )
 
     @log
     def get_sticker_set(

--- a/telegram/callbackquery.py
+++ b/telegram/callbackquery.py
@@ -329,7 +329,7 @@ class CallbackQuery(TelegramObject):
     def pin_message(self, *args: Any, **kwargs: Any) -> bool:
         """Shortcut for::
 
-             bot.pin_chat_message(chat_id=update.callback_query.message.chat_id,
+             bot.pin_chat_message(chat_id=message.chat_id,
                                   *args,
                                   **kwargs)
 
@@ -342,7 +342,7 @@ class CallbackQuery(TelegramObject):
     def unpin_message(self, *args: Any, **kwargs: Any) -> bool:
         """Shortcut for::
 
-             bot.unpin_chat_message(chat_id=update.callback_query.message.chat_id,
+             bot.unpin_chat_message(chat_id=message.chat_id,
                                     *args,
                                     **kwargs)
 

--- a/telegram/callbackquery.py
+++ b/telegram/callbackquery.py
@@ -325,3 +325,29 @@ class CallbackQuery(TelegramObject):
 
         """
         return self.message.delete(*args, **kwargs)
+
+    def pin_message(self, *args: Any, **kwargs: Any) -> bool:
+        """Shortcut for::
+
+             bot.pin_chat_message(chat_id=update.callback_query.message.chat_id,
+                                  *args,
+                                  **kwargs)
+
+        Returns:
+            :obj:`bool`: On success, :obj:`True` is returned.
+
+        """
+        return self.bot.pin_chat_message(self.message.chat_id, *args, **kwargs)
+
+    def unpin_message(self, *args: Any, **kwargs: Any) -> bool:
+        """Shortcut for::
+
+             bot.unpin_chat_message(chat_id=update.callback_query.message.chat_id,
+                                    *args,
+                                    **kwargs)
+
+        Returns:
+            :obj:`bool`: On success, :obj:`True` is returned.
+
+        """
+        return self.bot.unpin_chat_message(self.message.chat_id, *args, **kwargs)

--- a/telegram/callbackquery.py
+++ b/telegram/callbackquery.py
@@ -330,6 +330,7 @@ class CallbackQuery(TelegramObject):
         """Shortcut for::
 
              bot.pin_chat_message(chat_id=message.chat_id,
+                                  message_id=message.message_id,
                                   *args,
                                   **kwargs)
 
@@ -343,6 +344,7 @@ class CallbackQuery(TelegramObject):
         """Shortcut for::
 
              bot.unpin_chat_message(chat_id=message.chat_id,
+                                    message_id=message.message_id,
                                     *args,
                                     **kwargs)
 

--- a/telegram/callbackquery.py
+++ b/telegram/callbackquery.py
@@ -337,7 +337,7 @@ class CallbackQuery(TelegramObject):
             :obj:`bool`: On success, :obj:`True` is returned.
 
         """
-        return self.bot.pin_chat_message(self.message.chat_id, *args, **kwargs)
+        return self.message.pin(*args, **kwargs)
 
     def unpin_message(self, *args: Any, **kwargs: Any) -> bool:
         """Shortcut for::
@@ -350,4 +350,4 @@ class CallbackQuery(TelegramObject):
             :obj:`bool`: On success, :obj:`True` is returned.
 
         """
-        return self.bot.unpin_chat_message(self.message.chat_id, *args, **kwargs)
+        return self.message.unpin(*args, **kwargs)

--- a/telegram/chat.py
+++ b/telegram/chat.py
@@ -277,6 +277,32 @@ class Chat(TelegramObject):
         """
         return self.bot.set_chat_administrator_custom_title(self.id, *args, **kwargs)
 
+    def pin_message(self, *args: Any, **kwargs: Any) -> bool:
+        """Shortcut for::
+
+             bot.pin_chat_message(chat_id=update.effective_chat.id,
+                                  *args,
+                                  **kwargs)
+
+        Returns:
+            :obj:`bool`: On success, :obj:`True` is returned.
+
+        """
+        return self.bot.pin_chat_message(self.id, *args, **kwargs)
+
+    def unpin_message(self, *args: Any, **kwargs: Any) -> bool:
+        """Shortcut for::
+
+             bot.unpin_chat_message(chat_id=update.effective_chat.id,
+                                    *args,
+                                    **kwargs)
+
+        Returns:
+            :obj:`bool`: On success, :obj:`True` is returned.
+
+        """
+        return self.bot.unpin_chat_message(self.id, *args, **kwargs)
+
     def unpin_all_messages(self, *args: Any, **kwargs: Any) -> bool:
         """Shortcut for::
 

--- a/telegram/chat.py
+++ b/telegram/chat.py
@@ -46,8 +46,8 @@ class Chat(TelegramObject):
         photo (:class:`telegram.ChatPhoto`): Optional. Chat photo.
         description (:obj:`str`): Optional. Description, for groups, supergroups and channel chats.
         invite_link (:obj:`str`): Optional. Chat invite link, for supergroups and channel chats.
-        pinned_message (:class:`telegram.Message`): Optional. Pinned message, for supergroups.
-            Returned only in :meth:`telegram.Bot.get_chat`.
+        pinned_message (:class:`telegram.Message`): Optional. The most recent pinned message
+            (by sending date). Returned only in :meth:`telegram.Bot.get_chat`.
         permissions (:class:`telegram.ChatPermissions`): Optional. Default chat member permissions,
             for groups and supergroups. Returned only in :meth:`telegram.Bot.get_chat`.
         slow_mode_delay (:obj:`int`): Optional. For supergroups, the minimum allowed delay between
@@ -77,8 +77,8 @@ class Chat(TelegramObject):
             chats. Each administrator in a chat generates their own invite links, so the bot must
             first generate the link using ``export_chat_invite_link()``. Returned only
             in :meth:`telegram.Bot.get_chat`.
-        pinned_message (:class:`telegram.Message`, optional): Pinned message, for groups,
-            supergroups and channels. Returned only in :meth:`telegram.Bot.get_chat`.
+        pinned_message (:class:`telegram.Message`, optional): The most recent pinned message
+            (by sending date). Returned only in :meth:`telegram.Bot.get_chat`.
         permissions (:class:`telegram.ChatPermissions`): Optional. Default chat member permissions,
             for groups and supergroups. Returned only in :meth:`telegram.Bot.get_chat`.
         slow_mode_delay (:obj:`int`, optional): For supergroups, the minimum allowed delay between
@@ -276,6 +276,19 @@ class Chat(TelegramObject):
 
         """
         return self.bot.set_chat_administrator_custom_title(self.id, *args, **kwargs)
+
+    def unpin_all_chat_messages(self, *args: Any, **kwargs: Any) -> bool:
+        """Shortcut for::
+
+             bot.unpin_all_chat_messages(chat_id=message.chat_id,
+                                         *args,
+                                         **kwargs)
+
+        Returns:
+            :obj:`True`: On success.
+
+        """
+        return self.bot.unpin_all_chat_messages(chat_id=self.id, *args, **kwargs)
 
     def send_message(self, *args: Any, **kwargs: Any) -> 'Message':
         """Shortcut for::

--- a/telegram/chat.py
+++ b/telegram/chat.py
@@ -277,15 +277,15 @@ class Chat(TelegramObject):
         """
         return self.bot.set_chat_administrator_custom_title(self.id, *args, **kwargs)
 
-    def unpin_all_chat_messages(self, *args: Any, **kwargs: Any) -> bool:
+    def unpin_all_messages(self, *args: Any, **kwargs: Any) -> bool:
         """Shortcut for::
 
-             bot.unpin_all_chat_messages(chat_id=message.chat_id,
+             bot.unpin_all_chat_messages(chat_id=update.effective_chat.id,
                                          *args,
                                          **kwargs)
 
         Returns:
-            :obj:`True`: On success.
+            :obj:`bool`: On success, :obj:`True` is returned.
 
         """
         return self.bot.unpin_all_chat_messages(chat_id=self.id, *args, **kwargs)

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -1143,6 +1143,22 @@ class Message(TelegramObject):
             chat_id=self.chat_id, message_id=self.message_id, *args, **kwargs
         )
 
+    def unpin(self, *args: Any, **kwargs: Any) -> bool:
+        """Shortcut for::
+
+             bot.unpin_chat_message(chat_id=message.chat_id,
+                                    message_id=message.message_id,
+                                    *args,
+                                    **kwargs)
+
+        Returns:
+            :obj:`True`: On success.
+
+        """
+        return self.bot.unpin_chat_message(
+            chat_id=self.chat_id, message_id=self.message_id, *args, **kwargs
+        )
+
     def parse_entity(self, entity: MessageEntity) -> str:
         """Returns the text from a given :class:`telegram.MessageEntity`.
 

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -1136,7 +1136,7 @@ class Message(TelegramObject):
                                   **kwargs)
 
         Returns:
-            :obj:`True`: On success.
+            :obj:`bool`: On success, :obj:`True` is returned.
 
         """
         return self.bot.pin_chat_message(
@@ -1152,7 +1152,7 @@ class Message(TelegramObject):
                                     **kwargs)
 
         Returns:
-            :obj:`True`: On success.
+            :obj:`bool`: On success, :obj:`True` is returned.
 
         """
         return self.bot.unpin_chat_message(

--- a/telegram/user.py
+++ b/telegram/user.py
@@ -189,6 +189,45 @@ class User(TelegramObject):
             return util_mention_html(self.id, name)
         return util_mention_html(self.id, self.full_name)
 
+    def pin_message(self, *args: Any, **kwargs: Any) -> bool:
+        """Shortcut for::
+
+             bot.pin_chat_message(chat_id=update.effective_user.id,
+                                  *args,
+                                  **kwargs)
+
+        Returns:
+            :obj:`bool`: On success, :obj:`True` is returned.
+
+        """
+        return self.bot.pin_chat_message(self.id, *args, **kwargs)
+
+    def unpin_message(self, *args: Any, **kwargs: Any) -> bool:
+        """Shortcut for::
+
+             bot.unpin_chat_message(chat_id=update.effective_user.id,
+                                    *args,
+                                    **kwargs)
+
+        Returns:
+            :obj:`bool`: On success, :obj:`True` is returned.
+
+        """
+        return self.bot.unpin_chat_message(self.id, *args, **kwargs)
+
+    def unpin_all_messages(self, *args: Any, **kwargs: Any) -> bool:
+        """Shortcut for::
+
+             bot.unpin_all_chat_messages(chat_id=update.effective_user.id,
+                                         *args,
+                                         **kwargs)
+
+        Returns:
+            :obj:`bool`: On success, :obj:`True` is returned.
+
+        """
+        return self.bot.unpin_all_chat_messages(self.id, *args, **kwargs)
+
     def send_message(self, *args: Any, **kwargs: Any) -> 'Message':
         """Shortcut for::
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1281,7 +1281,7 @@ class TestBot:
         chat = bot.get_chat(super_group_id)
         assert chat.pinned_message == message3
 
-        assert bot.unpinChatMessage(super_group_id, message2.message_id)
+        assert bot.unpin_chat_message(super_group_id, message_id=message2.message_id)
         assert bot.unpin_chat_message(super_group_id)
 
         assert bot.unpin_all_chat_messages(super_group_id)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1263,15 +1263,22 @@ class TestBot:
     @flaky(3, 1)
     @pytest.mark.timeout(10)
     def test_pin_and_unpin_message(self, bot, super_group_id):
-        message = bot.send_message(super_group_id, text="test_pin_message")
+        message1 = bot.send_message(super_group_id, text="test_pin_message_1")
+        message2 = bot.send_message(super_group_id, text="test_pin_message_2")
+        message3 = bot.send_message(super_group_id, text="test_pin_message_3")
+
         assert bot.pin_chat_message(
-            chat_id=super_group_id, message_id=message.message_id, disable_notification=True
+            chat_id=super_group_id, message_id=message1.message_id, disable_notification=True
         )
+        message2.pin()
+        message3.pin()
 
         chat = bot.get_chat(super_group_id)
-        assert chat.pinned_message == message
+        assert chat.pinned_message == message3
 
-        assert bot.unpinChatMessage(super_group_id)
+        assert bot.unpinChatMessage(super_group_id, message2.message_id)
+
+        assert bot.unpin_all_chat_messages(super_group_id)
 
     # get_sticker_set, upload_sticker_file, create_new_sticker_set, add_sticker_to_set,
     # set_sticker_position_in_set and delete_sticker_from_set are tested in the

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1270,13 +1270,19 @@ class TestBot:
         assert bot.pin_chat_message(
             chat_id=super_group_id, message_id=message1.message_id, disable_notification=True
         )
-        message2.pin()
-        message3.pin()
+
+        bot.pin_chat_message(
+            chat_id=super_group_id, message_id=message2.message_id, disable_notification=True
+        )
+        bot.pin_chat_message(
+            chat_id=super_group_id, message_id=message3.message_id, disable_notification=True
+        )
 
         chat = bot.get_chat(super_group_id)
         assert chat.pinned_message == message3
 
         assert bot.unpinChatMessage(super_group_id, message2.message_id)
+        assert bot.unpin_chat_message(super_group_id)
 
         assert bot.unpin_all_chat_messages(super_group_id)
 

--- a/tests/test_callbackquery.py
+++ b/tests/test_callbackquery.py
@@ -228,7 +228,11 @@ class TestCallbackQuery:
             pytest.skip("Can't pin inline messages")
 
         def make_assertion(*args, **kwargs):
-            return args[0] == callback_query.message.chat_id
+            _id = callback_query.message.chat_id
+            try:
+                return kwargs['chat_id'] == _id
+            except KeyError:
+                return args[0] == _id
 
         monkeypatch.setattr(callback_query.bot, 'pin_chat_message', make_assertion)
         assert callback_query.pin_message()
@@ -238,7 +242,11 @@ class TestCallbackQuery:
             pytest.skip("Can't unpin inline messages")
 
         def make_assertion(*args, **kwargs):
-            return args[0] == callback_query.message.chat_id
+            _id = callback_query.message.chat_id
+            try:
+                return kwargs['chat_id'] == _id
+            except KeyError:
+                return args[0] == _id
 
         monkeypatch.setattr(callback_query.bot, 'unpin_chat_message', make_assertion)
         assert callback_query.unpin_message()

--- a/tests/test_callbackquery.py
+++ b/tests/test_callbackquery.py
@@ -223,6 +223,26 @@ class TestCallbackQuery:
         monkeypatch.setattr(callback_query.bot, 'delete_message', make_assertion)
         assert callback_query.delete_message()
 
+    def test_pin_message(self, monkeypatch, callback_query):
+        if callback_query.inline_message_id:
+            pytest.skip("Can't pin inline messages")
+
+        def make_assertion(*args, **kwargs):
+            return args[0] == callback_query.message.chat_id
+
+        monkeypatch.setattr(callback_query.bot, 'pin_chat_message', make_assertion)
+        assert callback_query.pin_message()
+
+    def test_unpin_message(self, monkeypatch, callback_query):
+        if callback_query.inline_message_id:
+            pytest.skip("Can't unpin inline messages")
+
+        def make_assertion(*args, **kwargs):
+            return args[0] == callback_query.message.chat_id
+
+        monkeypatch.setattr(callback_query.bot, 'unpin_chat_message', make_assertion)
+        assert callback_query.unpin_message()
+
     def test_equality(self):
         a = CallbackQuery(self.id_, self.from_user, 'chat')
         b = CallbackQuery(self.id_, self.from_user, 'chat')

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -183,6 +183,13 @@ class TestChat:
         monkeypatch.setattr('telegram.Bot.set_chat_administrator_custom_title', test)
         assert chat.set_administrator_custom_title(42, 'custom_title')
 
+    def test_unpin_all_chat_messages(self, monkeypatch, chat):
+        def test(*args, **kwargs):
+            return kwargs['chat_id'] == chat.id
+
+        monkeypatch.setattr(chat.bot, 'unpin_all_chat_messages', test)
+        assert chat.unpin_all_chat_messages()
+
     def test_instance_method_send_message(self, monkeypatch, chat):
         def test(*args, **kwargs):
             return args[0] == chat.id and args[1] == 'test'

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -183,12 +183,12 @@ class TestChat:
         monkeypatch.setattr('telegram.Bot.set_chat_administrator_custom_title', test)
         assert chat.set_administrator_custom_title(42, 'custom_title')
 
-    def test_unpin_all_chat_messages(self, monkeypatch, chat):
-        def test(*args, **kwargs):
+    def test_unpin_all_messages(self, monkeypatch, chat):
+        def make_assertion(*args, **kwargs):
             return kwargs['chat_id'] == chat.id
 
-        monkeypatch.setattr(chat.bot, 'unpin_all_chat_messages', test)
-        assert chat.unpin_all_chat_messages()
+        monkeypatch.setattr(chat.bot, 'unpin_all_chat_messages', make_assertion)
+        assert chat.unpin_all_messages()
 
     def test_instance_method_send_message(self, monkeypatch, chat):
         def test(*args, **kwargs):

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -183,9 +183,32 @@ class TestChat:
         monkeypatch.setattr('telegram.Bot.set_chat_administrator_custom_title', test)
         assert chat.set_administrator_custom_title(42, 'custom_title')
 
+    def test_pin_message(self, monkeypatch, chat):
+        def make_assertion(*args, **kwargs):
+            try:
+                return kwargs['chat_id'] == chat.id
+            except KeyError:
+                return args[0] == chat.id
+
+        monkeypatch.setattr(chat.bot, 'pin_chat_message', make_assertion)
+        assert chat.pin_message()
+
+    def test_unpin_message(self, monkeypatch, chat):
+        def make_assertion(*args, **kwargs):
+            try:
+                return kwargs['chat_id'] == chat.id
+            except KeyError:
+                return args[0] == chat.id
+
+        monkeypatch.setattr(chat.bot, 'unpin_chat_message', make_assertion)
+        assert chat.unpin_message()
+
     def test_unpin_all_messages(self, monkeypatch, chat):
         def make_assertion(*args, **kwargs):
-            return kwargs['chat_id'] == chat.id
+            try:
+                return kwargs['chat_id'] == chat.id
+            except KeyError:
+                return args[0] == chat.id
 
         monkeypatch.setattr(chat.bot, 'unpin_all_chat_messages', make_assertion)
         assert chat.unpin_all_messages()

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1044,21 +1044,21 @@ class TestMessage:
         assert message.stop_poll()
 
     def test_pin(self, monkeypatch, message):
-        def test(*args, **kwargs):
+        def make_assertion(*args, **kwargs):
             chat_id = kwargs['chat_id'] == message.chat_id
             message_id = kwargs['message_id'] == message.message_id
             return chat_id and message_id
 
-        monkeypatch.setattr(message.bot, 'pin_chat_message', test)
+        monkeypatch.setattr(message.bot, 'pin_chat_message', make_assertion)
         assert message.pin()
 
     def test_unpin(self, monkeypatch, message):
-        def test(*args, **kwargs):
+        def make_assertion(*args, **kwargs):
             chat_id = kwargs['chat_id'] == message.chat_id
             message_id = kwargs['message_id'] == message.message_id
             return chat_id and message_id
 
-        monkeypatch.setattr(message.bot, 'unpin_chat_message', test)
+        monkeypatch.setattr(message.bot, 'unpin_chat_message', make_assertion)
         assert message.unpin()
 
     def test_default_quote(self, message):

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1052,6 +1052,15 @@ class TestMessage:
         monkeypatch.setattr(message.bot, 'pin_chat_message', test)
         assert message.pin()
 
+    def test_unpin(self, monkeypatch, message):
+        def test(*args, **kwargs):
+            chat_id = kwargs['chat_id'] == message.chat_id
+            message_id = kwargs['message_id'] == message.message_id
+            return chat_id and message_id
+
+        monkeypatch.setattr(message.bot, 'unpin_chat_message', test)
+        assert message.unpin()
+
     def test_default_quote(self, message):
         message.bot.defaults = Defaults()
         kwargs = {}

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -144,6 +144,27 @@ class TestUser:
         monkeypatch.setattr(user.bot, 'get_user_profile_photos', test)
         assert user.get_profile_photos()
 
+    def test_pin_message(self, monkeypatch, user):
+        def make_assertion(*args, **kwargs):
+            return args[0] == user.id
+
+        monkeypatch.setattr(user.bot, 'pin_chat_message', make_assertion)
+        assert user.pin_message()
+
+    def test_unpin_message(self, monkeypatch, user):
+        def make_assertion(*args, **kwargs):
+            return args[0] == user.id
+
+        monkeypatch.setattr(user.bot, 'unpin_chat_message', make_assertion)
+        assert user.unpin_message()
+
+    def test_unpin_all_messages(self, monkeypatch, user):
+        def make_assertion(*args, **kwargs):
+            return args[0] == user.id
+
+        monkeypatch.setattr(user.bot, 'unpin_all_chat_messages', make_assertion)
+        assert user.unpin_all_messages()
+
     def test_instance_method_send_message(self, monkeypatch, user):
         def test(*args, **kwargs):
             return args[0] == user.id and args[1] == 'test'


### PR DESCRIPTION
Along with the bot API update, I also added a `unpin()` shortcut to message.py and `unpin_all_chat_messages()` shortcut to chat.py.
Also if the tests I wrote aren't good enough, please feel free to edit them.

The mypy build is failing because of something webhook handler related (probably due to API 5.0) (edit: Nvm it only failed for me locally, it's not failing here)
