### PR TITLE
Adjust calling of update_persistence

### DIFF
--- a/telegram/ext/defaults.py
+++ b/telegram/ext/defaults.py
@@ -173,7 +173,7 @@ class Defaults:
         )
 
     @property
-    def run_async(self) -> Optional[bool]:
+    def run_async(self) -> bool:
         return self._run_async
 
     @run_async.setter

--- a/telegram/ext/dispatcher.py
+++ b/telegram/ext/dispatcher.py
@@ -402,11 +402,17 @@ class Dispatcher:
     def has_running_threads(self) -> bool:
         return self.running or bool(self.__async_threads)
 
-    def process_update(self, update: Union[str, Update, TelegramError]) -> None:
-        """Processes a single update.
+    def process_update(self, update: Any) -> None:
+        """Processes a single update and updates the persistence.
+
+        Note:
+            If the update is handled by least one synchronously running handlers (i.e.
+            ``run_async=False`), :meth:`update_persistence` is called *once* after all handlers
+            synchronous handlers are done. Each asynchronously running handler will trigger
+            :meth:`update_persistence` on its own.
 
         Args:
-            update (:obj:`str` | :class:`telegram.Update` | :class:`telegram.TelegramError`):
+            update (:class:`telegram.Update` | :obj:`object` | :class:`telegram.TelegramError`):
                 The update to process.
 
         """
@@ -420,6 +426,8 @@ class Dispatcher:
             return
 
         context = None
+        handled = False
+        sync_modes = []
 
         for group in self.groups:
             try:
@@ -428,11 +436,9 @@ class Dispatcher:
                     if check is not None and check is not False:
                         if not context and self.use_context:
                             context = CallbackContext.from_update(update, self)
+                        handled = True
+                        sync_modes.append(handler.run_async)
                         handler.handle_update(update, self, check, context)
-
-                        # If handler runs async updating immediately doesn't make sense
-                        if not handler.run_async:
-                            self.update_persistence(update=update)
                         break
 
             # Stop processing with any other handler.
@@ -451,6 +457,16 @@ class Dispatcher:
                 # Errors should not stop the thread.
                 except Exception:
                     self.logger.exception('An uncaught error was raised while handling the error.')
+
+        # Update persistence, if handled
+        handled_only_async = all(sync_modes)
+        if handled:
+            # Respect default settings
+            if all(mode is DEFAULT_FALSE for mode in sync_modes) and self.bot.defaults:
+                handled_only_async = not self.bot.defaults.run_async
+            # If update was only handled by async handlers, we don't need to update here
+            if not handled_only_async:
+                self.update_persistence(update=update)
 
     def add_handler(self, handler: Handler, group: int = DEFAULT_GROUP) -> None:
         """Register a handler.

--- a/telegram/ext/dispatcher.py
+++ b/telegram/ext/dispatcher.py
@@ -463,7 +463,7 @@ class Dispatcher:
         if handled:
             # Respect default settings
             if all(mode is DEFAULT_FALSE for mode in sync_modes) and self.bot.defaults:
-                handled_only_async = not self.bot.defaults.run_async
+                handled_only_async = self.bot.defaults.run_async
             # If update was only handled by async handlers, we don't need to update here
             if not handled_only_async:
                 self.update_persistence(update=update)

--- a/tests/test_jobqueue.py
+++ b/tests/test_jobqueue.py
@@ -314,7 +314,7 @@ class TestJobQueue:
             next_months_days = calendar.monthrange(now.year, now.month + 1)[1]
 
         expected_reschedule_time += dtm.timedelta(this_months_days)
-        if next_months_days < this_months_days:
+        if day > next_months_days:
             expected_reschedule_time += dtm.timedelta(next_months_days)
 
         expected_reschedule_time = timezone.normalize(expected_reschedule_time)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1406,18 +1406,21 @@ class TestMessage:
     def test_default_quote(self, message):
         message.bot.defaults = Defaults()
 
-        message.bot.defaults._quote = False
-        assert message._quote(None, None) is None
+        try:
+            message.bot.defaults._quote = False
+            assert message._quote(None, None) is None
 
-        message.bot.defaults._quote = True
-        assert message._quote(None, None) == message.message_id
+            message.bot.defaults._quote = True
+            assert message._quote(None, None) == message.message_id
 
-        message.bot.defaults._quote = None
-        message.chat.type = Chat.PRIVATE
-        assert message._quote(None, None) is None
+            message.bot.defaults._quote = None
+            message.chat.type = Chat.PRIVATE
+            assert message._quote(None, None) is None
 
-        message.chat.type = Chat.GROUP
-        assert message._quote(None, None)
+            message.chat.type = Chat.GROUP
+            assert message._quote(None, None)
+        finally:
+            message.bot.defaults = None
 
     def test_equality(self):
         id_ = 1


### PR DESCRIPTION
This does two things:

* Respect the rather new `Defaults.run_async` when deciding if `update_persistence` should be called or not. This was just overlooked by me in #2210
* call `update_persistence` only once per update and only if the update was handled by at least once sync handler. Having a update handled by multiple groups can slow down the bot significantly otherwise.

Also this actually documents how stuff is updated (and fixes the annotation of `process_update` on the fly)