### PR TITLE
Include max_connections in start_webhook

### DIFF
--- a/telegram/ext/updater.py
+++ b/telegram/ext/updater.py
@@ -412,10 +412,10 @@ class Updater:
                    Since version 13.6, ``tornade>=6.1`` is required, which resolves the former
                    issue.
 
-            max_connections (:obj:`int`, optional): Maximum allowed number of simultaneous HTTPS
-                connections to the webhook for update delivery, 1-100.(upto 1000000 for local bot
-                API server) Defaults to ``40``. Use lower values to limit the load on your
-                bot's server, and higher values to increase your bot's throughput.
+            max_connections (:obj:`int`, optional): Passed to
+                :meth:`telegram.Bot.set_webhook`.
+
+                .. versionadded:: 13.6
 
         Returns:
             :obj:`Queue`: The update queue that can be filled from the main thread.

--- a/telegram/ext/updater.py
+++ b/telegram/ext/updater.py
@@ -363,6 +363,7 @@ class Updater:
         force_event_loop: bool = None,
         drop_pending_updates: bool = None,
         ip_address: str = None,
+        max_connections: int = 40,
     ) -> Optional[Queue]:
         """
         Starts a small http server to listen for updates via webhook. If :attr:`cert`
@@ -410,6 +411,11 @@ class Updater:
                 .. deprecated:: 13.6
                    Since version 13.6, ``tornade>=6.1`` is required, which resolves the former
                    issue.
+
+            max_connections (:obj:`int`, optional): Maximum allowed number of simultaneous HTTPS
+                connections to the webhook for update delivery, 1-100.(upto 1000000 for local bot
+                API server) Defaults to ``40``. Use lower values to limit the load on your
+                bot's server, and higher values to increase your bot's throughput.
 
         Returns:
             :obj:`Queue`: The update queue that can be filled from the main thread.
@@ -459,6 +465,7 @@ class Updater:
                     allowed_updates,
                     ready=webhook_ready,
                     ip_address=ip_address,
+                    max_connections=max_connections,
                 )
 
                 self.logger.debug('Waiting for Dispatcher and Webhook to start')
@@ -592,6 +599,7 @@ class Updater:
         allowed_updates,
         ready=None,
         ip_address=None,
+        max_connections: int = 40,
     ):
         self.logger.debug('Updater thread started (webhook)')
 
@@ -632,6 +640,7 @@ class Updater:
             allowed_updates=allowed_updates,
             cert=cert_file,
             ip_address=ip_address,
+            max_connections=max_connections,
         )
         if cert_file is not None:
             cert_file.close()
@@ -652,6 +661,7 @@ class Updater:
         cert=None,
         bootstrap_interval=5,
         ip_address=None,
+        max_connections: int = 40,
     ):
         retries = [0]
 
@@ -672,6 +682,7 @@ class Updater:
                 allowed_updates=allowed_updates,
                 ip_address=ip_address,
                 drop_pending_updates=drop_pending_updates,
+                max_connections=max_connections,
             )
             return False
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -319,6 +319,42 @@ class TestUpdater:
         updater.stop()
         assert self.test_flag == [True, True]
 
+    @pytest.mark.parametrize('pass_max_connections', [True, False])
+    def test_webhook_max_connections(self, monkeypatch, updater, pass_max_connections):
+        q = Queue()
+        max_connections = 42
+
+        def set_webhook(**kwargs):
+            print(kwargs)
+            self.test_flag = kwargs.get('max_connections') == (
+                max_connections if pass_max_connections else 40
+            )
+            return True
+
+        monkeypatch.setattr(updater.bot, 'set_webhook', set_webhook)
+        monkeypatch.setattr(updater.bot, 'delete_webhook', lambda *args, **kwargs: True)
+        monkeypatch.setattr('telegram.ext.Dispatcher.process_update', lambda _, u: q.put(u))
+
+        ip = '127.0.0.1'
+        port = randrange(1024, 49152)  # Select random port
+        if pass_max_connections:
+            updater.start_webhook(ip, port, webhook_url=None, max_connections=max_connections)
+        else:
+            updater.start_webhook(ip, port, webhook_url=None)
+
+        sleep(0.2)
+
+        # Now, we send an update to the server via urlopen
+        update = Update(
+            1,
+            message=Message(1, None, Chat(1, ''), from_user=User(1, '', False), text='Webhook 2'),
+        )
+        self._send_webhook_msg(ip, port, update.to_json())
+        sleep(0.2)
+        assert q.get(False) == update
+        updater.stop()
+        assert self.test_flag is True
+
     @pytest.mark.parametrize(('error',), argvalues=[(TelegramError(''),)], ids=('TelegramError',))
     def test_bootstrap_retries_success(self, monkeypatch, updater, error):
         retries = 2


### PR DESCRIPTION
It was earlier possible to set max_connections using the set_webhook method. With the 

1. Added `max_connections` args to `start_webhook` method
2. Updated the doc_string
3. Tested, it was able to set `max_connections` to user set value
