### PR TITLE
Fix type definition of CallbackQuery.edit_message_reply_markup(reply_markup=...)

### DIFF
--- a/telegram/callbackquery.py
+++ b/telegram/callbackquery.py
@@ -174,7 +174,7 @@ class CallbackQuery(TelegramObject):
         return self.message.edit_caption(caption=caption, *args, **kwargs)
 
     def edit_message_reply_markup(
-        self, reply_markup: 'InlineKeyboardMarkup', *args: Any, **kwargs: Any
+        self, reply_markup: Optional['InlineKeyboardMarkup'], *args: Any, **kwargs: Any
     ) -> Union[Message, bool]:
         """Shortcut for either::
 


### PR DESCRIPTION
Fix type definition of `CallbackQuery.edit_message_reply_markup(reply_markup=...)`

`CallbackQuery.edit_message_reply_markup` calls to either
* `Bot.edit_message_reply_markup(...)`, or
* `Message.edit_reply_markup(...)` 
    * which eventually calls `Bot.edit_message_reply_markup(...)`

In `Bot.edit_message_reply_markup`, the argument `reply_markup` is of type `Optional[InlineKeyboardMarkup]` which clears the inline keyboard of the message when set to `None`. However, the `None` branch of the type definition is not found in the `CallbackQuery.edit_message_reply_markup(...)` method. 

This PR fixes this issue.