### PR TITLE
Improve set_webhook

### DIFF
--- a/telegram/ext/updater.py
+++ b/telegram/ext/updater.py
@@ -255,12 +255,14 @@ class Updater:
         Args:
             poll_interval (:obj:`float`, optional): Time to wait between polling updates from
                 Telegram in seconds. Default is 0.0.
-            timeout (:obj:`float`, optional): Passed to :attr:`telegram.Bot.get_updates`.
+            timeout (:obj:`float`, optional): Passed to :meth:`telegram.Bot.get_updates`.
             drop_pending_updates (:obj:`bool`, optional): Whether to clean any pending updates on
                 Telegram servers before actually starting to poll. Default is :obj:`False`.
+
+                .. versionadded :: 13.4
             clean (:obj:`bool`, optional): Alias for ``drop_pending_updates``.
 
-                .. deprecated:: v13.4
+                .. deprecated:: 13.4
                     Use ``drop_pending_updates`` instead.
             bootstrap_retries (:obj:`int`, optional): Whether the bootstrapping phase of the
                 :class:`telegram.ext.Updater` will retry on failures on the Telegram server.
@@ -270,7 +272,7 @@ class Updater:
                 * > 0 - retry up to X times
 
             allowed_updates (List[:obj:`str`], optional): Passed to
-                :attr:`telegram.Bot.get_updates`.
+                :meth:`telegram.Bot.get_updates`.
             read_latency (:obj:`float` | :obj:`int`, optional): Grace time in seconds for receiving
                 the reply from server. Will be added to the ``timeout`` value and used as the read
                 timeout from server (Default: 2).
@@ -360,9 +362,11 @@ class Updater:
             key (:obj:`str`, optional): Path to the SSL key file.
             drop_pending_updates (:obj:`bool`, optional): Whether to clean any pending updates on
                 Telegram servers before actually starting to poll. Default is :obj:`False`.
+
+                .. versionadded :: 13.4
             clean (:obj:`bool`, optional): Alias for ``drop_pending_updates``.
 
-                .. deprecated:: v13.4
+                .. deprecated:: 13.4
                     Use ``drop_pending_updates`` instead.
             bootstrap_retries (:obj:`int`, optional): Whether the bootstrapping phase of the
                 :class:`telegram.ext.Updater` will retry on failures on the Telegram server.
@@ -374,10 +378,11 @@ class Updater:
             webhook_url (:obj:`str`, optional): Explicitly specify the webhook url. Useful behind
                 NAT, reverse proxy, etc. Default is derived from ``listen``, ``port`` &
                 ``url_path``.
-            ip_address (:obj:`str`, optional): The fixed IP address which will be used to send
-                webhook requests instead of the IP address resolved through DNS.
+            ip_address (:obj:`str`, optional): Passed to :meth:`telegram.Bot.set_webhook`.
+
+                .. versionadded :: 13.4
             allowed_updates (List[:obj:`str`], optional): Passed to
-                :attr:`telegram.Bot.set_webhook`.
+                :meth:`telegram.Bot.set_webhook`.
             force_event_loop (:obj:`bool`, optional): Force using the current event loop. See above
                 note for details. Defaults to :obj:`False`
 

--- a/telegram/ext/updater.py
+++ b/telegram/ext/updater.py
@@ -263,7 +263,7 @@ class Updater:
                 .. deprecated:: v13.4
                     Use ``drop_pending_updates`` instead.
             bootstrap_retries (:obj:`int`, optional): Whether the bootstrapping phase of the
-                `Updater` will retry on failures on the Telegram server.
+                :class:`telegram.ext.Updater` will retry on failures on the Telegram server.
 
                 * < 0 - retry indefinitely (default)
                 *   0 - no retries
@@ -272,7 +272,7 @@ class Updater:
             allowed_updates (List[:obj:`str`], optional): Passed to
                 :attr:`telegram.Bot.get_updates`.
             read_latency (:obj:`float` | :obj:`int`, optional): Grace time in seconds for receiving
-                the reply from server. Will be added to the `timeout` value and used as the read
+                the reply from server. Will be added to the ``timeout`` value and used as the read
                 timeout from server (Default: 2).
 
         Returns:
@@ -341,7 +341,7 @@ class Updater:
         and key are not provided, the webhook will be started directly on
         http://listen:port/url_path, so SSL can be handled by another
         application. Else, the webhook will be started on
-        https://listen:port/url_path
+        https://listen:port/url_path. Also calls :meth:`telegram.Bot.set_webhook` as required.
 
         Note:
             Due to an incompatibility of the Tornado library PTB uses for the webhook with Python
@@ -365,14 +365,15 @@ class Updater:
                 .. deprecated:: v13.4
                     Use ``drop_pending_updates`` instead.
             bootstrap_retries (:obj:`int`, optional): Whether the bootstrapping phase of the
-                `Updater` will retry on failures on the Telegram server.
+                :class:`telegram.ext.Updater` will retry on failures on the Telegram server.
 
                 * < 0 - retry indefinitely (default)
                 *   0 - no retries
                 * > 0 - retry up to X times
 
             webhook_url (:obj:`str`, optional): Explicitly specify the webhook url. Useful behind
-                NAT, reverse proxy, etc. Default is derived from `listen`, `port` & `url_path`.
+                NAT, reverse proxy, etc. Default is derived from ``listen``, ``port`` &
+                ``url_path``.
             ip_address (:obj:`str`, optional): The fixed IP address which will be used to send
                 webhook requests instead of the IP address resolved through DNS.
             allowed_updates (List[:obj:`str`], optional): Passed to

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -72,6 +72,7 @@ class TestUpdater:
     err_handler_called = Event()
     cb_handler_called = Event()
     offset = 0
+    test_flag = False
 
     @pytest.fixture(autouse=True)
     def reset(self):
@@ -80,6 +81,7 @@ class TestUpdater:
         self.attempts = 0
         self.err_handler_called.clear()
         self.cb_handler_called.clear()
+        self.test_flag = False
 
     def error_handler(self, bot, update, error):
         self.received = error.message
@@ -357,6 +359,42 @@ class TestUpdater:
         assert q.get(False) == update
         updater.stop()
 
+    def test_webhook_ssl_just_for_telegram(self, monkeypatch, updater):
+        q = Queue()
+
+        def set_webhook(**kwargs):
+            self.test_flag.append(bool(kwargs.get('certificate')))
+            return True
+
+        orig_wh_server_init = WebhookServer.__init__
+
+        def webhook_server_init(*args):
+            self.test_flag = [args[-1] is None]
+            orig_wh_server_init(*args)
+
+        monkeypatch.setattr(updater.bot, 'set_webhook', set_webhook)
+        monkeypatch.setattr(updater.bot, 'delete_webhook', lambda *args, **kwargs: True)
+        monkeypatch.setattr('telegram.ext.Dispatcher.process_update', lambda _, u: q.put(u))
+        monkeypatch.setattr(
+            'telegram.ext.utils.webhookhandler.WebhookServer.__init__', webhook_server_init
+        )
+
+        ip = '127.0.0.1'
+        port = randrange(1024, 49152)  # Select random port
+        updater.start_webhook(ip, port, webhook_url=None, cert='./tests/test_updater.py')
+        sleep(0.2)
+
+        # Now, we send an update to the server via urlopen
+        update = Update(
+            1,
+            message=Message(1, None, Chat(1, ''), from_user=User(1, '', False), text='Webhook 2'),
+        )
+        self._send_webhook_msg(ip, port, update.to_json())
+        sleep(0.2)
+        assert q.get(False) == update
+        updater.stop()
+        assert self.test_flag == [True, True]
+
     @pytest.mark.parametrize(('error',), argvalues=[(TelegramError(''),)], ids=('TelegramError',))
     def test_bootstrap_retries_success(self, monkeypatch, updater, error):
         retries = 2
@@ -391,41 +429,63 @@ class TestUpdater:
             updater._bootstrap(retries, False, 'path', None, bootstrap_interval=0)
         assert self.attempts == attempts
 
-    def test_bootstrap_clean_updates(self, monkeypatch, updater):
-        clean = True
-        expected_id = 4
-        self.offset = 0
+    @pytest.mark.parametrize('drop_pending_updates', (True, False))
+    def test_bootstrap_clean_updates(self, monkeypatch, updater, drop_pending_updates):
+        # As dropping pending updates is done by passing `drop_pending_updates` to
+        # set_webhook, we just check that we pass the correct value
+        self.test_flag = False
 
-        def get_updates(*args, **kwargs):
-            # we're hitting this func twice
-            # 1. no args, return list of updates
-            # 2. with 1 arg, int => if int == expected_id => test successful
+        def delete_webhook(**kwargs):
+            self.test_flag = kwargs.get('drop_pending_updates') == drop_pending_updates
 
-            # case 2
-            # 2nd call from bootstrap____clean
-            # we should be called with offset = 4
-            # save value passed in self.offset for assert down below
-            if len(args) > 0:
-                self.offset = int(args[0])
-                return []
-
-            class FakeUpdate:
-                def __init__(self, update_id):
-                    self.update_id = update_id
-
-            # case 1
-            # return list of obj's
-
-            # build list of fake updates
-            # returns list of 4 objects with
-            # update_id's 0, 1, 2 and 3
-            return [FakeUpdate(i) for i in range(0, expected_id)]
-
-        monkeypatch.setattr(updater.bot, 'get_updates', get_updates)
+        monkeypatch.setattr(updater.bot, 'delete_webhook', delete_webhook)
 
         updater.running = True
-        updater._bootstrap(1, clean, None, None, bootstrap_interval=0)
-        assert self.offset == expected_id
+        updater._bootstrap(
+            1,
+            drop_pending_updates=drop_pending_updates,
+            webhook_url=None,
+            allowed_updates=None,
+            bootstrap_interval=0,
+        )
+        assert self.test_flag is True
+
+    def test_clean_deprecation_warning_webhook(self, recwarn, updater, monkeypatch):
+        monkeypatch.setattr(updater.bot, 'set_webhook', lambda *args, **kwargs: True)
+        monkeypatch.setattr(updater.bot, 'delete_webhook', lambda *args, **kwargs: True)
+        # prevent api calls from @info decorator when updater.bot.id is used in thread names
+        monkeypatch.setattr(updater.bot, '_bot', User(id=123, first_name='bot', is_bot=True))
+        monkeypatch.setattr(updater.bot, '_commands', [])
+
+        ip = '127.0.0.1'
+        port = randrange(1024, 49152)  # Select random port
+        updater.start_webhook(ip, port, clean=True)
+        updater.stop()
+        assert len(recwarn) == 2
+        assert str(recwarn[0].message).startswith('Old Handler API')
+        assert str(recwarn[1].message).startswith('The argument `clean` of')
+
+    def test_clean_deprecation_warning_polling(self, recwarn, updater, monkeypatch):
+        monkeypatch.setattr(updater.bot, 'set_webhook', lambda *args, **kwargs: True)
+        monkeypatch.setattr(updater.bot, 'delete_webhook', lambda *args, **kwargs: True)
+        # prevent api calls from @info decorator when updater.bot.id is used in thread names
+        monkeypatch.setattr(updater.bot, '_bot', User(id=123, first_name='bot', is_bot=True))
+        monkeypatch.setattr(updater.bot, '_commands', [])
+
+        updater.start_polling(clean=True)
+        updater.stop()
+        assert len(recwarn) == 2
+        for msg in recwarn:
+            print(msg)
+        assert str(recwarn[0].message).startswith('Old Handler API')
+        assert str(recwarn[1].message).startswith('The argument `clean` of')
+
+    def test_clean_drop_pending_mutually_exclusive(self, updater):
+        with pytest.raises(TypeError, match='`clean` and `drop_pending_updates` are mutually'):
+            updater.start_polling(clean=True, drop_pending_updates=False)
+
+        with pytest.raises(TypeError, match='`clean` and `drop_pending_updates` are mutually'):
+            updater.start_webhook(clean=True, drop_pending_updates=False)
 
     @flaky(3, 1)
     def test_webhook_invalid_posts(self, updater):

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -247,7 +247,7 @@ class TestUpdater:
                 cert=None,
                 key=None,
                 bootstrap_retries=0,
-                clean=False,
+                drop_pending_updates=False,
                 webhook_url=None,
                 allowed_updates=None,
             )
@@ -274,7 +274,7 @@ class TestUpdater:
                     cert=None,
                     key=None,
                     bootstrap_retries=0,
-                    clean=False,
+                    drop_pending_updates=False,
                     webhook_url=None,
                     allowed_updates=None,
                 )
@@ -307,7 +307,7 @@ class TestUpdater:
                 cert=None,
                 key=None,
                 bootstrap_retries=0,
-                clean=False,
+                drop_pending_updates=False,
                 webhook_url=None,
                 allowed_updates=None,
                 force_event_loop=True,
@@ -328,7 +328,7 @@ class TestUpdater:
                 cert='./tests/test_updater.py',
                 key='./tests/test_updater.py',
                 bootstrap_retries=0,
-                clean=False,
+                drop_pending_updates=False,
                 webhook_url=None,
                 allowed_updates=None,
             )


### PR DESCRIPTION
When ready closes #2416

Already tested 

* polling
* nginx reverse proxy webhooks with letsencrypt (not passing `cert` to TG) & with self-signed certificate (passing `cert` to TG)

To be done:

- [x] test having the built-in Webserver handle the SSL stuff. IISC I can't test that on my lolcal setup, though …
- [x] double check if docs are updated enough
- [x] unit tests
- [x] add dreprecation of `clean` to #2347 

This also

* deprecated the `clean` argument in favor of `drop_pending_updates` as a) that conforms with the TG nomenclature, b) that name is more speaking
* adds the `ip_address` parameter of `set_webhook` to `start_webhook` (tbh I don't really understand what it's good for, do we need some special casing for that?)

When ready:

- [ ] Update the wiki page on webhooks according to the changes

### Checklist for PRs

- [x] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (I did that but leaving it as todo here so we double check the version number before merging)

