### PR TITLE
Fix: overly escape and offset error for markdown v2 and HTML symbols when nested

### DIFF
--- a/telegram/message.py
+++ b/telegram/message.py
@@ -2171,11 +2171,12 @@ class Message(TelegramObject):
                 }
                 parsed_entities.extend(list(nested_entities.keys()))
 
+                orig_text = text
                 text = escape(text)
 
                 if nested_entities:
                     text = Message._parse_html(
-                        text, nested_entities, urled=urled, offset=entity.offset
+                        orig_text, nested_entities, urled=urled, offset=entity.offset
                     )
 
                 if entity.type == MessageEntity.TEXT_LINK:

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -2341,7 +2341,11 @@ class Message(TelegramObject):
                         )
 
                     text = Message._parse_markdown(
-                        text, nested_entities, urled=urled, offset=entity.offset, version=version
+                        orig_text,
+                        nested_entities,
+                        urled=urled,
+                        offset=entity.offset,
+                        version=version,
                     )
 
                 if entity.type == MessageEntity.TEXT_LINK:

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -266,7 +266,7 @@ class TestMessage:
     ]
     test_text_v2 = (
         r'Test for <bold, ita_lic, \`code, links, text-mention and `\pre. '
-        'http://google.com and bold nested in strk-trgh nested in italic. Python pre.'
+        'http://google.com and bold nested in strk>trgh nested in italic. Python pre.'
     )
     test_message = Message(
         message_id=1,
@@ -357,7 +357,7 @@ class TestMessage:
             r'<a href="http://github.com/abc\)def">links</a>, '
             '<a href="tg://user?id=123456789">text-mention</a> and '
             r'<pre>`\pre</pre>. http://google.com '
-            'and <i>bold <b>nested in <s>strk-trgh</s> nested in</b> italic</i>. '
+            'and <i>bold <b>nested in <s>strk&gt;trgh</s> nested in</b> italic</i>. '
             '<pre><code class="python">Python pre</code></pre>.'
         )
         text_html = self.test_message_v2.text_html
@@ -375,7 +375,7 @@ class TestMessage:
             r'<a href="http://github.com/abc\)def">links</a>, '
             '<a href="tg://user?id=123456789">text-mention</a> and '
             r'<pre>`\pre</pre>. <a href="http://google.com">http://google.com</a> '
-            'and <i>bold <b>nested in <s>strk-trgh</s> nested in</b> italic</i>. '
+            'and <i>bold <b>nested in <s>strk&gt;trgh</s> nested in</b> italic</i>. '
             '<pre><code class="python">Python pre</code></pre>.'
         )
         text_html = self.test_message_v2.text_html_urled
@@ -396,7 +396,7 @@ class TestMessage:
             r'__Test__ for <*bold*, _ita\_lic_, `\\\`code`, '
             '[links](http://github.com/abc\\\\\\)def), '
             '[text\\-mention](tg://user?id=123456789) and ```\\`\\\\pre```\\. '
-            r'http://google\.com and _bold *nested in ~strk\-trgh~ nested in* italic_\. '
+            r'http://google\.com and _bold *nested in ~strk\>trgh~ nested in* italic_\. '
             '```python\nPython pre```\\.'
         )
         text_markdown = self.test_message_v2.text_markdown_v2
@@ -442,7 +442,7 @@ class TestMessage:
             r'__Test__ for <*bold*, _ita\_lic_, `\\\`code`, '
             '[links](http://github.com/abc\\\\\\)def), '
             '[text\\-mention](tg://user?id=123456789) and ```\\`\\\\pre```\\. '
-            r'[http://google\.com](http://google.com) and _bold *nested in ~strk\-trgh~ '
+            r'[http://google\.com](http://google.com) and _bold *nested in ~strk\>trgh~ '
             'nested in* italic_\\. ```python\nPython pre```\\.'
         )
         text_markdown = self.test_message_v2.text_markdown_v2_urled
@@ -473,7 +473,7 @@ class TestMessage:
             r'<a href="http://github.com/abc\)def">links</a>, '
             '<a href="tg://user?id=123456789">text-mention</a> and '
             r'<pre>`\pre</pre>. http://google.com '
-            'and <i>bold <b>nested in <s>strk-trgh</s> nested in</b> italic</i>. '
+            'and <i>bold <b>nested in <s>strk&gt;trgh</s> nested in</b> italic</i>. '
             '<pre><code class="python">Python pre</code></pre>.'
         )
         caption_html = self.test_message_v2.caption_html
@@ -491,7 +491,7 @@ class TestMessage:
             r'<a href="http://github.com/abc\)def">links</a>, '
             '<a href="tg://user?id=123456789">text-mention</a> and '
             r'<pre>`\pre</pre>. <a href="http://google.com">http://google.com</a> '
-            'and <i>bold <b>nested in <s>strk-trgh</s> nested in</b> italic</i>. '
+            'and <i>bold <b>nested in <s>strk&gt;trgh</s> nested in</b> italic</i>. '
             '<pre><code class="python">Python pre</code></pre>.'
         )
         caption_html = self.test_message_v2.caption_html_urled
@@ -512,7 +512,7 @@ class TestMessage:
             r'__Test__ for <*bold*, _ita\_lic_, `\\\`code`, '
             '[links](http://github.com/abc\\\\\\)def), '
             '[text\\-mention](tg://user?id=123456789) and ```\\`\\\\pre```\\. '
-            r'http://google\.com and _bold *nested in ~strk\-trgh~ nested in* italic_\. '
+            r'http://google\.com and _bold *nested in ~strk\>trgh~ nested in* italic_\. '
             '```python\nPython pre```\\.'
         )
         caption_markdown = self.test_message_v2.caption_markdown_v2
@@ -539,7 +539,7 @@ class TestMessage:
             r'__Test__ for <*bold*, _ita\_lic_, `\\\`code`, '
             '[links](http://github.com/abc\\\\\\)def), '
             '[text\\-mention](tg://user?id=123456789) and ```\\`\\\\pre```\\. '
-            r'[http://google\.com](http://google.com) and _bold *nested in ~strk\-trgh~ '
+            r'[http://google\.com](http://google.com) and _bold *nested in ~strk\>trgh~ '
             'nested in* italic_\\. ```python\nPython pre```\\.'
         )
         caption_markdown = self.test_message_v2.caption_markdown_v2_urled
@@ -698,7 +698,7 @@ class TestMessage:
             r'__Test__ for <*bold*, _ita\_lic_, `\\\`code`, '
             '[links](http://github.com/abc\\\\\\)def), '
             '[text\\-mention](tg://user?id=123456789) and ```\\`\\\\pre```\\. '
-            r'http://google\.com and _bold *nested in ~strk\-trgh~ nested in* italic_\. '
+            r'http://google\.com and _bold *nested in ~strk\>trgh~ nested in* italic_\. '
             '```python\nPython pre```\\.'
         )
 
@@ -738,7 +738,7 @@ class TestMessage:
             r'<a href="http://github.com/abc\)def">links</a>, '
             '<a href="tg://user?id=123456789">text-mention</a> and '
             r'<pre>`\pre</pre>. http://google.com '
-            'and <i>bold <b>nested in <s>strk-trgh</s> nested in</b> italic</i>. '
+            'and <i>bold <b>nested in <s>strk&gt;trgh</s> nested in</b> italic</i>. '
             '<pre><code class="python">Python pre</code></pre>.'
         )
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -259,14 +259,14 @@ class TestMessage:
         },
         {'length': 5, 'offset': 57, 'type': 'pre'},
         {'length': 17, 'offset': 64, 'type': 'url'},
-        {'length': 36, 'offset': 86, 'type': 'italic'},
-        {'length': 24, 'offset': 91, 'type': 'bold'},
-        {'length': 4, 'offset': 101, 'type': 'strikethrough'},
-        {'length': 10, 'offset': 124, 'type': 'pre', 'language': 'python'},
+        {'length': 41, 'offset': 86, 'type': 'italic'},
+        {'length': 29, 'offset': 91, 'type': 'bold'},
+        {'length': 9, 'offset': 101, 'type': 'strikethrough'},
+        {'length': 10, 'offset': 129, 'type': 'pre', 'language': 'python'},
     ]
     test_text_v2 = (
         r'Test for <bold, ita_lic, \`code, links, text-mention and `\pre. '
-        'http://google.com and bold nested in strk nested in italic. Python pre.'
+        'http://google.com and bold nested in strk-trgh nested in italic. Python pre.'
     )
     test_message = Message(
         message_id=1,
@@ -357,7 +357,7 @@ class TestMessage:
             r'<a href="http://github.com/abc\)def">links</a>, '
             '<a href="tg://user?id=123456789">text-mention</a> and '
             r'<pre>`\pre</pre>. http://google.com '
-            'and <i>bold <b>nested in <s>strk</s> nested in</b> italic</i>. '
+            'and <i>bold <b>nested in <s>strk-trgh</s> nested in</b> italic</i>. '
             '<pre><code class="python">Python pre</code></pre>.'
         )
         text_html = self.test_message_v2.text_html
@@ -375,7 +375,7 @@ class TestMessage:
             r'<a href="http://github.com/abc\)def">links</a>, '
             '<a href="tg://user?id=123456789">text-mention</a> and '
             r'<pre>`\pre</pre>. <a href="http://google.com">http://google.com</a> '
-            'and <i>bold <b>nested in <s>strk</s> nested in</b> italic</i>. '
+            'and <i>bold <b>nested in <s>strk-trgh</s> nested in</b> italic</i>. '
             '<pre><code class="python">Python pre</code></pre>.'
         )
         text_html = self.test_message_v2.text_html_urled
@@ -396,7 +396,7 @@ class TestMessage:
             r'__Test__ for <*bold*, _ita\_lic_, `\\\`code`, '
             '[links](http://github.com/abc\\\\\\)def), '
             '[text\\-mention](tg://user?id=123456789) and ```\\`\\\\pre```\\. '
-            r'http://google\.com and _bold *nested in ~strk~ nested in* italic_\. '
+            r'http://google\.com and _bold *nested in ~strk\-trgh~ nested in* italic_\. '
             '```python\nPython pre```\\.'
         )
         text_markdown = self.test_message_v2.text_markdown_v2
@@ -442,7 +442,7 @@ class TestMessage:
             r'__Test__ for <*bold*, _ita\_lic_, `\\\`code`, '
             '[links](http://github.com/abc\\\\\\)def), '
             '[text\\-mention](tg://user?id=123456789) and ```\\`\\\\pre```\\. '
-            r'[http://google\.com](http://google.com) and _bold *nested in ~strk~ '
+            r'[http://google\.com](http://google.com) and _bold *nested in ~strk\-trgh~ '
             'nested in* italic_\\. ```python\nPython pre```\\.'
         )
         text_markdown = self.test_message_v2.text_markdown_v2_urled
@@ -473,7 +473,7 @@ class TestMessage:
             r'<a href="http://github.com/abc\)def">links</a>, '
             '<a href="tg://user?id=123456789">text-mention</a> and '
             r'<pre>`\pre</pre>. http://google.com '
-            'and <i>bold <b>nested in <s>strk</s> nested in</b> italic</i>. '
+            'and <i>bold <b>nested in <s>strk-trgh</s> nested in</b> italic</i>. '
             '<pre><code class="python">Python pre</code></pre>.'
         )
         caption_html = self.test_message_v2.caption_html
@@ -491,7 +491,7 @@ class TestMessage:
             r'<a href="http://github.com/abc\)def">links</a>, '
             '<a href="tg://user?id=123456789">text-mention</a> and '
             r'<pre>`\pre</pre>. <a href="http://google.com">http://google.com</a> '
-            'and <i>bold <b>nested in <s>strk</s> nested in</b> italic</i>. '
+            'and <i>bold <b>nested in <s>strk-trgh</s> nested in</b> italic</i>. '
             '<pre><code class="python">Python pre</code></pre>.'
         )
         caption_html = self.test_message_v2.caption_html_urled
@@ -512,7 +512,7 @@ class TestMessage:
             r'__Test__ for <*bold*, _ita\_lic_, `\\\`code`, '
             '[links](http://github.com/abc\\\\\\)def), '
             '[text\\-mention](tg://user?id=123456789) and ```\\`\\\\pre```\\. '
-            r'http://google\.com and _bold *nested in ~strk~ nested in* italic_\. '
+            r'http://google\.com and _bold *nested in ~strk\-trgh~ nested in* italic_\. '
             '```python\nPython pre```\\.'
         )
         caption_markdown = self.test_message_v2.caption_markdown_v2
@@ -539,7 +539,7 @@ class TestMessage:
             r'__Test__ for <*bold*, _ita\_lic_, `\\\`code`, '
             '[links](http://github.com/abc\\\\\\)def), '
             '[text\\-mention](tg://user?id=123456789) and ```\\`\\\\pre```\\. '
-            r'[http://google\.com](http://google.com) and _bold *nested in ~strk~ '
+            r'[http://google\.com](http://google.com) and _bold *nested in ~strk\-trgh~ '
             'nested in* italic_\\. ```python\nPython pre```\\.'
         )
         caption_markdown = self.test_message_v2.caption_markdown_v2_urled
@@ -698,7 +698,7 @@ class TestMessage:
             r'__Test__ for <*bold*, _ita\_lic_, `\\\`code`, '
             '[links](http://github.com/abc\\\\\\)def), '
             '[text\\-mention](tg://user?id=123456789) and ```\\`\\\\pre```\\. '
-            r'http://google\.com and _bold *nested in ~strk~ nested in* italic_\. '
+            r'http://google\.com and _bold *nested in ~strk\-trgh~ nested in* italic_\. '
             '```python\nPython pre```\\.'
         )
 
@@ -738,7 +738,7 @@ class TestMessage:
             r'<a href="http://github.com/abc\)def">links</a>, '
             '<a href="tg://user?id=123456789">text-mention</a> and '
             r'<pre>`\pre</pre>. http://google.com '
-            'and <i>bold <b>nested in <s>strk</s> nested in</b> italic</i>. '
+            'and <i>bold <b>nested in <s>strk-trgh</s> nested in</b> italic</i>. '
             '<pre><code class="python">Python pre</code></pre>.'
         )
 


### PR DESCRIPTION
Previously, PTB is producing incorrect results when formatting a message into the Markdown v2 format (`Message.(text|caption)_markdown_v2`). Specifically, when there is any of the need-to-escape characters <code>_*[]()~`>#+-=|{}.!</code> appear in a nested entities, the last few characters was repeated at the end of the range. 

For example

Message | What PTB gives | Expected result
-- | -- | --
`<b><hashtag>#boldhashtag</hashtag></b>` | `*#boldhashtag*g` | `*#boldhashtag*`
`<b><i>a{b+c}d</i></b>` | `*_a\{b\+c\}d_\\}d*` | `*_a\{b\+c\}d_*`

_\* `<hashtag />` is used here just to represent the hashtag entity, Telegram does not support such a tag._

The issue is suspected to be caused by the used of _escaped_ text sequence for nested entities, which is causing a discrepancy in the length of text due to the introduction of `\`.

This PR fixes the issue by using the original text (`orig_text`) as a basis for nested entity parsing. It also includes updated tests to address this issue.