### PR TITLE
Update docs & ignore edited channel posts

### DIFF
--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -62,7 +62,7 @@ class ConversationHandler(Handler[Update]):
     managing four collections of other handlers.
 
     Note:
-        ``ConversationHandler`` will only accept updates that are instances of (subclasses of)
+        ``ConversationHandler`` will only accept updates that are (subclass-)instances of
         :class:`telegram.Update`. This is, because depending on the :attr:`per_user` and
         :attr:`per_chat` ``ConversationHandler`` relies on
         :attr:`telegram.Update.effective_user` and/or :attr:`telegram.Update.effective_chat` in order

--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -65,10 +65,10 @@ class ConversationHandler(Handler[Update]):
         ``ConversationHandler`` will only accept updates that are instances of (subclasses of)
         :class:`telegram.Update`. This is, because depending on the :attr:`per_user` and
         :attr:`per_chat` ``ConversationHandler`` relies on
-        :attr:`telegram.Update.effective_user`, :attr:`telegram.Update.effective_chat` in order
+        :attr:`telegram.Update.effective_user` and/or :attr:`telegram.Update.effective_chat` in order
         to determine which conversation an update should belong to. For ``per_message=True``,
-        ``ConversationHandler`` uses ``update.callback_query.message.message_id`` for
-        ``per_chat=True`` and ``update.callback_query.inline_message_id`` for ``per_chat=False``.
+        ``ConversationHandler`` uses ``update.callback_query.message.message_id`` when
+        ``per_chat=True`` and ``update.callback_query.inline_message_id`` when ``per_chat=False``.
         For a more detailed explanation, please see our `FAQ`_.
 
         Finally, ``ConversationHandler``, does *not* handle (edited) channel posts.

--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -62,7 +62,7 @@ class ConversationHandler(Handler[Update]):
     managing four collections of other handlers.
 
     Note:
-        ``ConversationHandler`` will only accept updates that a instances of (subclasses of)
+        ``ConversationHandler`` will only accept updates that are instances of (subclasses of)
         :class:`telegram.Update`. This is, because depending on the :attr:`per_user` and
         :attr:`per_chat` ``ConversationHandler`` relies on
         :attr:`telegram.Update.effective_user`, :attr:`telegram.Update.effective_chat` in order

--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -65,8 +65,8 @@ class ConversationHandler(Handler[Update]):
         ``ConversationHandler`` will only accept updates that are (subclass-)instances of
         :class:`telegram.Update`. This is, because depending on the :attr:`per_user` and
         :attr:`per_chat` ``ConversationHandler`` relies on
-        :attr:`telegram.Update.effective_user` and/or :attr:`telegram.Update.effective_chat` in order
-        to determine which conversation an update should belong to. For ``per_message=True``,
+        :attr:`telegram.Update.effective_user` and/or :attr:`telegram.Update.effective_chat` in
+        order to determine which conversation an update should belong to. For ``per_message=True``,
         ``ConversationHandler`` uses ``update.callback_query.message.message_id`` when
         ``per_chat=True`` and ``update.callback_query.inline_message_id`` when ``per_chat=False``.
         For a more detailed explanation, please see our `FAQ`_.

--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -58,8 +58,22 @@ class _ConversationTimeoutContext:
 
 class ConversationHandler(Handler[Update]):
     """
-    A handler to hold a conversation with a single user by managing four collections of other
-    handlers.
+    A handler to hold a conversation with a single or multiple users through Telegram updates by
+    managing four collections of other handlers.
+
+    Note:
+        ``ConversationHandler`` will only accept updates that a instances of (subclasses of)
+        :class:`telegram.Update`. This is, because depending on the :attr:`per_user` and
+        :attr:`per_chat` ``ConversationHandler`` relies on
+        :attr:`telegram.Update.effective_user`, :attr:`telegram.Update.effective_chat` in order
+        to determine which conversation an update should belong to. For ``per_message=True``,
+        ``ConversationHandler`` uses ``update.callback_query.message.message_id`` for
+        ``per_chat=True`` and ``update.callback_query.inline_message_id`` for ``per_chat=False``.
+        For a more detailed explanation, please see our `FAQ`_.
+
+        Finally, ``ConversationHandler``, does *not* handle (edited) channel posts.
+
+    .. _`FAQ`: https://git.io/JtcyU
 
     The first collection, a ``list`` named :attr:`entry_points`, is used to initiate the
     conversation, for example with a :class:`telegram.ext.CommandHandler` or
@@ -424,7 +438,7 @@ class ConversationHandler(Handler[Update]):
         if not isinstance(update, Update):
             return None
         # Ignore messages in channels
-        if update.channel_post:
+        if update.channel_post or update.edited_channel_post:
             return None
         if self.per_chat and not update.effective_chat:
             return None

--- a/tests/test_conversationhandler.py
+++ b/tests/test_conversationhandler.py
@@ -726,10 +726,14 @@ class TestConversationHandler:
 
     def test_channel_message_without_chat(self, bot):
         handler = ConversationHandler(
-            entry_points=[CommandHandler('start', self.start_end)], states={}, fallbacks=[]
+            entry_points=[MessageHandler(Filters.all, self.start_end)], states={}, fallbacks=[]
         )
-        message = Message(0, None, None, Chat(0, Chat.CHANNEL, 'Misses Test'), bot=bot)
-        update = Update(0, message=message)
+        message = Message(0, date=None, chat=Chat(0, Chat.CHANNEL, 'Misses Test'), bot=bot)
+
+        update = Update(0, channel_post=message)
+        assert not handler.check_update(update)
+
+        update = Update(0, edited_channel_post=message)
         assert not handler.check_update(update)
 
     def test_all_update_types(self, dp, bot, user1):


### PR DESCRIPTION
See #2338, but I ended up changing more than the docs, so here is a standalone PR

* I did *not* list all the different update/handler types, as that's beyond the scope of the docs imho. Also, for the most updates it's rather obvious, which updates are associated with a chat/user/message id and which aren't.
* Instead I linked the FAQ, which can be more easily extended and also the wiki is the better place for elaborate explanations.
* Channel posts are ignored, see #487. This PR makes it also ignore *edited* channel posts, for completeness sake. Note that this is *not* a user facing change, as CH already ignores new posts, and hence a conversation that would be able to handle edited channel posts (i.e. `per_user=per_message=False`, `per_chat=True`)  can't even be started. Okay, yeah, if all of `per_user=per_chat=per_message=False`, then a CH can currenlty handle edited channel posts, but if someone uses that, they should overthink their design pattern …