### PR TITLE
[#2526] set data['send_phone_number_to_provider'] from corresponding …

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -77,6 +77,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `naveenvhegde <https://github.com/naveenvhegde>`_
 - `neurrone <https://github.com/neurrone>`_
 - `NikitaPirate <https://github.com/NikitaPirate>`_
+- `Nikolai Krivenko <https://github.com/nkrivenko>`_
 - `njittam <https://github.com/njittam>`_
 - `Noam Meltzer <https://github.com/tsnoam>`_
 - `Oleg Shlyazhko <https://github.com/ollmer>`_

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -3425,7 +3425,7 @@ class Bot(TelegramObject):
         if is_flexible is not None:
             data['is_flexible'] = is_flexible
         if send_phone_number_to_provider is not None:
-            data['send_phone_number_to_provider'] = send_email_to_provider
+            data['send_phone_number_to_provider'] = send_phone_number_to_provider
         if send_email_to_provider is not None:
             data['send_email_to_provider'] = send_email_to_provider
 

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -94,7 +94,7 @@ class TestInvoice:
         assert message.invoice.total_amount == self.total_amount
 
     @flaky(3, 1)
-    def test_send_all_args(self, bot, chat_id, provider_token):
+    def test_send_all_args(self, bot, chat_id, provider_token, monkeypatch):
         message = bot.send_invoice(
             chat_id,
             self.title,
@@ -127,6 +127,61 @@ class TestInvoice:
         assert message.invoice.description == self.description
         assert message.invoice.title == self.title
         assert message.invoice.total_amount == self.total_amount
+
+        # We do this next one as safety guard to make sure that we pass all of the optional
+        # parameters correctly because #2526 went unnoticed for 3 years …
+        def make_assertion(*args, **_):
+            kwargs = args[1]
+            return (
+                kwargs['chat_id'] == 'chat_id'
+                and kwargs['title'] == 'title'
+                and kwargs['description'] == 'description'
+                and kwargs['payload'] == 'payload'
+                and kwargs['provider_token'] == 'provider_token'
+                and kwargs['currency'] == 'currency'
+                and kwargs['prices'] == [p.to_dict() for p in self.prices]
+                and kwargs['max_tip_amount'] == 'max_tip_amount'
+                and kwargs['suggested_tip_amounts'] == 'suggested_tip_amounts'
+                and kwargs['start_parameter'] == 'start_parameter'
+                and kwargs['provider_data'] == 'provider_data'
+                and kwargs['photo_url'] == 'photo_url'
+                and kwargs['photo_size'] == 'photo_size'
+                and kwargs['photo_width'] == 'photo_width'
+                and kwargs['photo_height'] == 'photo_height'
+                and kwargs['need_name'] == 'need_name'
+                and kwargs['need_phone_number'] == 'need_phone_number'
+                and kwargs['need_email'] == 'need_email'
+                and kwargs['need_shipping_address'] == 'need_shipping_address'
+                and kwargs['send_phone_number_to_provider'] == 'send_phone_number_to_provider'
+                and kwargs['send_email_to_provider'] == 'send_email_to_provider'
+                and kwargs['is_flexible'] == 'is_flexible'
+            )
+
+        monkeypatch.setattr(bot, '_message', make_assertion)
+        assert bot.send_invoice(
+            chat_id='chat_id',
+            title='title',
+            description='description',
+            payload='payload',
+            provider_token='provider_token',
+            currency='currency',
+            prices=self.prices,
+            max_tip_amount='max_tip_amount',
+            suggested_tip_amounts='suggested_tip_amounts',
+            start_parameter='start_parameter',
+            provider_data='provider_data',
+            photo_url='photo_url',
+            photo_size='photo_size',
+            photo_width='photo_width',
+            photo_height='photo_height',
+            need_name='need_name',
+            need_phone_number='need_phone_number',
+            need_email='need_email',
+            need_shipping_address='need_shipping_address',
+            send_phone_number_to_provider='send_phone_number_to_provider',
+            send_email_to_provider='send_email_to_provider',
+            is_flexible='is_flexible',
+        )
 
     def test_send_object_as_provider_data(self, monkeypatch, bot, chat_id, provider_token):
         def test(url, data, **kwargs):


### PR DESCRIPTION
Fixed setting `data['send_phone_number_to_provider']` from `send_email_to_provider`. closes #2526 

<!--
Hey! You're PRing? Cool! Please have a look at the below checklist. It's here to help both you and the maintainers to remember some aspects. Make sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
-->

### Checklist for PRs

- [ ] Created new or adapted existing unit tests
- [x] Added myself alphabetically to `AUTHORS.rst` (optional)
