### PR TITLE
Fixing timerbot.py Closes #2502

### DIFF
--- a/examples/timerbot.py
+++ b/examples/timerbot.py
@@ -64,7 +64,7 @@ def set_timer(update: Update, context: CallbackContext) -> None:
             return
 
         job_removed = remove_job_if_exists(str(chat_id), context)
-        context.job_queue.run_once(alarm, due, context=chat_id, name=str(chat_id))
+        context.job_queue.run_repeating(alarm, due, context=chat_id, name=str(chat_id))
 
         text = 'Timer successfully set!'
         if job_removed:


### PR DESCRIPTION
Using context.job_queue.run_repeating instead on run_once as timer alarm job needs to be run repeatedly based on the timer.
Currently it only runs once and removes the job from queue automatically.

Check #2502 for more info on the issue.