### PR TITLE
Add 1.5 constants

### DIFF
--- a/telegram/callbackquery.py
+++ b/telegram/callbackquery.py
@@ -18,9 +18,9 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 # pylint: disable=W0622
 """This module contains an object that represents a Telegram CallbackQuery"""
-from typing import TYPE_CHECKING, Any, List, Optional, Union, Tuple
+from typing import TYPE_CHECKING, Any, List, Optional, Union, Tuple, ClassVar
 
-from telegram import Message, TelegramObject, User, Location, ReplyMarkup
+from telegram import Message, TelegramObject, User, Location, ReplyMarkup, constants
 from telegram.utils.types import JSONDict
 
 if TYPE_CHECKING:
@@ -633,3 +633,10 @@ class CallbackQuery(TelegramObject):
             timeout=timeout,
             api_kwargs=api_kwargs,
         )
+
+    MAX_ANSWER_TEXT_LENGTH: ClassVar[int] = constants.MAX_ANSWER_CALLBACK_QUERY_TEXT_LENGTH
+    """
+    :const:`telegram.constants.MAX_ANSWER_CALLBACK_QUERY_TEXT_LENGTH`
+
+    .. versionadded:: 13.2
+    """

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -32,6 +32,9 @@ Attributes:
     MAX_MESSAGES_PER_SECOND (:obj:`int`): 30
     MAX_MESSAGES_PER_MINUTE_PER_GROUP (:obj:`int`): 20
     MAX_INLINE_QUERY_RESULTS (:obj:`int`): 50
+    MAX_ANSWER_CALLBACK_QUERY_TEXT_LENGTH (:obj:`int`): 200
+
+        .. versionadded:: 13.2
 
 The following constant have been found by experimentation:
 
@@ -149,6 +152,7 @@ MAX_MESSAGES_PER_SECOND: int = 30
 MAX_MESSAGES_PER_MINUTE_PER_GROUP: int = 20
 MAX_MESSAGE_ENTITIES: int = 100
 MAX_INLINE_QUERY_RESULTS: int = 50
+MAX_ANSWER_CALLBACK_QUERY_TEXT_LENGTH: int = 200
 
 CHAT_PRIVATE: str = 'private'
 CHAT_GROUP: str = 'group'

--- a/telegram/inline/inlinequery.py
+++ b/telegram/inline/inlinequery.py
@@ -19,9 +19,9 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represents a Telegram InlineQuery."""
 
-from typing import TYPE_CHECKING, Any, Optional, List, Union, Callable
+from typing import TYPE_CHECKING, Any, Optional, List, Union, Callable, ClassVar
 
-from telegram import Location, TelegramObject, User
+from telegram import Location, TelegramObject, User, constants
 from telegram.utils.types import JSONDict
 
 if TYPE_CHECKING:
@@ -142,3 +142,10 @@ class InlineQuery(TelegramObject):
             timeout=timeout,
             api_kwargs=api_kwargs,
         )
+
+    MAX_RESULTS: ClassVar[int] = constants.MAX_INLINE_QUERY_RESULTS
+    """
+    :const:`telegram.constants.MAX_INLINE_QUERY_RESULTS`
+
+    .. versionadded:: 13.2
+    """


### PR DESCRIPTION
Adds a constant for max text length in `answer_callback_query` and the corresponding shortcut in `CallbackQuery`. Also adds a shortcut in `InlineQuery` for the max number of results.

Change is pretty easy, but @Poolitzer maybe you still can have a glance? Just in case you can come up with bettern names for the new constant & the shortcuts.