### PR TITLE
Stabilize some tests

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -49,7 +49,7 @@ from telegram import (
 from telegram.constants import MAX_INLINE_QUERY_RESULTS
 from telegram.error import BadRequest, InvalidToken, NetworkError, RetryAfter
 from telegram.utils.helpers import from_timestamp, escape_markdown, to_timestamp
-from tests.conftest import expect_bad_request, check_defaults_handling
+from tests.conftest import expect_bad_request, check_defaults_handling, GITHUB_ACTION
 from tests.bots import FALLBACKS
 
 
@@ -1274,6 +1274,7 @@ class TestBot:
                     chat_id, game_short_name, reply_to_message_id=reply_to_message.message_id
                 )
 
+    @pytest.mark.xfail(GITHUB_ACTION, reason='Can fail due to race conditions')
     def test_set_game_score_1(self, game_bot, chat_id):
         # NOTE: numbering of methods assures proper order between test_set_game_scoreX methods
         # First, test setting a score.
@@ -1292,6 +1293,7 @@ class TestBot:
         assert message.game.photo[0].file_size == game.game.photo[0].file_size
         assert message.game.text != game.game.text
 
+    @pytest.mark.xfail(GITHUB_ACTION, reason='Can fail due to race conditions')
     def test_set_game_score_2(self, game_bot, chat_id):
         # NOTE: numbering of methods assures proper order between test_set_game_scoreX methods
         # Test setting a score higher than previous
@@ -1312,6 +1314,7 @@ class TestBot:
         assert message.game.photo[0].file_size == game.game.photo[0].file_size
         assert message.game.text == game.game.text
 
+    @pytest.mark.xfail(GITHUB_ACTION, reason='Can fail due to race conditions')
     def test_set_game_score_3(self, game_bot, chat_id):
         # NOTE: numbering of methods assures proper order between test_set_game_scoreX methods
         # Test setting a score lower than previous (should raise error)
@@ -1325,6 +1328,7 @@ class TestBot:
                 user_id=chat_id, score=score, chat_id=game.chat_id, message_id=game.message_id
             )
 
+    @pytest.mark.xfail(GITHUB_ACTION, reason='Can fail due to race conditions')
     def test_set_game_score_4(self, game_bot, chat_id):
         # NOTE: numbering of methods assures proper order between test_set_game_scoreX methods
         # Test force setting a lower score
@@ -1350,6 +1354,7 @@ class TestBot:
         game2 = game_bot.send_game(chat_id, game_short_name)
         assert str(score) in game2.game.text
 
+    @pytest.mark.xfail(GITHUB_ACTION, reason='Can fail due to race conditions')
     def test_get_game_high_scores(self, game_bot, chat_id):
         # We need a game to get the scores for
         game_short_name = 'test_game'

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -99,6 +99,14 @@ def game_bot():
     return Bot(FALLBACKS[0]["token"])
 
 
+cond = False
+
+if GITHUB_ACTION:
+    cond = True
+
+xfail = pytest.mark.xfail(cond, reason='Can fail due to race conditions')
+
+
 class TestBot:
     @pytest.mark.parametrize(
         'token',
@@ -1274,7 +1282,7 @@ class TestBot:
                     chat_id, game_short_name, reply_to_message_id=reply_to_message.message_id
                 )
 
-    @pytest.mark.xfail(GITHUB_ACTION, reason='Can fail due to race conditions')
+    @xfail
     def test_set_game_score_1(self, game_bot, chat_id):
         # NOTE: numbering of methods assures proper order between test_set_game_scoreX methods
         # First, test setting a score.
@@ -1293,7 +1301,7 @@ class TestBot:
         assert message.game.photo[0].file_size == game.game.photo[0].file_size
         assert message.game.text != game.game.text
 
-    @pytest.mark.xfail(GITHUB_ACTION, reason='Can fail due to race conditions')
+    @xfail
     def test_set_game_score_2(self, game_bot, chat_id):
         # NOTE: numbering of methods assures proper order between test_set_game_scoreX methods
         # Test setting a score higher than previous
@@ -1314,7 +1322,7 @@ class TestBot:
         assert message.game.photo[0].file_size == game.game.photo[0].file_size
         assert message.game.text == game.game.text
 
-    @pytest.mark.xfail(GITHUB_ACTION, reason='Can fail due to race conditions')
+    @xfail
     def test_set_game_score_3(self, game_bot, chat_id):
         # NOTE: numbering of methods assures proper order between test_set_game_scoreX methods
         # Test setting a score lower than previous (should raise error)
@@ -1328,7 +1336,7 @@ class TestBot:
                 user_id=chat_id, score=score, chat_id=game.chat_id, message_id=game.message_id
             )
 
-    @pytest.mark.xfail(GITHUB_ACTION, reason='Can fail due to race conditions')
+    @xfail
     def test_set_game_score_4(self, game_bot, chat_id):
         # NOTE: numbering of methods assures proper order between test_set_game_scoreX methods
         # Test force setting a lower score
@@ -1354,7 +1362,7 @@ class TestBot:
         game2 = game_bot.send_game(chat_id, game_short_name)
         assert str(score) in game2.game.text
 
-    @pytest.mark.xfail(GITHUB_ACTION, reason='Can fail due to race conditions')
+    @xfail
     def test_get_game_high_scores(self, game_bot, chat_id):
         # We need a game to get the scores for
         game_short_name = 'test_game'

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -95,13 +95,9 @@ def inline_results():
 
 
 BASE_GAME_SCORE = 60  # Base game score for game tests
-cond = False  # This condition is only relevant for github actions game tests.
-
-if GITHUB_ACTION:
-    cond = True
 
 xfail = pytest.mark.xfail(
-    cond,
+    bool(GITHUB_ACTION),  # This condition is only relevant for github actions game tests.
     reason='Can fail due to race conditions when multiple test suites '
     'with the same bot token are run at the same time',
 )

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1298,23 +1298,27 @@ class TestBot:
     @flaky(3, 1)
     def test_set_game_score_2(self, bot, chat_id):
         # NOTE: numbering of methods assures proper order between test_set_game_scoreX methods
-        game_short_name = 'test_game'
-        game = bot.send_game(chat_id, game_short_name)
 
-        score = int(BASE_TIME) - HIGHSCORE_DELTA + 1
+        def func():
+            game_short_name = 'test_game'
+            game = bot.send_game(chat_id, game_short_name)
 
-        message = bot.set_game_score(
-            user_id=chat_id,
-            score=score,
-            chat_id=game.chat_id,
-            message_id=game.message_id,
-            disable_edit_message=True,
-        )
+            score = int(BASE_TIME) - HIGHSCORE_DELTA + 1
 
-        assert message.game.description == game.game.description
-        assert message.game.animation.file_id == game.game.animation.file_id
-        assert message.game.photo[0].file_size == game.game.photo[0].file_size
-        assert message.game.text == game.game.text
+            message = bot.set_game_score(
+                user_id=chat_id,
+                score=score,
+                chat_id=game.chat_id,
+                message_id=game.message_id,
+                disable_edit_message=True,
+            )
+
+            assert message.game.description == game.game.description
+            assert message.game.animation.file_id == game.game.animation.file_id
+            assert message.game.photo[0].file_size == game.game.photo[0].file_size
+            assert message.game.text == game.game.text
+
+        expect_bad_request(func, 'Bot_score_not_modified', 'This test can be flaky.')
 
     @flaky(3, 1)
     def test_set_game_score_3(self, bot, chat_id):
@@ -1332,27 +1336,32 @@ class TestBot:
     @flaky(3, 1)
     def test_set_game_score_4(self, bot, chat_id):
         # NOTE: numbering of methods assures proper order between test_set_game_scoreX methods
-        game_short_name = 'test_game'
-        game = bot.send_game(chat_id, game_short_name)
 
-        score = int(BASE_TIME) - HIGHSCORE_DELTA - 2
+        def func():
 
-        message = bot.set_game_score(
-            user_id=chat_id,
-            score=score,
-            chat_id=game.chat_id,
-            message_id=game.message_id,
-            force=True,
-        )
+            game_short_name = 'test_game'
+            game = bot.send_game(chat_id, game_short_name)
 
-        assert message.game.description == game.game.description
-        assert message.game.animation.file_id == game.game.animation.file_id
-        assert message.game.photo[0].file_size == game.game.photo[0].file_size
+            score = int(BASE_TIME) - HIGHSCORE_DELTA - 2
 
-        # For some reason the returned message does not contain the updated score. need to fetch
-        # the game again...
-        game2 = bot.send_game(chat_id, game_short_name)
-        assert str(score) in game2.game.text
+            message = bot.set_game_score(
+                user_id=chat_id,
+                score=score,
+                chat_id=game.chat_id,
+                message_id=game.message_id,
+                force=True,
+            )
+
+            assert message.game.description == game.game.description
+            assert message.game.animation.file_id == game.game.animation.file_id
+            assert message.game.photo[0].file_size == game.game.photo[0].file_size
+
+            # For some reason the returned message doesn't contain the updated score. need to fetch
+            # the game again...
+            game2 = bot.send_game(chat_id, game_short_name)
+            assert str(score) in game2.game.text
+
+        expect_bad_request(func, 'Bot_score_not_modified', 'This test can be flaky')
 
     @flaky(3, 1)
     def test_set_game_score_too_low_score(self, bot, chat_id):

--- a/tests/test_sticker.py
+++ b/tests/test_sticker.py
@@ -305,7 +305,9 @@ def sticker_set(bot):
         try:
             for i in range(1, 50):
                 bot.delete_sticker_from_set(ss.stickers[-i].file_id)
-        except BadRequest:
+        except BadRequest as e:
+            if e.message == 'Stickerset_not_modified':
+                return ss
             raise Exception('stickerset is growing too large.')
     return ss
 
@@ -317,7 +319,9 @@ def animated_sticker_set(bot):
         try:
             for i in range(1, 50):
                 bot.delete_sticker_from_set(ss.stickers[-i].file_id)
-        except BadRequest:
+        except BadRequest as e:
+            if e.message == 'Stickerset_not_modified':
+                return ss
             raise Exception('stickerset is growing too large.')
     return ss
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -44,7 +44,7 @@ from telegram.ext.utils.webhookhandler import WebhookServer
 
 signalskip = pytest.mark.skipif(
     sys.platform == 'win32',
-    reason='Can\'t send signals without stopping ' 'whole process on windows',
+    reason="Can't send signals without stopping whole process on windows",
 )
 
 
@@ -366,6 +366,10 @@ class TestUpdater:
         port = randrange(1024, 49152)  # Select random port
         updater.start_webhook(ip, port, clean=True, force_event_loop=False)
         updater.stop()
+
+        for warning in recwarn.list:
+            print(warning.message)
+
         assert len(recwarn) == 3
         assert str(recwarn[0].message).startswith('Old Handler API')
         assert str(recwarn[1].message).startswith('The argument `clean` of')
@@ -380,9 +384,9 @@ class TestUpdater:
 
         updater.start_polling(clean=True)
         updater.stop()
-        assert len(recwarn) == 2
         for msg in recwarn:
             print(msg)
+        assert len(recwarn) == 2
         assert str(recwarn[0].message).startswith('Old Handler API')
         assert str(recwarn[1].message).startswith('The argument `clean` of')
 
@@ -477,6 +481,9 @@ class TestUpdater:
 
         with caplog.at_level(logging.INFO):
             updater.idle()
+
+        if caplog.records[-1].getMessage().startswith('Error while getting Updates: Conflict'):
+            caplog.records.pop()  # For stability
 
         rec = caplog.records[-2]
         assert rec.getMessage().startswith(f'Received signal {signal.SIGTERM}')

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -482,6 +482,8 @@ class TestUpdater:
         with caplog.at_level(logging.INFO):
             updater.idle()
 
+        # There is a chance of a conflict when getting updates since there can be many tests
+        # (bots) running simultaneously while testing in github actions.
         if caplog.records[-1].getMessage().startswith('Error while getting Updates: Conflict'):
             caplog.records.pop()  # For stability
 


### PR DESCRIPTION
Tries to fix tests like: 

- [ ]  [test_clean_depr_warn_polling](https://github.com/python-telegram-bot/python-telegram-bot/runs/2493716321?check_suite_focus=true), 
- [ ]  [test_clean_depr_warn_webhook](https://github.com/python-telegram-bot/python-telegram-bot/runs/2582381833?check_suite_focus=true), 
First two will be fixed when the tests actually fail and the error is printed to console
- [x]  [Stickerset_not_modified](https://github.com/python-telegram-bot/python-telegram-bot/runs/2518489659?check_suite_focus=true), 
- [x]  [test_idle](https://github.com/python-telegram-bot/python-telegram-bot/runs/2533442877?check_suite_focus=true), 
- [x]  [Botscore_not_modified](https://github.com/python-telegram-bot/python-telegram-bot/runs/2582219566?check_suite_focus=true)

Checks will be run many times to expose the failing ones