### PR TITLE
Pin cryptography to 3.3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 certifi
-cryptography!=3.4
+cryptography==3.3.2
 # only telegram.ext: # Keep this line here; used in setup(-raw).py
 tornado>=5.1
 APScheduler==3.6.3


### PR DESCRIPTION
See #2372

I propose to leave #2372 open and give the cryptography time to figure out their plans for the future. As we need cryptography only for passports (and I've never met anyone acutally using those …) it's not a main security issue. Nevertheless I subscribed to the cryptography release channel to keep an eye on the changelog for security fixes.

If the situation is more clear in the future we can think about how we want to approach the issue.