### PR TITLE
Set logging on vendored lib instead of upstream

### DIFF
--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -85,7 +85,7 @@ def _render_part(self: RequestField, name: str, value: str) -> str:  # pylint: d
 
 RequestField._render_part = _render_part  # type: ignore  # pylint: disable=W0212
 
-logging.getLogger('urllib3').setLevel(logging.WARNING)
+logging.getLogger('telegram.vendor.ptb_urllib3.urllib3').setLevel(logging.WARNING)
 
 USER_AGENT = 'Python Telegram Bot (https://github.com/python-telegram-bot/python-telegram-bot)'
 


### PR DESCRIPTION
IISC that setting was just not changed when we started vendoring urllib3. see [this thread](https://t.me/pythontelegrambotgroup/446393) for reference.