### PR TITLE
add escape for '!' in echobot example

### DIFF
--- a/examples/echobot.py
+++ b/examples/echobot.py
@@ -34,7 +34,7 @@ def start(update: Update, _: CallbackContext) -> None:
     """Send a message when the command /start is issued."""
     user = update.effective_user
     update.message.reply_markdown_v2(
-        f'Hi {user.mention_markdown_v2()}!',
+        f'Hi {user.mention_markdown_v2()}\!',
         reply_markup=ForceReply(selective=True),
     )
 


### PR DESCRIPTION
tiny fix for '!' escape which was missed
