### PR TITLE
Fix incomplete type annotations for CallbackContext

### DIFF
--- a/telegram/ext/callbackcontext.py
+++ b/telegram/ext/callbackcontext.py
@@ -30,7 +30,6 @@ from typing import (
     Union,
     Generic,
     Type,
-    TypeVar,
 )
 
 from telegram import Update, CallbackQuery
@@ -41,8 +40,6 @@ if TYPE_CHECKING:
     from telegram import Bot
     from telegram.ext import Dispatcher, Job, JobQueue
     from telegram.ext.utils.types import CCT
-
-CC = TypeVar('CC', bound='CallbackContext')
 
 
 class CallbackContext(Generic[UD, CD, BD]):
@@ -106,7 +103,7 @@ class CallbackContext(Generic[UD, CD, BD]):
         '__dict__',
     )
 
-    def __init__(self: 'CallbackContext[UD, CD, BD]', dispatcher: 'Dispatcher[CCT, UD, CD, BD]'):
+    def __init__(self: 'CCT', dispatcher: 'Dispatcher[CCT, UD, CD, BD]'):
         """
         Args:
             dispatcher (:class:`telegram.ext.Dispatcher`):
@@ -226,13 +223,13 @@ class CallbackContext(Generic[UD, CD, BD]):
 
     @classmethod
     def from_error(
-        cls: Type[CC],
+        cls: Type['CCT'],
         update: object,
         error: Exception,
-        dispatcher: 'Dispatcher',
+        dispatcher: 'Dispatcher[CCT, UD, CD, BD]',
         async_args: Union[List, Tuple] = None,
         async_kwargs: Dict[str, object] = None,
-    ) -> CC:
+    ) -> 'CCT':
         """
         Constructs an instance of :class:`telegram.ext.CallbackContext` to be passed to the error
         handlers.
@@ -262,7 +259,9 @@ class CallbackContext(Generic[UD, CD, BD]):
         return self
 
     @classmethod
-    def from_update(cls: Type[CC], update: object, dispatcher: 'Dispatcher') -> CC:
+    def from_update(
+        cls: Type['CCT'], update: object, dispatcher: 'Dispatcher[CCT, UD, CD, BD]'
+    ) -> 'CCT':
         """
         Constructs an instance of :class:`telegram.ext.CallbackContext` to be passed to the
         handlers.
@@ -277,7 +276,7 @@ class CallbackContext(Generic[UD, CD, BD]):
         Returns:
             :class:`telegram.ext.CallbackContext`
         """
-        self = cls(dispatcher)
+        self = cls(dispatcher)  # type: ignore[arg-type]
 
         if update is not None and isinstance(update, Update):
             chat = update.effective_chat
@@ -296,7 +295,7 @@ class CallbackContext(Generic[UD, CD, BD]):
         return self
 
     @classmethod
-    def from_job(cls: Type[CC], job: 'Job', dispatcher: 'Dispatcher') -> CC:
+    def from_job(cls: Type['CCT'], job: 'Job', dispatcher: 'Dispatcher[CCT, UD, CD, BD]') -> 'CCT':
         """
         Constructs an instance of :class:`telegram.ext.CallbackContext` to be passed to a
         job callback.
@@ -311,7 +310,7 @@ class CallbackContext(Generic[UD, CD, BD]):
         Returns:
             :class:`telegram.ext.CallbackContext`
         """
-        self = cls(dispatcher)
+        self = cls(dispatcher)  # type: ignore[arg-type]
         self.job = job
         return self
 

--- a/telegram/ext/callbackcontext.py
+++ b/telegram/ext/callbackcontext.py
@@ -40,6 +40,7 @@ from telegram.ext.utils.types import UD, CD, BD
 if TYPE_CHECKING:
     from telegram import Bot
     from telegram.ext import Dispatcher, Job, JobQueue
+    from telegram.ext.utils.types import CCT
 
 CC = TypeVar('CC', bound='CallbackContext')
 
@@ -105,7 +106,7 @@ class CallbackContext(Generic[UD, CD, BD]):
         '__dict__',
     )
 
-    def __init__(self, dispatcher: 'Dispatcher'):
+    def __init__(self: 'CallbackContext[UD, CD, BD]', dispatcher: 'Dispatcher[CCT, UD, CD, BD]'):
         """
         Args:
             dispatcher (:class:`telegram.ext.Dispatcher`):
@@ -125,7 +126,7 @@ class CallbackContext(Generic[UD, CD, BD]):
         self.async_kwargs: Optional[Dict[str, object]] = None
 
     @property
-    def dispatcher(self) -> 'Dispatcher':
+    def dispatcher(self) -> 'Dispatcher[CCT, UD, CD, BD]':
         """:class:`telegram.ext.Dispatcher`: The dispatcher associated with this context."""
         return self._dispatcher
 


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool! Please have a look at the below checklist. It's here to help both you and the maintainers to remember some aspects. Make sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
-->

### Checklist for PRs

- [ ] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [ ] Created new or adapted existing unit tests
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)


### If the PR contains API changes (otherwise, you can delete this passage)

* New classes:
    - [ ] Added `self._id_attrs` and corresponding documentation
    - [ ] `__init__` accepts `**_kwargs`
    
* Added new shortcuts:
    - [ ] In `Chat` & `User` for all methods that accept `chat/user_id`
    - [ ] In `Message` for all methods that accept `chat_id` and `message_id`
    - [ ] For new `Message` shortcuts: Added `quote` argument if methods accepts `reply_to_message_id`
    - [ ] In `CallbackQuery` for all methods that accept either `chat_id` and `message_id` or `inline_message_id`
    
* If relevant:

    - [ ] Added new constants at `telegram.constants` and shortcuts to them as class variables
    - [ ] Added new handlers for new update types
    - [ ] Added new filters for new message (sub)types
    - [ ] Added or updated documentation for the changed class(es) and/or method(s)
    - [ ] Updated the Bot API version number in all places: `README.rst` and `README_RAW.rst` (including the badge), as well as `telegram.constants.BOT_API_VERSION`
    - [ ] Added logic for arbitrary callback data in `tg.ext.Bot` for new methods that either accept a `reply_markup` in some form or have a return type that is/contains `telegram.Message`

closes #2580.