### PR TITLE
Pass job to error handler where possible

### DIFF
--- a/telegram/ext/callbackcontext.py
+++ b/telegram/ext/callbackcontext.py
@@ -88,7 +88,8 @@ class CallbackContext(Generic[UD, CD, BD]):
             that raised the error. Only present when the raising function was run asynchronously
             using :meth:`telegram.ext.Dispatcher.run_async`.
         job (:class:`telegram.ext.Job`): Optional. The job which originated this callback.
-            Only present when passed to the callback of :class:`telegram.ext.Job`.
+            Only present when passed to the callback of :class:`telegram.ext.Job` or in error
+            handlers if the error is caused by a `repeating` job.
 
     """
 
@@ -231,6 +232,7 @@ class CallbackContext(Generic[UD, CD, BD]):
         dispatcher: 'Dispatcher',
         async_args: Union[List, Tuple] = None,
         async_kwargs: Dict[str, object] = None,
+        job: 'Job' = None,
     ) -> CC:
         """
         Constructs an instance of :class:`telegram.ext.CallbackContext` to be passed to the error
@@ -244,12 +246,15 @@ class CallbackContext(Generic[UD, CD, BD]):
             error (:obj:`Exception`): The error.
             dispatcher (:class:`telegram.ext.Dispatcher`): The dispatcher associated with this
                 context.
-            async_args (List[:obj:`object`]): Optional. Positional arguments of the function that
+            async_args (List[:obj:`object`], optional): Positional arguments of the function that
                 raised the error. Pass only when the raising function was run asynchronously using
                 :meth:`telegram.ext.Dispatcher.run_async`.
-            async_kwargs (Dict[:obj:`str`, :obj:`object`]): Optional. Keyword arguments of the
+            async_kwargs (Dict[:obj:`str`, :obj:`object`], optional): Keyword arguments of the
                 function that raised the error. Pass only when the raising function was run
                 asynchronously using :meth:`telegram.ext.Dispatcher.run_async`.
+            job (:class:`telegram.ext.Job`, optional): The job associated with the error.
+
+                .. versionadded:: 13.6.1
 
         Returns:
             :class:`telegram.ext.CallbackContext`
@@ -258,6 +263,7 @@ class CallbackContext(Generic[UD, CD, BD]):
         self.error = error
         self.async_args = async_args
         self.async_kwargs = async_kwargs
+        self.job = job
         return self
 
     @classmethod

--- a/telegram/ext/jobqueue.py
+++ b/telegram/ext/jobqueue.py
@@ -83,7 +83,9 @@ class JobQueue:
 
     def _dispatch_error(self, event: JobEvent) -> None:
         try:
-            self._dispatcher.dispatch_error(None, event.exception)
+            aps_job = self.scheduler.get_job(event.job_id)
+            job = Job._from_aps_job(aps_job, self) if aps_job else None  # pylint: disable=W0212
+            self._dispatcher.dispatch_error(None, event.exception, job=job)
         # Errors should not stop the thread.
         except Exception:
             self.logger.exception(
@@ -591,7 +593,7 @@ class Job:
                 self.callback(dispatcher.bot, self)  # type: ignore[arg-type,call-arg]
         except Exception as exc:
             try:
-                dispatcher.dispatch_error(None, exc)
+                dispatcher.dispatch_error(None, exc, job=self)
             # Errors should not stop the thread.
             except Exception:
                 dispatcher.logger.exception(


### PR DESCRIPTION
Closes #2568 - at least partly.

For jobs that run only once, APS already drops the job from memory before reporting any exception so that we can't get it back by its ID. One could maybe try to work around that somehow by reworking some of the internals of `JobQueue` (bascially tell APS to run `job.run(dispatcher)` instead of running the `callback` directly, but I'm not sure if that's worth it.

That would also make it even more complicated for custom persistence solutions like the recently introduced `ptbcontrib/ptb_sqlalchemy_jobstore` (even though this shouldn't be the main reason to to do it)
The main use case probably is to stop repeating jobs that cause exceptions, anyway.

Because this adds a new parameter to `CallbackContext.from_error`, this is maybe kind of breaking if people subclassed for `ContextTypes` and overrode that. Anyway, not that urgent so I'll be putting it on the v14 milestone for now.

**edit:** We could just make `tg.ext.Job` callable (where `job(dispatcher)` just does `job.run(dispatcher)`). This would probably solve all of the issues mentioned above 🤔 

### Checklist for PRs

- [ ] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings  - did that but should be updated before merging
- [x] Created new or adapted existing unit tests
