### PR TITLE
docs: fix simple typo, submition -> submission

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1559,7 +1559,7 @@ class TestBot:
         with pytest.raises(OkException):
             bot.send_photo(chat_id, open('tests/data/telegram.jpg', 'rb'), timeout=TIMEOUT)
 
-        # Test JSON submition
+        # Test JSON submission
         with pytest.raises(OkException):
             bot.get_chat_administrators(chat_id, timeout=TIMEOUT)
 


### PR DESCRIPTION
There is a small typo in tests/test_bot.py.

Should read `submission` rather than `submition`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md