### PR TITLE
Api 5.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,11 +10,11 @@ repos:
         - --diff
         - --check
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.1
     hooks:
     -   id: flake8
 -   repo: https://github.com/PyCQA/pylint
-    rev: pylint-2.7.2
+    rev: v2.8.2
     hooks:
     -   id: pylint
         files: ^(telegram|examples)/.*\.py$
@@ -48,7 +48,7 @@ repos:
           - APScheduler==3.6.3
           - . # this basically does `pip install -e .`
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.10.0
+    rev: v2.13.0
     hooks:
     -   id: pyupgrade
         files: ^(telegram|examples|tests)/.*\.py$

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ We have a vibrant community of developers helping each other in our `Telegram gr
    :target: https://pypi.org/project/python-telegram-bot/
    :alt: Supported Python versions
 
-.. image:: https://img.shields.io/badge/Bot%20API-5.1-blue?logo=telegram
+.. image:: https://img.shields.io/badge/Bot%20API-5.2-blue?logo=telegram
    :target: https://core.telegram.org/bots/api-changelog
    :alt: Supported Bot API versions
 
@@ -111,7 +111,7 @@ Installing both ``python-telegram-bot`` and ``python-telegram-bot-raw`` in conju
 Telegram API support
 ====================
 
-All types and methods of the Telegram Bot API **5.1** are supported.
+All types and methods of the Telegram Bot API **5.2** are supported.
 
 ==========
 Installing

--- a/README_RAW.rst
+++ b/README_RAW.rst
@@ -20,7 +20,7 @@ We have a vibrant community of developers helping each other in our `Telegram gr
    :target: https://pypi.org/project/python-telegram-bot-raw/
    :alt: Supported Python versions
 
-.. image:: https://img.shields.io/badge/Bot%20API-5.1-blue?logo=telegram
+.. image:: https://img.shields.io/badge/Bot%20API-5.2-blue?logo=telegram
    :target: https://core.telegram.org/bots/api-changelog
    :alt: Supported Bot API versions
 
@@ -105,7 +105,7 @@ Installing both ``python-telegram-bot`` and ``python-telegram-bot-raw`` in conju
 Telegram API support
 ====================
 
-All types and methods of the Telegram Bot API **5.1** are supported.
+All types and methods of the Telegram Bot API **5.2** are supported.
 
 ==========
 Installing

--- a/docs/source/telegram.inputinvoicemessagecontent.rst
+++ b/docs/source/telegram.inputinvoicemessagecontent.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/telegram/inline/inputinvoicemessagecontent.py
+
 telegram.InputInvoiceMessageContent
 ===================================
 

--- a/docs/source/telegram.inputinvoicemessagecontent.rst
+++ b/docs/source/telegram.inputinvoicemessagecontent.rst
@@ -1,0 +1,6 @@
+telegram.InputInvoiceMessageContent
+===================================
+
+.. autoclass:: telegram.InputInvoiceMessageContent
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.rst
+++ b/docs/source/telegram.rst
@@ -62,6 +62,7 @@ telegram package
     telegram.voice
     telegram.voicechatstarted
     telegram.voicechatended
+    telegram.voicechatscheduled
     telegram.voicechatparticipantsinvited
     telegram.webhookinfo
 

--- a/docs/source/telegram.rst
+++ b/docs/source/telegram.rst
@@ -106,6 +106,7 @@ Inline Mode
     telegram.inputlocationmessagecontent
     telegram.inputvenuemessagecontent
     telegram.inputcontactmessagecontent
+    telegram.inputinvoicemessagecontent
     telegram.choseninlineresult
 
 Payments

--- a/docs/source/telegram.voicechatscheduled.rst
+++ b/docs/source/telegram.voicechatscheduled.rst
@@ -1,0 +1,7 @@
+telegram.VoiceChatScheduled
+===========================
+
+.. autoclass:: telegram.VoiceChatScheduled
+    :members:
+    :show-inheritance:
+

--- a/docs/source/telegram.voicechatscheduled.rst
+++ b/docs/source/telegram.voicechatscheduled.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/telegram/voicechat.py
+
 telegram.VoiceChatScheduled
 ===========================
 

--- a/examples/paymentbot.py
+++ b/examples/paymentbot.py
@@ -44,7 +44,6 @@ def start_with_shipping_callback(update: Update, context: CallbackContext) -> No
     payload = "Custom-Payload"
     # In order to get a provider_token see https://core.telegram.org/bots/payments#getting-a-token
     provider_token = "PROVIDER_TOKEN"
-    start_parameter = "test-payment"
     currency = "USD"
     # price in dollars
     price = 1
@@ -60,7 +59,6 @@ def start_with_shipping_callback(update: Update, context: CallbackContext) -> No
         description,
         payload,
         provider_token,
-        start_parameter,
         currency,
         prices,
         need_name=True,
@@ -79,7 +77,6 @@ def start_without_shipping_callback(update: Update, context: CallbackContext) ->
     payload = "Custom-Payload"
     # In order to get a provider_token see https://core.telegram.org/bots/payments#getting-a-token
     provider_token = "PROVIDER_TOKEN"
-    start_parameter = "test-payment"
     currency = "USD"
     # price in dollars
     price = 1
@@ -89,7 +86,7 @@ def start_without_shipping_callback(update: Update, context: CallbackContext) ->
     # optionally pass need_name=True, need_phone_number=True,
     # need_email=True, need_shipping_address=True, is_flexible=True
     context.bot.send_invoice(
-        chat_id, title, description, payload, provider_token, start_parameter, currency, prices
+        chat_id, title, description, payload, provider_token, currency, prices
     )
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,12 +4,12 @@ cryptography!=3.4,!=3.4.1,!=3.4.2,!=3.4.3
 pre-commit
 # Make sure that the versions specified here match the pre-commit settings!
 black==20.8b1
-flake8==3.8.4
-pylint==2.7.2
+flake8==3.9.1
+pylint==2.8.2
 mypy==0.812
-pyupgrade==2.10.0
+pyupgrade==2.13.0
 
-pytest==6.2.2
+pytest==6.2.3
 
 flaky
 beautifulsoup4

--- a/telegram/__init__.py
+++ b/telegram/__init__.py
@@ -56,7 +56,12 @@ from .messageentity import MessageEntity
 from .messageid import MessageId
 from .games.game import Game
 from .poll import Poll, PollOption, PollAnswer
-from .voicechat import VoiceChatStarted, VoiceChatEnded, VoiceChatParticipantsInvited
+from .voicechat import (
+    VoiceChatStarted,
+    VoiceChatEnded,
+    VoiceChatParticipantsInvited,
+    VoiceChatScheduled,
+)
 from .loginurl import LoginUrl
 from .proximityalerttriggered import ProximityAlertTriggered
 from .games.callbackgame import CallbackGame
@@ -283,6 +288,7 @@ __all__ = (  # Keep this alphabetically ordered
     'Voice',
     'VoiceChatStarted',
     'VoiceChatEnded',
+    'VoiceChatScheduled',
     'VoiceChatParticipantsInvited',
     'WebhookInfo',
 )

--- a/telegram/__init__.py
+++ b/telegram/__init__.py
@@ -101,8 +101,9 @@ from .inline.inlinequeryresultgame import InlineQueryResultGame
 from .inline.inputtextmessagecontent import InputTextMessageContent
 from .inline.inputlocationmessagecontent import InputLocationMessageContent
 from .inline.inputvenuemessagecontent import InputVenueMessageContent
-from .inline.inputcontactmessagecontent import InputContactMessageContent
 from .payment.labeledprice import LabeledPrice
+from .inline.inputinvoicemessagecontent import InputInvoiceMessageContent
+from .inline.inputcontactmessagecontent import InputContactMessageContent
 from .payment.shippingoption import ShippingOption
 from .payment.precheckoutquery import PreCheckoutQuery
 from .payment.shippingquery import ShippingQuery
@@ -207,6 +208,7 @@ __all__ = (  # Keep this alphabetically ordered
     'InlineQueryResultVoice',
     'InputContactMessageContent',
     'InputFile',
+    'InputInvoiceMessageContent',
     'InputLocationMessageContent',
     'InputMedia',
     'InputMediaAnimation',

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -3294,6 +3294,14 @@ class Bot(TelegramObject):
     ) -> Message:
         """Use this method to send invoices.
 
+        Warning:
+            As of API 5.2 :attr:`start_parameter` is an optional argument and therefore the order
+            of the arguments had to be changed. Use keyword arguments to make sure that the
+            arguments are passed correctly.
+
+        .. versionchanged:: 13.5
+            As of Bot API 5.2, the parameter :attr:`start_parameter` is optional.
+
         Args:
             chat_id (:obj:`int` | :obj:`str`): Unique identifier for the target chat or username
                 of the target channel (in the format ``@channelusername``).

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -538,7 +538,7 @@ class Bot(TelegramObject):
         timeout: ODVInput[float] = DEFAULT_NONE,
         api_kwargs: JSONDict = None,
     ) -> Message:
-        """Use this method to forward messages of any kind.
+        """Use this method to forward messages of any kind. Service messages can't be forwarded.
 
         Args:
             chat_id (:obj:`int` | :obj:`str`): Unique identifier for the target chat or username
@@ -3295,7 +3295,8 @@ class Bot(TelegramObject):
         """Use this method to send invoices.
 
         Args:
-            chat_id (:obj:`int` | :obj:`str`): Unique identifier for the target private chat.
+            chat_id (:obj:`int` | :obj:`str`): Unique identifier for the target chat or username
+                of the target channel (in the format ``@channelusername``).
             title (:obj:`str`): Product name, 1-32 characters.
             description (:obj:`str`): Product description, 1-255 characters.
             payload (:obj:`str`): Bot-defined invoice payload, 1-128 bytes. This will not be
@@ -3321,8 +3322,12 @@ class Bot(TelegramObject):
                 ``max_tip_amount``.
 
                 .. versionadded:: 13.5
-            start_parameter (:obj:`str`, optional): Unique deep-linking parameter that can be used
-                to generate this invoice when used as a start parameter.
+            start_parameter (:obj:`str`, optional): Unique deep-linking parameter. If left empty,
+                *forwarded copies* of the sent message will have a *Pay* button, allowing
+                multiple users to pay directly from the forwarded message, using the same invoice.
+                If non-empty, forwarded copies of the sent message will have a *URL* button with a
+                deep link to the bot (instead of a *Pay* button), with the value used as the
+                start parameter.
 
                 .. versionchanged:: 13.5
                     As of Bot API 5.2, this parameter is optional.
@@ -5010,9 +5015,9 @@ class Bot(TelegramObject):
         api_kwargs: JSONDict = None,
     ) -> MessageId:
         """
-        Use this method to copy messages of any kind. The method is analogous to the method
-        forwardMessages, but the copied message doesn't have a link to the original message.
-        Returns the MessageId of the sent message on success.
+        Use this method to copy messages of any kind. Service messages and invoice messages can't
+        be copied. The method is analogous to the method :meth:`forward_message`, but the copied
+        message doesn't have a link to the original message.
 
         Args:
             chat_id (:obj:`int` | :obj:`str`): Unique identifier for the target chat or username

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -3268,9 +3268,9 @@ class Bot(TelegramObject):
         description: str,
         payload: str,
         provider_token: str,
-        start_parameter: str,
         currency: str,
         prices: List['LabeledPrice'],
+        start_parameter: str = None,
         photo_url: str = None,
         photo_size: int = None,
         photo_width: int = None,
@@ -3289,6 +3289,8 @@ class Bot(TelegramObject):
         timeout: ODVInput[float] = DEFAULT_NONE,
         api_kwargs: JSONDict = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
+        max_tip_amount: int = None,
+        suggested_tip_amounts: List[int] = None,
     ) -> Message:
         """Use this method to send invoices.
 
@@ -3300,12 +3302,30 @@ class Bot(TelegramObject):
                 displayed to the user, use for your internal processes.
             provider_token (:obj:`str`): Payments provider token, obtained via
                 `@BotFather <https://t.me/BotFather>`_.
-            start_parameter (:obj:`str`): Unique deep-linking parameter that can be used to
-                generate this invoice when used as a start parameter.
             currency (:obj:`str`): Three-letter ISO 4217 currency code.
             prices (List[:class:`telegram.LabeledPrice`)]: Price breakdown, a JSON-serialized list
                 of components (e.g. product price, tax, discount, delivery cost, delivery tax,
                 bonus, etc.).
+            max_tip_amount (:obj:`int`, optional): The maximum accepted amount for tips in the
+                smallest units of the currency (integer, not float/double). For example, for a
+                maximum tip of US$ 1.45 pass ``max_tip_amount = 145``. See the exp parameter in
+                `currencies.json <https://core.telegram.org/bots/payments/currencies.json>`_, it
+                shows the number of digits past the decimal point for each currency (2 for the
+                majority of currencies). Defaults to ``0``.
+
+                .. versionadded:: 13.5
+            suggested_tip_amounts (List[:obj:`int`], optional): A JSON-serialized array of
+                suggested amounts of tips in the smallest units of the currency (integer, not
+                float/double). At most 4 suggested tip amounts can be specified. The suggested tip
+                amounts must be positive, passed in a strictly increased order and must not exceed
+                ``max_tip_amount``.
+
+                .. versionadded:: 13.5
+            start_parameter (:obj:`str`, optional): Unique deep-linking parameter that can be used
+                to generate this invoice when used as a start parameter.
+
+                .. versionchanged:: 13.5
+                    As of Bot API 5.2, this parameter is optional.
             provider_data (:obj:`str` | :obj:`object`, optional): JSON-serialized data about the
                 invoice, which will be shared with the payment provider. A detailed description of
                 required fields should be provided by the payment provider. When an object is
@@ -3358,10 +3378,15 @@ class Bot(TelegramObject):
             'description': description,
             'payload': payload,
             'provider_token': provider_token,
-            'start_parameter': start_parameter,
             'currency': currency,
             'prices': [p.to_dict() for p in prices],
         }
+        if max_tip_amount is not None:
+            data['max_tip_amount'] = max_tip_amount
+        if suggested_tip_amounts is not None:
+            data['suggested_tip_amounts'] = suggested_tip_amounts
+        if start_parameter is not None:
+            data['start_parameter'] = start_parameter
         if provider_data is not None:
             if isinstance(provider_data, str):
                 data['provider_data'] = provider_data

--- a/telegram/chat.py
+++ b/telegram/chat.py
@@ -958,7 +958,7 @@ class Chat(TelegramObject):
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_invoice`.
 
         .. versionchanged:: 13.5
-            As of Bot API 5.2, this parameter is optional.
+            As of Bot API 5.2, the parameter :attr:`start_parameter` is optional.
 
         Returns:
             :class:`telegram.Message`: On success, instance representing the message posted.

--- a/telegram/chat.py
+++ b/telegram/chat.py
@@ -922,9 +922,9 @@ class Chat(TelegramObject):
         description: str,
         payload: str,
         provider_token: str,
-        start_parameter: str,
         currency: str,
         prices: List['LabeledPrice'],
+        start_parameter: str = None,
         photo_url: str = None,
         photo_size: int = None,
         photo_width: int = None,
@@ -943,12 +943,17 @@ class Chat(TelegramObject):
         timeout: ODVInput[float] = DEFAULT_NONE,
         api_kwargs: JSONDict = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
+        max_tip_amount: int = None,
+        suggested_tip_amounts: List[int] = None,
     ) -> 'Message':
         """Shortcut for::
 
             bot.send_invoice(update.effective_chat.id, *args, **kwargs)
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_invoice`.
+
+        .. versionchanged:: 13.5
+            As of Bot API 5.2, this parameter is optional.
 
         Returns:
             :class:`telegram.Message`: On success, instance representing the message posted.
@@ -960,9 +965,9 @@ class Chat(TelegramObject):
             description=description,
             payload=payload,
             provider_token=provider_token,
-            start_parameter=start_parameter,
             currency=currency,
             prices=prices,
+            start_parameter=start_parameter,
             photo_url=photo_url,
             photo_size=photo_size,
             photo_width=photo_width,
@@ -981,6 +986,8 @@ class Chat(TelegramObject):
             timeout=timeout,
             api_kwargs=api_kwargs,
             allow_sending_without_reply=allow_sending_without_reply,
+            max_tip_amount=max_tip_amount,
+            suggested_tip_amounts=suggested_tip_amounts,
         )
 
     def send_location(

--- a/telegram/chat.py
+++ b/telegram/chat.py
@@ -143,6 +143,11 @@ class Chat(TelegramObject):
 
     """
 
+    SENDER: ClassVar[str] = constants.CHAT_SENDER
+    """:const:`telegram.constants.CHAT_SENDER`
+
+    .. versionadded:: 13.5
+    """
     PRIVATE: ClassVar[str] = constants.CHAT_PRIVATE
     """:const:`telegram.constants.CHAT_PRIVATE`"""
     GROUP: ClassVar[str] = constants.CHAT_GROUP

--- a/telegram/chat.py
+++ b/telegram/chat.py
@@ -957,6 +957,11 @@ class Chat(TelegramObject):
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_invoice`.
 
+        Warning:
+            As of API 5.2 :attr:`start_parameter` is an optional argument and therefore the order
+            of the arguments had to be changed. Use keyword arguments to make sure that the
+            arguments are passed correctly.
+
         .. versionchanged:: 13.5
             As of Bot API 5.2, the parameter :attr:`start_parameter` is optional.
 

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -21,7 +21,7 @@ The following constants were extracted from the
 `Telegram Bots API <https://core.telegram.org/bots/api>`_.
 
 Attributes:
-    BOT_API_VERSION (:obj:`str`): `5.1`. Telegram Bot API version supported by this
+    BOT_API_VERSION (:obj:`str`): `5.2`. Telegram Bot API version supported by this
         version of `python-telegram-bot`. Also available as ``telegram.bot_api_version``.
 
         .. versionadded:: 13.4
@@ -67,8 +67,7 @@ Attributes:
     CHATACTION_RECORD_AUDIO (:obj:`str`): 'record_audio'
 
         .. deprecated:: 13.5
-           Deprecated by Telegram. Use :const:`CHATACTION_RECORD_VOICE` instead, as backwards
-           compatibility is not guaranteed by Telegram.
+           Deprecated by Telegram. Use :const:`CHATACTION_RECORD_VOICE` instead.
     CHATACTION_RECORD_VOICE (:obj:`str`): 'record_voice'
 
         .. versionadded:: 13.5
@@ -78,8 +77,7 @@ Attributes:
     CHATACTION_UPLOAD_AUDIO (:obj:`str`): 'upload_audio'
 
         .. deprecated:: 13.5
-           Deprecated by Telegram. Use :const:`CHATACTION_UPLOAD_VOICE` instead, as backwards
-           compatibility is not guaranteed by Telegram.
+           Deprecated by Telegram. Use :const:`CHATACTION_UPLOAD_VOICE` instead.
     CHATACTION_UPLOAD_VOICE (:obj:`str`): 'upload_voice'
 
         .. versionadded:: 13.5
@@ -160,7 +158,7 @@ Attributes:
 """
 from typing import List
 
-BOT_API_VERSION: str = '5.1'
+BOT_API_VERSION: str = '5.2'
 MAX_MESSAGE_LENGTH: int = 4096
 MAX_CAPTION_LENGTH: int = 1024
 ANONYMOUS_ADMIN_ID: int = 1087968824

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -59,6 +59,9 @@ Attributes:
     CHAT_GROUP (:obj:`str`): 'group'
     CHAT_SUPERGROUP (:obj:`str`): 'supergroup'
     CHAT_CHANNEL (:obj:`str`): 'channel'
+    CHAT_SENDER (:obj:`str`): 'sender'. Only relevant for :attr:`telegram.InlineQuery.chat_type`.
+
+        .. versionadded:: 13.5
 
 :class:`telegram.ChatAction`:
 
@@ -177,6 +180,7 @@ MAX_MESSAGE_ENTITIES: int = 100
 MAX_INLINE_QUERY_RESULTS: int = 50
 MAX_ANSWER_CALLBACK_QUERY_TEXT_LENGTH: int = 200
 
+CHAT_SENDER: str = 'sender'
 CHAT_PRIVATE: str = 'private'
 CHAT_GROUP: str = 'group'
 CHAT_SUPERGROUP: str = 'supergroup'

--- a/telegram/ext/dispatcher.py
+++ b/telegram/ext/dispatcher.py
@@ -210,7 +210,7 @@ class Dispatcher:
         # For backward compatibility, we allow a "singleton" mode for the dispatcher. When there's
         # only one instance of Dispatcher, it will be possible to use the `run_async` decorator.
         with self.__singleton_lock:
-            if self.__singleton_semaphore.acquire(blocking=False):
+            if self.__singleton_semaphore.acquire(blocking=False):  # pylint: disable=R1732
                 self._set_singleton(self)
             else:
                 self._set_singleton(None)

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -1051,6 +1051,15 @@ officedocument.wordprocessingml.document")``.
         proximity_alert_triggered = _ProximityAlertTriggered()
         """Messages that contain :attr:`telegram.Message.proximity_alert_triggered`."""
 
+        class _VoiceChatScheduled(MessageFilter):
+            name = 'Filters.status_update.voice_chat_started'
+
+            def filter(self, message: Message) -> bool:
+                return bool(message.voice_chat_scheduled)
+
+        voice_chat_scheduled = _VoiceChatScheduled()
+        """Messages that contain :attr:`telegram.Message.voice_chat_scheduled`."""
+
         class _VoiceChatStarted(MessageFilter):
             name = 'Filters.status_update.voice_chat_started'
 
@@ -1093,6 +1102,7 @@ officedocument.wordprocessingml.document")``.
                 or self.pinned_message(message)
                 or self.connected_website(message)
                 or self.proximity_alert_triggered(message)
+                or self.voice_chat_scheduled(message)
                 or self.voice_chat_started(message)
                 or self.voice_chat_ended(message)
                 or self.voice_chat_participants_invited(message)
@@ -1133,6 +1143,10 @@ officedocument.wordprocessingml.document")``.
             :attr:`telegram.Message.pinned_message`.
         proximity_alert_triggered: Messages that contain
             :attr:`telegram.Message.proximity_alert_triggered`.
+        voice_chat_schedule: Messages that contain
+            :attr:`telegram.Message.voice_chat_schedule`.
+
+            .. versionadded:: 13.5
         voice_chat_started: Messages that contain
             :attr:`telegram.Message.voice_chat_started`.
 

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -1052,7 +1052,7 @@ officedocument.wordprocessingml.document")``.
         """Messages that contain :attr:`telegram.Message.proximity_alert_triggered`."""
 
         class _VoiceChatScheduled(MessageFilter):
-            name = 'Filters.status_update.voice_chat_started'
+            name = 'Filters.status_update.voice_chat_scheduled'
 
             def filter(self, message: Message) -> bool:
                 return bool(message.voice_chat_scheduled)
@@ -1144,7 +1144,7 @@ officedocument.wordprocessingml.document")``.
         proximity_alert_triggered: Messages that contain
             :attr:`telegram.Message.proximity_alert_triggered`.
         voice_chat_schedule: Messages that contain
-            :attr:`telegram.Message.voice_chat_schedule`.
+            :attr:`telegram.Message.voice_chat_scheduled`.
 
             .. versionadded:: 13.5
         voice_chat_started: Messages that contain

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -1143,7 +1143,7 @@ officedocument.wordprocessingml.document")``.
             :attr:`telegram.Message.pinned_message`.
         proximity_alert_triggered: Messages that contain
             :attr:`telegram.Message.proximity_alert_triggered`.
-        voice_chat_schedule: Messages that contain
+        voice_chat_scheduled: Messages that contain
             :attr:`telegram.Message.voice_chat_scheduled`.
 
             .. versionadded:: 13.5

--- a/telegram/inline/inlinekeyboardmarkup.py
+++ b/telegram/inline/inlinekeyboardmarkup.py
@@ -49,6 +49,8 @@ class InlineKeyboardMarkup(ReplyMarkup):
         # Required
         self.inline_keyboard = inline_keyboard
 
+        self._id_attrs = (self.inline_keyboard,)
+
     def to_dict(self) -> JSONDict:
         data = super().to_dict()
 
@@ -127,19 +129,6 @@ class InlineKeyboardMarkup(ReplyMarkup):
         """
         button_grid = [[button] for button in button_column]
         return cls(button_grid, **kwargs)
-
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, self.__class__):
-            if len(self.inline_keyboard) != len(other.inline_keyboard):
-                return False
-            for idx, row in enumerate(self.inline_keyboard):
-                if len(row) != len(other.inline_keyboard[idx]):
-                    return False
-                for jdx, button in enumerate(row):
-                    if button != other.inline_keyboard[idx][jdx]:
-                        return False
-            return True
-        return super().__eq__(other)
 
     def __hash__(self) -> int:
         return hash(tuple(tuple(button for button in row) for row in self.inline_keyboard))

--- a/telegram/inline/inlinequery.py
+++ b/telegram/inline/inlinequery.py
@@ -38,25 +38,35 @@ class InlineQuery(TelegramObject):
     considered equal, if their :attr:`id` is equal.
 
     Note:
-        * In Python ``from`` is a reserved word, use ``from_user`` instead.
+        In Python ``from`` is a reserved word, use ``from_user`` instead.
 
     Args:
         id (:obj:`str`): Unique identifier for this query.
         from_user (:class:`telegram.User`): Sender.
-        location (:class:`telegram.Location`, optional): Sender location, only for bots that
-            request user location.
         query (:obj:`str`): Text of the query (up to 256 characters).
         offset (:obj:`str`): Offset of the results to be returned, can be controlled by the bot.
+        chat_type (:obj:`str`, optional): Type of the chat, from which the inline query was sent.
+            Can be either ``'sender'`` for a private chat with the inline query sender,
+            ``'private'``, ``'group'``, ``'supergroup'``, or ``'channel'``. The chat type should be
+            always known for requests sent from official clients and most third-party clients,
+            unless the request was sent from a secret chat.
+
+            .. versionadded:: 13.5
+        location (:class:`telegram.Location`, optional): Sender location, only for bots that
+            request user location.
         bot (:class:`telegram.Bot`, optional): The Bot to use for instance methods.
         **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
     Attributes:
         id (:obj:`str`): Unique identifier for this query.
         from_user (:class:`telegram.User`): Sender.
-        location (:class:`telegram.Location`): Optional. Sender location, only for bots that
-            request user location.
         query (:obj:`str`): Text of the query (up to 256 characters).
         offset (:obj:`str`): Offset of the results to be returned, can be controlled by the bot.
+        location (:class:`telegram.Location`): Optional. Sender location, only for bots that
+            request user location.
+        chat_type (:obj:`str`, optional): Type of the chat, from which the inline query was sent.
+
+            .. versionadded:: 13.5
 
     """
 
@@ -68,6 +78,7 @@ class InlineQuery(TelegramObject):
         offset: str,
         location: Location = None,
         bot: 'Bot' = None,
+        chat_type: str = None,
         **_kwargs: Any,
     ):
         # Required
@@ -78,6 +89,7 @@ class InlineQuery(TelegramObject):
 
         # Optional
         self.location = location
+        self.chat_type = chat_type
 
         self.bot = bot
         self._id_attrs = (self.id,)

--- a/telegram/inline/inlinequery.py
+++ b/telegram/inline/inlinequery.py
@@ -46,9 +46,10 @@ class InlineQuery(TelegramObject):
         query (:obj:`str`): Text of the query (up to 256 characters).
         offset (:obj:`str`): Offset of the results to be returned, can be controlled by the bot.
         chat_type (:obj:`str`, optional): Type of the chat, from which the inline query was sent.
-            Can be either ``'sender'`` for a private chat with the inline query sender,
-            ``'private'``, ``'group'``, ``'supergroup'``, or ``'channel'``. The chat type should be
-            always known for requests sent from official clients and most third-party clients,
+            Can be either :attr:`telegram.Chat.SENDER` for a private chat with the inline query
+            sender, :attr:`telegram.Chat.PRIVATE`, :attr:`telegram.Chat.GROUP`,
+            :attr:`telegram.Chat.SUPERGROUP` or :attr:`telegram.Chat.CHANNEL`. The chat type should
+            be always known for requests sent from official clients and most third-party clients,
             unless the request was sent from a secret chat.
 
             .. versionadded:: 13.5

--- a/telegram/inline/inputinvoicemessagecontent.py
+++ b/telegram/inline/inputinvoicemessagecontent.py
@@ -60,10 +60,10 @@ class InputInvoiceMessageContent(InputMessageContent):
             positive, passed in a strictly increased order and must not exceed max_tip_amount.
         provider_data (:obj:`str`, optional): A JSON-serialized object for data about the invoice,
             which will be shared with the payment provider. A detailed description of the required
-                fields should be provided by the payment provider.
+            fields should be provided by the payment provider.
         photo_url (:obj:`str`, optional): URL of the product photo for the invoice. Can be a photo
             of the goods or a marketing image for a service. People like it better when they see
-                what they are paying for.
+            what they are paying for.
         photo_size (:obj:`int`, optional): Photo size.
         photo_width (:obj:`int`, optional): Photo width.
         photo_height (:obj:`int`, optional): Photo height.
@@ -106,10 +106,10 @@ class InputInvoiceMessageContent(InputMessageContent):
             positive, passed in a strictly increased order and must not exceed max_tip_amount.
         provider_data (:obj:`str`): Optional. A JSON-serialized object for data about the invoice,
             which will be shared with the payment provider. A detailed description of the required
-                fields should be provided by the payment provider.
+            fields should be provided by the payment provider.
         photo_url (:obj:`str`): Optional. URL of the product photo for the invoice. Can be a photo
             of the goods or a marketing image for a service. People like it better when they see
-                what they are paying for.
+            what they are paying for.
         photo_size (:obj:`int`): Optional. Photo size.
         photo_width (:obj:`int`): Optional. Photo width.
         photo_height (:obj:`int`): Optional. Photo height.

--- a/telegram/inline/inputinvoicemessagecontent.py
+++ b/telegram/inline/inputinvoicemessagecontent.py
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-"""This module contains the classes that represent Telegram InputInvoiceMessageContent."""
+"""This module contains a class that represents a Telegram InputInvoiceMessageContent."""
 
 from typing import Any, List, Optional, TYPE_CHECKING
 
@@ -33,7 +33,7 @@ class InputInvoiceMessageContent(InputMessageContent):
 
     Objects of this class are comparable in terms of equality. Two objects of this class are
     considered equal, if their :attr:`title`, :attr:`description`, :attr:`payload`,
-    :attr:`provider_token`, :attr:`currencies` and :attr:`prices` are equal.
+    :attr:`provider_token`, :attr:`currency` and :attr:`prices` are equal.
 
     .. versionadded:: 13.5
 
@@ -51,13 +51,15 @@ class InputInvoiceMessageContent(InputMessageContent):
             etc.)
         max_tip_amount (:obj:`int`, optional): The maximum accepted amount for tips in the smallest
             units of the currency (integer, not float/double). For example, for a maximum tip of
-            US$ 1.45 pass ``max_tip_amount = 145``. See the exp parameter in currencies.json, it
+            US$ 1.45 pass ``max_tip_amount = 145``. See the ``exp`` parameter in
+            `currencies.json <https://core.telegram.org/bots/payments/currencies.json>`_, it
             shows the number of digits past the decimal point for each currency (2 for the majority
             of currencies). Defaults to ``0``.
         suggested_tip_amounts (List[:obj:`int`], optional): A JSON-serialized array of suggested
             amounts of tip in the smallest units of the currency (integer, not float/double). At
             most 4 suggested tip amounts can be specified. The suggested tip amounts must be
-            positive, passed in a strictly increased order and must not exceed max_tip_amount.
+            positive, passed in a strictly increased order and must not exceed
+            :attr:`max_tip_amount`.
         provider_data (:obj:`str`, optional): A JSON-serialized object for data about the invoice,
             which will be shared with the payment provider. A detailed description of the required
             fields should be provided by the payment provider.
@@ -93,23 +95,14 @@ class InputInvoiceMessageContent(InputMessageContent):
         currency (:obj:`str`): Three-letter ISO 4217 currency code, see more on
             `currencies <https://core.telegram.org/bots/payments#supported-currencies>`_
         prices (List[:class:`telegram.LabeledPrice`]): Price breakdown, a JSON-serialized list of
-            components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus,
-            etc.)
+            components.
         max_tip_amount (:obj:`int`): Optional. The maximum accepted amount for tips in the smallest
-            units of the currency (integer, not float/double). For example, for a maximum tip of
-            US$ 1.45 pass ``max_tip_amount = 145``. See the exp parameter in currencies.json, it
-            shows the number of digits past the decimal point for each currency (2 for the majority
-            of currencies). Defaults to ``0``.
+            units of the currency (integer, not float/double).
         suggested_tip_amounts (List[:obj:`int`]): Optional. A JSON-serialized array of suggested
-            amounts of tip in the smallest units of the currency (integer, not float/double). At
-            most 4 suggested tip amounts can be specified. The suggested tip amounts must be
-            positive, passed in a strictly increased order and must not exceed max_tip_amount.
+            amounts of tip in the smallest units of the currency (integer, not float/double).
         provider_data (:obj:`str`): Optional. A JSON-serialized object for data about the invoice,
-            which will be shared with the payment provider. A detailed description of the required
-            fields should be provided by the payment provider.
-        photo_url (:obj:`str`): Optional. URL of the product photo for the invoice. Can be a photo
-            of the goods or a marketing image for a service. People like it better when they see
-            what they are paying for.
+            which will be shared with the payment provider.
+        photo_url (:obj:`str`): Optional. URL of the product photo for the invoice.
         photo_size (:obj:`int`): Optional. Photo size.
         photo_width (:obj:`int`): Optional. Photo width.
         photo_height (:obj:`int`): Optional. Photo height.

--- a/telegram/inline/inputinvoicemessagecontent.py
+++ b/telegram/inline/inputinvoicemessagecontent.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python
+#
+# A library that provides a Python interface to the Telegram Bot API
+# Copyright (C) 2015-2021
+# Leandro Toledo de Souza <devs@python-telegram-bot.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+"""This module contains the classes that represent Telegram InputInvoiceMessageContent."""
+
+from typing import Any, List, Optional, TYPE_CHECKING
+
+from telegram import InputMessageContent, LabeledPrice
+from telegram.utils.types import JSONDict
+
+if TYPE_CHECKING:
+    from telegram import Bot
+
+
+class InputInvoiceMessageContent(InputMessageContent):
+    """
+    Represents the content of a invoice message to be sent as the result of an inline query.
+
+    Objects of this class are comparable in terms of equality. Two objects of this class are
+    considered equal, if their :attr:`title`, :attr:`description`, :attr:`payload`,
+    :attr:`provider_token`, :attr:`currencies` and :attr:`prices` are equal.
+
+    .. versionadded:: 13.5
+
+    Args:
+        title (:obj:`str`): Product name, 1-32 characters
+        description (:obj:`str`): Product description, 1-255 characters
+        payload (:obj:`str`):Bot-defined invoice payload, 1-128 bytes. This will not be displayed
+            to the user, use for your internal processes.
+        provider_token (:obj:`str`): Payment provider token, obtained via
+            `@Botfather <https://t.me/Botfather>`_.
+        currency (:obj:`str`): Three-letter ISO 4217 currency code, see more on
+            `currencies <https://core.telegram.org/bots/payments#supported-currencies>`_
+        prices (List[:class:`telegram.LabeledPrice`]): Price breakdown, a JSON-serialized list of
+            components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus,
+            etc.)
+        max_tip_amount (:obj:`int`, optional): The maximum accepted amount for tips in the smallest
+            units of the currency (integer, not float/double). For example, for a maximum tip of
+            US$ 1.45 pass ``max_tip_amount = 145``. See the exp parameter in currencies.json, it
+            shows the number of digits past the decimal point for each currency (2 for the majority
+            of currencies). Defaults to ``0``.
+        suggested_tip_amounts (List[:obj:`int`], optional): A JSON-serialized array of suggested
+            amounts of tip in the smallest units of the currency (integer, not float/double). At
+            most 4 suggested tip amounts can be specified. The suggested tip amounts must be
+            positive, passed in a strictly increased order and must not exceed max_tip_amount.
+        provider_data (:obj:`str`, optional): A JSON-serialized object for data about the invoice,
+            which will be shared with the payment provider. A detailed description of the required
+                fields should be provided by the payment provider.
+        photo_url (:obj:`str`, optional): URL of the product photo for the invoice. Can be a photo
+            of the goods or a marketing image for a service. People like it better when they see
+                what they are paying for.
+        photo_size (:obj:`int`, optional): Photo size.
+        photo_width (:obj:`int`, optional): Photo width.
+        photo_height (:obj:`int`, optional): Photo height.
+        need_name (:obj:`bool`, optional): Pass :obj:`True`, if you require the user's full name to
+            complete the order.
+        need_phone_number (:obj:`bool`, optional): Pass :obj:`True`, if you require the user's
+            phone number to complete the order
+        need_email (:obj:`bool`, optional): Pass :obj:`True`, if you require the user's email
+            address to complete the order.
+        need_shipping_address (:obj:`bool`, optional): Pass :obj:`True`, if you require the user's
+            shipping address to complete the order
+        send_phone_number_to_provider (:obj:`bool`, optional): Pass :obj:`True`, if user's phone
+            number should be sent to provider.
+        send_email_to_provider (:obj:`bool`, optional): Pass :obj:`True`, if user's email address
+            should be sent to provider.
+        is_flexible (:obj:`bool`, optional): Pass :obj:`True`, if the final price depends on the
+            shipping method.
+        **kwargs (:obj:`dict`): Arbitrary keyword arguments.
+
+    Attributes:
+        title (:obj:`str`): Product name, 1-32 characters
+        description (:obj:`str`): Product description, 1-255 characters
+        payload (:obj:`str`):Bot-defined invoice payload, 1-128 bytes. This will not be displayed
+            to the user, use for your internal processes.
+        provider_token (:obj:`str`): Payment provider token, obtained via
+            `@Botfather <https://t.me/Botfather>`_.
+        currency (:obj:`str`): Three-letter ISO 4217 currency code, see more on
+            `currencies <https://core.telegram.org/bots/payments#supported-currencies>`_
+        prices (List[:class:`telegram.LabeledPrice`]): Price breakdown, a JSON-serialized list of
+            components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus,
+            etc.)
+        max_tip_amount (:obj:`int`): Optional. The maximum accepted amount for tips in the smallest
+            units of the currency (integer, not float/double). For example, for a maximum tip of
+            US$ 1.45 pass ``max_tip_amount = 145``. See the exp parameter in currencies.json, it
+            shows the number of digits past the decimal point for each currency (2 for the majority
+            of currencies). Defaults to ``0``.
+        suggested_tip_amounts (List[:obj:`int`]): Optional. A JSON-serialized array of suggested
+            amounts of tip in the smallest units of the currency (integer, not float/double). At
+            most 4 suggested tip amounts can be specified. The suggested tip amounts must be
+            positive, passed in a strictly increased order and must not exceed max_tip_amount.
+        provider_data (:obj:`str`): Optional. A JSON-serialized object for data about the invoice,
+            which will be shared with the payment provider. A detailed description of the required
+                fields should be provided by the payment provider.
+        photo_url (:obj:`str`): Optional. URL of the product photo for the invoice. Can be a photo
+            of the goods or a marketing image for a service. People like it better when they see
+                what they are paying for.
+        photo_size (:obj:`int`): Optional. Photo size.
+        photo_width (:obj:`int`): Optional. Photo width.
+        photo_height (:obj:`int`): Optional. Photo height.
+        need_name (:obj:`bool`): Optional. Pass :obj:`True`, if you require the user's full name to
+            complete the order.
+        need_phone_number (:obj:`bool`): Optional. Pass :obj:`True`, if you require the user's
+            phone number to complete the order
+        need_email (:obj:`bool`): Optional. Pass :obj:`True`, if you require the user's email
+            address to complete the order.
+        need_shipping_address (:obj:`bool`): Optional. Pass :obj:`True`, if you require the user's
+            shipping address to complete the order
+        send_phone_number_to_provider (:obj:`bool`): Optional. Pass :obj:`True`, if user's phone
+            number should be sent to provider.
+        send_email_to_provider (:obj:`bool`): Optional. Pass :obj:`True`, if user's email address
+            should be sent to provider.
+        is_flexible (:obj:`bool`): Optional. Pass :obj:`True`, if the final price depends on the
+            shipping method.
+
+    """
+
+    def __init__(
+        self,
+        title: str,
+        description: str,
+        payload: str,
+        provider_token: str,
+        currency: str,
+        prices: List[LabeledPrice],
+        max_tip_amount: int = None,
+        suggested_tip_amounts: List[int] = None,
+        provider_data: str = None,
+        photo_url: str = None,
+        photo_size: int = None,
+        photo_width: int = None,
+        photo_height: int = None,
+        need_name: bool = None,
+        need_phone_number: bool = None,
+        need_email: bool = None,
+        need_shipping_address: bool = None,
+        send_phone_number_to_provider: bool = None,
+        send_email_to_provider: bool = None,
+        is_flexible: bool = None,
+        **_kwargs: Any,
+    ):
+        # Required
+        self.title = title
+        self.description = description
+        self.payload = payload
+        self.provider_token = provider_token
+        self.currency = currency
+        self.prices = prices
+        # Optionals
+        self.max_tip_amount = int(max_tip_amount) if max_tip_amount else None
+        self.suggested_tip_amounts = (
+            [int(sta) for sta in suggested_tip_amounts] if suggested_tip_amounts else None
+        )
+        self.provider_data = provider_data
+        self.photo_url = photo_url
+        self.photo_size = int(photo_size) if photo_size else None
+        self.photo_width = int(photo_width) if photo_width else None
+        self.photo_height = int(photo_height) if photo_height else None
+        self.need_name = need_name
+        self.need_phone_number = need_phone_number
+        self.need_email = need_email
+        self.need_shipping_address = need_shipping_address
+        self.send_phone_number_to_provider = send_phone_number_to_provider
+        self.send_email_to_provider = send_email_to_provider
+        self.is_flexible = is_flexible
+
+        self._id_attrs = (
+            self.title,
+            self.description,
+            self.payload,
+            self.provider_token,
+            self.currency,
+            self.prices,
+        )
+
+    def __hash__(self) -> int:
+        # we override this as self.prices is a list and not hashable
+        prices = tuple(self.prices)
+        return hash(
+            (
+                self.title,
+                self.description,
+                self.payload,
+                self.provider_token,
+                self.currency,
+                prices,
+            )
+        )
+
+    def to_dict(self) -> JSONDict:
+        data = super().to_dict()
+
+        data['prices'] = [price.to_dict() for price in self.prices]
+
+        return data
+
+    @classmethod
+    def de_json(
+        cls, data: Optional[JSONDict], bot: 'Bot'
+    ) -> Optional['InputInvoiceMessageContent']:
+        data = cls.parse_data(data)
+
+        if not data:
+            return None
+
+        data['prices'] = LabeledPrice.de_list(data.get('prices'), bot)
+
+        return cls(**data, bot=bot)

--- a/telegram/inline/inputmessagecontent.py
+++ b/telegram/inline/inputmessagecontent.py
@@ -25,6 +25,7 @@ class InputMessageContent(TelegramObject):
     """Base class for Telegram InputMessageContent Objects.
 
     See: :class:`telegram.InputContactMessageContent`,
+    :class:`telegram.InputInvoiceMessageContent`,
     :class:`telegram.InputLocationMessageContent`, :class:`telegram.InputTextMessageContent` and
     :class:`telegram.InputVenueMessageContent` for more details.
 

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -315,7 +315,7 @@ class Message(TelegramObject):
 
             .. versionadded:: 13.5
         voice_chat_started (:class:`telegram.VoiceChatStarted`): Optional. Service message: voice
-            chat started
+            chat started.
 
             .. versionadded:: 13.4
         voice_chat_ended (:class:`telegram.VoiceChatEnded`): Optional. Service message: voice chat

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -1669,7 +1669,7 @@ class Message(TelegramObject):
         .. versionadded:: 13.2
 
         .. versionchanged:: 13.5
-            As of Bot API 5.2, this parameter is optional.
+            As of Bot API 5.2, the parameter :attr:`start_parameter` is optional.
 
         Args:
             quote (:obj:`bool`, optional): If set to :obj:`True`, the invoice is sent as an actual

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -1620,9 +1620,9 @@ class Message(TelegramObject):
         description: str,
         payload: str,
         provider_token: str,
-        start_parameter: str,
         currency: str,
         prices: List['LabeledPrice'],
+        start_parameter: str = None,
         photo_url: str = None,
         photo_size: int = None,
         photo_width: int = None,
@@ -1642,6 +1642,8 @@ class Message(TelegramObject):
         api_kwargs: JSONDict = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
         quote: bool = None,
+        max_tip_amount: int = None,
+        suggested_tip_amounts: List[int] = None,
     ) -> 'Message':
         """Shortcut for::
 
@@ -1649,13 +1651,16 @@ class Message(TelegramObject):
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_invoice`.
 
+        .. versionadded:: 13.2
+
+        .. versionchanged:: 13.5
+            As of Bot API 5.2, this parameter is optional.
+
         Args:
             quote (:obj:`bool`, optional): If set to :obj:`True`, the invoice is sent as an actual
                 reply to this message. If ``reply_to_message_id`` is passed in ``kwargs``, this
                 parameter will be ignored. Default: :obj:`True` in group chats and :obj:`False`
                 in private chats.
-
-        .. versionadded:: 13.2
 
         Returns:
             :class:`telegram.Message`: On success, instance representing the message posted.
@@ -1668,9 +1673,9 @@ class Message(TelegramObject):
             description=description,
             payload=payload,
             provider_token=provider_token,
-            start_parameter=start_parameter,
             currency=currency,
             prices=prices,
+            start_parameter=start_parameter,
             photo_url=photo_url,
             photo_size=photo_size,
             photo_width=photo_width,
@@ -1689,6 +1694,8 @@ class Message(TelegramObject):
             timeout=timeout,
             api_kwargs=api_kwargs,
             allow_sending_without_reply=allow_sending_without_reply,
+            max_tip_amount=max_tip_amount,
+            suggested_tip_amounts=suggested_tip_amounts,
         )
 
     def forward(

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -1666,6 +1666,11 @@ class Message(TelegramObject):
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_invoice`.
 
+        Warning:
+            As of API 5.2 :attr:`start_parameter` is an optional argument and therefore the order
+            of the arguments had to be changed. Use keyword arguments to make sure that the
+            arguments are passed correctly.
+
         .. versionadded:: 13.2
 
         .. versionchanged:: 13.5

--- a/telegram/message.py
+++ b/telegram/message.py
@@ -53,6 +53,7 @@ from telegram import (
     ProximityAlertTriggered,
     ReplyMarkup,
     MessageAutoDeleteTimerChanged,
+    VoiceChatScheduled,
 )
 from telegram.utils.helpers import (
     escape_markdown,
@@ -204,6 +205,10 @@ class Message(TelegramObject):
         proximity_alert_triggered (:class:`telegram.ProximityAlertTriggered`, optional): Service
             message. A user in the chat triggered another user's proximity alert while sharing
             Live Location.
+        voice_chat_scheduled (:class:`telegram.VoiceChatScheduled`, optional): Service message:
+            voice chat scheduled.
+
+            .. versionadded:: 13.5
         voice_chat_started (:class:`telegram.VoiceChatStarted`, optional): Service message: voice
             chat started.
 
@@ -305,6 +310,10 @@ class Message(TelegramObject):
         proximity_alert_triggered (:class:`telegram.ProximityAlertTriggered`): Optional. Service
             message. A user in the chat triggered another user's proximity alert while sharing
             Live Location.
+        voice_chat_scheduled (:class:`telegram.VoiceChatScheduled`): Optional. Service message:
+            voice chat scheduled.
+
+            .. versionadded:: 13.5
         voice_chat_started (:class:`telegram.VoiceChatStarted`): Optional. Service message: voice
             chat started
 
@@ -360,6 +369,7 @@ class Message(TelegramObject):
         'dice',
         'passport_data',
         'proximity_alert_triggered',
+        'voice_chat_scheduled',
         'voice_chat_started',
         'voice_chat_ended',
         'voice_chat_participants_invited',
@@ -423,6 +433,7 @@ class Message(TelegramObject):
         voice_chat_ended: VoiceChatEnded = None,
         voice_chat_participants_invited: VoiceChatParticipantsInvited = None,
         message_auto_delete_timer_changed: MessageAutoDeleteTimerChanged = None,
+        voice_chat_scheduled: VoiceChatScheduled = None,
         **_kwargs: Any,
     ):
         # Required
@@ -478,6 +489,7 @@ class Message(TelegramObject):
         self.dice = dice
         self.via_bot = via_bot
         self.proximity_alert_triggered = proximity_alert_triggered
+        self.voice_chat_scheduled = voice_chat_scheduled
         self.voice_chat_started = voice_chat_started
         self.voice_chat_ended = voice_chat_ended
         self.voice_chat_participants_invited = voice_chat_participants_invited
@@ -551,6 +563,9 @@ class Message(TelegramObject):
             data.get('proximity_alert_triggered'), bot
         )
         data['reply_markup'] = InlineKeyboardMarkup.de_json(data.get('reply_markup'), bot)
+        data['voice_chat_scheduled'] = VoiceChatScheduled.de_json(
+            data.get('voice_chat_scheduled'), bot
+        )
         data['voice_chat_started'] = VoiceChatStarted.de_json(data.get('voice_chat_started'), bot)
         data['voice_chat_ended'] = VoiceChatEnded.de_json(data.get('voice_chat_ended'), bot)
         data['voice_chat_participants_invited'] = VoiceChatParticipantsInvited.de_json(

--- a/telegram/replykeyboardmarkup.py
+++ b/telegram/replykeyboardmarkup.py
@@ -89,18 +89,14 @@ class ReplyKeyboardMarkup(ReplyMarkup):
         self.one_time_keyboard = bool(one_time_keyboard)
         self.selective = bool(selective)
 
+        self._id_attrs = (self.keyboard,)
+
     def to_dict(self) -> JSONDict:
         data = super().to_dict()
 
         data['keyboard'] = []
         for row in self.keyboard:
-            button_row: List[Union[JSONDict, str]] = []
-            for button in row:
-                if isinstance(button, KeyboardButton):
-                    button_row.append(button.to_dict())  # telegram.KeyboardButton
-                else:
-                    button_row.append(button)  # str
-            data['keyboard'].append(button_row)
+            data['keyboard'].append([button.to_dict() for button in row])
         return data
 
     @classmethod
@@ -240,19 +236,6 @@ class ReplyKeyboardMarkup(ReplyMarkup):
             selective=selective,
             **kwargs,
         )
-
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, self.__class__):
-            if len(self.keyboard) != len(other.keyboard):
-                return False
-            for idx, row in enumerate(self.keyboard):
-                if len(row) != len(other.keyboard[idx]):
-                    return False
-                for jdx, button in enumerate(row):
-                    if button != other.keyboard[idx][jdx]:
-                        return False
-            return True
-        return super().__eq__(other)
 
     def __hash__(self) -> int:
         return hash(

--- a/telegram/user.py
+++ b/telegram/user.py
@@ -655,6 +655,11 @@ class User(TelegramObject):
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_invoice`.
 
+        Warning:
+            As of API 5.2 :attr:`start_parameter` is an optional argument and therefore the order
+            of the arguments had to be changed. Use keyword arguments to make sure that the
+            arguments are passed correctly.
+
         .. versionchanged:: 13.5
             As of Bot API 5.2, the parameter :attr:`start_parameter` is optional.
 

--- a/telegram/user.py
+++ b/telegram/user.py
@@ -625,9 +625,9 @@ class User(TelegramObject):
         description: str,
         payload: str,
         provider_token: str,
-        start_parameter: str,
         currency: str,
         prices: List['LabeledPrice'],
+        start_parameter: str = None,
         photo_url: str = None,
         photo_size: int = None,
         photo_width: int = None,
@@ -646,12 +646,17 @@ class User(TelegramObject):
         timeout: ODVInput[float] = DEFAULT_NONE,
         api_kwargs: JSONDict = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
+        max_tip_amount: int = None,
+        suggested_tip_amounts: List[int] = None,
     ) -> 'Message':
         """Shortcut for::
 
             bot.send_message(update.effective_user.id, *args, **kwargs)
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_invoice`.
+
+        .. versionchanged:: 13.5
+            As of Bot API 5.2, this parameter is optional.
 
         Returns:
             :class:`telegram.Message`: On success, instance representing the message posted.
@@ -663,9 +668,9 @@ class User(TelegramObject):
             description=description,
             payload=payload,
             provider_token=provider_token,
-            start_parameter=start_parameter,
             currency=currency,
             prices=prices,
+            start_parameter=start_parameter,
             photo_url=photo_url,
             photo_size=photo_size,
             photo_width=photo_width,
@@ -684,6 +689,8 @@ class User(TelegramObject):
             timeout=timeout,
             api_kwargs=api_kwargs,
             allow_sending_without_reply=allow_sending_without_reply,
+            max_tip_amount=max_tip_amount,
+            suggested_tip_amounts=suggested_tip_amounts,
         )
 
     def send_location(

--- a/telegram/user.py
+++ b/telegram/user.py
@@ -656,7 +656,7 @@ class User(TelegramObject):
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_invoice`.
 
         .. versionchanged:: 13.5
-            As of Bot API 5.2, this parameter is optional.
+            As of Bot API 5.2, the parameter :attr:`start_parameter` is optional.
 
         Returns:
             :class:`telegram.Message`: On success, instance representing the message posted.

--- a/telegram/voicechat.py
+++ b/telegram/voicechat.py
@@ -122,12 +122,12 @@ class VoiceChatScheduled(TelegramObject):
     considered equal, if their :attr:`start_date` are equal.
 
     Args:
-        start_date ((:class:`datetime.datetime`): Point in time (Unix timestamp) when the voice
+        start_date (:obj:`datetime.datetime`): Point in time (Unix timestamp) when the voice
             chat is supposed to be started by a chat administrator
         **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
     Attributes:
-        start_date ((:class:`datetime.datetime`): Point in time (Unix timestamp) when the voice
+        start_date (:obj:`datetime.datetime`): Point in time (Unix timestamp) when the voice
             chat is supposed to be started by a chat administrator
 
     """

--- a/telegram/voicechat.py
+++ b/telegram/voicechat.py
@@ -19,9 +19,11 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains objects related to Telegram voice chats."""
 
+import datetime as dtm
 from typing import TYPE_CHECKING, Any, Optional, List
 
 from telegram import TelegramObject, User
+from telegram.utils.helpers import from_timestamp, to_timestamp
 from telegram.utils.types import JSONDict
 
 if TYPE_CHECKING:
@@ -53,6 +55,7 @@ class VoiceChatEnded(TelegramObject):
 
     Args:
         duration (:obj:`int`): Voice chat duration in seconds.
+        **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
     Attributes:
         duration (:obj:`int`): Voice chat duration in seconds.
@@ -78,6 +81,7 @@ class VoiceChatParticipantsInvited(TelegramObject):
     Args:
         users (List[:class:`telegram.User`]):  New members that
             were invited to the voice chat.
+        **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
     Attributes:
         users (List[:class:`telegram.User`]):  New members that
@@ -108,4 +112,46 @@ class VoiceChatParticipantsInvited(TelegramObject):
         data = super().to_dict()
 
         data["users"] = [u.to_dict() for u in self.users]
+        return data
+
+
+class VoiceChatScheduled(TelegramObject):
+    """This object represents a service message about a voice chat scheduled in the chat.
+
+    Objects of this class are comparable in terms of equality. Two objects of this class are
+    considered equal, if their :attr:`start_date` are equal.
+
+    Args:
+        start_date ((:class:`datetime.datetime`): Point in time (Unix timestamp) when the voice
+            chat is supposed to be started by a chat administrator
+        **kwargs (:obj:`dict`): Arbitrary keyword arguments.
+
+    Attributes:
+        start_date ((:class:`datetime.datetime`): Point in time (Unix timestamp) when the voice
+            chat is supposed to be started by a chat administrator
+
+    """
+
+    def __init__(self, start_date: dtm.datetime, **_kwargs: Any) -> None:
+        self.start_date = start_date
+
+        self._id_attrs = (self.start_date,)
+
+    @classmethod
+    def de_json(cls, data: Optional[JSONDict], bot: 'Bot') -> Optional['VoiceChatScheduled']:
+        data = cls.parse_data(data)
+
+        if not data:
+            return None
+
+        data['start_date'] = from_timestamp(data['start_date'])
+
+        return cls(**data, bot=bot)
+
+    def to_dict(self) -> JSONDict:
+        data = super().to_dict()
+
+        # Required
+        data['start_date'] = to_timestamp(self.start_date)
+
         return data

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -416,18 +416,9 @@ class TestChat:
             description = kwargs['description'] == 'description'
             payload = kwargs['payload'] == 'payload'
             provider_token = kwargs['provider_token'] == 'provider_token'
-            start_parameter = kwargs['start_parameter'] == 'start_parameter'
             currency = kwargs['currency'] == 'currency'
             prices = kwargs['prices'] == 'prices'
-            args = (
-                title
-                and description
-                and payload
-                and provider_token
-                and start_parameter
-                and currency
-                and prices
-            )
+            args = title and description and payload and provider_token and currency and prices
             return kwargs['chat_id'] == chat.id and args
 
         assert check_shortcut_signature(Chat.send_invoice, Bot.send_invoice, ['chat_id'], [])
@@ -440,7 +431,6 @@ class TestChat:
             'description',
             'payload',
             'provider_token',
-            'start_parameter',
             'currency',
             'prices',
         )

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -860,6 +860,11 @@ class TestFilters:
         assert Filters.status_update.proximity_alert_triggered(update)
         update.message.proximity_alert_triggered = None
 
+        update.message.voice_chat_scheduled = 'scheduled'
+        assert Filters.status_update(update)
+        assert Filters.status_update.voice_chat_scheduled(update)
+        update.message.voice_chat_scheduled = None
+
         update.message.voice_chat_started = 'hello'
         assert Filters.status_update(update)
         assert Filters.status_update.voice_chat_started(update)

--- a/tests/test_inlinequery.py
+++ b/tests/test_inlinequery.py
@@ -19,7 +19,7 @@
 
 import pytest
 
-from telegram import User, Location, InlineQuery, Update, Bot
+from telegram import User, Location, InlineQuery, Update, Bot, Chat
 from tests.conftest import check_shortcut_signature, check_shortcut_call, check_defaults_handling
 
 
@@ -31,6 +31,7 @@ def inline_query(bot):
         TestInlineQuery.query,
         TestInlineQuery.offset,
         location=TestInlineQuery.location,
+        chat_type=TestInlineQuery.chat_type,
         bot=bot,
     )
 
@@ -41,6 +42,7 @@ class TestInlineQuery:
     query = 'query text'
     offset = 'offset'
     location = Location(8.8, 53.1)
+    chat_type = Chat.SENDER
 
     def test_de_json(self, bot):
         json_dict = {
@@ -49,6 +51,7 @@ class TestInlineQuery:
             'query': self.query,
             'offset': self.offset,
             'location': self.location.to_dict(),
+            'chat_type': self.chat_type,
         }
         inline_query_json = InlineQuery.de_json(json_dict, bot)
 
@@ -57,6 +60,7 @@ class TestInlineQuery:
         assert inline_query_json.location == self.location
         assert inline_query_json.query == self.query
         assert inline_query_json.offset == self.offset
+        assert inline_query_json.chat_type == self.chat_type
 
     def test_to_dict(self, inline_query):
         inline_query_dict = inline_query.to_dict()
@@ -67,6 +71,7 @@ class TestInlineQuery:
         assert inline_query_dict['location'] == inline_query.location.to_dict()
         assert inline_query_dict['query'] == inline_query.query
         assert inline_query_dict['offset'] == inline_query.offset
+        assert inline_query_dict['chat_type'] == inline_query.chat_type
 
     def test_answer(self, monkeypatch, inline_query):
         def make_assertion(*_, **kwargs):

--- a/tests/test_inlinequeryhandler.py
+++ b/tests/test_inlinequeryhandler.py
@@ -242,3 +242,23 @@ class TestCallbackQueryHandler:
 
         cdp.process_update(inline_query)
         assert self.test_flag
+
+    @pytest.mark.parametrize('chat_types', [[Chat.SENDER], [Chat.SENDER, Chat.SUPERGROUP], []])
+    @pytest.mark.parametrize(
+        'chat_type,result', [(Chat.SENDER, True), (Chat.CHANNEL, False), (None, False)]
+    )
+    def test_chat_types(self, cdp, inline_query, chat_types, chat_type, result):
+        try:
+            inline_query.inline_query.chat_type = chat_type
+
+            handler = InlineQueryHandler(self.callback_context, chat_types=chat_types)
+            cdp.add_handler(handler)
+            cdp.process_update(inline_query)
+
+            if not chat_types:
+                assert self.test_flag is False
+            else:
+                assert self.test_flag == result
+
+        finally:
+            inline_query.chat_type = None

--- a/tests/test_inputinvoicemessagecontent.py
+++ b/tests/test_inputinvoicemessagecontent.py
@@ -181,7 +181,7 @@ class TestInputInvoiceMessageContent:
             == input_invoice_message_content.is_flexible
         )
 
-    def test_do_json(self, bot):
+    def test_de_json(self, bot):
         assert InputInvoiceMessageContent.de_json({}, bot=bot) is None
 
         json_dict = {

--- a/tests/test_inputinvoicemessagecontent.py
+++ b/tests/test_inputinvoicemessagecontent.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python
+#
+# A library that provides a Python interface to the Telegram Bot API
+# Copyright (C) 2015-2021
+# Leandro Toledo de Souza <devs@python-telegram-bot.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+
+import pytest
+
+from telegram import (
+    InputInvoiceMessageContent,
+    LabeledPrice,
+    InputTextMessageContent,
+)
+
+
+@pytest.fixture(scope='class')
+def input_invoice_message_content():
+    return InputInvoiceMessageContent(
+        title=TestInputInvoiceMessageContent.title,
+        description=TestInputInvoiceMessageContent.description,
+        payload=TestInputInvoiceMessageContent.payload,
+        provider_token=TestInputInvoiceMessageContent.provider_token,
+        currency=TestInputInvoiceMessageContent.currency,
+        prices=TestInputInvoiceMessageContent.prices,
+        max_tip_amount=TestInputInvoiceMessageContent.max_tip_amount,
+        suggested_tip_amounts=TestInputInvoiceMessageContent.suggested_tip_amounts,
+        provider_data=TestInputInvoiceMessageContent.provider_data,
+        photo_url=TestInputInvoiceMessageContent.photo_url,
+        photo_size=TestInputInvoiceMessageContent.photo_size,
+        photo_width=TestInputInvoiceMessageContent.photo_width,
+        photo_height=TestInputInvoiceMessageContent.photo_height,
+        need_name=TestInputInvoiceMessageContent.need_name,
+        need_phone_number=TestInputInvoiceMessageContent.need_phone_number,
+        need_email=TestInputInvoiceMessageContent.need_email,
+        need_shipping_address=TestInputInvoiceMessageContent.need_shipping_address,
+        send_phone_number_to_provider=TestInputInvoiceMessageContent.send_phone_number_to_provider,
+        send_email_to_provider=TestInputInvoiceMessageContent.send_email_to_provider,
+        is_flexible=TestInputInvoiceMessageContent.is_flexible,
+    )
+
+
+class TestInputInvoiceMessageContent:
+    title = 'invoice title'
+    description = 'invoice description'
+    payload = 'invoice payload'
+    provider_token = 'provider token'
+    currency = 'PTBCoin'
+    prices = [LabeledPrice('label1', 42), LabeledPrice('label2', 314)]
+    max_tip_amount = 420
+    suggested_tip_amounts = ['314', '256']
+    provider_data = 'provider data'
+    photo_url = 'photo_url'
+    photo_size = '314'
+    photo_width = '420'
+    photo_height = '256'
+    need_name = True
+    need_phone_number = True
+    need_email = True
+    need_shipping_address = True
+    send_phone_number_to_provider = True
+    send_email_to_provider = True
+    is_flexible = True
+
+    def test_expected_values(self, input_invoice_message_content):
+        assert input_invoice_message_content.title == self.title
+        assert input_invoice_message_content.description == self.description
+        assert input_invoice_message_content.payload == self.payload
+        assert input_invoice_message_content.provider_token == self.provider_token
+        assert input_invoice_message_content.currency == self.currency
+        assert input_invoice_message_content.prices == self.prices
+        assert input_invoice_message_content.max_tip_amount == self.max_tip_amount
+        assert input_invoice_message_content.suggested_tip_amounts == [
+            int(amount) for amount in self.suggested_tip_amounts
+        ]
+        assert input_invoice_message_content.provider_data == self.provider_data
+        assert input_invoice_message_content.photo_url == self.photo_url
+        assert input_invoice_message_content.photo_size == int(self.photo_size)
+        assert input_invoice_message_content.photo_width == int(self.photo_width)
+        assert input_invoice_message_content.photo_height == int(self.photo_height)
+        assert input_invoice_message_content.need_name == self.need_name
+        assert input_invoice_message_content.need_phone_number == self.need_phone_number
+        assert input_invoice_message_content.need_email == self.need_email
+        assert input_invoice_message_content.need_shipping_address == self.need_shipping_address
+        assert (
+            input_invoice_message_content.send_phone_number_to_provider
+            == self.send_phone_number_to_provider
+        )
+        assert input_invoice_message_content.send_email_to_provider == self.send_email_to_provider
+        assert input_invoice_message_content.is_flexible == self.is_flexible
+
+    def test_to_dict(self, input_invoice_message_content):
+        input_invoice_message_content_dict = input_invoice_message_content.to_dict()
+
+        assert isinstance(input_invoice_message_content_dict, dict)
+        assert input_invoice_message_content_dict['title'] == input_invoice_message_content.title
+        assert (
+            input_invoice_message_content_dict['description']
+            == input_invoice_message_content.description
+        )
+        assert (
+            input_invoice_message_content_dict['payload'] == input_invoice_message_content.payload
+        )
+        assert (
+            input_invoice_message_content_dict['provider_token']
+            == input_invoice_message_content.provider_token
+        )
+        assert (
+            input_invoice_message_content_dict['currency']
+            == input_invoice_message_content.currency
+        )
+        assert input_invoice_message_content_dict['prices'] == [
+            price.to_dict() for price in input_invoice_message_content.prices
+        ]
+        assert (
+            input_invoice_message_content_dict['max_tip_amount']
+            == input_invoice_message_content.max_tip_amount
+        )
+        assert (
+            input_invoice_message_content_dict['suggested_tip_amounts']
+            == input_invoice_message_content.suggested_tip_amounts
+        )
+        assert (
+            input_invoice_message_content_dict['provider_data']
+            == input_invoice_message_content.provider_data
+        )
+        assert (
+            input_invoice_message_content_dict['photo_url']
+            == input_invoice_message_content.photo_url
+        )
+        assert (
+            input_invoice_message_content_dict['photo_size']
+            == input_invoice_message_content.photo_size
+        )
+        assert (
+            input_invoice_message_content_dict['photo_width']
+            == input_invoice_message_content.photo_width
+        )
+        assert (
+            input_invoice_message_content_dict['photo_height']
+            == input_invoice_message_content.photo_height
+        )
+        assert (
+            input_invoice_message_content_dict['need_name']
+            == input_invoice_message_content.need_name
+        )
+        assert (
+            input_invoice_message_content_dict['need_phone_number']
+            == input_invoice_message_content.need_phone_number
+        )
+        assert (
+            input_invoice_message_content_dict['need_email']
+            == input_invoice_message_content.need_email
+        )
+        assert (
+            input_invoice_message_content_dict['need_shipping_address']
+            == input_invoice_message_content.need_shipping_address
+        )
+        assert (
+            input_invoice_message_content_dict['send_phone_number_to_provider']
+            == input_invoice_message_content.send_phone_number_to_provider
+        )
+        assert (
+            input_invoice_message_content_dict['send_email_to_provider']
+            == input_invoice_message_content.send_email_to_provider
+        )
+        assert (
+            input_invoice_message_content_dict['is_flexible']
+            == input_invoice_message_content.is_flexible
+        )
+
+    def test_do_json(self, bot):
+        assert InputInvoiceMessageContent.de_json({}, bot=bot) is None
+
+        json_dict = {
+            'title': self.title,
+            'description': self.description,
+            'payload': self.payload,
+            'provider_token': self.provider_token,
+            'currency': self.currency,
+            'prices': [price.to_dict() for price in self.prices],
+            'max_tip_amount': self.max_tip_amount,
+            'suggested_tip_amounts': self.suggested_tip_amounts,
+            'provider_data': self.provider_data,
+            'photo_url': self.photo_url,
+            'photo_size': self.photo_size,
+            'photo_width': self.photo_width,
+            'photo_height': self.photo_height,
+            'need_name': self.need_name,
+            'need_phone_number': self.need_phone_number,
+            'need_email': self.need_email,
+            'need_shipping_address': self.need_shipping_address,
+            'send_phone_number_to_provider': self.send_phone_number_to_provider,
+            'send_email_to_provider': self.send_email_to_provider,
+            'is_flexible': self.is_flexible,
+        }
+
+        input_invoice_message_content = InputInvoiceMessageContent.de_json(json_dict, bot=bot)
+
+        assert input_invoice_message_content.title == self.title
+        assert input_invoice_message_content.description == self.description
+        assert input_invoice_message_content.payload == self.payload
+        assert input_invoice_message_content.provider_token == self.provider_token
+        assert input_invoice_message_content.currency == self.currency
+        assert input_invoice_message_content.prices == self.prices
+        assert input_invoice_message_content.max_tip_amount == self.max_tip_amount
+        assert input_invoice_message_content.suggested_tip_amounts == [
+            int(amount) for amount in self.suggested_tip_amounts
+        ]
+        assert input_invoice_message_content.provider_data == self.provider_data
+        assert input_invoice_message_content.photo_url == self.photo_url
+        assert input_invoice_message_content.photo_size == int(self.photo_size)
+        assert input_invoice_message_content.photo_width == int(self.photo_width)
+        assert input_invoice_message_content.photo_height == int(self.photo_height)
+        assert input_invoice_message_content.need_name == self.need_name
+        assert input_invoice_message_content.need_phone_number == self.need_phone_number
+        assert input_invoice_message_content.need_email == self.need_email
+        assert input_invoice_message_content.need_shipping_address == self.need_shipping_address
+        assert (
+            input_invoice_message_content.send_phone_number_to_provider
+            == self.send_phone_number_to_provider
+        )
+        assert input_invoice_message_content.send_email_to_provider == self.send_email_to_provider
+        assert input_invoice_message_content.is_flexible == self.is_flexible
+
+    def test_equality(self):
+        a = InputInvoiceMessageContent(
+            self.title,
+            self.description,
+            self.payload,
+            self.provider_token,
+            self.currency,
+            self.prices,
+        )
+        b = InputInvoiceMessageContent(
+            self.title,
+            self.description,
+            self.payload,
+            self.provider_token,
+            self.currency,
+            self.prices,
+            max_tip_amount=100,
+            provider_data='foobar',
+        )
+        c = InputInvoiceMessageContent(
+            self.title,
+            self.description,
+            self.payload,
+            self.provider_token,
+            self.currency,
+            # the first prices amount & the second lebal changed
+            [LabeledPrice('label1', 24), LabeledPrice('label22', 314)],
+        )
+        d = InputInvoiceMessageContent(
+            self.title,
+            self.description,
+            'different_payload',
+            self.provider_token,
+            self.currency,
+            self.prices,
+        )
+        e = InputTextMessageContent('text')
+
+        assert a == b
+        assert hash(a) == hash(b)
+
+        assert a != c
+        assert hash(a) != hash(c)
+
+        assert a != d
+        assert hash(a) != hash(d)
+
+        assert a != e
+        assert hash(a) != hash(e)

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -44,6 +44,8 @@ class TestInvoice:
     start_parameter = 'start_parameter'
     currency = 'EUR'
     total_amount = sum([p.amount for p in prices])
+    max_tip_amount = 42
+    suggested_tip_amounts = [13, 42]
 
     def test_de_json(self, bot):
         invoice_json = Invoice.de_json(
@@ -77,18 +79,17 @@ class TestInvoice:
     @pytest.mark.timeout(10)
     def test_send_required_args_only(self, bot, chat_id, provider_token):
         message = bot.send_invoice(
-            chat_id,
-            self.title,
-            self.description,
-            self.payload,
-            provider_token,
-            self.start_parameter,
-            self.currency,
-            self.prices,
+            chat_id=chat_id,
+            title=self.title,
+            description=self.description,
+            payload=self.payload,
+            provider_token=provider_token,
+            currency=self.currency,
+            prices=self.prices,
         )
 
         assert message.invoice.currency == self.currency
-        assert message.invoice.start_parameter == self.start_parameter
+        assert message.invoice.start_parameter == ''
         assert message.invoice.description == self.description
         assert message.invoice.title == self.title
         assert message.invoice.total_amount == self.total_amount
@@ -102,9 +103,11 @@ class TestInvoice:
             self.description,
             self.payload,
             provider_token,
-            self.start_parameter,
             self.currency,
             self.prices,
+            max_tip_amount=self.max_tip_amount,
+            suggested_tip_amounts=self.suggested_tip_amounts,
+            start_parameter=self.start_parameter,
             provider_data=self.provider_data,
             photo_url='https://raw.githubusercontent.com/'
             'python-telegram-bot/logos/master/'
@@ -142,10 +145,10 @@ class TestInvoice:
             self.description,
             self.payload,
             provider_token,
-            self.start_parameter,
             self.currency,
             self.prices,
             provider_data={'test_data': 123456789},
+            start_parameter=self.start_parameter,
         )
 
     @flaky(3, 1)
@@ -171,7 +174,6 @@ class TestInvoice:
                 self.description,
                 self.payload,
                 provider_token,
-                self.start_parameter,
                 self.currency,
                 self.prices,
                 allow_sending_without_reply=custom,
@@ -185,7 +187,6 @@ class TestInvoice:
                 self.description,
                 self.payload,
                 provider_token,
-                self.start_parameter,
                 self.currency,
                 self.prices,
                 reply_to_message_id=reply_to_message.message_id,
@@ -199,7 +200,6 @@ class TestInvoice:
                     self.description,
                     self.payload,
                     provider_token,
-                    self.start_parameter,
                     self.currency,
                     self.prices,
                     reply_to_message_id=reply_to_message.message_id,

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1094,18 +1094,9 @@ class TestMessage:
             description = kwargs['description'] == 'description'
             payload = kwargs['payload'] == 'payload'
             provider_token = kwargs['provider_token'] == 'provider_token'
-            start_parameter = kwargs['start_parameter'] == 'start_parameter'
             currency = kwargs['currency'] == 'currency'
             prices = kwargs['prices'] == 'prices'
-            args = (
-                title
-                and description
-                and payload
-                and provider_token
-                and start_parameter
-                and currency
-                and prices
-            )
+            args = title and description and payload and provider_token and currency and prices
             return kwargs['chat_id'] == message.chat_id and args
 
         assert check_shortcut_signature(
@@ -1120,7 +1111,6 @@ class TestMessage:
             'description',
             'payload',
             'provider_token',
-            'start_parameter',
             'currency',
             'prices',
         )
@@ -1129,7 +1119,6 @@ class TestMessage:
             'description',
             'payload',
             'provider_token',
-            'start_parameter',
             'currency',
             'prices',
             quote=True,

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -52,6 +52,7 @@ from telegram import (
     VoiceChatEnded,
     VoiceChatParticipantsInvited,
     MessageAutoDeleteTimerChanged,
+    VoiceChatScheduled,
 )
 from telegram.ext import Defaults
 from tests.conftest import check_shortcut_signature, check_shortcut_call, check_defaults_handling
@@ -171,6 +172,7 @@ def message(bot):
                 User(1, 'John', False), User(2, 'Doe', False), 42
             )
         },
+        {'voice_chat_scheduled': VoiceChatScheduled(datetime.utcnow())},
         {'voice_chat_started': VoiceChatStarted()},
         {'voice_chat_ended': VoiceChatEnded(100)},
         {
@@ -224,6 +226,7 @@ def message(bot):
         'dice',
         'via_bot',
         'proximity_alert_triggered',
+        'voice_chat_scheduled',
         'voice_chat_started',
         'voice_chat_ended',
         'voice_chat_participants_invited',

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -287,18 +287,9 @@ class TestUser:
             description = kwargs['description'] == 'description'
             payload = kwargs['payload'] == 'payload'
             provider_token = kwargs['provider_token'] == 'provider_token'
-            start_parameter = kwargs['start_parameter'] == 'start_parameter'
             currency = kwargs['currency'] == 'currency'
             prices = kwargs['prices'] == 'prices'
-            args = (
-                title
-                and description
-                and payload
-                and provider_token
-                and start_parameter
-                and currency
-                and prices
-            )
+            args = title and description and payload and provider_token and currency and prices
             return kwargs['chat_id'] == user.id and args
 
         assert check_shortcut_signature(User.send_invoice, Bot.send_invoice, ['chat_id'], [])
@@ -311,7 +302,6 @@ class TestUser:
             'description',
             'payload',
             'provider_token',
-            'start_parameter',
             'currency',
             'prices',
         )

--- a/tests/test_voicechat.py
+++ b/tests/test_voicechat.py
@@ -16,9 +16,17 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 
+import datetime as dtm
 import pytest
 
-from telegram import VoiceChatStarted, VoiceChatEnded, VoiceChatParticipantsInvited, User
+from telegram import (
+    VoiceChatStarted,
+    VoiceChatEnded,
+    VoiceChatParticipantsInvited,
+    User,
+    VoiceChatScheduled,
+)
+from telegram.utils.helpers import to_timestamp
 
 
 @pytest.fixture(scope='class')
@@ -112,3 +120,40 @@ class TestVoiceChatParticipantsInvited:
 
         assert a != e
         assert hash(a) != hash(e)
+
+
+class TestVoiceChatScheduled:
+    start_date = dtm.datetime.utcnow()
+
+    def test_expected_values(self):
+        assert pytest.approx(VoiceChatScheduled(start_date=self.start_date) == self.start_date)
+
+    def test_de_json(self, bot):
+        assert VoiceChatScheduled.de_json({}, bot=bot) is None
+
+        json_dict = {'start_date': to_timestamp(self.start_date)}
+        voice_chat_scheduled = VoiceChatScheduled.de_json(json_dict, bot)
+
+        assert pytest.approx(voice_chat_scheduled.start_date == self.start_date)
+
+    def test_to_dict(self):
+        voice_chat_scheduled = VoiceChatScheduled(self.start_date)
+        voice_chat_scheduled_dict = voice_chat_scheduled.to_dict()
+
+        assert isinstance(voice_chat_scheduled_dict, dict)
+        assert voice_chat_scheduled_dict["start_date"] == to_timestamp(self.start_date)
+
+    def test_equality(self):
+        a = VoiceChatScheduled(self.start_date)
+        b = VoiceChatScheduled(self.start_date)
+        c = VoiceChatScheduled(dtm.datetime.utcnow() + dtm.timedelta(seconds=5))
+        d = VoiceChatStarted()
+
+        assert a == b
+        assert hash(a) == hash(b)
+
+        assert a != c
+        assert hash(a) != hash(c)
+
+        assert a != d
+        assert hash(a) != hash(d)


### PR DESCRIPTION
WIP

* docs preview at https://python-telegram-bot.readthedocs.io/en/api-5.2/
* new parameter for `InlineQueryHandler` is up for discussion, see https://t.me/c/1494805131/14941

In addition to a warning about `start_parameter` getting optional in `send_invoice`, the two TG-Warnings schould be included in the release notes:

⚠️ WARNING! ⚠️
After the next Bot API update (Bot API 5.3) there will be a one-time change of the value of the field file_unique_id in objects of the type PhotoSize and of the fields small_file_unique_id and big_file_unique_id in objects of the type ChatPhoto.

⚠️ WARNING! ⚠️
Service messages about non-bot users joining the chat will be soon removed from large groups. We recommend using the “chat_member” update as a replacement.

### Checklist for PRs

- [x] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)


### If the PR contains API changes (otherwise, you can delete this passage)

* New classes:
    - [x] Added `self._id_attrs` and corresponding documentation
    - [x] `__init__` accepts `**_kwargs`
    
* Added new shortcuts:
    - [ ] In `Chat` & `User` for all methods that accept `chat/user_id`
    - [ ] In `Message` for all methods that accept `chat_id` and `message_id`
    - [ ] For new `Message` shortcuts: Added `quote` argument if methods accepts `reply_to_message_id`
    - [ ] In `CallbackQuery` for all methods that accept either `chat_id` and `message_id` or `inline_message_id`
    
* If relevant:

    - [x] Added new constants at `telegram.constants` and shortcuts to them as class variables
    - [ ] Added new handlers for new update types
    - [x] Added new filters for new message (sub)types
    - [x] Added or updated documentation for the changed class(es) and/or method(s)
    - [x] Updated the Bot API version number in all places: `README.rst` and `README_RAW.rst` (including the badge), as well as `telegram.constants.BOT_API_VERSION`
