### PR TITLE
Improve tests

### DIFF
--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -104,7 +104,6 @@ class TestAnimation:
         assert message.animation.thumb.height == self.height
 
     @flaky(3, 1)
-    @pytest.mark.filterwarnings("ignore:.*custom attributes")
     def test_send_animation_custom_filename(self, bot, chat_id, animation_file, monkeypatch):
         def make_assertion(url, data, **kwargs):
             return data['animation'].filename == 'custom_filename'

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -717,7 +717,6 @@ class TestBot:
             bot.send_chat_action(chat_id, 'unknown action')
 
     # TODO: Needs improvement. We need incoming inline query to test answer.
-    @pytest.mark.filterwarnings("ignore:.*custom attributes")
     def test_answer_inline_query(self, monkeypatch, bot):
         # For now just test that our internals pass the correct data
         def test(url, data, *args, **kwargs):
@@ -970,7 +969,6 @@ class TestBot:
         monkeypatch.delattr(bot, '_post')
 
     # TODO: Needs improvement. No feasible way to test until bots can add members.
-    @pytest.mark.filterwarnings("ignore:.*custom attributes")
     def test_kick_chat_member(self, monkeypatch, bot):
         def test(url, data, *args, **kwargs):
             chat_id = data['chat_id'] == 2


### PR DESCRIPTION
Once again, tries to fix `test_idle` and `test_clean_deprecation_warning` based on log info from 
https://github.com/python-telegram-bot/python-telegram-bot/runs/2705725177,
https://github.com/python-telegram-bot/python-telegram-bot/pull/2560/checks?check_run_id=2814583591

Also removes unused `filterwarnings` from some tests