### PR TITLE
Update chat actions

### DIFF
--- a/telegram/chataction.py
+++ b/telegram/chataction.py
@@ -28,7 +28,17 @@ class ChatAction:
     FIND_LOCATION: ClassVar[str] = constants.CHATACTION_FIND_LOCATION
     """:const:`telegram.constants.CHATACTION_FIND_LOCATION`"""
     RECORD_AUDIO: ClassVar[str] = constants.CHATACTION_RECORD_AUDIO
-    """:const:`telegram.constants.CHATACTION_RECORD_AUDIO`"""
+    """:const:`telegram.constants.CHATACTION_RECORD_AUDIO`
+
+        .. deprecated:: 13.5
+           Deprecated by Telegram. Use :attr:`RECORD_VOICE` instead, as backwards
+           compatibility is not guaranteed by Telegram.
+    """
+    RECORD_VOICE: ClassVar[str] = constants.CHATACTION_RECORD_VOICE
+    """:const:`telegram.constants.CHATACTION_RECORD_VOICE`
+
+        .. versionadded:: 13.5
+    """
     RECORD_VIDEO: ClassVar[str] = constants.CHATACTION_RECORD_VIDEO
     """:const:`telegram.constants.CHATACTION_RECORD_VIDEO`"""
     RECORD_VIDEO_NOTE: ClassVar[str] = constants.CHATACTION_RECORD_VIDEO_NOTE
@@ -36,7 +46,17 @@ class ChatAction:
     TYPING: ClassVar[str] = constants.CHATACTION_TYPING
     """:const:`telegram.constants.CHATACTION_TYPING`"""
     UPLOAD_AUDIO: ClassVar[str] = constants.CHATACTION_UPLOAD_AUDIO
-    """:const:`telegram.constants.CHATACTION_UPLOAD_AUDIO`"""
+    """:const:`telegram.constants.CHATACTION_UPLOAD_AUDIO`
+
+        .. deprecated:: 13.5
+           Deprecated by Telegram. Use :attr:`UPLOAD_VOICE` instead, as backwards
+           compatibility is not guaranteed by Telegram.
+    """
+    UPLOAD_VOICE: ClassVar[str] = constants.CHATACTION_UPLOAD_VOICE
+    """:const:`telegram.constants.CHATACTION_UPLOAD_VOICE`
+
+        .. versionadded:: 13.5
+    """
     UPLOAD_DOCUMENT: ClassVar[str] = constants.CHATACTION_UPLOAD_DOCUMENT
     """:const:`telegram.constants.CHATACTION_UPLOAD_DOCUMENT`"""
     UPLOAD_PHOTO: ClassVar[str] = constants.CHATACTION_UPLOAD_PHOTO

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -65,10 +65,24 @@ Attributes:
 Attributes:
     CHATACTION_FIND_LOCATION (:obj:`str`): 'find_location'
     CHATACTION_RECORD_AUDIO (:obj:`str`): 'record_audio'
+
+        .. deprecated:: 13.5
+           Deprecated by Telegram. Use :const:`CHATACTION_RECORD_VOICE` instead, as backwards
+           compatibility is not guaranteed by Telegram.
+    CHATACTION_RECORD_VOICE (:obj:`str`): 'record_voice'
+
+        .. versionadded:: 13.5
     CHATACTION_RECORD_VIDEO (:obj:`str`): 'record_video'
     CHATACTION_RECORD_VIDEO_NOTE (:obj:`str`): 'record_video_note'
     CHATACTION_TYPING (:obj:`str`): 'typing'
     CHATACTION_UPLOAD_AUDIO (:obj:`str`): 'upload_audio'
+
+        .. deprecated:: 13.5
+           Deprecated by Telegram. Use :const:`CHATACTION_UPLOAD_VOICE` instead, as backwards
+           compatibility is not guaranteed by Telegram.
+    CHATACTION_UPLOAD_VOICE (:obj:`str`): 'upload_voice'
+
+        .. versionadded:: 13.5
     CHATACTION_UPLOAD_DOCUMENT (:obj:`str`): 'upload_document'
     CHATACTION_UPLOAD_PHOTO (:obj:`str`): 'upload_photo'
     CHATACTION_UPLOAD_VIDEO (:obj:`str`): 'upload_video'
@@ -172,10 +186,12 @@ CHAT_CHANNEL: str = 'channel'
 
 CHATACTION_FIND_LOCATION: str = 'find_location'
 CHATACTION_RECORD_AUDIO: str = 'record_audio'
+CHATACTION_RECORD_VOICE: str = 'record_voice'
 CHATACTION_RECORD_VIDEO: str = 'record_video'
 CHATACTION_RECORD_VIDEO_NOTE: str = 'record_video_note'
 CHATACTION_TYPING: str = 'typing'
 CHATACTION_UPLOAD_AUDIO: str = 'upload_audio'
+CHATACTION_UPLOAD_VOICE: str = 'upload_voice'
 CHATACTION_UPLOAD_DOCUMENT: str = 'upload_document'
 CHATACTION_UPLOAD_PHOTO: str = 'upload_photo'
 CHATACTION_UPLOAD_VIDEO: str = 'upload_video'

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -614,8 +614,25 @@ class TestBot:
 
     @flaky(3, 1)
     @pytest.mark.timeout(10)
-    def test_send_chat_action(self, bot, chat_id):
-        assert bot.send_chat_action(chat_id, ChatAction.TYPING)
+    @pytest.mark.parametrize(
+        'chat_action',
+        [
+            ChatAction.FIND_LOCATION,
+            ChatAction.RECORD_AUDIO,
+            ChatAction.RECORD_VIDEO,
+            ChatAction.RECORD_VIDEO_NOTE,
+            ChatAction.RECORD_VOICE,
+            ChatAction.TYPING,
+            ChatAction.UPLOAD_AUDIO,
+            ChatAction.UPLOAD_DOCUMENT,
+            ChatAction.UPLOAD_PHOTO,
+            ChatAction.UPLOAD_VIDEO,
+            ChatAction.UPLOAD_VIDEO_NOTE,
+            ChatAction.UPLOAD_VOICE,
+        ],
+    )
+    def test_send_chat_action(self, bot, chat_id, chat_action):
+        assert bot.send_chat_action(chat_id, chat_action)
 
     # TODO: Needs improvement. We need incoming inline query to test answer.
     def test_answer_inline_query(self, monkeypatch, bot):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -633,6 +633,8 @@ class TestBot:
     )
     def test_send_chat_action(self, bot, chat_id, chat_action):
         assert bot.send_chat_action(chat_id, chat_action)
+        with pytest.raises(BadRequest, match='Wrong parameter action'):
+            bot.send_chat_action(chat_action, 'unknown action')
 
     # TODO: Needs improvement. We need incoming inline query to test answer.
     def test_answer_inline_query(self, monkeypatch, bot):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -634,7 +634,7 @@ class TestBot:
     def test_send_chat_action(self, bot, chat_id, chat_action):
         assert bot.send_chat_action(chat_id, chat_action)
         with pytest.raises(BadRequest, match='Wrong parameter action'):
-            bot.send_chat_action(chat_action, 'unknown action')
+            bot.send_chat_action(chat_id, 'unknown action')
 
     # TODO: Needs improvement. We need incoming inline query to test answer.
     def test_answer_inline_query(self, monkeypatch, bot):


### PR DESCRIPTION
Found out by accident that `chatAction.upload/record_audio` has been replaced by `voice` somewhere between [11/2020](http://web.archive.org/web/20201104220443/https://core.telegram.org/bots/api) and [12/2020](http://web.archive.org/web/20201206123042/https://core.telegram.org/bots/api). Kudos [@RenshouSorinozuka](t.me/RenshouSorinozuka) for making me find this :D 

the audio-things still work because of this: https://github.com/tdlib/telegram-bot-api/blob/bf371b21b97c4c8d0b2e2646db05c654cb05480e/telegram-bot-api/Client.cpp#L4850 but backward compatibility is undocumented. I pinged botsupport asking them to at least document the change/announce somewhere, so I'd wait with mergen a bit to give them a change to update the docs, which we then could properly copy.

Also I didn't find a good way to add a deprecation warning to constants … Maybe someone has an idea? Then again, maybe it's not necessary.

### Checklist for PRs

- [x] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)


### If the PR contains API changes (otherwise, you can delete this passage)
    
* If relevant:

    - [x] Added new constants at `telegram.constants` and shortcuts to them as class variables
    - [ ] Added new handlers for new update types
    - [ ] Added new filters for new message (sub)types
    - [ ] Added or updated documentation for the changed class(es) and/or method(s)
    - [ ] Updated the Bot API version number in all places: `README.rst` and `README_RAW.rst` (including the badge), as well as `telegram.constants.BOT_API_VERSION`
