### PR TITLE
Remove deprecated arg from deeplinking.py

### DIFF
--- a/examples/deeplinking.py
+++ b/examples/deeplinking.py
@@ -124,7 +124,7 @@ def main() -> None:
 
     # We can also pass on the deep-linking payload
     dispatcher.add_handler(
-        CommandHandler("start", deep_linked_level_3, Filters.regex(USING_ENTITIES), pass_args=True)
+        CommandHandler("start", deep_linked_level_3, Filters.regex(USING_ENTITIES))
     )
 
     # Possible with inline keyboard buttons as well


### PR DESCRIPTION
for some reason `pass_args=True` was still being passed to a `CommandHandler`