### PR TITLE
Api 5.0 WP 9.5 (Google Place Venues)

### DIFF
--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -1523,13 +1523,18 @@ class Bot(TelegramObject):
         venue: Venue = None,
         foursquare_type: str = None,
         api_kwargs: JSONDict = None,
+        google_place_id: str = None,
+        google_place_type: str = None,
     ) -> Optional[Message]:
         """Use this method to send information about a venue.
 
         Note:
-            You can either supply :obj:`venue`, or :obj:`latitude`, :obj:`longitude`,
-            :obj:`title` and :obj:`address` and optionally :obj:`foursquare_id` and optionally
-            :obj:`foursquare_type`.
+            * You can either supply :obj:`venue`, or :obj:`latitude`, :obj:`longitude`,
+              :obj:`title` and :obj:`address` and optionally :obj:`foursquare_id` and
+              :obj:`foursquare_type` or optionally :obj:`google_place_id` and
+              :obj:`google_place_type`.
+            * Foursquare details and Google Pace details are mutually exclusive. However, this
+              behaviour is undocumented and might be changed by Telegram.
 
         Args:
             chat_id (:obj:`int` | :obj:`str`): Unique identifier for the target chat or username
@@ -1542,6 +1547,10 @@ class Bot(TelegramObject):
             foursquare_type (:obj:`str`, optional): Foursquare type of the venue, if known.
                 (For example, "arts_entertainment/default", "arts_entertainment/aquarium" or
                 "food/icecream".)
+            google_place_id (:obj:`str`, optional): Google Places identifier of the venue.
+            google_place_type (:obj:`str`, optional): Google Places type of the venue. (See
+                `supported types \
+                <https://developers.google.com/places/web-service/supported_types>`_.)
             venue (:class:`telegram.Venue`, optional): The venue to send.
             disable_notification (:obj:`bool`, optional): Sends the message silently. Users will
                 receive a notification with no sound.
@@ -1576,6 +1585,8 @@ class Bot(TelegramObject):
             title = venue.title
             foursquare_id = venue.foursquare_id
             foursquare_type = venue.foursquare_type
+            google_place_id = venue.google_place_id
+            google_place_type = venue.google_place_type
 
         data: JSONDict = {
             'chat_id': chat_id,
@@ -1589,6 +1600,10 @@ class Bot(TelegramObject):
             data['foursquare_id'] = foursquare_id
         if foursquare_type:
             data['foursquare_type'] = foursquare_type
+        if google_place_id:
+            data['google_place_id'] = google_place_id
+        if google_place_type:
+            data['google_place_type'] = google_place_type
 
         return self._message(  # type: ignore[return-value]
             'sendVenue',

--- a/telegram/files/venue.py
+++ b/telegram/files/venue.py
@@ -33,13 +33,18 @@ class Venue(TelegramObject):
     Objects of this class are comparable in terms of equality. Two objects of this class are
     considered equal, if their :attr:`location` and :attr:`title` are equal.
 
+    Note:
+      Foursquare details and Google Pace details are mutually exclusive. However, this
+      behaviour is undocumented and might be changed by Telegram.
+
     Attributes:
         location (:class:`telegram.Location`): Venue location.
         title (:obj:`str`): Name of the venue.
         address (:obj:`str`): Address of the venue.
         foursquare_id (:obj:`str`): Optional. Foursquare identifier of the venue.
-        foursquare_type (:obj:`str`): Optional. Foursquare type of the venue. (For example,
-            "arts_entertainment/default", "arts_entertainment/aquarium" or "food/icecream".)
+        foursquare_type (:obj:`str`): Optional. Foursquare type of the venue.
+        google_place_id (:obj:`str`): Optional. Google Places identifier of the venue.
+        google_place_type (:obj:`str`): Optional. Google Places type of the venue.
 
     Args:
         location (:class:`telegram.Location`): Venue location.
@@ -48,6 +53,9 @@ class Venue(TelegramObject):
         foursquare_id (:obj:`str`, optional): Foursquare identifier of the venue.
         foursquare_type (:obj:`str`, optional): Foursquare type of the venue. (For example,
             "arts_entertainment/default", "arts_entertainment/aquarium" or "food/icecream".)
+        google_place_id (:obj:`str`, optional): Google Places identifier of the venue.
+        google_place_type (:obj:`str`, optional): Google Places type of the venue. (See
+            `supported types <https://developers.google.com/places/web-service/supported_types>`_.)
         **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
     """
@@ -59,6 +67,8 @@ class Venue(TelegramObject):
         address: str,
         foursquare_id: str = None,
         foursquare_type: str = None,
+        google_place_id: str = None,
+        google_place_type: str = None,
         **_kwargs: Any,
     ):
         # Required
@@ -68,6 +78,8 @@ class Venue(TelegramObject):
         # Optionals
         self.foursquare_id = foursquare_id
         self.foursquare_type = foursquare_type
+        self.google_place_id = google_place_id
+        self.google_place_type = google_place_type
 
         self._id_attrs = (self.location, self.title)
 

--- a/telegram/inline/inlinequeryresultvenue.py
+++ b/telegram/inline/inlinequeryresultvenue.py
@@ -32,6 +32,10 @@ class InlineQueryResultVenue(InlineQueryResult):
     use :attr:`input_message_content` to send a message with the specified content instead of the
     venue.
 
+    Note:
+      Foursquare details and Google Pace details are mutually exclusive. However, this
+      behaviour is undocumented and might be changed by Telegram.
+
     Attributes:
         type (:obj:`str`): 'venue'.
         id (:obj:`str`): Unique identifier for this result, 1-64 Bytes.
@@ -41,8 +45,8 @@ class InlineQueryResultVenue(InlineQueryResult):
         address (:obj:`str`): Address of the venue.
         foursquare_id (:obj:`str`): Optional. Foursquare identifier of the venue if known.
         foursquare_type (:obj:`str`): Optional. Foursquare type of the venue, if known.
-            (For example, "arts_entertainment/default", "arts_entertainment/aquarium" or
-            "food/icecream".)
+        google_place_id (:obj:`str`): Optional. Google Places identifier of the venue.
+        google_place_type (:obj:`str`): Optional. Google Places type of the venue.
         reply_markup (:class:`telegram.InlineKeyboardMarkup`): Optional. Inline keyboard attached
             to the message.
         input_message_content (:class:`telegram.InputMessageContent`): Optional. Content of the
@@ -61,6 +65,9 @@ class InlineQueryResultVenue(InlineQueryResult):
         foursquare_type (:obj:`str`, optional): Foursquare type of the venue, if known.
             (For example, "arts_entertainment/default", "arts_entertainment/aquarium" or
             "food/icecream".)
+        google_place_id (:obj:`str`, optional): Google Places identifier of the venue.
+        google_place_type (:obj:`str`, optional): Google Places type of the venue. (See
+            `supported types <https://developers.google.com/places/web-service/supported_types>`_.)
         reply_markup (:class:`telegram.InlineKeyboardMarkup`, optional): Inline keyboard attached
             to the message.
         input_message_content (:class:`telegram.InputMessageContent`, optional): Content of the
@@ -86,6 +93,8 @@ class InlineQueryResultVenue(InlineQueryResult):
         thumb_url: str = None,
         thumb_width: int = None,
         thumb_height: int = None,
+        google_place_id: str = None,
+        google_place_type: str = None,
         **_kwargs: Any,
     ):
 
@@ -99,6 +108,8 @@ class InlineQueryResultVenue(InlineQueryResult):
         # Optional
         self.foursquare_id = foursquare_id
         self.foursquare_type = foursquare_type
+        self.google_place_id = google_place_id
+        self.google_place_type = google_place_type
         self.reply_markup = reply_markup
         self.input_message_content = input_message_content
         self.thumb_url = thumb_url

--- a/telegram/inline/inputvenuemessagecontent.py
+++ b/telegram/inline/inputvenuemessagecontent.py
@@ -30,6 +30,10 @@ class InputVenueMessageContent(InputMessageContent):
     considered equal, if their :attr:`latitude`, :attr:`longitude` and :attr:`title`
     are equal.
 
+    Note:
+      Foursquare details and Google Pace details are mutually exclusive. However, this
+      behaviour is undocumented and might be changed by Telegram.
+
     Attributes:
         latitude (:obj:`float`): Latitude of the location in degrees.
         longitude (:obj:`float`): Longitude of the location in degrees.
@@ -37,8 +41,8 @@ class InputVenueMessageContent(InputMessageContent):
         address (:obj:`str`): Address of the venue.
         foursquare_id (:obj:`str`): Optional. Foursquare identifier of the venue, if known.
         foursquare_type (:obj:`str`): Optional. Foursquare type of the venue, if known.
-            (For example, "arts_entertainment/default", "arts_entertainment/aquarium" or
-            "food/icecream".)
+        google_place_id (:obj:`str`): Optional. Google Places identifier of the venue.
+        google_place_type (:obj:`str`): Optional. Google Places type of the venue.
 
     Args:
         latitude (:obj:`float`): Latitude of the location in degrees.
@@ -49,6 +53,9 @@ class InputVenueMessageContent(InputMessageContent):
         foursquare_type (:obj:`str`, optional): Foursquare type of the venue, if known.
             (For example, "arts_entertainment/default", "arts_entertainment/aquarium" or
             "food/icecream".)
+        google_place_id (:obj:`str`, optional): Google Places identifier of the venue.
+        google_place_type (:obj:`str`, optional): Google Places type of the venue. (See
+            `supported types <https://developers.google.com/places/web-service/supported_types>`_.)
         **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
     """
@@ -61,6 +68,8 @@ class InputVenueMessageContent(InputMessageContent):
         address: str,
         foursquare_id: str = None,
         foursquare_type: str = None,
+        google_place_id: str = None,
+        google_place_type: str = None,
         **_kwargs: Any,
     ):
         # Required
@@ -71,6 +80,8 @@ class InputVenueMessageContent(InputMessageContent):
         # Optionals
         self.foursquare_id = foursquare_id
         self.foursquare_type = foursquare_type
+        self.google_place_id = google_place_id
+        self.google_place_type = google_place_type
 
         self._id_attrs = (
             self.latitude,

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -193,6 +193,9 @@ class TestBot:
         address = 'address'
         foursquare_id = 'foursquare id'
         foursquare_type = 'foursquare type'
+        google_place_id = 'google_place id'
+        google_place_type = 'google_place type'
+
         message = bot.send_venue(
             chat_id=chat_id,
             title=title,
@@ -210,6 +213,28 @@ class TestBot:
         assert message.venue.location.longitude == longitude
         assert message.venue.foursquare_id == foursquare_id
         assert message.venue.foursquare_type == foursquare_type
+        assert message.venue.google_place_id is None
+        assert message.venue.google_place_type is None
+
+        message = bot.send_venue(
+            chat_id=chat_id,
+            title=title,
+            address=address,
+            latitude=latitude,
+            longitude=longitude,
+            google_place_id=google_place_id,
+            google_place_type=google_place_type,
+        )
+
+        assert message.venue
+        assert message.venue.title == title
+        assert message.venue.address == address
+        assert message.venue.location.latitude == latitude
+        assert message.venue.location.longitude == longitude
+        assert message.venue.google_place_id == google_place_id
+        assert message.venue.google_place_type == google_place_type
+        assert message.venue.foursquare_id is None
+        assert message.venue.foursquare_type is None
 
     @flaky(3, 1)
     @pytest.mark.timeout(10)

--- a/tests/test_inlinequeryresultvenue.py
+++ b/tests/test_inlinequeryresultvenue.py
@@ -43,6 +43,8 @@ def inline_query_result_venue():
         thumb_height=TestInlineQueryResultVenue.thumb_height,
         input_message_content=TestInlineQueryResultVenue.input_message_content,
         reply_markup=TestInlineQueryResultVenue.reply_markup,
+        google_place_id=TestInlineQueryResultVenue.google_place_id,
+        google_place_type=TestInlineQueryResultVenue.google_place_type,
     )
 
 
@@ -55,6 +57,8 @@ class TestInlineQueryResultVenue:
     address = 'address'
     foursquare_id = 'foursquare id'
     foursquare_type = 'foursquare type'
+    google_place_id = 'google place id'
+    google_place_type = 'google place type'
     thumb_url = 'thumb url'
     thumb_width = 10
     thumb_height = 15
@@ -70,6 +74,8 @@ class TestInlineQueryResultVenue:
         assert inline_query_result_venue.address == self.address
         assert inline_query_result_venue.foursquare_id == self.foursquare_id
         assert inline_query_result_venue.foursquare_type == self.foursquare_type
+        assert inline_query_result_venue.google_place_id == self.google_place_id
+        assert inline_query_result_venue.google_place_type == self.google_place_type
         assert inline_query_result_venue.thumb_url == self.thumb_url
         assert inline_query_result_venue.thumb_width == self.thumb_width
         assert inline_query_result_venue.thumb_height == self.thumb_height
@@ -96,6 +102,14 @@ class TestInlineQueryResultVenue:
         assert (
             inline_query_result_venue_dict['foursquare_type']
             == inline_query_result_venue.foursquare_type
+        )
+        assert (
+            inline_query_result_venue_dict['google_place_id']
+            == inline_query_result_venue.google_place_id
+        )
+        assert (
+            inline_query_result_venue_dict['google_place_type']
+            == inline_query_result_venue.google_place_type
         )
         assert inline_query_result_venue_dict['thumb_url'] == inline_query_result_venue.thumb_url
         assert (

--- a/tests/test_inputvenuemessagecontent.py
+++ b/tests/test_inputvenuemessagecontent.py
@@ -31,6 +31,8 @@ def input_venue_message_content():
         TestInputVenueMessageContent.address,
         foursquare_id=TestInputVenueMessageContent.foursquare_id,
         foursquare_type=TestInputVenueMessageContent.foursquare_type,
+        google_place_id=TestInputVenueMessageContent.google_place_id,
+        google_place_type=TestInputVenueMessageContent.google_place_type,
     )
 
 
@@ -41,6 +43,8 @@ class TestInputVenueMessageContent:
     address = 'address'
     foursquare_id = 'foursquare id'
     foursquare_type = 'foursquare type'
+    google_place_id = 'google place id'
+    google_place_type = 'google place type'
 
     def test_expected_values(self, input_venue_message_content):
         assert input_venue_message_content.longitude == self.longitude
@@ -49,6 +53,8 @@ class TestInputVenueMessageContent:
         assert input_venue_message_content.address == self.address
         assert input_venue_message_content.foursquare_id == self.foursquare_id
         assert input_venue_message_content.foursquare_type == self.foursquare_type
+        assert input_venue_message_content.google_place_id == self.google_place_id
+        assert input_venue_message_content.google_place_type == self.google_place_type
 
     def test_to_dict(self, input_venue_message_content):
         input_venue_message_content_dict = input_venue_message_content.to_dict()
@@ -67,6 +73,14 @@ class TestInputVenueMessageContent:
         assert (
             input_venue_message_content_dict['foursquare_type']
             == input_venue_message_content.foursquare_type
+        )
+        assert (
+            input_venue_message_content_dict['google_place_id']
+            == input_venue_message_content.google_place_id
+        )
+        assert (
+            input_venue_message_content_dict['google_place_type']
+            == input_venue_message_content.google_place_type
         )
 
     def test_equality(self):

--- a/tests/test_venue.py
+++ b/tests/test_venue.py
@@ -30,6 +30,8 @@ def venue():
         TestVenue.address,
         foursquare_id=TestVenue.foursquare_id,
         foursquare_type=TestVenue.foursquare_type,
+        google_place_id=TestVenue.google_place_id,
+        google_place_type=TestVenue.google_place_type,
     )
 
 
@@ -39,6 +41,8 @@ class TestVenue:
     address = 'address'
     foursquare_id = 'foursquare id'
     foursquare_type = 'foursquare type'
+    google_place_id = 'google place id'
+    google_place_type = 'google place type'
 
     def test_de_json(self, bot):
         json_dict = {
@@ -47,6 +51,8 @@ class TestVenue:
             'address': TestVenue.address,
             'foursquare_id': TestVenue.foursquare_id,
             'foursquare_type': TestVenue.foursquare_type,
+            'google_place_id': TestVenue.google_place_id,
+            'google_place_type': TestVenue.google_place_type,
         }
         venue = Venue.de_json(json_dict, bot)
 
@@ -55,6 +61,8 @@ class TestVenue:
         assert venue.address == self.address
         assert venue.foursquare_id == self.foursquare_id
         assert venue.foursquare_type == self.foursquare_type
+        assert venue.google_place_id == self.google_place_id
+        assert venue.google_place_type == self.google_place_type
 
     def test_send_with_venue(self, monkeypatch, bot, chat_id, venue):
         def test(url, data, **kwargs):
@@ -65,6 +73,8 @@ class TestVenue:
                 and data['address'] == self.address
                 and data['foursquare_id'] == self.foursquare_id
                 and data['foursquare_type'] == self.foursquare_type
+                and data['google_place_id'] == self.google_place_id
+                and data['google_place_type'] == self.google_place_type
             )
 
         monkeypatch.setattr(bot.request, 'post', test)
@@ -84,6 +94,8 @@ class TestVenue:
         assert venue_dict['address'] == venue.address
         assert venue_dict['foursquare_id'] == venue.foursquare_id
         assert venue_dict['foursquare_type'] == venue.foursquare_type
+        assert venue_dict['google_place_id'] == venue.google_place_id
+        assert venue_dict['google_place_type'] == venue.google_place_type
 
     def test_equality(self):
         a = Venue(Location(0, 0), self.title, self.address)


### PR DESCRIPTION
TBH I didn't try to send `InputVenueMessageContent` and `ILQRVenue` with both foursquare and google place details, but as that doesn't seem to work to `send_venue`, I assume it doesn't for those either …