### PR TITLE
API 5.3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ We have a vibrant community of developers helping each other in our `Telegram gr
    :target: https://pypi.org/project/python-telegram-bot/
    :alt: Supported Python versions
 
-.. image:: https://img.shields.io/badge/Bot%20API-5.2-blue?logo=telegram
+.. image:: https://img.shields.io/badge/Bot%20API-5.3-blue?logo=telegram
    :target: https://core.telegram.org/bots/api-changelog
    :alt: Supported Bot API versions
 
@@ -111,7 +111,7 @@ Installing both ``python-telegram-bot`` and ``python-telegram-bot-raw`` in conju
 Telegram API support
 ====================
 
-All types and methods of the Telegram Bot API **5.2** are supported.
+All types and methods of the Telegram Bot API **5.3** are supported.
 
 ==========
 Installing

--- a/README_RAW.rst
+++ b/README_RAW.rst
@@ -20,7 +20,7 @@ We have a vibrant community of developers helping each other in our `Telegram gr
    :target: https://pypi.org/project/python-telegram-bot-raw/
    :alt: Supported Python versions
 
-.. image:: https://img.shields.io/badge/Bot%20API-5.2-blue?logo=telegram
+.. image:: https://img.shields.io/badge/Bot%20API-5.3-blue?logo=telegram
    :target: https://core.telegram.org/bots/api-changelog
    :alt: Supported Bot API versions
 
@@ -105,7 +105,7 @@ Installing both ``python-telegram-bot`` and ``python-telegram-bot-raw`` in conju
 Telegram API support
 ====================
 
-All types and methods of the Telegram Bot API **5.2** are supported.
+All types and methods of the Telegram Bot API **5.3** are supported.
 
 ==========
 Installing

--- a/docs/source/telegram.botcommandscope.rst
+++ b/docs/source/telegram.botcommandscope.rst
@@ -1,0 +1,8 @@
+:github_url: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/telegram/botcommandscope.py
+
+telegram.BotCommandScope
+========================
+
+.. autoclass:: telegram.BotCommandScope
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.botcommandscopeallchatadministrators.rst
+++ b/docs/source/telegram.botcommandscopeallchatadministrators.rst
@@ -1,0 +1,8 @@
+:github_url: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/telegram/botcommandscope.py
+
+telegram.BotCommandScopeAllChatAdministrators
+=============================================
+
+.. autoclass:: telegram.BotCommandScopeAllChatAdministrators
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.botcommandscopeallgroupchats.rst
+++ b/docs/source/telegram.botcommandscopeallgroupchats.rst
@@ -1,0 +1,8 @@
+:github_url: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/telegram/botcommandscope.py
+
+telegram.BotCommandScopeAllGroupChats
+=======================================
+
+.. autoclass:: telegram.BotCommandScopeAllGroupChats
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.botcommandscopeallprivatechats.rst
+++ b/docs/source/telegram.botcommandscopeallprivatechats.rst
@@ -1,0 +1,8 @@
+:github_url: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/telegram/botcommandscope.py
+
+telegram.BotCommandScopeAllPrivateChats
+=======================================
+
+.. autoclass:: telegram.BotCommandScopeAllPrivateChats
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.botcommandscopechat.rst
+++ b/docs/source/telegram.botcommandscopechat.rst
@@ -1,0 +1,8 @@
+:github_url: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/telegram/botcommandscope.py
+
+telegram.BotCommandScopeChat
+============================
+
+.. autoclass:: telegram.BotCommandScopeChat
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.botcommandscopechatadministrators.rst
+++ b/docs/source/telegram.botcommandscopechatadministrators.rst
@@ -1,0 +1,8 @@
+:github_url: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/telegram/botcommandscope.py
+
+telegram.BotCommandScopeChatAdministrators
+==========================================
+
+.. autoclass:: telegram.BotCommandScopeChatAdministrators
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.botcommandscopechatmember.rst
+++ b/docs/source/telegram.botcommandscopechatmember.rst
@@ -1,0 +1,8 @@
+:github_url: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/telegram/botcommandscope.py
+
+telegram.BotCommandScopeChatMember
+==================================
+
+.. autoclass:: telegram.BotCommandScopeChatMember
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.botcommandscopedefault.rst
+++ b/docs/source/telegram.botcommandscopedefault.rst
@@ -1,0 +1,8 @@
+:github_url: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/telegram/botcommandscope.py
+
+telegram.BotCommandScopeDefault
+===============================
+
+.. autoclass:: telegram.BotCommandScopeDefault
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.chatmemberadministrator.rst
+++ b/docs/source/telegram.chatmemberadministrator.rst
@@ -1,7 +1,7 @@
 :github_url: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/telegram/chatmember.py
 
 telegram.ChatMemberAdministrator
-===================
+================================
 
 .. autoclass:: telegram.ChatMemberAdministrator
     :members:

--- a/docs/source/telegram.chatmemberadministrator.rst
+++ b/docs/source/telegram.chatmemberadministrator.rst
@@ -1,0 +1,8 @@
+:github_url: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/telegram/chatmember.py
+
+telegram.ChatMemberAdministrator
+===================
+
+.. autoclass:: telegram.ChatMemberAdministrator
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.chatmemberbanned.rst
+++ b/docs/source/telegram.chatmemberbanned.rst
@@ -1,7 +1,7 @@
 :github_url: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/telegram/chatmember.py
 
 telegram.ChatMemberBanned
-===================
+=========================
 
 .. autoclass:: telegram.ChatMemberBanned
     :members:

--- a/docs/source/telegram.chatmemberbanned.rst
+++ b/docs/source/telegram.chatmemberbanned.rst
@@ -1,0 +1,8 @@
+:github_url: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/telegram/chatmember.py
+
+telegram.ChatMemberBanned
+===================
+
+.. autoclass:: telegram.ChatMemberBanned
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.chatmemberleft.rst
+++ b/docs/source/telegram.chatmemberleft.rst
@@ -1,7 +1,7 @@
 :github_url: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/telegram/chatmember.py
 
 telegram.ChatMemberLeft
-===================
+=======================
 
 .. autoclass:: telegram.ChatMemberLeft
     :members:

--- a/docs/source/telegram.chatmemberleft.rst
+++ b/docs/source/telegram.chatmemberleft.rst
@@ -1,0 +1,8 @@
+:github_url: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/telegram/chatmember.py
+
+telegram.ChatMemberLeft
+===================
+
+.. autoclass:: telegram.ChatMemberLeft
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.chatmembermember.rst
+++ b/docs/source/telegram.chatmembermember.rst
@@ -1,7 +1,7 @@
 :github_url: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/telegram/chatmember.py
 
 telegram.ChatMemberMember
-===================
+=========================
 
 .. autoclass:: telegram.ChatMemberMember
     :members:

--- a/docs/source/telegram.chatmembermember.rst
+++ b/docs/source/telegram.chatmembermember.rst
@@ -1,0 +1,8 @@
+:github_url: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/telegram/chatmember.py
+
+telegram.ChatMemberMember
+===================
+
+.. autoclass:: telegram.ChatMemberMember
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.chatmemberowner.rst
+++ b/docs/source/telegram.chatmemberowner.rst
@@ -1,0 +1,9 @@
+:github_url: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/telegram/chatmember.py
+
+telegram.ChatMemberOwner
+===================
+
+.. autoclass:: telegram.ChatMemberOwner
+    :members:
+    :show-inheritance:
+

--- a/docs/source/telegram.chatmemberowner.rst
+++ b/docs/source/telegram.chatmemberowner.rst
@@ -1,7 +1,7 @@
 :github_url: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/telegram/chatmember.py
 
 telegram.ChatMemberOwner
-===================
+========================
 
 .. autoclass:: telegram.ChatMemberOwner
     :members:

--- a/docs/source/telegram.chatmemberrestricted.rst
+++ b/docs/source/telegram.chatmemberrestricted.rst
@@ -1,0 +1,8 @@
+:github_url: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/telegram/chatmember.py
+
+telegram.ChatMemberRestricted
+===================
+
+.. autoclass:: telegram.ChatMemberRestricted
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.chatmemberrestricted.rst
+++ b/docs/source/telegram.chatmemberrestricted.rst
@@ -1,7 +1,7 @@
 :github_url: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/telegram/chatmember.py
 
 telegram.ChatMemberRestricted
-===================
+=============================
 
 .. autoclass:: telegram.ChatMemberRestricted
     :members:

--- a/docs/source/telegram.rst
+++ b/docs/source/telegram.rst
@@ -7,6 +7,14 @@ telegram package
     telegram.audio
     telegram.bot
     telegram.botcommand
+    telegram.botcommandscope
+    telegram.botcommandscopedefault
+    telegram.botcommandscopeallprivatechats
+    telegram.botcommandscopeallgroupchats
+    telegram.botcommandscopeallchatadministrators
+    telegram.botcommandscopechat
+    telegram.botcommandscopechatadministrators
+    telegram.botcommandscopechatmember
     telegram.callbackquery
     telegram.chat
     telegram.chataction

--- a/docs/source/telegram.rst
+++ b/docs/source/telegram.rst
@@ -21,6 +21,12 @@ telegram package
     telegram.chatinvitelink
     telegram.chatlocation
     telegram.chatmember
+    telegram.chatmemberowner
+    telegram.chatmemberadministrator
+    telegram.chatmembermember
+    telegram.chatmemberrestricted
+    telegram.chatmemberleft
+    telegram.chatmemberbanned
     telegram.chatmemberupdated
     telegram.chatpermissions
     telegram.chatphoto

--- a/examples/conversationbot.py
+++ b/examples/conversationbot.py
@@ -44,7 +44,9 @@ def start(update: Update, context: CallbackContext) -> int:
         'Hi! My name is Professor Bot. I will hold a conversation with you. '
         'Send /cancel to stop talking to me.\n\n'
         'Are you a boy or a girl?',
-        reply_markup=ReplyKeyboardMarkup(reply_keyboard, one_time_keyboard=True),
+        reply_markup=ReplyKeyboardMarkup(
+            reply_keyboard, one_time_keyboard=True, input_field_placeholder='Boy or Girl?'
+        ),
     )
 
     return GENDER

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,8 +43,9 @@ omit =
 
 [coverage:report]
 exclude_lines =
+    pragma: no cover
+    @overload
     if TYPE_CHECKING:
-    ...
 
 [mypy]
 warn_unused_ignores = True

--- a/telegram/__init__.py
+++ b/telegram/__init__.py
@@ -25,7 +25,15 @@ from .files.chatphoto import ChatPhoto
 from .chat import Chat
 from .chatlocation import ChatLocation
 from .chatinvitelink import ChatInviteLink
-from .chatmember import ChatMember
+from .chatmember import (
+    ChatMember,
+    ChatMemberOwner,
+    ChatMemberAdministrator,
+    ChatMemberMember,
+    ChatMemberRestricted,
+    ChatMemberLeft,
+    ChatMemberBanned,
+)
 from .chatmemberupdated import ChatMemberUpdated
 from .chatpermissions import ChatPermissions
 from .files.photosize import PhotoSize
@@ -188,6 +196,12 @@ __all__ = (  # Keep this alphabetically ordered
     'ChatInviteLink',
     'ChatLocation',
     'ChatMember',
+    'ChatMemberOwner',
+    'ChatMemberAdministrator',
+    'ChatMemberMember',
+    'ChatMemberRestricted',
+    'ChatMemberLeft',
+    'ChatMemberBanned',
     'ChatMemberUpdated',
     'ChatPermissions',
     'ChatPhoto',

--- a/telegram/__init__.py
+++ b/telegram/__init__.py
@@ -153,6 +153,16 @@ from .passport.credentials import (
     FileCredentials,
     TelegramDecryptionError,
 )
+from .botcommandscope import (
+    BotCommandScope,
+    BotCommandScopeDefault,
+    BotCommandScopeAllPrivateChats,
+    BotCommandScopeAllGroupChats,
+    BotCommandScopeAllChatAdministrators,
+    BotCommandScopeChat,
+    BotCommandScopeChatAdministrators,
+    BotCommandScopeChatMember,
+)
 from .bot import Bot
 from .version import __version__, bot_api_version  # noqa: F401
 
@@ -163,6 +173,14 @@ __all__ = (  # Keep this alphabetically ordered
     'Audio',
     'Bot',
     'BotCommand',
+    'BotCommandScope',
+    'BotCommandScopeAllChatAdministrators',
+    'BotCommandScopeAllGroupChats',
+    'BotCommandScopeAllPrivateChats',
+    'BotCommandScopeChat',
+    'BotCommandScopeChatAdministrators',
+    'BotCommandScopeChatMember',
+    'BotCommandScopeDefault',
     'CallbackGame',
     'CallbackQuery',
     'Chat',

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -2316,6 +2316,62 @@ class Bot(TelegramObject):
         supergroups and channels, the user will not be able to return to the group on their own
         using invite links, etc., unless unbanned first. The bot must be an administrator in the
         chat for this to work and must have the appropriate admin rights.
+        Args:
+            chat_id (:obj:`int` | :obj:`str`): Unique identifier for the target group or username
+                of the target supergroup or channel (in the format ``@channelusername``).
+            user_id (:obj:`int`): Unique identifier of the target user.
+            timeout (:obj:`int` | :obj:`float`, optional): If this value is specified, use it as
+                the read timeout from the server (instead of the one specified during creation of
+                the connection pool).
+            until_date (:obj:`int` | :obj:`datetime.datetime`, optional): Date when the user will
+                be unbanned, unix time. If user is banned for more than 366 days or less than 30
+                seconds from the current time they are considered to be banned forever. Applied
+                for supergroups and channels only.
+                For timezone naive :obj:`datetime.datetime` objects, the default timezone of the
+                bot will be used.
+            revoke_messages (:obj:`bool`, optional): Pass :obj:`True` to delete all messages from
+                the chat for the user that is being removed. If :obj:`False`, the user will be able
+                to see messages in the group that were sent before the user was removed.
+                Always :obj:`True` for supergroups and channels.
+                .. versionadded:: 13.4
+            api_kwargs (:obj:`dict`, optional): Arbitrary keyword arguments to be passed to the
+                Telegram API.
+        Returns:
+            :obj:`bool`: On success, :obj:`True` is returned.
+        Raises:
+            :class:`telegram.error.TelegramError`
+        """
+        warnings.warn(
+            '`bot.kick_chat_member` is deprecated. Use `bot.ban_chat_member` instead.',
+            TelegramDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.ban_chat_member(
+            chat_id=chat_id,
+            user_id=user_id,
+            timeout=timeout,
+            until_date=until_date,
+            api_kwargs=api_kwargs,
+            revoke_messages=revoke_messages,
+        )
+
+    @log
+    def ban_chat_member(
+        self,
+        chat_id: Union[str, int],
+        user_id: Union[str, int],
+        timeout: ODVInput[float] = DEFAULT_NONE,
+        until_date: Union[int, datetime] = None,
+        api_kwargs: JSONDict = None,
+        revoke_messages: bool = None,
+    ) -> bool:
+        """
+        Use this method to ban a user from a group, supergroup or a channel. In the case of
+        supergroups and channels, the user will not be able to return to the group on their own
+        using invite links, etc., unless unbanned first. The bot must be an administrator in the
+        chat for this to work and must have the appropriate admin rights.
+
+         .. versionadded:: 13.7
 
         Args:
             chat_id (:obj:`int` | :obj:`str`): Unique identifier for the target group or username
@@ -2358,7 +2414,7 @@ class Bot(TelegramObject):
         if revoke_messages is not None:
             data['revoke_messages'] = revoke_messages
 
-        result = self._post('kickChatMember', data, timeout=timeout, api_kwargs=api_kwargs)
+        result = self._post('banChatMember', data, timeout=timeout, api_kwargs=api_kwargs)
 
         return result  # type: ignore[return-value]
 
@@ -3072,6 +3128,38 @@ class Bot(TelegramObject):
                 the connection pool).
             api_kwargs (:obj:`dict`, optional): Arbitrary keyword arguments to be passed to the
                 Telegram API.
+        Returns:
+            :obj:`int`: Number of members in the chat.
+        Raises:
+            :class:`telegram.error.TelegramError`
+        """
+        warnings.warn(
+            '`bot.get_chat_members_count` is depreciated. '
+            'Use `bot.get_chat_member_count` instead.',
+            TelegramDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.get_chat_member_count(chat_id=chat_id, timeout=timeout, api_kwargs=api_kwargs)
+
+    @log
+    def get_chat_member_count(
+        self,
+        chat_id: Union[str, int],
+        timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: JSONDict = None,
+    ) -> int:
+        """Use this method to get the number of members in a chat.
+
+         .. versionadded:: 13.7
+
+        Args:
+            chat_id (:obj:`int` | :obj:`str`): Unique identifier for the target chat or username
+                of the target supergroup or channel (in the format ``@channelusername``).
+            timeout (:obj:`int` | :obj:`float`, optional): If this value is specified, use it as
+                the read timeout from the server (instead of the one specified during creation of
+                the connection pool).
+            api_kwargs (:obj:`dict`, optional): Arbitrary keyword arguments to be passed to the
+                Telegram API.
 
         Returns:
             :obj:`int`: Number of members in the chat.
@@ -3082,7 +3170,7 @@ class Bot(TelegramObject):
         """
         data: JSONDict = {'chat_id': chat_id}
 
-        result = self._post('getChatMembersCount', data, timeout=timeout, api_kwargs=api_kwargs)
+        result = self._post('getChatMemberCount', data, timeout=timeout, api_kwargs=api_kwargs)
 
         return result  # type: ignore[return-value]
 
@@ -5210,6 +5298,8 @@ class Bot(TelegramObject):
     """Alias for :meth:`get_user_profile_photos`"""
     getFile = get_file
     """Alias for :meth:`get_file`"""
+    banChatMember = ban_chat_member
+    """Alias for :meth:`ban_chat_member`"""
     kickChatMember = kick_chat_member
     """Alias for :meth:`kick_chat_member`"""
     unbanChatMember = unban_chat_member
@@ -5242,6 +5332,8 @@ class Bot(TelegramObject):
     """Alias for :meth:`set_chat_sticker_set`"""
     deleteChatStickerSet = delete_chat_sticker_set
     """Alias for :meth:`delete_chat_sticker_set`"""
+    getChatMemberCount = get_chat_member_count
+    """Alias for :meth:`get_chat_member_count`"""
     getChatMembersCount = get_chat_members_count
     """Alias for :meth:`get_chat_members_count`"""
     getWebhookInfo = get_webhook_info

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -5109,7 +5109,7 @@ class Bot(TelegramObject):
 
         result = self._post('getMyCommands', data, timeout=timeout, api_kwargs=api_kwargs)
 
-        if (scope is None or scope.type == 'default') and language_code is None:
+        if (scope is None or scope.type == scope.DEFAULT) and language_code is None:
             self._commands = BotCommand.de_list(result, self)  # type: ignore[assignment,arg-type]
             return self._commands  # type: ignore[return-value]
 
@@ -5169,7 +5169,7 @@ class Bot(TelegramObject):
 
         # Set commands only for default scope. No need to check for outcome.
         # If request failed, we won't come this far
-        if (scope is None or scope.type == 'default') and language_code is None:
+        if (scope is None or scope.type == scope.DEFAULT) and language_code is None:
             self._commands = cmds
 
         return result  # type: ignore[return-value]
@@ -5219,7 +5219,7 @@ class Bot(TelegramObject):
 
         result = self._post('deleteMyCommands', data, timeout=timeout, api_kwargs=api_kwargs)
 
-        if (scope is None or scope.type == 'default') and language_code is None:
+        if (scope is None or scope.type == scope.DEFAULT) and language_code is None:
             self._commands = []
 
         return result  # type: ignore[return-value]

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -5087,7 +5087,9 @@ class Bot(TelegramObject):
         language_code: str = None,
     ) -> bool:
         """
-        Use this method to change the list of the bot's commands.
+        Use this method to change the list of the bot's commands. See the
+        `Telegram docs <https://core.telegram.org/bots#commands>`_ for more details about bot
+        commands.
 
         Args:
             commands (List[:class:`BotCommand` | (:obj:`str`, :obj:`str`)]): A JSON-serialized list

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -2326,37 +2326,9 @@ class Bot(TelegramObject):
         revoke_messages: bool = None,
     ) -> bool:
         """
-        Use this method to kick a user from a group, supergroup or a channel. In the case of
-        supergroups and channels, the user will not be able to return to the group on their own
-        using invite links, etc., unless unbanned first. The bot must be an administrator in the
-        chat for this to work and must have the appropriate admin rights.
+        Deprecated, use :func:`~telegram.Bot.ban_chat_member` instead.
 
-        Args:
-            chat_id (:obj:`int` | :obj:`str`): Unique identifier for the target group or username
-                of the target supergroup or channel (in the format ``@channelusername``).
-            user_id (:obj:`int`): Unique identifier of the target user.
-            timeout (:obj:`int` | :obj:`float`, optional): If this value is specified, use it as
-                the read timeout from the server (instead of the one specified during creation of
-                the connection pool).
-            until_date (:obj:`int` | :obj:`datetime.datetime`, optional): Date when the user will
-                be unbanned, unix time. If user is banned for more than 366 days or less than 30
-                seconds from the current time they are considered to be banned forever. Applied
-                for supergroups and channels only.
-                For timezone naive :obj:`datetime.datetime` objects, the default timezone of the
-                bot will be used.
-            revoke_messages (:obj:`bool`, optional): Pass :obj:`True` to delete all messages from
-                the chat for the user that is being removed. If :obj:`False`, the user will be able
-                to see messages in the group that were sent before the user was removed.
-                Always :obj:`True` for supergroups and channels.
-                .. versionadded:: 13.4
-            api_kwargs (:obj:`dict`, optional): Arbitrary keyword arguments to be passed to the
-                Telegram API.
-
-        Returns:
-            :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
+        .. deprecated:: 13.7
 
         """
         warnings.warn(
@@ -3136,23 +3108,13 @@ class Bot(TelegramObject):
         timeout: ODVInput[float] = DEFAULT_NONE,
         api_kwargs: JSONDict = None,
     ) -> int:
-        """Use this method to get the number of members in a chat.
+        """
+        Deprecated, use :func:`~telegram.Bot.get_chat_member_count` instead.
 
-        Args:
-            chat_id (:obj:`int` | :obj:`str`): Unique identifier for the target chat or username
-                of the target supergroup or channel (in the format ``@channelusername``).
-            timeout (:obj:`int` | :obj:`float`, optional): If this value is specified, use it as
-                the read timeout from the server (instead of the one specified during creation of
-                the connection pool).
-            api_kwargs (:obj:`dict`, optional): Arbitrary keyword arguments to be passed to the
-                Telegram API.
-        Returns:
-            :obj:`int`: Number of members in the chat.
-        Raises:
-            :class:`telegram.error.TelegramError`
+        .. deprecated:: 13.7
         """
         warnings.warn(
-            '`bot.get_chat_members_count` is depreciated. '
+            '`bot.get_chat_members_count` is deprecated. '
             'Use `bot.get_chat_member_count` instead.',
             TelegramDeprecationWarning,
             stacklevel=2,

--- a/telegram/botcommandscope.py
+++ b/telegram/botcommandscope.py
@@ -106,7 +106,9 @@ class BotCommandScope(TelegramObject):
             cls.CHAT_MEMBER: BotCommandScopeChatMember,
         }
 
-        return _class_mapping.get(data['type'], cls)(**data, bot=bot)
+        if cls is BotCommandScope:
+            return _class_mapping.get(data['type'], cls)(**data, bot=bot)
+        return cls(**data)
 
 
 class BotCommandScopeDefault(BotCommandScope):

--- a/telegram/botcommandscope.py
+++ b/telegram/botcommandscope.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python
+#
+# A library that provides a Python interface to the Telegram Bot API
+# Copyright (C) 2021
+# Leandro Toledo de Souza <devs@python-telegram-bot.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+# pylint: disable=W0622
+"""This module contains objects representing to Telegram bot command scopes."""
+from typing import Any, Union, Optional, TYPE_CHECKING, Dict, Type
+
+from telegram import TelegramObject, constants
+from telegram.utils.types import JSONDict
+
+if TYPE_CHECKING:
+    from telegram import Bot
+
+
+class BotCommandScope(TelegramObject):
+    """Base class for objects that represent the scope to which bot commands are applied.
+    Currently, the following 7 scopes are supported:
+
+    * :class:`telegram.BotCommandScopeDefault`
+    * :class:`telegram.BotCommandScopeAllPrivateChats`
+    * :class:`telegram.BotCommandScopeAllGroupChats`
+    * :class:`telegram.BotCommandScopeAllChatAdministrators`
+    * :class:`telegram.BotCommandScopeChat`
+    * :class:`telegram.BotCommandScopeChatAdministrators`
+    * :class:`telegram.BotCommandScopeChatMember`
+
+    Objects of this class are comparable in terms of equality. Two objects of this class are
+    considered equal, if their :attr:`type` is equal. For subclasses with additional attributes,
+    the notion of equality is overridden.
+
+    Note:
+        Please see the `official docs`_ on how Telegram determines which commands to display.
+
+    .. _`official docs`: https://core.telegram.org/bots/api#determining-list-of-commands
+
+    .. versionadded:: 13.7
+
+    Args:
+        type (:obj:`str`): Scope type.
+
+    Attributes:
+        type (:obj:`str`): Scope type.
+    """
+
+    __slots__ = ('type',)
+
+    DEFAULT = constants.BOT_COMMAND_SCOPE_DEFAULT
+    """:const:`telegram.constants.BOT_COMMAND_SCOPE_DEFAULT`"""
+    ALL_PRIVATE_CHATS = constants.BOT_COMMAND_SCOPE_ALL_PRIVATE_CHATS
+    """:const:`telegram.constants.BOT_COMMAND_SCOPE_ALL_PRIVATE_CHATS`"""
+    ALL_GROUP_CHATS = constants.BOT_COMMAND_SCOPE_ALL_GROUP_CHATS
+    """:const:`telegram.constants.BOT_COMMAND_SCOPE_ALL_GROUP_CHATS`"""
+    ALL_CHAT_ADMINISTRATORS = constants.BOT_COMMAND_SCOPE_ALL_CHAT_ADMINISTRATORS
+    """:const:`telegram.constants.BOT_COMMAND_SCOPE_ALL_CHAT_ADMINISTRATORS`"""
+    CHAT = constants.BOT_COMMAND_SCOPE_CHAT
+    """:const:`telegram.constants.BOT_COMMAND_SCOPE_CHAT`"""
+    CHAT_ADMINISTRATORS = constants.BOT_COMMAND_SCOPE_CHAT_ADMINISTRATORS
+    """:const:`telegram.constants.BOT_COMMAND_SCOPE_CHAT_ADMINISTRATORS`"""
+    CHAT_MEMBER = constants.BOT_COMMAND_SCOPE_CHAT_MEMBER
+    """:const:`telegram.constants.BOT_COMMAND_SCOPE_CHAT_MEMBER`"""
+
+    def __init__(self, type: str, **_kwargs: Any):
+        self.type = type
+        self._id_attrs = (self.type,)
+
+    @classmethod
+    def de_json(cls, data: Optional[JSONDict], bot: 'Bot') -> Optional['BotCommandScope']:
+        """Converts JSON data to a the appropriate :class:`BotCommandScope` object, i.e. takes
+        care of selecting the correct subclass.
+
+        Args:
+            data (Dict[:obj:`str`, ...]): The JSON data.
+            bot (:class:`telegram.Bot`): The bot associated with this object.
+
+        Returns:
+            The Telegram object.
+
+        """
+        data = cls._parse_data(data)
+
+        if not data:
+            return None
+
+        _class_mapping: Dict[str, Type['BotCommandScope']] = {
+            cls.DEFAULT: BotCommandScopeDefault,
+            cls.ALL_PRIVATE_CHATS: BotCommandScopeAllPrivateChats,
+            cls.ALL_GROUP_CHATS: BotCommandScopeAllGroupChats,
+            cls.ALL_CHAT_ADMINISTRATORS: BotCommandScopeAllChatAdministrators,
+            cls.CHAT: BotCommandScopeChat,
+            cls.CHAT_ADMINISTRATORS: BotCommandScopeChatAdministrators,
+            cls.CHAT_MEMBER: BotCommandScopeChatMember,
+        }
+
+        return _class_mapping.get(data['type'], cls)(**data, bot=bot)
+
+
+class BotCommandScopeDefault(BotCommandScope):
+    """Represents the default scope of bot commands. Default commands are used if no commands with
+    a `narrower scope`_ are specified for the user.
+
+    .. _`narrower scope`: https://core.telegram.org/bots/api#determining-list-of-commands
+
+    .. versionadded:: 13.7
+
+    Attributes:
+        type (:obj:`str`): Scope type :attr:`telegram.BotCommandScope.DEFAULT`.
+    """
+
+    __slots__ = ()
+
+    def __init__(self, **_kwargs: Any):
+        super().__init__(type=BotCommandScope.DEFAULT)
+
+
+class BotCommandScopeAllPrivateChats(BotCommandScope):
+    """Represents the scope of bot commands, covering all private chats.
+
+    .. versionadded:: 13.7
+
+    Attributes:
+        type (:obj:`str`): Scope type :attr:`telegram.BotCommandScope.ALL_PRIVATE_CHATS`.
+    """
+
+    __slots__ = ()
+
+    def __init__(self, **_kwargs: Any):
+        super().__init__(type=BotCommandScope.ALL_PRIVATE_CHATS)
+
+
+class BotCommandScopeAllGroupChats(BotCommandScope):
+    """Represents the scope of bot commands, covering all group and supergroup chats.
+
+    .. versionadded:: 13.7
+
+    Attributes:
+        type (:obj:`str`): Scope type :attr:`telegram.BotCommandScope.ALL_GROUP_CHATS`.
+    """
+
+    __slots__ = ()
+
+    def __init__(self, **_kwargs: Any):
+        super().__init__(type=BotCommandScope.ALL_GROUP_CHATS)
+
+
+class BotCommandScopeAllChatAdministrators(BotCommandScope):
+    """Represents the scope of bot commands, covering all group and supergroup chat administrators.
+
+    .. versionadded:: 13.7
+
+    Attributes:
+        type (:obj:`str`): Scope type :attr:`telegram.BotCommandScope.ALL_CHAT_ADMINISTRATORS`.
+    """
+
+    __slots__ = ()
+
+    def __init__(self, **_kwargs: Any):
+        super().__init__(type=BotCommandScope.ALL_CHAT_ADMINISTRATORS)
+
+
+class BotCommandScopeChat(BotCommandScope):
+    """Represents the scope of bot commands, covering a specific chat.
+
+    Objects of this class are comparable in terms of equality. Two objects of this class are
+    considered equal, if their :attr:`type` and :attr:`chat_id` are equal.
+
+    .. versionadded:: 13.7
+
+    Args:
+        chat_id (:obj:`str` | :obj:`int`): Unique identifier for the target chat or username of the
+            target supergroup (in the format ``@supergroupusername``)
+
+    Attributes:
+        type (:obj:`str`): Scope type :attr:`telegram.BotCommandScope.CHAT`.
+        chat_id (:obj:`str` | :obj:`int`): Unique identifier for the target chat or username of the
+            target supergroup (in the format ``@supergroupusername``)
+    """
+
+    __slots__ = ('chat_id',)
+
+    def __init__(self, chat_id: Union[str, int], **_kwargs: Any):
+        super().__init__(type=BotCommandScope.CHAT)
+        self.chat_id = (
+            chat_id if isinstance(chat_id, str) and chat_id.startswith('@') else int(chat_id)
+        )
+        self._id_attrs = (self.type, self.chat_id)
+
+
+class BotCommandScopeChatAdministrators(BotCommandScope):
+    """Represents the scope of bot commands, covering all administrators of a specific group or
+    supergroup chat.
+
+    Objects of this class are comparable in terms of equality. Two objects of this class are
+    considered equal, if their :attr:`type` and :attr:`chat_id` are equal.
+
+    .. versionadded:: 13.7
+
+    Args:
+        chat_id (:obj:`str` | :obj:`int`): Unique identifier for the target chat or username of the
+            target supergroup (in the format ``@supergroupusername``)
+
+    Attributes:
+        type (:obj:`str`): Scope type :attr:`telegram.BotCommandScope.CHAT_ADMINISTRATORS`.
+        chat_id (:obj:`str` | :obj:`int`): Unique identifier for the target chat or username of the
+            target supergroup (in the format ``@supergroupusername``)
+    """
+
+    __slots__ = ('chat_id',)
+
+    def __init__(self, chat_id: Union[str, int], **_kwargs: Any):
+        super().__init__(type=BotCommandScope.CHAT_ADMINISTRATORS)
+        self.chat_id = (
+            chat_id if isinstance(chat_id, str) and chat_id.startswith('@') else int(chat_id)
+        )
+        self._id_attrs = (self.type, self.chat_id)
+
+
+class BotCommandScopeChatMember(BotCommandScope):
+    """Represents the scope of bot commands, covering a specific member of a group or supergroup
+    chat.
+
+    Objects of this class are comparable in terms of equality. Two objects of this class are
+    considered equal, if their :attr:`type`, :attr:`chat_id` and :attr:`user_id` are equal.
+
+    .. versionadded:: 13.7
+
+    Args:
+        chat_id (:obj:`str` | :obj:`int`): Unique identifier for the target chat or username of the
+            target supergroup (in the format ``@supergroupusername``)
+        user_id (:obj:`int`): Unique identifier of the target user.
+
+    Attributes:
+        type (:obj:`str`): Scope type :attr:`telegram.BotCommandScope.CHAT_MEMBER`.
+        chat_id (:obj:`str` | :obj:`int`): Unique identifier for the target chat or username of the
+            target supergroup (in the format ``@supergroupusername``)
+        user_id (:obj:`int`): Unique identifier of the target user.
+    """
+
+    __slots__ = ('chat_id', 'user_id')
+
+    def __init__(self, chat_id: Union[str, int], user_id: int, **_kwargs: Any):
+        super().__init__(type=BotCommandScope.CHAT_MEMBER)
+        self.chat_id = (
+            chat_id if isinstance(chat_id, str) and chat_id.startswith('@') else int(chat_id)
+        )
+        self.user_id = int(user_id)
+        self._id_attrs = (self.type, self.chat_id, self.user_id)

--- a/telegram/botcommandscope.py
+++ b/telegram/botcommandscope.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 # pylint: disable=W0622
-"""This module contains objects representing to Telegram bot command scopes."""
+"""This module contains objects representing Telegram bot command scopes."""
 from typing import Any, Union, Optional, TYPE_CHECKING, Dict, Type
 
 from telegram import TelegramObject, constants

--- a/telegram/botcommandscope.py
+++ b/telegram/botcommandscope.py
@@ -57,7 +57,7 @@ class BotCommandScope(TelegramObject):
         type (:obj:`str`): Scope type.
     """
 
-    __slots__ = ('type',)
+    __slots__ = ('type', '_id_attrs')
 
     DEFAULT = constants.BOT_COMMAND_SCOPE_DEFAULT
     """:const:`telegram.constants.BOT_COMMAND_SCOPE_DEFAULT`"""

--- a/telegram/chat.py
+++ b/telegram/chat.py
@@ -326,9 +326,8 @@ class Chat(TelegramObject):
 
         .. deprecated:: 13.7
         """
-
         warnings.warn(
-            '`Chat.get_members_count` is deprecated. ' 'Use `Chat.get_member_count` instead.',
+            '`Chat.get_members_count` is deprecated. Use `Chat.get_member_count` instead.',
             TelegramDeprecationWarning,
             stacklevel=2,
         )

--- a/telegram/chat.py
+++ b/telegram/chat.py
@@ -18,11 +18,13 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represents a Telegram Chat."""
+import warnings
 from datetime import datetime
 from typing import TYPE_CHECKING, List, Optional, ClassVar, Union, Tuple, Any
 
 from telegram import ChatPhoto, TelegramObject, constants
 from telegram.utils.types import JSONDict, FileInput, ODVInput, DVInput
+from telegram.utils.deprecate import TelegramDeprecationWarning
 
 from .chatpermissions import ChatPermissions
 from .chatlocation import ChatLocation
@@ -319,18 +321,37 @@ class Chat(TelegramObject):
     def get_members_count(
         self, timeout: ODVInput[float] = DEFAULT_NONE, api_kwargs: JSONDict = None
     ) -> int:
+        """
+        Deprecated, use :func:`~telegram.Chat.get_member_count` instead.
+
+        .. deprecated:: 13.7
+        """
+
+        warnings.warn(
+            '`Chat.get_members_count` is deprecated. ' 'Use `Chat.get_member_count` instead.',
+            TelegramDeprecationWarning,
+            stacklevel=2,
+        )
+
+        return self.get_member_count(
+            timeout=timeout,
+            api_kwargs=api_kwargs,
+        )
+
+    def get_member_count(
+        self, timeout: ODVInput[float] = DEFAULT_NONE, api_kwargs: JSONDict = None
+    ) -> int:
         """Shortcut for::
 
-            bot.get_chat_members_count(update.effective_chat.id, *args, **kwargs)
+            bot.get_chat_member_count(update.effective_chat.id, *args, **kwargs)
 
         For the documentation of the arguments, please see
-        :meth:`telegram.Bot.get_chat_members_count`.
+        :meth:`telegram.Bot.get_chat_member_count`.
 
         Returns:
             :obj:`int`
-
         """
-        return self.bot.get_chat_members_count(
+        return self.bot.get_chat_member_count(
             chat_id=self.id,
             timeout=timeout,
             api_kwargs=api_kwargs,
@@ -367,12 +388,39 @@ class Chat(TelegramObject):
         api_kwargs: JSONDict = None,
         revoke_messages: bool = None,
     ) -> bool:
+        """
+        Deprecated, use :func:`~telegram.Chat.ban_member` instead.
+
+        .. deprecated:: 13.7
+        """
+        warnings.warn(
+            '`Chat.kick_member` is deprecated. Use `Chat.ban_member` instead.',
+            TelegramDeprecationWarning,
+            stacklevel=2,
+        )
+
+        return self.ban_member(
+            user_id=user_id,
+            timeout=timeout,
+            until_date=until_date,
+            api_kwargs=api_kwargs,
+            revoke_messages=revoke_messages,
+        )
+
+    def ban_member(
+        self,
+        user_id: Union[str, int],
+        timeout: ODVInput[float] = DEFAULT_NONE,
+        until_date: Union[int, datetime] = None,
+        api_kwargs: JSONDict = None,
+        revoke_messages: bool = None,
+    ) -> bool:
         """Shortcut for::
 
-            bot.kick_chat_member(update.effective_chat.id, *args, **kwargs)
+            bot.ban_chat_member(update.effective_chat.id, *args, **kwargs)
 
         For the documentation of the arguments, please see
-        :meth:`telegram.Bot.kick_chat_member`.
+        :meth:`telegram.Bot.ban_chat_member`.
 
         Returns:
             :obj:`bool`: If the action was sent successfully.
@@ -383,7 +431,7 @@ class Chat(TelegramObject):
             member that added them.
 
         """
-        return self.bot.kick_chat_member(
+        return self.bot.ban_chat_member(
             chat_id=self.id,
             user_id=user_id,
             timeout=timeout,

--- a/telegram/chatmember.py
+++ b/telegram/chatmember.py
@@ -71,11 +71,13 @@ class ChatMember(TelegramObject):
             channels, see channel members, see anonymous administrators in supergroups and ignore
             slow mode. Implied by any other administrator privilege.
 
+            .. versionadded:: 13.4
             .. deprecated:: 13.7
 
         can_manage_voice_chats (:obj:`bool`, optional): Administrators only. :obj:`True`, if the
             administrator can manage voice chats.
 
+            .. versionadded:: 13.4
             .. deprecated:: 13.7
 
         can_change_info (:obj:`bool`, optional): Administrators and restricted only. :obj:`True`,
@@ -176,11 +178,13 @@ class ChatMember(TelegramObject):
             log, chat statistics, message statistics in channels, see channel members, see
             anonymous administrators in supergroups and ignore slow mode.
 
+            .. versionadded:: 13.4
             .. deprecated:: 13.7
 
         can_manage_voice_chats (:obj:`bool`): Optional. if the administrator can manage
             voice chats.
 
+            .. versionadded:: 13.4
             .. deprecated:: 13.7
 
         can_change_info (:obj:`bool`): Optional. If the user can change the chat title, photo and

--- a/telegram/chatmember.py
+++ b/telegram/chatmember.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represents a Telegram ChatMember."""
 import datetime
-from typing import TYPE_CHECKING, Any, Optional, ClassVar
+from typing import TYPE_CHECKING, Any, Optional, ClassVar, Dict, Type
 
 from telegram import TelegramObject, User, constants
 from telegram.utils.helpers import from_timestamp, to_timestamp
@@ -29,7 +29,15 @@ if TYPE_CHECKING:
 
 
 class ChatMember(TelegramObject):
-    """This object contains information about one member of a chat.
+    """Base class for Telegram ChatMember Objects..
+    Currently, the following 6 types of chat members are supported:
+
+    * :class:`telegram.ChatMemberOwner`
+    * :class:`telegram.ChatMemberAdministrator`
+    * :class:`telegram.ChatMemberMember`
+    * :class:`telegram.ChatMemberRestricted`
+    * :class:`telegram.ChatMemberLeft`
+    * :class:`telegram.ChatMemberBanned`
 
     Objects of this class are comparable in terms of equality. Two objects of this class are
     considered equal, if their :attr:`user` and :attr:`status` are equal.
@@ -242,7 +250,16 @@ class ChatMember(TelegramObject):
         data['user'] = User.de_json(data.get('user'), bot)
         data['until_date'] = from_timestamp(data.get('until_date', None))
 
-        return cls(**data)
+        _class_mapping: Dict[str, Type['ChatMember']] = {
+            cls.CREATOR: ChatMemberOwner,
+            cls.ADMINISTRATOR: ChatMemberAdministrator,
+            cls.MEMBER: ChatMemberMember,
+            cls.RESTRICTED: ChatMemberRestricted,
+            cls.LEFT: ChatMemberLeft,
+            cls.KICKED: ChatMemberBanned,
+        }
+
+        return _class_mapping.get(data['status'], cls)(**data, bot=bot)
 
     def to_dict(self) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
@@ -251,3 +268,341 @@ class ChatMember(TelegramObject):
         data['until_date'] = to_timestamp(self.until_date)
 
         return data
+
+
+class ChatMemberOwner(ChatMember):
+    """
+    Represents a chat member that owns the chat
+    and has all administrator privileges.
+
+    .. versionadded:: 13.7
+
+    Args:
+        status (:obj:`str`): The member's status in the chat,
+            always “creator”.
+        user (:class:`telegram.User`): Information about the user.
+        custom_title (:obj:`str`, optional): Custom title for this user.
+        is_anonymous (:obj:`bool`, optional):  :obj:`True`, if the
+            user's presence in the chat is hidden.
+
+    Attributes:
+        status (:obj:`str`): The member's status in the chat,
+            always “creator”.
+        user (:class:`telegram.User`): Information about the user.
+        custom_title (:obj:`str`): Optional. Custom title for
+            this user.
+        is_anonymous (:obj:`bool`): Optional. :obj:`True`, if the user's
+            presence in the chat is hidden.
+    """
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        status: str,
+        user: User,
+        custom_title: str = None,
+        is_anonymous: bool = None,
+        **_kwargs: Any,
+    ):
+        super().__init__(
+            user=user, status=status, custom_title=custom_title, is_anonymous=is_anonymous
+        )
+
+
+class ChatMemberAdministrator(ChatMember):
+    """
+    Represents a chat member that has some additional privileges.
+
+    .. versionadded:: 13.7
+
+    Args:
+        status (:obj:`str`): The member's status in the chat,
+            always “administrator”.
+        user (:class:`telegram.User`): Information about the user.
+        can_be_edited (:obj:`bool`, optional): :obj:`True`, if the bot
+            is allowed to edit administrator privileges of that user.
+        custom_title (:obj:`str`, optional): Custom title for this user.
+        is_anonymous (:obj:`bool`, optional): :obj:`True`, if the  user's
+            presence in the chat is hidden.
+        can_manage_chat (:obj:`bool`, optional): :obj:`True`, if the administrator
+            can access the chat event log, chat statistics, message statistics in
+            channels, see channel members, see anonymous administrators in supergroups
+            and ignore slow mode. Implied by any other administrator privilege.
+        can_post_messages (:obj:`bool`, optional): :obj:`True`, if the
+            administrator can post in the channel, channels only.
+        can_edit_messages (:obj:`bool`, optional): :obj:`True`, if the
+            administrator can edit messages of other users and can pin
+            messages; channels only.
+        can_delete_messages (:obj:`bool`, optional): :obj:`True`, if the
+            administrator can delete messages of other users.
+        can_manage_voice_chats (:obj:`bool`, optional): :obj:`True`, if the
+            administrator can manage voice chats.
+        can_restrict_members (:obj:`bool`, optional): :obj:`True`, if the
+            administrator can restrict, ban or unban chat members.
+        can_promote_members (:obj:`bool`, optional): :obj:`True`, if the administrator
+            can add new administrators with a subset of his own privileges or demote
+            administrators that he has promoted, directly or indirectly (promoted by
+            administrators that were appointed by the user).
+        can_change_info (:obj:`bool`, optional): :obj:`True`, if the user can change
+            the chat title, photo and other settings.
+        can_invite_users (:obj:`bool`, optional): :obj:`True`, if the user can invite
+            new users to the chat.
+        can_pin_messages (:obj:`bool`, optional): :obj:`True`, if the user is allowed
+            to pin messages; groups and supergroups only.
+
+    Attributes:
+        status (:obj:`str`): The member's status in the chat,
+            always “administrator”.
+        user (:class:`telegram.User`): Information about the user.
+        can_be_edited (:obj:`bool`): Optional. :obj:`True`, if the bot
+            is allowed to edit administrator privileges of that user.
+        custom_title (:obj:`str`): Optional. Custom title for this user.
+        is_anonymous (:obj:`bool`): Optional. :obj:`True`, if the  user's
+            presence in the chat is hidden.
+        can_manage_chat (:obj:`bool`): Optional. :obj:`True`, if the administrator
+            can access the chat event log, chat statistics, message statistics in
+            channels, see channel members, see anonymous administrators in supergroups
+            and ignore slow mode. Implied by any other administrator privilege.
+        can_post_messages (:obj:`bool`): Optional. :obj:`True`, if the
+            administrator can post in the channel, channels only.
+        can_edit_messages (:obj:`bool`): Optional. :obj:`True`, if the
+            administrator can edit messages of other users and can pin
+            messages; channels only.
+        can_delete_messages (:obj:`bool`): Optional. :obj:`True`, if the
+            administrator can delete messages of other users.
+        can_manage_voice_chats (:obj:`bool`): Optional. :obj:`True`, if the
+            administrator can manage voice chats.
+        can_restrict_members (:obj:`bool`): Optional. :obj:`True`, if the
+            administrator can restrict, ban or unban chat members.
+        can_promote_members (:obj:`bool`): Optional. :obj:`True`, if the administrator
+            can add new administrators with a subset of his own privileges or demote
+            administrators that he has promoted, directly or indirectly (promoted by
+            administrators that were appointed by the user).
+        can_change_info (:obj:`bool`): Optional. :obj:`True`, if the user can change
+            the chat title, photo and other settings.
+        can_invite_users (:obj:`bool`): Optional. :obj:`True`, if the user can invite
+            new users to the chat.
+        can_pin_messages (:obj:`bool`): Optional. :obj:`True`, if the user is allowed
+            to pin messages; groups and supergroups only.
+    """
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        status: str,
+        user: User,
+        can_be_edited: bool = None,
+        custom_title: str = None,
+        is_anonymous: bool = None,
+        can_manage_chat: bool = None,
+        can_post_messages: bool = None,
+        can_edit_messages: bool = None,
+        can_delete_messages: bool = None,
+        can_manage_voice_chats: bool = None,
+        can_restrict_members: bool = None,
+        can_promote_members: bool = None,
+        can_change_info: bool = None,
+        can_invite_users: bool = None,
+        can_pin_messages: bool = None,
+        **_kwargs: Any,
+    ):
+        super().__init__(
+            user=user,
+            status=status,
+            can_be_edited=can_be_edited,
+            custom_title=custom_title,
+            is_anonymous=is_anonymous,
+            can_manage_chat=can_manage_chat,
+            can_post_messages=can_post_messages,
+            can_edit_messages=can_edit_messages,
+            can_delete_messages=can_delete_messages,
+            can_manage_voice_chats=can_manage_voice_chats,
+            can_restrict_members=can_restrict_members,
+            can_promote_members=can_promote_members,
+            can_change_info=can_change_info,
+            can_invite_users=can_invite_users,
+            can_pin_messages=can_pin_messages,
+        )
+
+
+class ChatMemberMember(ChatMember):
+    """
+    Represents a chat member that has no additional
+    privileges or restrictions.
+
+    .. versionadded:: 13.7
+
+    Args:
+        status (:obj:`str`): The member's status in the chat,
+            always “member”.
+        user (:class:`telegram.User`): Information about the user.
+
+    Attributes:
+        status (:obj:`str`): The member's status in the chat,
+            always “member”.
+        user (:class:`telegram.User`): Information about the user.
+
+    """
+
+    __slots__ = ()
+
+    def __init__(self, status: str, user: User, **_kwargs: Any):
+        super().__init__(user=user, status=status)
+
+
+class ChatMemberRestricted(ChatMember):
+    """
+    Represents a chat member that is under certain restrictions
+    in the chat. Supergroups only.
+
+    .. versionadded:: 13.7
+
+    Args:
+        status (:obj:`str`): The member's status in the chat,
+            always “restricted”.
+        user (:class:`telegram.User`): Information about the user.
+        is_member (:obj:`bool`, optional): :obj:`True`, if the user is a
+            member of the chat at the moment of the request.
+        can_change_info (:obj:`bool`, optional): :obj:`True`, if the user can change
+            the chat title, photo and other settings.
+        can_invite_users (:obj:`bool`, optional): :obj:`True`, if the user can invite
+            new users to the chat.
+        can_pin_messages (:obj:`bool`, optional): :obj:`True`, if the user is allowed
+            to pin messages; groups and supergroups only.
+        can_send_messages (:obj:`bool`, optional): :obj:`True`, if the user is allowed
+            to send text messages, contacts, locations and venues.
+        can_send_media_messages (:obj:`bool`, optional): :obj:`True`, if the user is allowed
+            to send audios, documents, photos, videos, video notes and voice notes.
+        can_send_polls (:obj:`bool`, optional): :obj:`True`, if the user is allowed
+            to send polls.
+        can_send_other_messages (:obj:`bool`, optional): :obj:`True`, if the user is allowed
+            to send animations, games, stickers and use inline bots.
+        can_add_web_page_previews (:obj:`bool`, optional): :obj:`True`, if the user is
+           allowed to add web page previews to their messages.
+        until_date (:class:`datetime.datetime`, optional): Date when restrictions
+           will be lifted for this user.
+
+    Attributes:
+        status (:obj:`str`): The member's status in the chat,
+            always “restricted”.
+        user (:class:`telegram.User`): Information about the user.
+        is_member (:obj:`bool`): Optional. :obj:`True`, if the user is a
+            member of the chat at the moment of the request.
+        can_change_info (:obj:`bool`): Optional. :obj:`True`, if the user can change
+            the chat title, photo and other settings.
+        can_invite_users (:obj:`bool`): Optional. :obj:`True`, if the user can invite
+            new users to the chat.
+        can_pin_messages (:obj:`bool`): Optional. :obj:`True`, if the user is allowed
+            to pin messages; groups and supergroups only.
+        can_send_messages (:obj:`bool`): Optional. :obj:`True`, if the user is allowed
+            to send text messages, contacts, locations and venues.
+        can_send_media_messages (:obj:`bool`): Optional. :obj:`True`, if the user is allowed
+            to send audios, documents, photos, videos, video notes and voice notes.
+        can_send_polls (:obj:`bool`): Optional. :obj:`True`, if the user is allowed
+            to send polls.
+        can_send_other_messages (:obj:`bool`): Optional. :obj:`True`, if the user is allowed
+            to send animations, games, stickers and use inline bots.
+        can_add_web_page_previews (:obj:`bool`): Optional. :obj:`True`, if the user is
+           allowed to add web page previews to their messages.
+        until_date (:class:`datetime.datetime`): Optional. Date when restrictions
+           will be lifted for this user.
+
+    """
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        status: str,
+        user: User,
+        is_member: bool = None,
+        can_change_info: bool = None,
+        can_invite_users: bool = None,
+        can_pin_messages: bool = None,
+        can_send_messages: bool = None,
+        can_send_media_messages: bool = None,
+        can_send_polls: bool = None,
+        can_send_other_messages: bool = None,
+        can_add_web_page_previews: bool = None,
+        until_date: datetime.datetime = None,
+        **_kwargs: Any,
+    ):
+        super().__init__(
+            user=user,
+            status=status,
+            is_member=is_member,
+            can_change_info=can_change_info,
+            can_invite_users=can_invite_users,
+            can_pin_messages=can_pin_messages,
+            can_send_messages=can_send_messages,
+            can_send_media_messages=can_send_media_messages,
+            can_send_polls=can_send_polls,
+            can_send_other_messages=can_send_other_messages,
+            can_add_web_page_previews=can_add_web_page_previews,
+            until_date=until_date,
+        )
+
+
+class ChatMemberLeft(ChatMember):
+    """
+    Represents a chat member that isn't currently a member of the chat,
+    but may join it themselves.
+
+    .. versionadded:: 13.7
+
+    Args:
+        status (:obj:`str`): The member's status in the chat,
+            always “left”.
+        user (:class:`telegram.User`): Information about the user.
+
+    Attributes:
+        status (:obj:`str`): The member's status in the chat,
+            always “left”.
+        user (:class:`telegram.User`): Information about the user.
+    """
+
+    __slots__ = ()
+
+    def __init__(self, status: str, user: User, **_kwargs: Any):
+        super().__init__(user=user, status=status)
+
+
+class ChatMemberBanned(ChatMember):
+    """
+    Represents a chat member that was banned in the chat and
+    can't return to the chat or view chat messages.
+
+    .. versionadded:: 13.7
+
+    Args:
+        status (:obj:`str`): The member's status in the chat,
+            always “kicked”.
+        user (:class:`telegram.User`): Information about the user.
+        until_date (:class:`datetime.datetime`, optional): Date when restrictions
+           will be lifted for this user.
+
+    Attributes:
+        status (:obj:`str`): The member's status in the chat,
+            always “kicked”.
+        user (:class:`telegram.User`): Information about the user.
+        until_date (:class:`datetime.datetime`): Optional. Date when restrictions
+           will be lifted for this user.
+
+    """
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        status: str,
+        user: User,
+        until_date: datetime.datetime = None,
+        **_kwargs: Any,
+    ):
+        super().__init__(
+            user=user,
+            status=status,
+            until_date=until_date,
+        )

--- a/telegram/chatmember.py
+++ b/telegram/chatmember.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 
 class ChatMember(TelegramObject):
-    """Base class for Telegram ChatMember Objects..
+    """Base class for Telegram ChatMember Objects.
     Currently, the following 6 types of chat members are supported:
 
     * :class:`telegram.ChatMemberOwner`
@@ -48,101 +48,207 @@ class ChatMember(TelegramObject):
             'member', 'restricted', 'left' or 'kicked'.
         custom_title (:obj:`str`, optional): Owner and administrators only.
             Custom title for this user.
+
+            .. deprecated:: 13.7
+
         is_anonymous (:obj:`bool`, optional): Owner and administrators only. :obj:`True`, if the
             user's presence in the chat is hidden.
+
+            .. deprecated:: 13.7
+
         until_date (:class:`datetime.datetime`, optional): Restricted and kicked only. Date when
             restrictions will be lifted for this user.
+
+            .. deprecated:: 13.7
+
         can_be_edited (:obj:`bool`, optional): Administrators only. :obj:`True`, if the bot is
             allowed to edit administrator privileges of that user.
+
+            .. deprecated:: 13.7
+
         can_manage_chat (:obj:`bool`, optional): Administrators only. :obj:`True`, if the
             administrator can access the chat event log, chat statistics, message statistics in
             channels, see channel members, see anonymous administrators in supergroups and ignore
             slow mode. Implied by any other administrator privilege.
 
-            .. versionadded:: 13.4
+            .. deprecated:: 13.7
 
         can_manage_voice_chats (:obj:`bool`, optional): Administrators only. :obj:`True`, if the
             administrator can manage voice chats.
 
-            .. versionadded:: 13.4
+            .. deprecated:: 13.7
 
         can_change_info (:obj:`bool`, optional): Administrators and restricted only. :obj:`True`,
             if the user can change the chat title, photo and other settings.
+
+            .. deprecated:: 13.7
+
         can_post_messages (:obj:`bool`, optional): Administrators only. :obj:`True`, if the
             administrator can post in the channel, channels only.
+
+            .. deprecated:: 13.7
+
         can_edit_messages (:obj:`bool`, optional): Administrators only. :obj:`True`, if the
             administrator can edit messages of other users and can pin messages; channels only.
+
+            .. deprecated:: 13.7
+
         can_delete_messages (:obj:`bool`, optional): Administrators only. :obj:`True`, if the
             administrator can delete messages of other users.
+
+            .. deprecated:: 13.7
+
         can_invite_users (:obj:`bool`, optional): Administrators and restricted only. :obj:`True`,
             if the user can invite new users to the chat.
+
+            .. deprecated:: 13.7
+
         can_restrict_members (:obj:`bool`, optional): Administrators only. :obj:`True`, if the
             administrator can restrict, ban or unban chat members.
+
+            .. deprecated:: 13.7
+
         can_pin_messages (:obj:`bool`, optional): Administrators and restricted only. :obj:`True`,
             if the user can pin messages, groups and supergroups only.
+
+            .. deprecated:: 13.7
+
         can_promote_members (:obj:`bool`, optional): Administrators only. :obj:`True`, if the
             administrator can add new administrators with a subset of his own privileges or demote
             administrators that he has promoted, directly or indirectly (promoted by administrators
             that were appointed by the user).
+
+            .. deprecated:: 13.7
+
         is_member (:obj:`bool`, optional): Restricted only. :obj:`True`, if the user is a member of
             the chat at the moment of the request.
+
+            .. deprecated:: 13.7
+
         can_send_messages (:obj:`bool`, optional): Restricted only. :obj:`True`, if the user can
             send text messages, contacts, locations and venues.
+
+            .. deprecated:: 13.7
+
         can_send_media_messages (:obj:`bool`, optional): Restricted only. :obj:`True`, if the user
             can send audios, documents, photos, videos, video notes and voice notes.
+
+            .. deprecated:: 13.7
+
         can_send_polls (:obj:`bool`, optional): Restricted only. :obj:`True`, if the user is
             allowed to send polls.
+
+            .. deprecated:: 13.7
+
         can_send_other_messages (:obj:`bool`, optional): Restricted only. :obj:`True`, if the user
             can send animations, games, stickers and use inline bots.
+
+            .. deprecated:: 13.7
+
         can_add_web_page_previews (:obj:`bool`, optional): Restricted only. :obj:`True`, if user
             may add web page previews to his messages.
+
+            .. deprecated:: 13.7
 
     Attributes:
         user (:class:`telegram.User`): Information about the user.
         status (:obj:`str`): The member's status in the chat.
         custom_title (:obj:`str`): Optional. Custom title for owner and administrators.
+
+            .. deprecated:: 13.7
+
         is_anonymous (:obj:`bool`): Optional. :obj:`True`, if the user's presence in the chat is
             hidden.
+
+            .. deprecated:: 13.7
+
         until_date (:class:`datetime.datetime`): Optional. Date when restrictions will be lifted
             for this user.
+
+            .. deprecated:: 13.7
+
         can_be_edited (:obj:`bool`): Optional. If the bot is allowed to edit administrator
             privileges of that user.
+
+            .. deprecated:: 13.7
+
         can_manage_chat (:obj:`bool`): Optional. If the administrator can access the chat event
             log, chat statistics, message statistics in channels, see channel members, see
             anonymous administrators in supergroups and ignore slow mode.
 
-            .. versionadded:: 13.4
+            .. deprecated:: 13.7
 
         can_manage_voice_chats (:obj:`bool`): Optional. if the administrator can manage
             voice chats.
 
-            .. versionadded:: 13.4
+            .. deprecated:: 13.7
 
         can_change_info (:obj:`bool`): Optional. If the user can change the chat title, photo and
             other settings.
+
+            .. deprecated:: 13.7
+
         can_post_messages (:obj:`bool`): Optional. If the administrator can post in the channel.
+
+            .. deprecated:: 13.7
+
         can_edit_messages (:obj:`bool`): Optional. If the administrator can edit messages of other
             users.
+
+            .. deprecated:: 13.7
+
         can_delete_messages (:obj:`bool`): Optional. If the administrator can delete messages of
             other users.
+
+            .. deprecated:: 13.7
+
         can_invite_users (:obj:`bool`): Optional. If the user can invite new users to the chat.
+
+            .. deprecated:: 13.7
+
         can_restrict_members (:obj:`bool`): Optional. If the administrator can restrict, ban or
             unban chat members.
+
+            .. deprecated:: 13.7
+
         can_pin_messages (:obj:`bool`): Optional. If the user can pin messages.
+
+            .. deprecated:: 13.7
+
         can_promote_members (:obj:`bool`): Optional. If the administrator can add new
             administrators.
+
+            .. deprecated:: 13.7
+
         is_member (:obj:`bool`): Optional. Restricted only. :obj:`True`, if the user is a member of
             the chat at the moment of the request.
+
+            .. deprecated:: 13.7
+
         can_send_messages (:obj:`bool`): Optional. If the user can send text messages, contacts,
             locations and venues.
+
+            .. deprecated:: 13.7
+
         can_send_media_messages (:obj:`bool`): Optional. If the user can send media messages,
             implies can_send_messages.
+
+            .. deprecated:: 13.7
+
         can_send_polls (:obj:`bool`): Optional. :obj:`True`, if the user is allowed to
             send polls.
+
+            .. deprecated:: 13.7
+
         can_send_other_messages (:obj:`bool`): Optional. If the user can send animations, games,
             stickers and use inline bots, implies can_send_media_messages.
+
+            .. deprecated:: 13.7
+
         can_add_web_page_previews (:obj:`bool`): Optional. If user may add web page previews to his
             messages, implies can_send_media_messages
+
+            .. deprecated:: 13.7
 
     """
 
@@ -259,7 +365,9 @@ class ChatMember(TelegramObject):
             cls.KICKED: ChatMemberBanned,
         }
 
-        return _class_mapping.get(data['status'], cls)(**data, bot=bot)
+        if cls is ChatMember:
+            return _class_mapping.get(data['status'], cls)(**data, bot=bot)
+        return cls(**data)
 
     def to_dict(self) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
@@ -278,16 +386,14 @@ class ChatMemberOwner(ChatMember):
     .. versionadded:: 13.7
 
     Args:
-        status (:obj:`str`): The member's status in the chat,
-            always “creator”.
         user (:class:`telegram.User`): Information about the user.
         custom_title (:obj:`str`, optional): Custom title for this user.
-        is_anonymous (:obj:`bool`, optional):  :obj:`True`, if the
+        is_anonymous (:obj:`bool`, optional): :obj:`True`, if the
             user's presence in the chat is hidden.
 
     Attributes:
         status (:obj:`str`): The member's status in the chat,
-            always “creator”.
+            always :attr:`telegram.ChatMember.CREATOR`.
         user (:class:`telegram.User`): Information about the user.
         custom_title (:obj:`str`): Optional. Custom title for
             this user.
@@ -299,14 +405,16 @@ class ChatMemberOwner(ChatMember):
 
     def __init__(
         self,
-        status: str,
         user: User,
         custom_title: str = None,
         is_anonymous: bool = None,
         **_kwargs: Any,
     ):
         super().__init__(
-            user=user, status=status, custom_title=custom_title, is_anonymous=is_anonymous
+            status=ChatMember.CREATOR,
+            user=user,
+            custom_title=custom_title,
+            is_anonymous=is_anonymous,
         )
 
 
@@ -317,8 +425,6 @@ class ChatMemberAdministrator(ChatMember):
     .. versionadded:: 13.7
 
     Args:
-        status (:obj:`str`): The member's status in the chat,
-            always “administrator”.
         user (:class:`telegram.User`): Information about the user.
         can_be_edited (:obj:`bool`, optional): :obj:`True`, if the bot
             is allowed to edit administrator privileges of that user.
@@ -353,7 +459,7 @@ class ChatMemberAdministrator(ChatMember):
 
     Attributes:
         status (:obj:`str`): The member's status in the chat,
-            always “administrator”.
+            always :attr:`telegram.ChatMember.ADMINISTRATOR`.
         user (:class:`telegram.User`): Information about the user.
         can_be_edited (:obj:`bool`): Optional. :obj:`True`, if the bot
             is allowed to edit administrator privileges of that user.
@@ -391,7 +497,6 @@ class ChatMemberAdministrator(ChatMember):
 
     def __init__(
         self,
-        status: str,
         user: User,
         can_be_edited: bool = None,
         custom_title: str = None,
@@ -409,8 +514,8 @@ class ChatMemberAdministrator(ChatMember):
         **_kwargs: Any,
     ):
         super().__init__(
+            status=ChatMember.ADMINISTRATOR,
             user=user,
-            status=status,
             can_be_edited=can_be_edited,
             custom_title=custom_title,
             is_anonymous=is_anonymous,
@@ -435,13 +540,11 @@ class ChatMemberMember(ChatMember):
     .. versionadded:: 13.7
 
     Args:
-        status (:obj:`str`): The member's status in the chat,
-            always “member”.
         user (:class:`telegram.User`): Information about the user.
 
     Attributes:
         status (:obj:`str`): The member's status in the chat,
-            always “member”.
+            always :attr:`telegram.ChatMember.MEMBER`.
         user (:class:`telegram.User`): Information about the user.
 
     """
@@ -449,7 +552,7 @@ class ChatMemberMember(ChatMember):
     __slots__ = ()
 
     def __init__(self, status: str, user: User, **_kwargs: Any):
-        super().__init__(user=user, status=status)
+        super().__init__(status=ChatMember.MEMBER, user=user)
 
 
 class ChatMemberRestricted(ChatMember):
@@ -460,8 +563,6 @@ class ChatMemberRestricted(ChatMember):
     .. versionadded:: 13.7
 
     Args:
-        status (:obj:`str`): The member's status in the chat,
-            always “restricted”.
         user (:class:`telegram.User`): Information about the user.
         is_member (:obj:`bool`, optional): :obj:`True`, if the user is a
             member of the chat at the moment of the request.
@@ -486,7 +587,7 @@ class ChatMemberRestricted(ChatMember):
 
     Attributes:
         status (:obj:`str`): The member's status in the chat,
-            always “restricted”.
+            always :attr:`telegram.ChatMember.RESTRICTED`.
         user (:class:`telegram.User`): Information about the user.
         is_member (:obj:`bool`): Optional. :obj:`True`, if the user is a
             member of the chat at the moment of the request.
@@ -515,7 +616,6 @@ class ChatMemberRestricted(ChatMember):
 
     def __init__(
         self,
-        status: str,
         user: User,
         is_member: bool = None,
         can_change_info: bool = None,
@@ -530,8 +630,8 @@ class ChatMemberRestricted(ChatMember):
         **_kwargs: Any,
     ):
         super().__init__(
+            status=ChatMember.RESTRICTED,
             user=user,
-            status=status,
             is_member=is_member,
             can_change_info=can_change_info,
             can_invite_users=can_invite_users,
@@ -553,20 +653,18 @@ class ChatMemberLeft(ChatMember):
     .. versionadded:: 13.7
 
     Args:
-        status (:obj:`str`): The member's status in the chat,
-            always “left”.
         user (:class:`telegram.User`): Information about the user.
 
     Attributes:
         status (:obj:`str`): The member's status in the chat,
-            always “left”.
+            always :attr:`telegram.ChatMember.LEFT`.
         user (:class:`telegram.User`): Information about the user.
     """
 
     __slots__ = ()
 
     def __init__(self, status: str, user: User, **_kwargs: Any):
-        super().__init__(user=user, status=status)
+        super().__init__(status=ChatMember.LEFT, user=user)
 
 
 class ChatMemberBanned(ChatMember):
@@ -577,15 +675,13 @@ class ChatMemberBanned(ChatMember):
     .. versionadded:: 13.7
 
     Args:
-        status (:obj:`str`): The member's status in the chat,
-            always “kicked”.
         user (:class:`telegram.User`): Information about the user.
         until_date (:class:`datetime.datetime`, optional): Date when restrictions
            will be lifted for this user.
 
     Attributes:
         status (:obj:`str`): The member's status in the chat,
-            always “kicked”.
+            always :attr:`telegram.ChatMember.KICKED`.
         user (:class:`telegram.User`): Information about the user.
         until_date (:class:`datetime.datetime`): Optional. Date when restrictions
            will be lifted for this user.
@@ -596,13 +692,12 @@ class ChatMemberBanned(ChatMember):
 
     def __init__(
         self,
-        status: str,
         user: User,
         until_date: datetime.datetime = None,
         **_kwargs: Any,
     ):
         super().__init__(
+            status=ChatMember.KICKED,
             user=user,
-            status=status,
             until_date=until_date,
         )

--- a/telegram/chatmember.py
+++ b/telegram/chatmember.py
@@ -50,8 +50,10 @@ class ChatMember(TelegramObject):
 
     Args:
         user (:class:`telegram.User`): Information about the user.
-        status (:obj:`str`): The member's status in the chat. Can be 'creator', 'administrator',
-            'member', 'restricted', 'left' or 'kicked'.
+        status (:obj:`str`): The member's status in the chat. Can be
+            :attr:`~telegram.ChatMember.ADMINISTRATOR`, :attr:`~telegram.ChatMember.CREATOR`,
+            :attr:`~telegram.ChatMember.KICKED`, :attr:`~telegram.ChatMember.LEFT`,
+            :attr:`~telegram.ChatMember.MEMBER` or :attr:`~telegram.ChatMember.RESTRICTED`.
         custom_title (:obj:`str`, optional): Owner and administrators only.
             Custom title for this user.
 

--- a/telegram/chatmember.py
+++ b/telegram/chatmember.py
@@ -43,7 +43,7 @@ class ChatMember(TelegramObject):
     considered equal, if their :attr:`user` and :attr:`status` are equal.
 
     Note:
-        As of Bot API 5.3, :class:`ChatMember` is nothing bot the base class for the subclasses
+        As of Bot API 5.3, :class:`ChatMember` is nothing but the base class for the subclasses
         listed above and is no longer returned directly by :meth:`~telegram.Bot.get_chat`.
         Therefore, most of the arguments and attributes were deprecated and you should no longer
         use :class:`ChatMember` directly.

--- a/telegram/chatmember.py
+++ b/telegram/chatmember.py
@@ -561,7 +561,7 @@ class ChatMemberMember(ChatMember):
 
     __slots__ = ()
 
-    def __init__(self, status: str, user: User, **_kwargs: Any):
+    def __init__(self, user: User, **_kwargs: Any):
         super().__init__(status=ChatMember.MEMBER, user=user)
 
 
@@ -673,7 +673,7 @@ class ChatMemberLeft(ChatMember):
 
     __slots__ = ()
 
-    def __init__(self, status: str, user: User, **_kwargs: Any):
+    def __init__(self, user: User, **_kwargs: Any):
         super().__init__(status=ChatMember.LEFT, user=user)
 
 

--- a/telegram/chatmember.py
+++ b/telegram/chatmember.py
@@ -42,6 +42,12 @@ class ChatMember(TelegramObject):
     Objects of this class are comparable in terms of equality. Two objects of this class are
     considered equal, if their :attr:`user` and :attr:`status` are equal.
 
+    Note:
+        As of Bot API 5.3, :class:`ChatMember` is nothing bot the base class for the subclasses
+        listed above and is no longer returned directly by :meth:`~telegram.Bot.get_chat`.
+        Therefore, most of the arguments and attributes were deprecated and you should no longer
+        use :class:`ChatMember` directly.
+
     Args:
         user (:class:`telegram.User`): Information about the user.
         status (:obj:`str`): The member's status in the chat. Can be 'creator', 'administrator',

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -205,6 +205,31 @@ Attributes:
 
         .. versionadded:: 13.5
 
+:class:`telegram.BotCommandScope`:
+
+Attributes:
+    BOT_COMMAND_SCOPE_DEFAULT (:obj:`str`): ``'default'``
+
+        ..versionadded:: 13.7
+    BOT_COMMAND_SCOPE_ALL_PRIVATE_CHATS (:obj:`str`): ``'all_private_chats'``
+
+        ..versionadded:: 13.7
+    BOT_COMMAND_SCOPE_ALL_GROUP_CHATS (:obj:`str`): ``'all_group_chats'``
+
+        ..versionadded:: 13.7
+    BOT_COMMAND_SCOPE_ALL_CHAT_ADMINISTRATORS (:obj:`str`): ``'all_chat_administrators'``
+
+        ..versionadded:: 13.7
+    BOT_COMMAND_SCOPE_CHAT (:obj:`str`): ``'chat'``
+
+        ..versionadded:: 13.7
+    BOT_COMMAND_SCOPE_CHAT_ADMINISTRATORS (:obj:`str`): ``'chat_administrators'``
+
+        ..versionadded:: 13.7
+    BOT_COMMAND_SCOPE_CHAT_MEMBER (:obj:`str`): ``'chat_member'``
+
+        ..versionadded:: 13.7
+
 """
 from typing import List
 
@@ -343,3 +368,11 @@ UPDATE_ALL_TYPES = [
     UPDATE_MY_CHAT_MEMBER,
     UPDATE_CHAT_MEMBER,
 ]
+
+BOT_COMMAND_SCOPE_DEFAULT = 'default'
+BOT_COMMAND_SCOPE_ALL_PRIVATE_CHATS = 'all_private_chats'
+BOT_COMMAND_SCOPE_ALL_GROUP_CHATS = 'all_group_chats'
+BOT_COMMAND_SCOPE_ALL_CHAT_ADMINISTRATORS = 'all_chat_administrators'
+BOT_COMMAND_SCOPE_CHAT = 'chat'
+BOT_COMMAND_SCOPE_CHAT_ADMINISTRATORS = 'chat_administrators'
+BOT_COMMAND_SCOPE_CHAT_MEMBER = 'chat_member'

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -21,7 +21,7 @@ The following constants were extracted from the
 `Telegram Bots API <https://core.telegram.org/bots/api>`_.
 
 Attributes:
-    BOT_API_VERSION (:obj:`str`): `5.2`. Telegram Bot API version supported by this
+    BOT_API_VERSION (:obj:`str`): `5.3`. Telegram Bot API version supported by this
         version of `python-telegram-bot`. Also available as ``telegram.bot_api_version``.
 
         .. versionadded:: 13.4
@@ -233,7 +233,7 @@ Attributes:
 """
 from typing import List
 
-BOT_API_VERSION: str = '5.2'
+BOT_API_VERSION: str = '5.3'
 MAX_MESSAGE_LENGTH: int = 4096
 MAX_CAPTION_LENGTH: int = 1024
 ANONYMOUS_ADMIN_ID: int = 1087968824

--- a/telegram/ext/__init__.py
+++ b/telegram/ext/__init__.py
@@ -32,7 +32,7 @@ from .dispatcher import Dispatcher, DispatcherHandlerStop, run_async
 # try-except is just  here in case the __init__ is called twice (like in the tests)
 # this block is also the reason for the pylint-ignore at the top of the file
 try:
-    del Dispatcher.__slots__  # type: ignore[has-type]
+    del Dispatcher.__slots__
 except AttributeError as exc:
     if str(exc) == '__slots__':
         pass

--- a/telegram/forcereply.py
+++ b/telegram/forcereply.py
@@ -31,15 +31,21 @@ class ForceReply(ReplyMarkup):
     to sacrifice privacy mode.
 
     Objects of this class are comparable in terms of equality. Two objects of this class are
-    considered equal, if their :attr:`selective` is equal.
+    considered equal, if their :attr:`selective`, and :attr:`input_field_placeholder` are equal.
 
     Args:
         selective (:obj:`bool`, optional): Use this parameter if you want to force reply from
             specific users only. Targets:
 
-            1) Users that are @mentioned in the text of the Message object.
-            2) If the bot's message is a reply (has reply_to_message_id), sender of the
-               original message.
+            1) Users that are @mentioned in the :attr:`~telegram.Message.text` of the
+               :class:`telegram.Message` object.
+            2) If the bot's message is a reply (has reply_to_message_id), sender of the original
+               message.
+
+        input_field_placeholder (:obj:`str`, optional): The placeholder to be shown in the input
+            field when the reply is active; 1-64 characters.
+
+            .. versionadded:: 13.7
 
         **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
@@ -47,15 +53,26 @@ class ForceReply(ReplyMarkup):
         force_reply (:obj:`True`): Shows reply interface to the user, as if they manually selected
             the bots message and tapped 'Reply'.
         selective (:obj:`bool`): Optional. Force reply from specific users only.
+        input_field_placeholder (:obj:`str`): Optional. The placeholder shown in the input
+            field when the reply is active.
+
+            .. versionadded:: 13.7
 
     """
 
-    __slots__ = ('selective', 'force_reply', '_id_attrs')
+    __slots__ = ('selective', 'force_reply', 'input_field_placeholder', '_id_attrs')
 
-    def __init__(self, force_reply: bool = True, selective: bool = False, **_kwargs: Any):
+    def __init__(
+        self,
+        force_reply: bool = True,
+        selective: bool = False,
+        input_field_placeholder: str = None,
+        **_kwargs: Any,
+    ):
         # Required
         self.force_reply = bool(force_reply)
         # Optionals
         self.selective = bool(selective)
+        self.input_field_placeholder = input_field_placeholder
 
-        self._id_attrs = (self.selective,)
+        self._id_attrs = (self.selective, self.input_field_placeholder)

--- a/telegram/forcereply.py
+++ b/telegram/forcereply.py
@@ -31,7 +31,7 @@ class ForceReply(ReplyMarkup):
     to sacrifice privacy mode.
 
     Objects of this class are comparable in terms of equality. Two objects of this class are
-    considered equal, if their :attr:`selective`, and :attr:`input_field_placeholder` are equal.
+    considered equal, if their :attr:`selective` is equal.
 
     Args:
         selective (:obj:`bool`, optional): Use this parameter if you want to force reply from
@@ -39,8 +39,8 @@ class ForceReply(ReplyMarkup):
 
             1) Users that are @mentioned in the :attr:`~telegram.Message.text` of the
                :class:`telegram.Message` object.
-            2) If the bot's message is a reply (has reply_to_message_id), sender of the original
-               message.
+            2) If the bot's message is a reply (has ``reply_to_message_id``), sender of the
+               original message.
 
         input_field_placeholder (:obj:`str`, optional): The placeholder to be shown in the input
             field when the reply is active; 1-64 characters.
@@ -75,4 +75,4 @@ class ForceReply(ReplyMarkup):
         self.selective = bool(selective)
         self.input_field_placeholder = input_field_placeholder
 
-        self._id_attrs = (self.selective, self.input_field_placeholder)
+        self._id_attrs = (self.selective,)

--- a/telegram/replykeyboardmarkup.py
+++ b/telegram/replykeyboardmarkup.py
@@ -48,11 +48,17 @@ class ReplyKeyboardMarkup(ReplyMarkup):
         selective (:obj:`bool`, optional): Use this parameter if you want to show the keyboard to
             specific users only. Targets:
 
-            1) Users that are @mentioned in the text of the Message object.
-            2) If the bot's message is a reply (has ``reply_to_message_id``), sender of the
-               original message.
+            1) Users that are @mentioned in the :attr:`~telegram.Message.text` of the
+               :class:`telegram.Message` object.
+            2) If the bot's message is a reply (has reply_to_message_id), sender of the original
+               message.
 
             Defaults to :obj:`False`.
+
+        input_field_placeholder (:obj:`str`, optional): The placeholder to be shown in the input
+            field when the keyboard is active; 1-64 characters.
+
+            .. versionadded:: 13.7
 
         **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
@@ -62,10 +68,21 @@ class ReplyKeyboardMarkup(ReplyMarkup):
         one_time_keyboard (:obj:`bool`): Optional. Requests clients to hide the keyboard as soon as
             it's been used.
         selective (:obj:`bool`): Optional. Show the keyboard to specific users only.
+        input_field_placeholder (:obj:`str`): Optional. The placeholder shown in the input
+            field when the reply is active.
+
+            .. versionadded:: 13.7
 
     """
 
-    __slots__ = ('selective', 'keyboard', 'resize_keyboard', 'one_time_keyboard', '_id_attrs')
+    __slots__ = (
+        'selective',
+        'keyboard',
+        'resize_keyboard',
+        'one_time_keyboard',
+        'input_field_placeholder',
+        '_id_attrs',
+    )
 
     def __init__(
         self,
@@ -73,6 +90,7 @@ class ReplyKeyboardMarkup(ReplyMarkup):
         resize_keyboard: bool = False,
         one_time_keyboard: bool = False,
         selective: bool = False,
+        input_field_placeholder: str = None,
         **_kwargs: Any,
     ):
         # Required
@@ -90,6 +108,7 @@ class ReplyKeyboardMarkup(ReplyMarkup):
         self.resize_keyboard = bool(resize_keyboard)
         self.one_time_keyboard = bool(one_time_keyboard)
         self.selective = bool(selective)
+        self.input_field_placeholder = input_field_placeholder
 
         self._id_attrs = (self.keyboard,)
 
@@ -109,6 +128,7 @@ class ReplyKeyboardMarkup(ReplyMarkup):
         resize_keyboard: bool = False,
         one_time_keyboard: bool = False,
         selective: bool = False,
+        input_field_placeholder: str = None,
         **kwargs: object,
     ) -> 'ReplyKeyboardMarkup':
         """Shortcut for::
@@ -134,9 +154,14 @@ class ReplyKeyboardMarkup(ReplyMarkup):
 
                 1) Users that are @mentioned in the text of the Message object.
                 2) If the bot's message is a reply (has reply_to_message_id), sender of the
-                    original message.
+                   original message.
 
                 Defaults to :obj:`False`.
+
+            input_field_placeholder (:obj:`str`): Optional. The placeholder shown in the input
+                field when the reply is active.
+
+                .. versionadded:: 13.7
             **kwargs (:obj:`dict`): Arbitrary keyword arguments.
         """
         return cls(
@@ -144,6 +169,7 @@ class ReplyKeyboardMarkup(ReplyMarkup):
             resize_keyboard=resize_keyboard,
             one_time_keyboard=one_time_keyboard,
             selective=selective,
+            input_field_placeholder=input_field_placeholder,
             **kwargs,
         )
 
@@ -154,6 +180,7 @@ class ReplyKeyboardMarkup(ReplyMarkup):
         resize_keyboard: bool = False,
         one_time_keyboard: bool = False,
         selective: bool = False,
+        input_field_placeholder: str = None,
         **kwargs: object,
     ) -> 'ReplyKeyboardMarkup':
         """Shortcut for::
@@ -179,9 +206,14 @@ class ReplyKeyboardMarkup(ReplyMarkup):
 
                 1) Users that are @mentioned in the text of the Message object.
                 2) If the bot's message is a reply (has reply_to_message_id), sender of the
-                    original message.
+                   original message.
 
                 Defaults to :obj:`False`.
+
+            input_field_placeholder (:obj:`str`): Optional. The placeholder shown in the input
+                field when the reply is active.
+
+                .. versionadded:: 13.7
             **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
         """
@@ -190,6 +222,7 @@ class ReplyKeyboardMarkup(ReplyMarkup):
             resize_keyboard=resize_keyboard,
             one_time_keyboard=one_time_keyboard,
             selective=selective,
+            input_field_placeholder=input_field_placeholder,
             **kwargs,
         )
 
@@ -200,6 +233,7 @@ class ReplyKeyboardMarkup(ReplyMarkup):
         resize_keyboard: bool = False,
         one_time_keyboard: bool = False,
         selective: bool = False,
+        input_field_placeholder: str = None,
         **kwargs: object,
     ) -> 'ReplyKeyboardMarkup':
         """Shortcut for::
@@ -225,9 +259,14 @@ class ReplyKeyboardMarkup(ReplyMarkup):
 
                 1) Users that are @mentioned in the text of the Message object.
                 2) If the bot's message is a reply (has reply_to_message_id), sender of the
-                    original message.
+                   original message.
 
                 Defaults to :obj:`False`.
+
+            input_field_placeholder (:obj:`str`): Optional. The placeholder shown in the input
+                field when the reply is active.
+
+                .. versionadded:: 13.7
             **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
         """
@@ -237,6 +276,7 @@ class ReplyKeyboardMarkup(ReplyMarkup):
             resize_keyboard=resize_keyboard,
             one_time_keyboard=one_time_keyboard,
             selective=selective,
+            input_field_placeholder=input_field_placeholder,
             **kwargs,
         )
 

--- a/telegram/replykeyboardmarkup.py
+++ b/telegram/replykeyboardmarkup.py
@@ -50,8 +50,8 @@ class ReplyKeyboardMarkup(ReplyMarkup):
 
             1) Users that are @mentioned in the :attr:`~telegram.Message.text` of the
                :class:`telegram.Message` object.
-            2) If the bot's message is a reply (has reply_to_message_id), sender of the original
-               message.
+            2) If the bot's message is a reply (has ``reply_to_message_id``), sender of the
+               original message.
 
             Defaults to :obj:`False`.
 
@@ -153,7 +153,7 @@ class ReplyKeyboardMarkup(ReplyMarkup):
                 to specific users only. Targets:
 
                 1) Users that are @mentioned in the text of the Message object.
-                2) If the bot's message is a reply (has reply_to_message_id), sender of the
+                2) If the bot's message is a reply (has ``reply_to_message_id``), sender of the
                    original message.
 
                 Defaults to :obj:`False`.
@@ -205,7 +205,7 @@ class ReplyKeyboardMarkup(ReplyMarkup):
                 to specific users only. Targets:
 
                 1) Users that are @mentioned in the text of the Message object.
-                2) If the bot's message is a reply (has reply_to_message_id), sender of the
+                2) If the bot's message is a reply (has ``reply_to_message_id``), sender of the
                    original message.
 
                 Defaults to :obj:`False`.
@@ -258,7 +258,7 @@ class ReplyKeyboardMarkup(ReplyMarkup):
                 to specific users only. Targets:
 
                 1) Users that are @mentioned in the text of the Message object.
-                2) If the bot's message is a reply (has reply_to_message_id), sender of the
+                2) If the bot's message is a reply (has ``reply_to_message_id``), sender of the
                    original message.
 
                 Defaults to :obj:`False`.

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1363,6 +1363,11 @@ class TestBot:
         assert len(recwarn) == 1
         assert '`bot.get_chat_members_count` is depreciated' in str(recwarn[0].message)
 
+    def test_bot_command_property_warning(self, bot, recwarn):
+        _ = bot.commands
+        assert len(recwarn) == 1
+        assert 'Bot.commands has been deprecated since there can' in str(recwarn[0].message)
+
     @flaky(3, 1)
     def test_get_chat_member(self, bot, channel_id, chat_id):
         chat_member = bot.get_chat_member(channel_id, chat_id)
@@ -1984,6 +1989,9 @@ class TestBot:
         assert len(gotten_private_cmd) == len(private_cmds)
         assert gotten_private_cmd[0].command == private_cmds[0].command
 
+        assert len(bot.commands) == 2  # set from previous test. Makes sure this hasn't changed.
+        assert bot.commands[0].command == 'cmd1'
+
         # Delete command list from that supergroup and private chat-
         bot.delete_my_commands(private_scope)
         bot.delete_my_commands(group_scope, 'en')
@@ -1994,6 +2002,9 @@ class TestBot:
 
         assert len(deleted_grp_cmds) == 0 == len(group_cmds) - 1
         assert len(deleted_priv_cmds) == 0 == len(private_cmds) - 1
+
+        bot.delete_my_commands()  # Delete commands from default scope
+        assert not bot.commands  # Check if this has been updated to reflect the deletion.
 
     def test_log_out(self, monkeypatch, bot):
         # We don't actually make a request as to not break the test setup

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1361,7 +1361,7 @@ class TestBot:
     def test_get_chat_members_count_warning(self, bot, channel_id, recwarn):
         bot.get_chat_members_count(channel_id)
         assert len(recwarn) == 1
-        assert '`bot.get_chat_members_count` is depreciated' in str(recwarn[0].message)
+        assert '`bot.get_chat_members_count` is deprecated' in str(recwarn[0].message)
 
     def test_bot_command_property_warning(self, bot, recwarn):
         _ = bot.commands

--- a/tests/test_botcommandscope.py
+++ b/tests/test_botcommandscope.py
@@ -21,7 +21,6 @@ from copy import deepcopy
 import pytest
 
 from telegram import (
-    BotCommand,
     Dice,
     BotCommandScope,
     BotCommandScopeDefault,

--- a/tests/test_botcommandscope.py
+++ b/tests/test_botcommandscope.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python
+#
+# A library that provides a Python interface to the Telegram Bot API
+# Copyright (C) 2021
+# Leandro Toledo de Souza <devs@python-telegram-bot.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+from copy import deepcopy
+
+import pytest
+
+from telegram import (
+    BotCommand,
+    Dice,
+    BotCommandScope,
+    BotCommandScopeDefault,
+    BotCommandScopeAllPrivateChats,
+    BotCommandScopeAllGroupChats,
+    BotCommandScopeAllChatAdministrators,
+    BotCommandScopeChat,
+    BotCommandScopeChatAdministrators,
+    BotCommandScopeChatMember,
+)
+
+
+@pytest.fixture(scope="class", params=['str', 'int'])
+def chat_id(request):
+    if request.param == 'str':
+        return '@supergroupusername'
+    return 43
+
+
+@pytest.fixture(
+    scope="class",
+    params=[
+        BotCommandScope.DEFAULT,
+        BotCommandScope.ALL_PRIVATE_CHATS,
+        BotCommandScope.ALL_GROUP_CHATS,
+        BotCommandScope.ALL_CHAT_ADMINISTRATORS,
+        BotCommandScope.CHAT,
+        BotCommandScope.CHAT_ADMINISTRATORS,
+        BotCommandScope.CHAT_MEMBER,
+    ],
+)
+def scope_type(request):
+    return request.param
+
+
+@pytest.fixture(
+    scope="class",
+    params=[
+        BotCommandScopeDefault,
+        BotCommandScopeAllPrivateChats,
+        BotCommandScopeAllGroupChats,
+        BotCommandScopeAllChatAdministrators,
+        BotCommandScopeChat,
+        BotCommandScopeChatAdministrators,
+        BotCommandScopeChatMember,
+    ],
+    ids=[
+        BotCommandScope.DEFAULT,
+        BotCommandScope.ALL_PRIVATE_CHATS,
+        BotCommandScope.ALL_GROUP_CHATS,
+        BotCommandScope.ALL_CHAT_ADMINISTRATORS,
+        BotCommandScope.CHAT,
+        BotCommandScope.CHAT_ADMINISTRATORS,
+        BotCommandScope.CHAT_MEMBER,
+    ],
+)
+def scope_class(request):
+    return request.param
+
+
+@pytest.fixture(
+    scope="class",
+    params=[
+        (BotCommandScopeDefault, BotCommandScope.DEFAULT),
+        (BotCommandScopeAllPrivateChats, BotCommandScope.ALL_PRIVATE_CHATS),
+        (BotCommandScopeAllGroupChats, BotCommandScope.ALL_GROUP_CHATS),
+        (BotCommandScopeAllChatAdministrators, BotCommandScope.ALL_CHAT_ADMINISTRATORS),
+        (BotCommandScopeChat, BotCommandScope.CHAT),
+        (BotCommandScopeChatAdministrators, BotCommandScope.CHAT_ADMINISTRATORS),
+        (BotCommandScopeChatMember, BotCommandScope.CHAT_MEMBER),
+    ],
+    ids=[
+        BotCommandScope.DEFAULT,
+        BotCommandScope.ALL_PRIVATE_CHATS,
+        BotCommandScope.ALL_GROUP_CHATS,
+        BotCommandScope.ALL_CHAT_ADMINISTRATORS,
+        BotCommandScope.CHAT,
+        BotCommandScope.CHAT_ADMINISTRATORS,
+        BotCommandScope.CHAT_MEMBER,
+    ],
+)
+def scope_class_and_type(request):
+    return request.param
+
+
+@pytest.fixture(scope='class')
+def bot_command_scope(scope_class_and_type, chat_id):
+    return scope_class_and_type[0](type=scope_class_and_type[1], chat_id=chat_id, user_id=42)
+
+
+# All the scope types are very similar, so we test everything via parametrization
+class TestBotCommandScope:
+    def test_slot_behaviour(self, bot_command_scope, mro_slots):
+        for attr in bot_command_scope.__slots__:
+            assert getattr(bot_command_scope, attr, 'err') != 'err', f"got extra slot '{attr}'"
+        assert len(mro_slots(bot_command_scope)) == len(
+            set(mro_slots(bot_command_scope))
+        ), "duplicate slot"
+        with pytest.raises(AttributeError):
+            bot_command_scope.custom
+
+    def test_de_json(self, bot, scope_class_and_type, chat_id):
+        cls = scope_class_and_type[0]
+        type_ = scope_class_and_type[1]
+
+        assert cls.de_json({}, bot) is None
+
+        json_dict = {'type': type_, 'chat_id': chat_id, 'user_id': 42}
+        bot_command_scope = BotCommandScope.de_json(json_dict, bot)
+
+        assert isinstance(bot_command_scope, BotCommandScope)
+        assert isinstance(bot_command_scope, cls)
+        assert bot_command_scope.type == type_
+        if 'chat_id' in cls.__slots__:
+            assert bot_command_scope.chat_id == chat_id
+        if 'user_id' in cls.__slots__:
+            assert bot_command_scope.user_id == 42
+
+    def test_de_json_invalid_type(self, bot):
+        json_dict = {'type': 'invalid', 'chat_id': chat_id, 'user_id': 42}
+        bot_command_scope = BotCommandScope.de_json(json_dict, bot)
+
+        assert type(bot_command_scope) is BotCommandScope
+        assert bot_command_scope.type == 'invalid'
+
+    def test_to_dict(self, bot_command_scope):
+        bot_command_scope_dict = bot_command_scope.to_dict()
+
+        assert isinstance(bot_command_scope_dict, dict)
+        assert bot_command_scope['type'] == bot_command_scope.type
+        if hasattr(bot_command_scope, 'chat_id'):
+            assert bot_command_scope['chat_id'] == bot_command_scope.chat_id
+        if hasattr(bot_command_scope, 'user_id'):
+            assert bot_command_scope['user_id'] == bot_command_scope.user_id
+
+    def test_equality(self, bot_command_scope, bot):
+        a = BotCommandScope('base_type')
+        b = BotCommandScope('base_type')
+        c = bot_command_scope
+        d = deepcopy(bot_command_scope)
+        e = Dice(4, 'emoji')
+
+        assert a == b
+        assert hash(a) == hash(b)
+
+        assert a != c
+        assert hash(a) != hash(c)
+
+        assert a != d
+        assert hash(a) != hash(d)
+
+        assert a != e
+        assert hash(a) != hash(e)
+
+        assert c == d
+        assert hash(c) == hash(d)
+
+        assert c != e
+        assert hash(c) != hash(e)
+
+        if hasattr(c, 'chat_id'):
+            json_dict = c.to_dict()
+            json_dict['chat_id'] = 0
+            f = c.__class__.de_json(json_dict, bot)
+
+            assert c != f
+            assert hash(c) != hash(f)
+
+        if hasattr(c, 'user_id'):
+            json_dict = c.to_dict()
+            json_dict['user_id'] = 0
+            g = c.__class__.de_json(json_dict, bot)
+
+            assert c != g
+            assert hash(c) != hash(g)

--- a/tests/test_botcommandscope.py
+++ b/tests/test_botcommandscope.py
@@ -116,6 +116,7 @@ class TestBotCommandScope:
     def test_slot_behaviour(self, bot_command_scope, mro_slots, recwarn):
         for attr in bot_command_scope.__slots__:
             assert getattr(bot_command_scope, attr, 'err') != 'err', f"got extra slot '{attr}'"
+        assert not bot_command_scope.__dict__, f"got missing slot(s): {bot_command_scope.__dict__}"
         assert len(mro_slots(bot_command_scope)) == len(
             set(mro_slots(bot_command_scope))
         ), "duplicate slot"

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -176,18 +176,27 @@ class TestChat:
         monkeypatch.setattr(chat.bot, 'get_chat_administrators', make_assertion)
         assert chat.get_administrators()
 
-    def test_get_members_count(self, monkeypatch, chat):
+    def test_get_member_count(self, monkeypatch, chat):
         def make_assertion(*_, **kwargs):
             return kwargs['chat_id'] == chat.id
 
         assert check_shortcut_signature(
-            Chat.get_members_count, Bot.get_chat_members_count, ['chat_id'], []
+            Chat.get_member_count, Bot.get_chat_member_count, ['chat_id'], []
         )
-        assert check_shortcut_call(chat.get_members_count, chat.bot, 'get_chat_members_count')
-        assert check_defaults_handling(chat.get_members_count, chat.bot)
+        assert check_shortcut_call(chat.get_member_count, chat.bot, 'get_chat_member_count')
+        assert check_defaults_handling(chat.get_member_count, chat.bot)
 
-        monkeypatch.setattr(chat.bot, 'get_chat_members_count', make_assertion)
+        monkeypatch.setattr(chat.bot, 'get_chat_member_count', make_assertion)
+        assert chat.get_member_count()
+
+    def test_get_members_count_warning(self, chat, monkeypatch, recwarn):
+        def make_assertion(*_, **kwargs):
+            return kwargs['chat_id'] == chat.id
+
+        monkeypatch.setattr(chat.bot, 'get_chat_member_count', make_assertion)
         assert chat.get_members_count()
+        assert len(recwarn) == 1
+        assert '`Chat.get_members_count` is deprecated' in str(recwarn[0].message)
 
     def test_get_member(self, monkeypatch, chat):
         def make_assertion(*_, **kwargs):
@@ -202,19 +211,31 @@ class TestChat:
         monkeypatch.setattr(chat.bot, 'get_chat_member', make_assertion)
         assert chat.get_member(user_id=42)
 
-    def test_kick_member(self, monkeypatch, chat):
+    def test_ban_member(self, monkeypatch, chat):
         def make_assertion(*_, **kwargs):
             chat_id = kwargs['chat_id'] == chat.id
             user_id = kwargs['user_id'] == 42
             until = kwargs['until_date'] == 43
             return chat_id and user_id and until
 
-        assert check_shortcut_signature(Chat.kick_member, Bot.kick_chat_member, ['chat_id'], [])
-        assert check_shortcut_call(chat.kick_member, chat.bot, 'kick_chat_member')
-        assert check_defaults_handling(chat.kick_member, chat.bot)
+        assert check_shortcut_signature(Chat.ban_member, Bot.ban_chat_member, ['chat_id'], [])
+        assert check_shortcut_call(chat.ban_member, chat.bot, 'ban_chat_member')
+        assert check_defaults_handling(chat.ban_member, chat.bot)
 
-        monkeypatch.setattr(chat.bot, 'kick_chat_member', make_assertion)
+        monkeypatch.setattr(chat.bot, 'ban_chat_member', make_assertion)
+        assert chat.ban_member(user_id=42, until_date=43)
+
+    def test_kick_member_warning(self, chat, monkeypatch, recwarn):
+        def make_assertion(*_, **kwargs):
+            chat_id = kwargs['chat_id'] == chat.id
+            user_id = kwargs['user_id'] == 42
+            until = kwargs['until_date'] == 43
+            return chat_id and user_id and until
+
+        monkeypatch.setattr(chat.bot, 'ban_chat_member', make_assertion)
         assert chat.kick_member(user_id=42, until_date=43)
+        assert len(recwarn) == 1
+        assert '`Chat.kick_member` is deprecated' in str(recwarn[0].message)
 
     @pytest.mark.parametrize('only_if_banned', [True, False, None])
     def test_unban_member(self, monkeypatch, chat, only_if_banned):

--- a/tests/test_chatmember.py
+++ b/tests/test_chatmember.py
@@ -59,44 +59,42 @@ def user():
         ChatMember.KICKED,
     ],
 )
-def chatmember_class_and_status(request):
+def chat_member_class_and_status(request):
     return request.param
 
 
 @pytest.fixture(scope='class')
-def chatmember_types(chatmember_class_and_status, user):
-    return chatmember_class_and_status[0](status=chatmember_class_and_status[1], user=user)
+def chat_member_types(chat_member_class_and_status, user):
+    return chat_member_class_and_status[0](status=chat_member_class_and_status[1], user=user)
 
 
 class TestChatMember:
-    def test_slot_behaviour(self, chatmember_types, mro_slots, recwarn):
-        for attr in chatmember_types.__slots__:
-            assert getattr(chatmember_types, attr, 'err') != 'err', f"got extra slot '{attr}'"
-        assert len(mro_slots(chatmember_types)) == len(
-            set(mro_slots(chatmember_types))
+    def test_slot_behaviour(self, chat_member_types, mro_slots, recwarn):
+        for attr in chat_member_types.__slots__:
+            assert getattr(chat_member_types, attr, 'err') != 'err', f"got extra slot '{attr}'"
+        assert len(mro_slots(chat_member_types)) == len(
+            set(mro_slots(chat_member_types))
         ), "duplicate slot"
-        chatmember_types.custom, chatmember_types.status = 'warning!', chatmember_types.status
+        chat_member_types.custom, chat_member_types.status = 'warning!', chat_member_types.status
         assert len(recwarn) == 1 and 'custom' in str(recwarn[0].message), recwarn.list
-        with pytest.raises(AttributeError):
-            chatmember_types.custom2
 
-    def test_de_json_required_args(self, bot, chatmember_class_and_status, user):
-        cls = chatmember_class_and_status[0]
-        status = chatmember_class_and_status[1]
+    def test_de_json_required_args(self, bot, chat_member_class_and_status, user):
+        cls = chat_member_class_and_status[0]
+        status = chat_member_class_and_status[1]
 
         assert cls.de_json({}, bot) is None
 
         json_dict = {'status': status, 'user': user.to_dict()}
-        chatmember_type = ChatMember.de_json(json_dict, bot)
+        chat_member_type = ChatMember.de_json(json_dict, bot)
 
-        assert isinstance(chatmember_type, ChatMember)
-        assert isinstance(chatmember_type, cls)
-        assert chatmember_type.status == status
-        assert chatmember_type.user == user
+        assert isinstance(chat_member_type, ChatMember)
+        assert isinstance(chat_member_type, cls)
+        assert chat_member_type.status == status
+        assert chat_member_type.user == user
 
-    def test_de_json_all_args(self, bot, chatmember_class_and_status, user):
-        cls = chatmember_class_and_status[0]
-        status = chatmember_class_and_status[1]
+    def test_de_json_all_args(self, bot, chat_member_class_and_status, user):
+        cls = chat_member_class_and_status[0]
+        status = chat_member_class_and_status[1]
         time = datetime.datetime.utcnow()
 
         json_dict = {
@@ -122,88 +120,118 @@ class TestChatMember:
             'can_manage_chat': True,
             'can_manage_voice_chats': True,
         }
-        chatmember_type = ChatMember.de_json(json_dict, bot)
+        chat_member_type = ChatMember.de_json(json_dict, bot)
 
-        assert isinstance(chatmember_type, ChatMember)
-        assert isinstance(chatmember_type, cls)
-        assert chatmember_type.user == user
-        assert chatmember_type.status == status
-        if chatmember_type.custom_title is not None:
-            assert chatmember_type.custom_title == 'PTB'
-            assert type(chatmember_type) in {ChatMemberOwner, ChatMemberAdministrator}
-        if chatmember_type.is_anonymous is not None:
-            assert chatmember_type.is_anonymous is True
-            assert type(chatmember_type) in {ChatMemberOwner, ChatMemberAdministrator}
-        if chatmember_type.until_date is not None:
-            assert type(chatmember_type) in {ChatMemberBanned, ChatMemberRestricted}
-        if chatmember_type.can_be_edited is not None:
-            assert chatmember_type.can_be_edited is False
-            assert type(chatmember_type) == ChatMemberAdministrator
-        if chatmember_type.can_change_info is not None:
-            assert chatmember_type.can_change_info is True
-            assert type(chatmember_type) in {ChatMemberAdministrator, ChatMemberRestricted}
-        if chatmember_type.can_post_messages is not None:
-            assert chatmember_type.can_post_messages is False
-            assert type(chatmember_type) == ChatMemberAdministrator
-        if chatmember_type.can_edit_messages is not None:
-            assert chatmember_type.can_edit_messages is True
-            assert type(chatmember_type) == ChatMemberAdministrator
-        if chatmember_type.can_delete_messages is not None:
-            assert chatmember_type.can_delete_messages is True
-            assert type(chatmember_type) == ChatMemberAdministrator
-        if chatmember_type.can_invite_users is not None:
-            assert chatmember_type.can_invite_users is False
-            assert type(chatmember_type) in {ChatMemberAdministrator, ChatMemberRestricted}
-        if chatmember_type.can_restrict_members is not None:
-            assert chatmember_type.can_restrict_members is True
-            assert type(chatmember_type) == ChatMemberAdministrator
-        if chatmember_type.can_pin_messages is not None:
-            assert chatmember_type.can_pin_messages is False
-            assert type(chatmember_type) in {ChatMemberAdministrator, ChatMemberRestricted}
-        if chatmember_type.can_promote_members is not None:
-            assert chatmember_type.can_promote_members is True
-            assert type(chatmember_type) == ChatMemberAdministrator
-        if chatmember_type.can_send_messages is not None:
-            assert chatmember_type.can_send_messages is False
-            assert type(chatmember_type) == ChatMemberRestricted
-        if chatmember_type.can_send_media_messages is not None:
-            assert chatmember_type.can_send_media_messages is True
-            assert type(chatmember_type) == ChatMemberRestricted
-        if chatmember_type.can_send_polls is not None:
-            assert chatmember_type.can_send_polls is False
-            assert type(chatmember_type) == ChatMemberRestricted
-        if chatmember_type.can_send_other_messages is not None:
-            assert chatmember_type.can_send_other_messages is True
-            assert type(chatmember_type) == ChatMemberRestricted
-        if chatmember_type.can_add_web_page_previews is not None:
-            assert chatmember_type.can_add_web_page_previews is False
-            assert type(chatmember_type) == ChatMemberRestricted
-        if chatmember_type.can_manage_chat is not None:
-            assert chatmember_type.can_manage_chat is True
-            assert type(chatmember_type) == ChatMemberAdministrator
-        if chatmember_type.can_manage_voice_chats is not None:
-            assert chatmember_type.can_manage_voice_chats is True
-            assert type(chatmember_type) == ChatMemberAdministrator
+        assert isinstance(chat_member_type, ChatMember)
+        assert isinstance(chat_member_type, cls)
+        assert chat_member_type.user == user
+        assert chat_member_type.status == status
+        if chat_member_type.custom_title is not None:
+            assert chat_member_type.custom_title == 'PTB'
+            assert type(chat_member_type) in {ChatMemberOwner, ChatMemberAdministrator}
+        if chat_member_type.is_anonymous is not None:
+            assert chat_member_type.is_anonymous is True
+            assert type(chat_member_type) in {ChatMemberOwner, ChatMemberAdministrator}
+        if chat_member_type.until_date is not None:
+            assert type(chat_member_type) in {ChatMemberBanned, ChatMemberRestricted}
+        if chat_member_type.can_be_edited is not None:
+            assert chat_member_type.can_be_edited is False
+            assert type(chat_member_type) == ChatMemberAdministrator
+        if chat_member_type.can_change_info is not None:
+            assert chat_member_type.can_change_info is True
+            assert type(chat_member_type) in {ChatMemberAdministrator, ChatMemberRestricted}
+        if chat_member_type.can_post_messages is not None:
+            assert chat_member_type.can_post_messages is False
+            assert type(chat_member_type) == ChatMemberAdministrator
+        if chat_member_type.can_edit_messages is not None:
+            assert chat_member_type.can_edit_messages is True
+            assert type(chat_member_type) == ChatMemberAdministrator
+        if chat_member_type.can_delete_messages is not None:
+            assert chat_member_type.can_delete_messages is True
+            assert type(chat_member_type) == ChatMemberAdministrator
+        if chat_member_type.can_invite_users is not None:
+            assert chat_member_type.can_invite_users is False
+            assert type(chat_member_type) in {ChatMemberAdministrator, ChatMemberRestricted}
+        if chat_member_type.can_restrict_members is not None:
+            assert chat_member_type.can_restrict_members is True
+            assert type(chat_member_type) == ChatMemberAdministrator
+        if chat_member_type.can_pin_messages is not None:
+            assert chat_member_type.can_pin_messages is False
+            assert type(chat_member_type) in {ChatMemberAdministrator, ChatMemberRestricted}
+        if chat_member_type.can_promote_members is not None:
+            assert chat_member_type.can_promote_members is True
+            assert type(chat_member_type) == ChatMemberAdministrator
+        if chat_member_type.can_send_messages is not None:
+            assert chat_member_type.can_send_messages is False
+            assert type(chat_member_type) == ChatMemberRestricted
+        if chat_member_type.can_send_media_messages is not None:
+            assert chat_member_type.can_send_media_messages is True
+            assert type(chat_member_type) == ChatMemberRestricted
+        if chat_member_type.can_send_polls is not None:
+            assert chat_member_type.can_send_polls is False
+            assert type(chat_member_type) == ChatMemberRestricted
+        if chat_member_type.can_send_other_messages is not None:
+            assert chat_member_type.can_send_other_messages is True
+            assert type(chat_member_type) == ChatMemberRestricted
+        if chat_member_type.can_add_web_page_previews is not None:
+            assert chat_member_type.can_add_web_page_previews is False
+            assert type(chat_member_type) == ChatMemberRestricted
+        if chat_member_type.can_manage_chat is not None:
+            assert chat_member_type.can_manage_chat is True
+            assert type(chat_member_type) == ChatMemberAdministrator
+        if chat_member_type.can_manage_voice_chats is not None:
+            assert chat_member_type.can_manage_voice_chats is True
+            assert type(chat_member_type) == ChatMemberAdministrator
 
     def test_de_json_invalid_status(self, bot, user):
         json_dict = {'status': 'invalid', 'user': user.to_dict()}
-        chatmember_type = ChatMember.de_json(json_dict, bot)
+        chat_member_type = ChatMember.de_json(json_dict, bot)
 
-        assert type(chatmember_type) is ChatMember
-        assert chatmember_type.status == 'invalid'
+        assert type(chat_member_type) is ChatMember
+        assert chat_member_type.status == 'invalid'
 
-    def test_to_dict(self, chatmember_types, user):
-        chatmember_dict = chatmember_types.to_dict()
+    def test_de_json_subclass(self, chat_member_class_and_status, bot, chat_id, user):
+        """This makes sure that e.g. ChatMemberAdministrator(data, bot) never returns a
+        ChatMemberKicked instance."""
+        cls = chat_member_class_and_status[0]
+        time = datetime.datetime.utcnow()
+        json_dict = {
+            'user': user.to_dict(),
+            'status': 'status',
+            'custom_title': 'PTB',
+            'is_anonymous': True,
+            'until_date': to_timestamp(time),
+            'can_be_edited': False,
+            'can_change_info': True,
+            'can_post_messages': False,
+            'can_edit_messages': True,
+            'can_delete_messages': True,
+            'can_invite_users': False,
+            'can_restrict_members': True,
+            'can_pin_messages': False,
+            'can_promote_members': True,
+            'can_send_messages': False,
+            'can_send_media_messages': True,
+            'can_send_polls': False,
+            'can_send_other_messages': True,
+            'can_add_web_page_previews': False,
+            'can_manage_chat': True,
+            'can_manage_voice_chats': True,
+        }
+        assert type(cls.de_json(json_dict, bot)) is cls
 
-        assert isinstance(chatmember_dict, dict)
-        assert chatmember_dict['status'] == chatmember_types.status
-        assert chatmember_dict['user'] == user.to_dict()
+    def test_to_dict(self, chat_member_types, user):
+        chat_member_dict = chat_member_types.to_dict()
 
-    def test_equality(self, chatmember_types, user):
+        assert isinstance(chat_member_dict, dict)
+        assert chat_member_dict['status'] == chat_member_types.status
+        assert chat_member_dict['user'] == user.to_dict()
+
+    def test_equality(self, chat_member_types, user):
         a = ChatMember(status='status', user=user)
         b = ChatMember(status='status', user=user)
-        c = chatmember_types
-        d = deepcopy(chatmember_types)
+        c = chat_member_types
+        d = deepcopy(chat_member_types)
         e = Dice(4, 'emoji')
 
         assert a == b

--- a/tests/test_chatmember.py
+++ b/tests/test_chatmember.py
@@ -16,10 +16,12 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
+import datetime
 from copy import deepcopy
 
 import pytest
 
+from telegram.utils.helpers import to_timestamp
 from telegram import (
     User,
     ChatMember,
@@ -67,16 +69,18 @@ def chatmember_types(chatmember_class_and_status, user):
 
 
 class TestChatMember:
-    def test_slot_behaviour(self, chatmember_types, mro_slots):
+    def test_slot_behaviour(self, chatmember_types, mro_slots, recwarn):
         for attr in chatmember_types.__slots__:
             assert getattr(chatmember_types, attr, 'err') != 'err', f"got extra slot '{attr}'"
         assert len(mro_slots(chatmember_types)) == len(
             set(mro_slots(chatmember_types))
         ), "duplicate slot"
+        chatmember_types.custom, chatmember_types.status = 'warning!', chatmember_types.status
+        assert len(recwarn) == 1 and 'custom' in str(recwarn[0].message), recwarn.list
         with pytest.raises(AttributeError):
-            chatmember_types.custom
+            chatmember_types.custom2
 
-    def test_de_json(self, bot, chatmember_class_and_status, user):
+    def test_de_json_required_args(self, bot, chatmember_class_and_status, user):
         cls = chatmember_class_and_status[0]
         status = chatmember_class_and_status[1]
 
@@ -88,6 +92,98 @@ class TestChatMember:
         assert isinstance(chatmember_type, ChatMember)
         assert isinstance(chatmember_type, cls)
         assert chatmember_type.status == status
+        assert chatmember_type.user == user
+
+    def test_de_json_all_args(self, bot, chatmember_class_and_status, user):
+        cls = chatmember_class_and_status[0]
+        status = chatmember_class_and_status[1]
+        time = datetime.datetime.utcnow()
+
+        json_dict = {
+            'user': user.to_dict(),
+            'status': status,
+            'custom_title': 'PTB',
+            'is_anonymous': True,
+            'until_date': to_timestamp(time),
+            'can_be_edited': False,
+            'can_change_info': True,
+            'can_post_messages': False,
+            'can_edit_messages': True,
+            'can_delete_messages': True,
+            'can_invite_users': False,
+            'can_restrict_members': True,
+            'can_pin_messages': False,
+            'can_promote_members': True,
+            'can_send_messages': False,
+            'can_send_media_messages': True,
+            'can_send_polls': False,
+            'can_send_other_messages': True,
+            'can_add_web_page_previews': False,
+            'can_manage_chat': True,
+            'can_manage_voice_chats': True,
+        }
+        chatmember_type = ChatMember.de_json(json_dict, bot)
+
+        assert isinstance(chatmember_type, ChatMember)
+        assert isinstance(chatmember_type, cls)
+        assert chatmember_type.user == user
+        assert chatmember_type.status == status
+        if chatmember_type.custom_title is not None:
+            assert chatmember_type.custom_title == 'PTB'
+            assert type(chatmember_type) in {ChatMemberOwner, ChatMemberAdministrator}
+        if chatmember_type.is_anonymous is not None:
+            assert chatmember_type.is_anonymous is True
+            assert type(chatmember_type) in {ChatMemberOwner, ChatMemberAdministrator}
+        if chatmember_type.until_date is not None:
+            assert type(chatmember_type) in {ChatMemberBanned, ChatMemberRestricted}
+        if chatmember_type.can_be_edited is not None:
+            assert chatmember_type.can_be_edited is False
+            assert type(chatmember_type) == ChatMemberAdministrator
+        if chatmember_type.can_change_info is not None:
+            assert chatmember_type.can_change_info is True
+            assert type(chatmember_type) in {ChatMemberAdministrator, ChatMemberRestricted}
+        if chatmember_type.can_post_messages is not None:
+            assert chatmember_type.can_post_messages is False
+            assert type(chatmember_type) == ChatMemberAdministrator
+        if chatmember_type.can_edit_messages is not None:
+            assert chatmember_type.can_edit_messages is True
+            assert type(chatmember_type) == ChatMemberAdministrator
+        if chatmember_type.can_delete_messages is not None:
+            assert chatmember_type.can_delete_messages is True
+            assert type(chatmember_type) == ChatMemberAdministrator
+        if chatmember_type.can_invite_users is not None:
+            assert chatmember_type.can_invite_users is False
+            assert type(chatmember_type) in {ChatMemberAdministrator, ChatMemberRestricted}
+        if chatmember_type.can_restrict_members is not None:
+            assert chatmember_type.can_restrict_members is True
+            assert type(chatmember_type) == ChatMemberAdministrator
+        if chatmember_type.can_pin_messages is not None:
+            assert chatmember_type.can_pin_messages is False
+            assert type(chatmember_type) in {ChatMemberAdministrator, ChatMemberRestricted}
+        if chatmember_type.can_promote_members is not None:
+            assert chatmember_type.can_promote_members is True
+            assert type(chatmember_type) == ChatMemberAdministrator
+        if chatmember_type.can_send_messages is not None:
+            assert chatmember_type.can_send_messages is False
+            assert type(chatmember_type) == ChatMemberRestricted
+        if chatmember_type.can_send_media_messages is not None:
+            assert chatmember_type.can_send_media_messages is True
+            assert type(chatmember_type) == ChatMemberRestricted
+        if chatmember_type.can_send_polls is not None:
+            assert chatmember_type.can_send_polls is False
+            assert type(chatmember_type) == ChatMemberRestricted
+        if chatmember_type.can_send_other_messages is not None:
+            assert chatmember_type.can_send_other_messages is True
+            assert type(chatmember_type) == ChatMemberRestricted
+        if chatmember_type.can_add_web_page_previews is not None:
+            assert chatmember_type.can_add_web_page_previews is False
+            assert type(chatmember_type) == ChatMemberRestricted
+        if chatmember_type.can_manage_chat is not None:
+            assert chatmember_type.can_manage_chat is True
+            assert type(chatmember_type) == ChatMemberAdministrator
+        if chatmember_type.can_manage_voice_chats is not None:
+            assert chatmember_type.can_manage_voice_chats is True
+            assert type(chatmember_type) == ChatMemberAdministrator
 
     def test_de_json_invalid_status(self, bot, user):
         json_dict = {'status': 'invalid', 'user': user.to_dict()}

--- a/tests/test_chatmember.py
+++ b/tests/test_chatmember.py
@@ -72,6 +72,7 @@ class TestChatMember:
     def test_slot_behaviour(self, chat_member_types, mro_slots, recwarn):
         for attr in chat_member_types.__slots__:
             assert getattr(chat_member_types, attr, 'err') != 'err', f"got extra slot '{attr}'"
+        assert not chat_member_types.__dict__, f"got missing slot(s): {chat_member_types.__dict__}"
         assert len(mro_slots(chat_member_types)) == len(
             set(mro_slots(chat_member_types))
         ), "duplicate slot"

--- a/tests/test_forcereply.py
+++ b/tests/test_forcereply.py
@@ -65,8 +65,8 @@ class TestForceReply:
         assert force_reply_dict['input_field_placeholder'] == force_reply.input_field_placeholder
 
     def test_equality(self):
-        a = ForceReply(True, False, 'i will not go away')
-        b = ForceReply(False, False, 'i will not go away')
+        a = ForceReply(True, False)
+        b = ForceReply(False, False)
         c = ForceReply(True, True)
         d = ReplyKeyboardRemove()
 

--- a/tests/test_forcereply.py
+++ b/tests/test_forcereply.py
@@ -25,12 +25,17 @@ from telegram import ForceReply, ReplyKeyboardRemove
 
 @pytest.fixture(scope='class')
 def force_reply():
-    return ForceReply(TestForceReply.force_reply, TestForceReply.selective)
+    return ForceReply(
+        TestForceReply.force_reply,
+        TestForceReply.selective,
+        TestForceReply.input_field_placeholder,
+    )
 
 
 class TestForceReply:
     force_reply = True
     selective = True
+    input_field_placeholder = 'force replies can be annoying if not used properly'
 
     def test_slot_behaviour(self, force_reply, recwarn, mro_slots):
         for attr in force_reply.__slots__:
@@ -49,6 +54,7 @@ class TestForceReply:
     def test_expected(self, force_reply):
         assert force_reply.force_reply == self.force_reply
         assert force_reply.selective == self.selective
+        assert force_reply.input_field_placeholder == self.input_field_placeholder
 
     def test_to_dict(self, force_reply):
         force_reply_dict = force_reply.to_dict()
@@ -56,10 +62,11 @@ class TestForceReply:
         assert isinstance(force_reply_dict, dict)
         assert force_reply_dict['force_reply'] == force_reply.force_reply
         assert force_reply_dict['selective'] == force_reply.selective
+        assert force_reply_dict['input_field_placeholder'] == force_reply.input_field_placeholder
 
     def test_equality(self):
-        a = ForceReply(True, False)
-        b = ForceReply(False, False)
+        a = ForceReply(True, False, 'i will not go away')
+        b = ForceReply(False, False, 'i will not go away')
         c = ForceReply(True, True)
         d = ReplyKeyboardRemove()
 

--- a/tests/test_official.py
+++ b/tests/test_official.py
@@ -118,8 +118,12 @@ def check_object(h4):
         if field == 'from':
             field = 'from_user'
         elif (
-            name.startswith('InlineQueryResult') or name.startswith('InputMedia')
+            name.startswith('InlineQueryResult')
+            or name.startswith('InputMedia')
+            or name.startswith('BotCommandScope')
         ) and field == 'type':
+            continue
+        elif (name.startswith('ChatMember')) and field == 'status':
             continue
         elif (
             name.startswith('PassportElementError') and field == 'source'
@@ -136,7 +140,34 @@ def check_object(h4):
     if name == 'InputFile':
         return
     if name == 'InlineQueryResult':
-        ignored |= {'id', 'type'}
+        ignored |= {'id', 'type'}  # attributes common to all subclasses
+    if name == 'ChatMember':
+        ignored |= {'user', 'status'}  # attributes common to all subclasses
+    if name == 'ChatMember':
+        ignored |= {
+            'can_add_web_page_previews',  # for backwards compatibility
+            'can_be_edited',
+            'can_change_info',
+            'can_delete_messages',
+            'can_edit_messages',
+            'can_invite_users',
+            'can_manage_chat',
+            'can_manage_voice_chats',
+            'can_pin_messages',
+            'can_post_messages',
+            'can_promote_members',
+            'can_restrict_members',
+            'can_send_media_messages',
+            'can_send_messages',
+            'can_send_other_messages',
+            'can_send_polls',
+            'custom_title',
+            'is_anonymous',
+            'is_member',
+            'until_date',
+        }
+    if name == 'BotCommandScope':
+        ignored |= {'type'}  # attributes common to all subclasses
     elif name == 'User':
         ignored |= {'type'}  # TODO: Deprecation
     elif name in ('PassportFile', 'EncryptedPassportElement'):

--- a/tests/test_replykeyboardmarkup.py
+++ b/tests/test_replykeyboardmarkup.py
@@ -29,6 +29,7 @@ def reply_keyboard_markup():
         resize_keyboard=TestReplyKeyboardMarkup.resize_keyboard,
         one_time_keyboard=TestReplyKeyboardMarkup.one_time_keyboard,
         selective=TestReplyKeyboardMarkup.selective,
+        input_field_placeholder=TestReplyKeyboardMarkup.input_field_placeholder,
     )
 
 
@@ -37,6 +38,7 @@ class TestReplyKeyboardMarkup:
     resize_keyboard = True
     one_time_keyboard = True
     selective = True
+    input_field_placeholder = 'lol a keyboard'
 
     def test_slot_behaviour(self, reply_keyboard_markup, mro_slots, recwarn):
         inst = reply_keyboard_markup
@@ -101,6 +103,7 @@ class TestReplyKeyboardMarkup:
         assert reply_keyboard_markup.resize_keyboard == self.resize_keyboard
         assert reply_keyboard_markup.one_time_keyboard == self.one_time_keyboard
         assert reply_keyboard_markup.selective == self.selective
+        assert reply_keyboard_markup.input_field_placeholder == self.input_field_placeholder
 
     def test_to_dict(self, reply_keyboard_markup):
         reply_keyboard_markup_dict = reply_keyboard_markup.to_dict()
@@ -122,6 +125,10 @@ class TestReplyKeyboardMarkup:
             == reply_keyboard_markup.one_time_keyboard
         )
         assert reply_keyboard_markup_dict['selective'] == reply_keyboard_markup.selective
+        assert (
+            reply_keyboard_markup_dict['input_field_placeholder']
+            == reply_keyboard_markup.input_field_placeholder
+        )
 
     def test_equality(self):
         a = ReplyKeyboardMarkup.from_column(['button1', 'button2', 'button3'])


### PR DESCRIPTION
* `BotCommandScope*` is just for input, never output (at least for now), so we don't really need a proper `de_json`. But I realized that only after I had implemented it … If you think it's superfluous, we can remove
* Leaving the checklists empty for now so we can go over them once in the end.

### Checklist for PRs

- [x] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [x] Added myself alphabetically to `AUTHORS.rst` (optional)


### If the PR contains API changes (otherwise, you can delete this passage)

* New classes:
    - [x] Added `self._id_attrs` and corresponding documentation
    - [x] `__init__` accepts `**_kwargs`
    
* Added new shortcuts:
    - [x] In `Chat` & `User` for all methods that accept `chat/user_id` -> We need to deprecate `Chat.get_members_count` in favor of a new `Chat.get_member_count` and the same for `kick_chat_member` -> `ban_chat_member`
    - ~[ ] In `Message` for all methods that accept `chat_id` and `message_id`~
    - ~[ ] For new `Message` shortcuts: Added `quote` argument if methods accepts `reply_to_message_id`~
    - ~[ ] In `CallbackQuery` for all methods that accept either `chat_id` and `message_id` or `inline_message_id`~
    
* If relevant:

    - [x] Added new constants at `telegram.constants` and shortcuts to them as class variables
    - ~[ ] Added new handlers for new update types~
    - ~[ ] Added new filters for new message (sub)types~
    - [x] Added or updated documentation for the changed class(es) and/or method(s)
    - [x] Updated the Bot API version number in all places: `README.rst` and `README_RAW.rst` (including the badge), as well as `telegram.constants.BOT_API_VERSION`
    - ~[ ] Added logic for arbitrary callback data in `tg.ext.Bot` for new methods that either accept a `reply_markup` in some form or have a return type that is/contains `telegram.Message`~
