### PR TITLE
add stacklevel parameter to `set_new_attribute_deprecated`

### DIFF
--- a/telegram/utils/deprecate.py
+++ b/telegram/utils/deprecate.py
@@ -40,7 +40,8 @@ def set_new_attribute_deprecated(self: object, key: str, value: object) -> None:
     new = len(self.__dict__)
     if new > org:
         warnings.warn(
-            "Setting custom attributes on objects of the PTB library is deprecated.",
+            f"Setting custom attributes such as {key!r} on objects such as "
+            f"{self.__class__.__name__!r} of the PTB library is deprecated.",
             TelegramDeprecationWarning,
-            stacklevel=2,
+            stacklevel=3,
         )

--- a/telegram/utils/deprecate.py
+++ b/telegram/utils/deprecate.py
@@ -42,4 +42,5 @@ def set_new_attribute_deprecated(self: object, key: str, value: object) -> None:
         warnings.warn(
             "Setting custom attributes on objects of the PTB library is deprecated.",
             TelegramDeprecationWarning,
+            stacklevel=2,
         )


### PR DESCRIPTION
Adds the `stacklevel` parameter and details the warning message to `set_new_attribute_deprecated` so users can pinpoint where the warning originates from.

In response to https://t.me/pythontelegrambotgroup/491855