### PR TITLE
Add run_async parameter to ConversationHandler

### DIFF
--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -136,8 +136,13 @@ class ConversationHandler(Handler[Update]):
         map_to_parent (Dict[:obj:`object`, :obj:`object`], optional): A :obj:`dict` that can be
             used to instruct a nested conversationhandler to transition into a mapped state on
             its parent conversationhandler in place of a specified nested state.
-        run_async (:obj:`bool`, optional): Pass :obj:`True` to override the
-            :attr:`Handler.run_async` setting of all handlers.
+        run_async (:obj:`bool`, optional): Pass :obj:`True` to *override* the
+            :attr:`Handler.run_async` setting of all handlers (in :attr:`entry_points`,
+            :attr:`states` and :attr:`fallbacks`).
+
+            Note:
+                If set to :obj:`True`, you should not pass a handler instance, that needs to be
+                run synchronously in another context.
 
             .. versionadded:: 13.2
 
@@ -172,9 +177,8 @@ class ConversationHandler(Handler[Update]):
         map_to_parent (Dict[:obj:`object`, :obj:`object`]): Optional. A :obj:`dict` that can be
             used to instruct a nested conversationhandler to transition into a mapped state on
             its parent conversationhandler in place of a specified nested state.
-        run_async (:obj:`bool`): Pass :obj:`True` to override the
-            :attr:`Handler.run_async` setting of all handlers (in :attr:`entry_points`,
-            :attr:`states` and :attr:`fallbacks`).
+        run_async (:obj:`bool`): If :obj:`True`, will override the
+            :attr:`Handler.run_async` setting of all internal handlers on initialization.
 
             .. versionadded:: 13.2
 

--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -138,7 +138,9 @@ class ConversationHandler(Handler[Update]):
             its parent conversationhandler in place of a specified nested state.
         run_async (:obj:`bool`, optional): Pass :obj:`True` to override the
             :attr:`Handler.run_async` setting of all handlers (in :attr:`entry_points`,
-            :attr:`states` and :attr:`fallbacks:`.
+            :attr:`states` and :attr:`fallbacks`.
+
+            .. versionadded:: 13.2
 
     Raises:
         ValueError
@@ -173,7 +175,9 @@ class ConversationHandler(Handler[Update]):
             its parent conversationhandler in place of a specified nested state.
         run_async (:obj:`bool`): Pass :obj:`True` to override the
             :attr:`Handler.run_async` setting of all handlers (in :attr:`entry_points`,
-            :attr:`states` and :attr:`fallbacks:`.
+            :attr:`states` and :attr:`fallbacks`.
+
+            .. versionadded:: 13.2
 
     """
 

--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -99,6 +99,11 @@ class ConversationHandler(Handler[Update]):
         :attr:`END` to end the *parent* conversation from within the nested one. For an example on
         nested :class:`ConversationHandler` s, see our `examples`_.
 
+        Note that setting :attr:`run_async` to :obj:`True` will override the attribute
+        :attr:`run_async` in all the handlers used in this :class:`ConversationHandler` and set
+        them to :obj:`True`. This includes handlers used in :attr:`entry_points`, :attr:`states`,
+        and :attr:`fallback`.
+
     .. _`examples`: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/examples
 
     Args:
@@ -136,6 +141,9 @@ class ConversationHandler(Handler[Update]):
         map_to_parent (Dict[:obj:`object`, :obj:`object`], optional): A :obj:`dict` that can be
             used to instruct a nested conversationhandler to transition into a mapped state on
             its parent conversationhandler in place of a specified nested state.
+        run_async (:obj:`bool`, optional): If set to :obj:`True`, all the handlers in this
+            :class:`ConversationHandler` will be set with :attr:`run_async` equals to :obj:`True`.
+            Default is :obj:`False`.
 
     Raises:
         ValueError
@@ -168,6 +176,8 @@ class ConversationHandler(Handler[Update]):
         map_to_parent (Dict[:obj:`object`, :obj:`object`]): Optional. A :obj:`dict` that can be
             used to instruct a nested conversationhandler to transition into a mapped state on
             its parent conversationhandler in place of a specified nested state.
+        run_async (:obj:`bool`): If set to :obj:`True`, all the handlers in this
+            :class:`ConversationHandler` will be set with :attr:`run_async` equals to :obj:`True`.
 
     """
 
@@ -192,8 +202,9 @@ class ConversationHandler(Handler[Update]):
         name: str = None,
         persistent: bool = False,
         map_to_parent: Dict[object, object] = None,
+        run_async: bool = False,
     ):
-        self.run_async = False
+        self.run_async = run_async
 
         self._entry_points = entry_points
         self._states = states
@@ -229,7 +240,7 @@ class ConversationHandler(Handler[Update]):
                 "since message IDs are not globally unique."
             )
 
-        all_handlers = list()
+        all_handlers: List[Handler] = list()
         all_handlers.extend(entry_points)
         all_handlers.extend(fallbacks)
 
@@ -262,6 +273,10 @@ class ConversationHandler(Handler[Update]):
                         "since inline queries have no chat context."
                     )
                     break
+
+        if self.run_async:
+            for handler in all_handlers:
+                handler.run_async = True
 
     @property
     def entry_points(self) -> List[Handler]:

--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -137,8 +137,7 @@ class ConversationHandler(Handler[Update]):
             used to instruct a nested conversationhandler to transition into a mapped state on
             its parent conversationhandler in place of a specified nested state.
         run_async (:obj:`bool`, optional): Pass :obj:`True` to override the
-            :attr:`Handler.run_async` setting of all handlers (in :attr:`entry_points`,
-            :attr:`states` and :attr:`fallbacks`.
+            :attr:`Handler.run_async` setting of all handlers.
 
             .. versionadded:: 13.2
 
@@ -175,7 +174,7 @@ class ConversationHandler(Handler[Update]):
             its parent conversationhandler in place of a specified nested state.
         run_async (:obj:`bool`): Pass :obj:`True` to override the
             :attr:`Handler.run_async` setting of all handlers (in :attr:`entry_points`,
-            :attr:`states` and :attr:`fallbacks`.
+            :attr:`states` and :attr:`fallbacks`).
 
             .. versionadded:: 13.2
 

--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -99,11 +99,6 @@ class ConversationHandler(Handler[Update]):
         :attr:`END` to end the *parent* conversation from within the nested one. For an example on
         nested :class:`ConversationHandler` s, see our `examples`_.
 
-        Note that setting :attr:`run_async` to :obj:`True` will override the attribute
-        :attr:`run_async` in all the handlers used in this :class:`ConversationHandler` and set
-        them to :obj:`True`. This includes handlers used in :attr:`entry_points`, :attr:`states`,
-        and :attr:`fallback`.
-
     .. _`examples`: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/examples
 
     Args:
@@ -141,9 +136,9 @@ class ConversationHandler(Handler[Update]):
         map_to_parent (Dict[:obj:`object`, :obj:`object`], optional): A :obj:`dict` that can be
             used to instruct a nested conversationhandler to transition into a mapped state on
             its parent conversationhandler in place of a specified nested state.
-        run_async (:obj:`bool`, optional): If set to :obj:`True`, all the handlers in this
-            :class:`ConversationHandler` will be set with :attr:`run_async` equals to :obj:`True`.
-            Default is :obj:`False`.
+        run_async (:obj:`bool`, optional): Pass :obj:`True` to override the
+            :attr:`Handler.run_async` setting of all handlers (in :attr:`entry_points`,
+            :attr:`states` and :attr:`fallbacks:`.
 
     Raises:
         ValueError
@@ -176,8 +171,9 @@ class ConversationHandler(Handler[Update]):
         map_to_parent (Dict[:obj:`object`, :obj:`object`]): Optional. A :obj:`dict` that can be
             used to instruct a nested conversationhandler to transition into a mapped state on
             its parent conversationhandler in place of a specified nested state.
-        run_async (:obj:`bool`): If set to :obj:`True`, all the handlers in this
-            :class:`ConversationHandler` will be set with :attr:`run_async` equals to :obj:`True`.
+        run_async (:obj:`bool`): Pass :obj:`True` to override the
+            :attr:`Handler.run_async` setting of all handlers (in :attr:`entry_points`,
+            :attr:`states` and :attr:`fallbacks:`.
 
     """
 

--- a/tests/test_conversationhandler.py
+++ b/tests/test_conversationhandler.py
@@ -1450,6 +1450,7 @@ class TestConversationHandler:
             entry_points=[CommandHandler('start', self.start_end, run_async=True)],
             states=self.states,
             fallbacks=self.fallbacks,
+            run_async=False,
         )
 
         for handler in conv_handler.entry_points:

--- a/tests/test_conversationhandler.py
+++ b/tests/test_conversationhandler.py
@@ -1429,3 +1429,35 @@ class TestConversationHandler:
         assert self.current_state[user1.id] == self.STOPPING
         assert handler.conversations.get((0, user1.id)) is None
         assert not self.test_flag
+
+    def test_conversation_handler_run_async_true(self, dp):
+        conv_handler = ConversationHandler(
+            entry_points=self.entry_points,
+            states=self.states,
+            fallbacks=self.fallbacks,
+            run_async=True,
+        )
+
+        all_handlers = conv_handler.entry_points + conv_handler.fallbacks
+        for state_handlers in conv_handler.states.values():
+            all_handlers += state_handlers
+
+        for handler in all_handlers:
+            assert handler.run_async
+
+    def test_conversation_handler_run_async_false(self, dp):
+        conv_handler = ConversationHandler(
+            entry_points=[CommandHandler('start', self.start_end, run_async=True)],
+            states=self.states,
+            fallbacks=self.fallbacks,
+        )
+
+        for handler in conv_handler.entry_points:
+            assert handler.run_async
+
+        all_handlers = conv_handler.fallbacks
+        for state_handlers in conv_handler.states.values():
+            all_handlers += state_handlers
+
+        for handler in all_handlers:
+            assert not handler.run_async.value

--- a/tests/test_jobqueue.py
+++ b/tests/test_jobqueue.py
@@ -314,7 +314,7 @@ class TestJobQueue:
             next_months_days = calendar.monthrange(now.year, now.month + 1)[1]
 
         expected_reschedule_time += dtm.timedelta(this_months_days)
-        if next_months_days < this_months_days:
+        if day > next_months_days:
             expected_reschedule_time += dtm.timedelta(next_months_days)
 
         expected_reschedule_time = timezone.normalize(expected_reschedule_time)


### PR DESCRIPTION
- Add `run_async` parameter to `ConversationHandler`
- When `run_async` is set to `True`, overrides all handlers in this `ConversationHandler` with `run_async` equals to `True`
- Closes #2283 