### PR TITLE
Add Message shortcuts

### DIFF
--- a/telegram/chat.py
+++ b/telegram/chat.py
@@ -651,7 +651,7 @@ class Chat(TelegramObject):
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_chat_action`.
 
         Returns:
-            :obj:`True`: On success.
+            :obj:`bool`: On success, :obj:`True` is returned.
 
         """
         return self.bot.send_chat_action(

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -69,6 +69,7 @@ if TYPE_CHECKING:
         InputMediaDocument,
         InputMediaPhoto,
         InputMediaVideo,
+        LabeledPrice,
     )
 
 _UNDEFINED = object()
@@ -1477,6 +1478,149 @@ class Message(TelegramObject):
             reply_markup=reply_markup,
             timeout=timeout,
             emoji=emoji,
+            api_kwargs=api_kwargs,
+            allow_sending_without_reply=allow_sending_without_reply,
+        )
+
+    def reply_chat_action(
+        self,
+        action: str,
+        timeout: float = None,
+        api_kwargs: JSONDict = None,
+    ) -> bool:
+        """Shortcut for::
+
+            bot.send_chat_action(update.effective_message.chat_id, *args, **kwargs)
+
+        For the documentation of the arguments, please see :meth:`telegram.Bot.send_chat_action`.
+
+        .. versionadded:: 13.2
+
+        Returns:
+            :obj:`bool`: On success, :obj:`True` is returned.
+
+        """
+        return self.bot.send_chat_action(
+            chat_id=self.chat_id,
+            action=action,
+            timeout=timeout,
+            api_kwargs=api_kwargs,
+        )
+
+    def reply_game(
+        self,
+        game_short_name: str,
+        disable_notification: bool = False,
+        reply_to_message_id: Union[int, str] = None,
+        reply_markup: 'InlineKeyboardMarkup' = None,
+        timeout: float = None,
+        api_kwargs: JSONDict = None,
+        allow_sending_without_reply: bool = None,
+        quote: bool = None,
+    ) -> 'Message':
+        """Shortcut for::
+
+            bot.send_game(update.effective_message.chat_id, *args, **kwargs)
+
+        For the documentation of the arguments, please see :meth:`telegram.Bot.send_game`.
+
+        Args:
+            quote (:obj:`bool`, optional): If set to :obj:`True`, the game is sent as an actual
+                reply to this message. If ``reply_to_message_id`` is passed in ``kwargs``, this
+                parameter will be ignored. Default: :obj:`True` in group chats and :obj:`False`
+                in private chats.
+
+        .. versionadded:: 13.2
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        reply_to_message_id = self._quote(quote, reply_to_message_id)
+        return self.bot.send_game(
+            chat_id=self.chat_id,
+            game_short_name=game_short_name,
+            disable_notification=disable_notification,
+            reply_to_message_id=reply_to_message_id,
+            reply_markup=reply_markup,
+            timeout=timeout,
+            api_kwargs=api_kwargs,
+            allow_sending_without_reply=allow_sending_without_reply,
+        )
+
+    def reply_invoice(
+        self,
+        title: str,
+        description: str,
+        payload: str,
+        provider_token: str,
+        start_parameter: str,
+        currency: str,
+        prices: List['LabeledPrice'],
+        photo_url: str = None,
+        photo_size: int = None,
+        photo_width: int = None,
+        photo_height: int = None,
+        need_name: bool = None,
+        need_phone_number: bool = None,
+        need_email: bool = None,
+        need_shipping_address: bool = None,
+        is_flexible: bool = None,
+        disable_notification: bool = False,
+        reply_to_message_id: Union[int, str] = None,
+        reply_markup: 'InlineKeyboardMarkup' = None,
+        provider_data: Union[str, object] = None,
+        send_phone_number_to_provider: bool = None,
+        send_email_to_provider: bool = None,
+        timeout: float = None,
+        api_kwargs: JSONDict = None,
+        allow_sending_without_reply: bool = None,
+        quote: bool = None,
+    ) -> 'Message':
+        """Shortcut for::
+
+            bot.send_invoice(update.effective_message.chat_id, *args, **kwargs)
+
+        For the documentation of the arguments, please see :meth:`telegram.Bot.send_invoice`.
+
+        Args:
+            quote (:obj:`bool`, optional): If set to :obj:`True`, the invoice is sent as an actual
+                reply to this message. If ``reply_to_message_id`` is passed in ``kwargs``, this
+                parameter will be ignored. Default: :obj:`True` in group chats and :obj:`False`
+                in private chats.
+
+        .. versionadded:: 13.2
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        reply_to_message_id = self._quote(quote, reply_to_message_id)
+        return self.bot.send_invoice(
+            chat_id=self.chat_id,
+            title=title,
+            description=description,
+            payload=payload,
+            provider_token=provider_token,
+            start_parameter=start_parameter,
+            currency=currency,
+            prices=prices,
+            photo_url=photo_url,
+            photo_size=photo_size,
+            photo_width=photo_width,
+            photo_height=photo_height,
+            need_name=need_name,
+            need_phone_number=need_phone_number,
+            need_email=need_email,
+            need_shipping_address=need_shipping_address,
+            is_flexible=is_flexible,
+            disable_notification=disable_notification,
+            reply_to_message_id=reply_to_message_id,
+            reply_markup=reply_markup,
+            provider_data=provider_data,
+            send_phone_number_to_provider=send_phone_number_to_provider,
+            send_email_to_provider=send_email_to_provider,
+            timeout=timeout,
             api_kwargs=api_kwargs,
             allow_sending_without_reply=allow_sending_without_reply,
         )

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -618,7 +618,7 @@ class Message(TelegramObject):
     ) -> 'Message':
         """Shortcut for::
 
-            bot.send_message(update.message.chat_id, *args, **kwargs)
+            bot.send_message(update.effective_message.chat_id, *args, **kwargs)
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_message`.
 
@@ -662,8 +662,12 @@ class Message(TelegramObject):
     ) -> 'Message':
         """Shortcut for::
 
-            bot.send_message(update.message.chat_id, parse_mode=ParseMode.MARKDOWN, *args,
-            **kwargs)
+            bot.send_message(
+                update.effective_message.chat_id,
+                parse_mode=ParseMode.MARKDOWN,
+                *args,
+                **kwargs,
+            )
 
         Sends a message with Markdown version 1 formatting.
 
@@ -712,8 +716,12 @@ class Message(TelegramObject):
     ) -> 'Message':
         """Shortcut for::
 
-            bot.send_message(update.message.chat_id, parse_mode=ParseMode.MARKDOWN_V2, *args,
-            **kwargs)
+            bot.send_message(
+                update.effective_message.chat_id,
+                parse_mode=ParseMode.MARKDOWN_V2,
+                *args,
+                **kwargs,
+            )
 
         Sends a message with markdown version 2 formatting.
 
@@ -758,7 +766,12 @@ class Message(TelegramObject):
     ) -> 'Message':
         """Shortcut for::
 
-            bot.send_message(update.message.chat_id, parse_mode=ParseMode.HTML, *args, **kwargs)
+            bot.send_message(
+                update.effective_message.chat_id,
+                parse_mode=ParseMode.HTML,
+                *args,
+                **kwargs,
+            )
 
         Sends a message with HTML formatting.
 
@@ -802,7 +815,7 @@ class Message(TelegramObject):
     ) -> List['Message']:
         """Shortcut for::
 
-            bot.send_media_group(update.message.chat_id, *args, **kwargs)
+            bot.send_media_group(update.effective_message.chat_id, *args, **kwargs)
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_media_group`.
 
@@ -846,7 +859,7 @@ class Message(TelegramObject):
     ) -> 'Message':
         """Shortcut for::
 
-            bot.send_photo(update.message.chat_id, *args, **kwargs)
+            bot.send_photo(update.effective_message.chat_id, *args, **kwargs)
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_photo`.
 
@@ -897,7 +910,7 @@ class Message(TelegramObject):
     ) -> 'Message':
         """Shortcut for::
 
-            bot.send_audio(update.message.chat_id, *args, **kwargs)
+            bot.send_audio(update.effective_message.chat_id, *args, **kwargs)
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_audio`.
 
@@ -950,7 +963,7 @@ class Message(TelegramObject):
     ) -> 'Message':
         """Shortcut for::
 
-            bot.send_document(update.message.chat_id, *args, **kwargs)
+            bot.send_document(update.effective_message.chat_id, *args, **kwargs)
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_document`.
 
@@ -1003,7 +1016,7 @@ class Message(TelegramObject):
     ) -> 'Message':
         """Shortcut for::
 
-            bot.send_animation(update.message.chat_id, *args, **kwargs)
+            bot.send_animation(update.effective_message.chat_id, *args, **kwargs)
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_animation`.
 
@@ -1050,7 +1063,7 @@ class Message(TelegramObject):
     ) -> 'Message':
         """Shortcut for::
 
-            bot.send_sticker(update.message.chat_id, *args, **kwargs)
+            bot.send_sticker(update.effective_message.chat_id, *args, **kwargs)
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_sticker`.
 
@@ -1098,7 +1111,7 @@ class Message(TelegramObject):
     ) -> 'Message':
         """Shortcut for::
 
-            bot.send_video(update.message.chat_id, *args, **kwargs)
+            bot.send_video(update.effective_message.chat_id, *args, **kwargs)
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_video`.
 
@@ -1150,7 +1163,7 @@ class Message(TelegramObject):
     ) -> 'Message':
         """Shortcut for::
 
-            bot.send_video_note(update.message.chat_id, *args, **kwargs)
+            bot.send_video_note(update.effective_message.chat_id, *args, **kwargs)
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_video_note`.
 
@@ -1198,7 +1211,7 @@ class Message(TelegramObject):
     ) -> 'Message':
         """Shortcut for::
 
-            bot.send_voice(update.message.chat_id, *args, **kwargs)
+            bot.send_voice(update.effective_message.chat_id, *args, **kwargs)
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_voice`.
 
@@ -1248,7 +1261,7 @@ class Message(TelegramObject):
     ) -> 'Message':
         """Shortcut for::
 
-            bot.send_location(update.message.chat_id, *args, **kwargs)
+            bot.send_location(update.effective_message.chat_id, *args, **kwargs)
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_location`.
 
@@ -1301,7 +1314,7 @@ class Message(TelegramObject):
     ) -> 'Message':
         """Shortcut for::
 
-            bot.send_venue(update.message.chat_id, *args, **kwargs)
+            bot.send_venue(update.effective_message.chat_id, *args, **kwargs)
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_venue`.
 
@@ -1352,7 +1365,7 @@ class Message(TelegramObject):
     ) -> 'Message':
         """Shortcut for::
 
-            bot.send_contact(update.message.chat_id, *args, **kwargs)
+            bot.send_contact(update.effective_message.chat_id, *args, **kwargs)
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_contact`.
 
@@ -1406,7 +1419,7 @@ class Message(TelegramObject):
     ) -> 'Message':
         """Shortcut for::
 
-            bot.send_poll(update.message.chat_id, *args, **kwargs)
+            bot.send_poll(update.effective_message.chat_id, *args, **kwargs)
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_poll`.
 
@@ -1456,7 +1469,7 @@ class Message(TelegramObject):
     ) -> 'Message':
         """Shortcut for::
 
-            bot.send_dice(update.message.chat_id, *args, **kwargs)
+            bot.send_dice(update.effective_message.chat_id, *args, **kwargs)
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_dice`.
 
@@ -1635,8 +1648,8 @@ class Message(TelegramObject):
         """Shortcut for::
 
             bot.forward_message(chat_id=chat_id,
-                                from_chat_id=update.message.chat_id,
-                                message_id=update.message.message_id,
+                                from_chat_id=update.effective_message.chat_id,
+                                message_id=update.effective_message.message_id,
                                 *args,
                                 **kwargs)
 
@@ -1671,8 +1684,8 @@ class Message(TelegramObject):
         """Shortcut for::
 
             bot.copy_message(chat_id=chat_id,
-                             from_chat_id=update.message.chat_id,
-                             message_id=update.message.message_id,
+                             from_chat_id=update.effective_message.chat_id,
+                             message_id=update.effective_message.message_id,
                              *args,
                              **kwargs)
 

--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -40,11 +40,11 @@ try:
     from telegram.vendor.ptb_urllib3.urllib3.util.timeout import Timeout
 except ImportError:  # pragma: no cover
     try:
-        import urllib3  # type: ignore[no-redef]
-        import urllib3.contrib.appengine as appengine  # type: ignore[no-redef]
-        from urllib3.connection import HTTPConnection  # type: ignore[no-redef]
-        from urllib3.fields import RequestField  # type: ignore[no-redef]
-        from urllib3.util.timeout import Timeout  # type: ignore[no-redef]
+        import urllib3
+        import urllib3.contrib.appengine as appengine
+        from urllib3.connection import HTTPConnection
+        from urllib3.fields import RequestField
+        from urllib3.util.timeout import Timeout
 
         warnings.warn(
             'python-telegram-bot is using upstream urllib3. This is allowed but not '
@@ -83,7 +83,7 @@ def _render_part(self: RequestField, name: str, value: str) -> str:  # pylint: d
     return f'{name}="{value}"'
 
 
-RequestField._render_part = _render_part  # type: ignore  # pylint: disable=W0212
+RequestField._render_part = _render_part  # pylint: disable=W0212
 
 logging.getLogger('urllib3').setLevel(logging.WARNING)
 
@@ -130,14 +130,14 @@ class Request:
         # TODO: Support other platforms like mac and windows.
         if 'linux' in sys.platform:
             sockopts.append(
-                (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 120)
-            )  # pylint: disable=no-member
+                (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 120)  # pylint: disable=no-member
+            )
             sockopts.append(
-                (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 30)
-            )  # pylint: disable=no-member
+                (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 30)  # pylint: disable=no-member
+            )
             sockopts.append(
-                (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 8)
-            )  # pylint: disable=no-member
+                (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 8)  # pylint: disable=no-member
+            )
 
         self._con_pool_size = con_pool_size
 
@@ -163,7 +163,7 @@ class Request:
             appengine.AppEngineManager,
             'SOCKSProxyManager',  # noqa: F821
             urllib3.ProxyManager,
-        ] = None  # type: ignore
+        ] = None
         if not proxy_url:
             if appengine.is_appengine_sandbox():
                 # Use URLFetch service if running in App Engine
@@ -194,7 +194,7 @@ class Request:
         return self._con_pool_size
 
     def stop(self) -> None:
-        self._con_pool.clear()  # type: ignore
+        self._con_pool.clear()
 
     @staticmethod
     def _parse(json_data: bytes) -> Union[JSONDict, bool]:

--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -40,11 +40,11 @@ try:
     from telegram.vendor.ptb_urllib3.urllib3.util.timeout import Timeout
 except ImportError:  # pragma: no cover
     try:
-        import urllib3
-        import urllib3.contrib.appengine as appengine
-        from urllib3.connection import HTTPConnection
-        from urllib3.fields import RequestField
-        from urllib3.util.timeout import Timeout
+        import urllib3  # type: ignore[no-redef]
+        import urllib3.contrib.appengine as appengine  # type: ignore[no-redef]
+        from urllib3.connection import HTTPConnection  # type: ignore[no-redef]
+        from urllib3.fields import RequestField  # type: ignore[no-redef]
+        from urllib3.util.timeout import Timeout  # type: ignore[no-redef]
 
         warnings.warn(
             'python-telegram-bot is using upstream urllib3. This is allowed but not '
@@ -83,7 +83,7 @@ def _render_part(self: RequestField, name: str, value: str) -> str:  # pylint: d
     return f'{name}="{value}"'
 
 
-RequestField._render_part = _render_part  # pylint: disable=W0212
+RequestField._render_part = _render_part  # type: ignore[assignment]  # pylint: disable=W0212
 
 logging.getLogger('urllib3').setLevel(logging.WARNING)
 
@@ -163,7 +163,7 @@ class Request:
             appengine.AppEngineManager,
             'SOCKSProxyManager',  # noqa: F821
             urllib3.ProxyManager,
-        ] = None
+        ] = None  # type: ignore[assignment]
         if not proxy_url:
             if appengine.is_appengine_sandbox():
                 # Use URLFetch service if running in App Engine
@@ -194,7 +194,7 @@ class Request:
         return self._con_pool_size
 
     def stop(self) -> None:
-        self._con_pool.clear()
+        self._con_pool.clear()  # type: ignore[union-attr]
 
     @staticmethod
     def _parse(json_data: bytes) -> Union[JSONDict, bool]:

--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -83,7 +83,7 @@ def _render_part(self: RequestField, name: str, value: str) -> str:  # pylint: d
     return f'{name}="{value}"'
 
 
-RequestField._render_part = _render_part  # type: ignore[assignment]  # pylint: disable=W0212
+RequestField._render_part = _render_part  # type: ignore  # pylint: disable=W0212
 
 logging.getLogger('urllib3').setLevel(logging.WARNING)
 
@@ -163,7 +163,7 @@ class Request:
             appengine.AppEngineManager,
             'SOCKSProxyManager',  # noqa: F821
             urllib3.ProxyManager,
-        ] = None  # type: ignore[assignment]
+        ] = None  # type: ignore
         if not proxy_url:
             if appengine.is_appengine_sandbox():
                 # Use URLFetch service if running in App Engine
@@ -194,7 +194,7 @@ class Request:
         return self._con_pool_size
 
     def stop(self) -> None:
-        self._con_pool.clear()  # type: ignore[union-attr]
+        self._con_pool.clear()  # type: ignore
 
     @staticmethod
     def _parse(json_data: bytes) -> Union[JSONDict, bool]:


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool! Please have a look at the below checklist. It's here to help both you and the maintainers to remember some aspects. Make sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
-->

### Checklist for PRs

- [X] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [X] Created new or adapted existing unit tests
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)


### If the PR contains API changes (otherwise, you can delete this passage)
    
* Added new shortcuts:
    - [ ] In `Chat` & `User` for all methods that accept `chat/user_id`
    - [X] In `Message` for all methods that accept `chat_id` and `message_id`
    - [X] For new `Message` shortcuts: Added `quote` argument if methods accepts `reply_to_message_id`
    - [ ] In `CallbackQuery` for all methods that accept either `chat_id` and `message_id` or `inline_message_id`
    
* If relevant:

    - [ ] Added new constants at `telegram.constants` and shortcuts to them as class variables
    - [ ] Added new handlers for new update types
    - [ ] Added new filters for new message (sub)types
    - [X] Added or updated documentation for the changed class(es) and/or method(s)

### Summary

- Add new shortcuts for `Message` (closes #2322)
  - `reply_chat_action`
  - `reply_game`
  - `reply_invoice`
- Update docs in `Message` to change from `update.message` to `update.effective_message`
- Fix `send_chat_action` docs in `Chat`
- Updates in `telegram/utils/request.py`
  - ~~`mypy` was giving the error message `unused 'type: ignore' comment`, fixed by removing `type: ignore` in the file~~ **See updated comment below**
  - `pylint` was giving the error message `E1101: Module 'socket' has no 'TCP_KEEPIDLE' member (no-member)`, fixed by moving `# pylint: disable=no-member` to the actual line of code
