### PR TITLE
add **connection_pool_kw to Request() constructor

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -77,6 +77,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `naveenvhegde <https://github.com/naveenvhegde>`_
 - `neurrone <https://github.com/neurrone>`_
 - `NikitaPirate <https://github.com/NikitaPirate>`_
+- `Niklas Rosenstein <https://github.com/NiklasRosenstein>`_
 - `Nikolai Krivenko <https://github.com/nkrivenko>`_
 - `njittam <https://github.com/njittam>`_
 - `Noam Meltzer <https://github.com/tsnoam>`_

--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -121,6 +121,7 @@ class Request:
         urllib3_proxy_kwargs: JSONDict = None,
         connect_timeout: float = 5.0,
         read_timeout: float = 5.0,
+        **connection_pool_kw
     ):
         if urllib3_proxy_kwargs is None:
             urllib3_proxy_kwargs = {}
@@ -152,6 +153,7 @@ class Request:
             socket_options=sockopts,
             timeout=urllib3.Timeout(connect=self._connect_timeout, read=read_timeout, total=None),
         )
+        kwargs.update(connection_pool_kw)
 
         # Set a proxy according to the following order:
         # * proxy defined in proxy_url (+ urllib3_proxy_kwargs)

--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -109,7 +109,11 @@ class Request:
             between consecutive read operations for a response from the server. :obj:`None` will
             set an infinite timeout. This value is usually overridden by the various
             :class:`telegram.Bot` methods. Defaults to ``5.0``.
+        connection_pool_kw: Additional keyword arguments to pass to the underlying connection pool.
 
+    .. versionchanged:: (TODO: Which version?)
+
+        Added ``connection_pool_kw`` argument.
     """
 
     __slots__ = ('_connect_timeout', '_con_pool_size', '_con_pool', '__dict__')


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool! Please have a look at the below checklist. It's here to help both you and the maintainers to remember some aspects. Make sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
-->

### Checklist for PRs

- [x] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [ ] Created new or adapted existing unit tests
- [x] Added myself alphabetically to `AUTHORS.rst` (optional)


### If the PR contains API changes (otherwise, you can delete this passage)

* Updated classes:
    - [ ] `Request.__init__` now accepts `**connection_pool_kw`
    