### PR TITLE
move telegramdecryptionerror to error.py

### DIFF
--- a/telegram/__init__.py
+++ b/telegram/__init__.py
@@ -56,7 +56,7 @@ from .replymarkup import ReplyMarkup
 from .replykeyboardmarkup import ReplyKeyboardMarkup
 from .replykeyboardremove import ReplyKeyboardRemove
 from .forcereply import ForceReply
-from .error import TelegramError
+from .error import TelegramError, TelegramDecryptionError
 from .files.inputfile import InputFile
 from .files.file import File
 from .parsemode import ParseMode
@@ -159,7 +159,6 @@ from .passport.credentials import (
     SecureData,
     SecureValue,
     FileCredentials,
-    TelegramDecryptionError,
 )
 from .botcommandscope import (
     BotCommandScope,

--- a/telegram/__init__.py
+++ b/telegram/__init__.py
@@ -56,7 +56,7 @@ from .replymarkup import ReplyMarkup
 from .replykeyboardmarkup import ReplyKeyboardMarkup
 from .replykeyboardremove import ReplyKeyboardRemove
 from .forcereply import ForceReply
-from .error import TelegramError, TelegramDecryptionError
+from .error import TelegramError, PassportDecryptionError
 from .files.inputfile import InputFile
 from .files.file import File
 from .parsemode import ParseMode
@@ -307,7 +307,7 @@ __all__ = (  # Keep this alphabetically ordered
     'Sticker',
     'StickerSet',
     'SuccessfulPayment',
-    'TelegramDecryptionError',
+    'PassportDecryptionError',
     'TelegramError',
     'TelegramObject',
     'Update',

--- a/telegram/error.py
+++ b/telegram/error.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 # pylint: disable=C0115
 """This module contains an object that represents Telegram errors."""
-from typing import Tuple
+from typing import Tuple, Union
 
 
 def _lstrip_str(in_s: str, lstr: str) -> str:
@@ -149,3 +149,16 @@ class Conflict(TelegramError):
 
     def __reduce__(self) -> Tuple[type, Tuple[str]]:
         return self.__class__, (self.message,)
+
+
+class TelegramDecryptionError(TelegramError):
+    """Something went wrong with decryption."""
+
+    __slots__ = ('_msg',)
+
+    def __init__(self, message: Union[str, Exception]):
+        super().__init__(f"TelegramDecryptionError: {message}")
+        self._msg = str(message)
+
+    def __reduce__(self) -> Tuple[type, Tuple[str]]:
+        return self.__class__, (self._msg,)

--- a/telegram/error.py
+++ b/telegram/error.py
@@ -151,13 +151,13 @@ class Conflict(TelegramError):
         return self.__class__, (self.message,)
 
 
-class TelegramDecryptionError(TelegramError):
+class PassportDecryptionError(TelegramError):
     """Something went wrong with decryption."""
 
     __slots__ = ('_msg',)
 
     def __init__(self, message: Union[str, Exception]):
-        super().__init__(f"TelegramDecryptionError: {message}")
+        super().__init__(f"PassportDecryptionError: {message}")
         self._msg = str(message)
 
     def __reduce__(self) -> Tuple[type, Tuple[str]]:

--- a/telegram/passport/credentials.py
+++ b/telegram/passport/credentials.py
@@ -23,7 +23,7 @@ except ImportError:
     import json  # type: ignore[no-redef]
 
 from base64 import b64decode
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union, no_type_check
+from typing import TYPE_CHECKING, Any, List, Optional, no_type_check
 
 try:
     from cryptography.hazmat.backends import default_backend
@@ -41,24 +41,11 @@ except ImportError:
 
     CRYPTO_INSTALLED = False
 
-from telegram import TelegramError, TelegramObject
+from telegram import TelegramObject, TelegramDecryptionError
 from telegram.utils.types import JSONDict
 
 if TYPE_CHECKING:
     from telegram import Bot
-
-
-class TelegramDecryptionError(TelegramError):
-    """Something went wrong with decryption."""
-
-    __slots__ = ('_msg',)
-
-    def __init__(self, message: Union[str, Exception]):
-        super().__init__(f"TelegramDecryptionError: {message}")
-        self._msg = str(message)
-
-    def __reduce__(self) -> Tuple[type, Tuple[str]]:
-        return self.__class__, (self._msg,)
 
 
 @no_type_check

--- a/telegram/passport/credentials.py
+++ b/telegram/passport/credentials.py
@@ -41,7 +41,7 @@ except ImportError:
 
     CRYPTO_INSTALLED = False
 
-from telegram import TelegramObject, TelegramDecryptionError
+from telegram import TelegramObject, PassportDecryptionError
 from telegram.utils.types import JSONDict
 
 if TYPE_CHECKING:
@@ -64,7 +64,7 @@ def decrypt(secret, hash, data):
             b64decode it.
 
     Raises:
-        :class:`TelegramDecryptionError`: Given hash does not match hash of decrypted data.
+        :class:`PassportDecryptionError`: Given hash does not match hash of decrypted data.
 
     Returns:
         :obj:`bytes`: The decrypted data as bytes.
@@ -92,7 +92,7 @@ def decrypt(secret, hash, data):
     # If the newly calculated hash did not match the one telegram gave us
     if data_hash != hash:
         # Raise a error that is caught inside telegram.PassportData and transformed into a warning
-        raise TelegramDecryptionError(f"Hashes are not equal! {data_hash} != {hash}")
+        raise PassportDecryptionError(f"Hashes are not equal! {data_hash} != {hash}")
     # Return data without padding
     return data[data[0] :]
 
@@ -160,7 +160,7 @@ class EncryptedCredentials(TelegramObject):
         :obj:`str`: Lazily decrypt and return secret.
 
         Raises:
-            telegram.TelegramDecryptionError: Decryption failed. Usually due to bad
+            telegram.PassportDecryptionError: Decryption failed. Usually due to bad
                 private/public key but can also suggest malformed/tampered data.
         """
         if self._decrypted_secret is None:
@@ -182,7 +182,7 @@ class EncryptedCredentials(TelegramObject):
                 )
             except ValueError as exception:
                 # If decryption fails raise exception
-                raise TelegramDecryptionError(exception) from exception
+                raise PassportDecryptionError(exception) from exception
         return self._decrypted_secret
 
     @property
@@ -193,7 +193,7 @@ class EncryptedCredentials(TelegramObject):
             `decrypted_data.nonce`.
 
         Raises:
-            telegram.TelegramDecryptionError: Decryption failed. Usually due to bad
+            telegram.PassportDecryptionError: Decryption failed. Usually due to bad
                 private/public key but can also suggest malformed/tampered data.
         """
         if self._decrypted_data is None:

--- a/telegram/passport/passportdata.py
+++ b/telegram/passport/passportdata.py
@@ -95,7 +95,7 @@ class PassportData(TelegramObject):
             about documents and other Telegram Passport elements which were shared with the bot.
 
         Raises:
-            telegram.TelegramDecryptionError: Decryption failed. Usually due to bad
+            telegram.PassportDecryptionError: Decryption failed. Usually due to bad
                 private/public key but can also suggest malformed/tampered data.
         """
         if self._decrypted_data is None:
@@ -115,7 +115,7 @@ class PassportData(TelegramObject):
             `decrypted_data.payload`.
 
         Raises:
-            telegram.TelegramDecryptionError: Decryption failed. Usually due to bad
+            telegram.PassportDecryptionError: Decryption failed. Usually due to bad
                 private/public key but can also suggest malformed/tampered data.
         """
         return self.credentials.decrypted_data

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -21,7 +21,7 @@ from collections import defaultdict
 
 import pytest
 
-from telegram import TelegramError, TelegramDecryptionError
+from telegram import TelegramError, PassportDecryptionError
 from telegram.error import (
     Unauthorized,
     InvalidToken,
@@ -112,7 +112,7 @@ class TestErrors:
             (ChatMigrated(1234), ["message", "new_chat_id"]),
             (RetryAfter(12), ["message", "retry_after"]),
             (Conflict("test message"), ["message"]),
-            (TelegramDecryptionError("test message"), ["message"]),
+            (PassportDecryptionError("test message"), ["message"]),
             (InvalidCallbackData('test data'), ['callback_data']),
         ],
     )
@@ -147,7 +147,7 @@ class TestErrors:
                     ChatMigrated,
                     RetryAfter,
                     Conflict,
-                    TelegramDecryptionError,
+                    PassportDecryptionError,
                     InvalidCallbackData,
                 },
                 NetworkError: {BadRequest, TimedOut},

--- a/tests/test_passport.py
+++ b/tests/test_passport.py
@@ -28,7 +28,7 @@ from telegram import (
     PassportElementErrorSelfie,
     PassportElementErrorDataField,
     Credentials,
-    TelegramDecryptionError,
+    PassportDecryptionError,
 )
 
 
@@ -412,20 +412,20 @@ class TestPassport:
         data = deepcopy(RAW_PASSPORT_DATA)
         data['credentials']['hash'] = 'bm90Y29ycmVjdGhhc2g='  # Not correct hash
         passport_data = PassportData.de_json(data, bot=bot)
-        with pytest.raises(TelegramDecryptionError):
+        with pytest.raises(PassportDecryptionError):
             assert passport_data.decrypted_data
 
     def test_wrong_key(self, bot):
         short_key = b"-----BEGIN RSA PRIVATE KEY-----\r\nMIIBOQIBAAJBAKU+OZ2jJm7sCA/ec4gngNZhXYPu+DZ/TAwSMl0W7vAPXAsLplBk\r\nO8l6IBHx8N0ZC4Bc65mO3b2G8YAzqndyqH8CAwEAAQJAWOx3jQFzeVXDsOaBPdAk\r\nYTncXVeIc6tlfUl9mOLyinSbRNCy1XicOiOZFgH1rRKOGIC1235QmqxFvdecySoY\r\nwQIhAOFeGgeX9CrEPuSsd9+kqUcA2avCwqdQgSdy2qggRFyJAiEAu7QHT8JQSkHU\r\nDELfzrzc24AhjyG0z1DpGZArM8COascCIDK42SboXj3Z2UXiQ0CEcMzYNiVgOisq\r\nBUd5pBi+2mPxAiAM5Z7G/Sv1HjbKrOGh29o0/sXPhtpckEuj5QMC6E0gywIgFY6S\r\nNjwrAA+cMmsgY0O2fAzEKkDc5YiFsiXaGaSS4eA=\r\n-----END RSA PRIVATE KEY-----"
         b = Bot(bot.token, private_key=short_key)
         passport_data = PassportData.de_json(RAW_PASSPORT_DATA, bot=b)
-        with pytest.raises(TelegramDecryptionError):
+        with pytest.raises(PassportDecryptionError):
             assert passport_data.decrypted_data
 
         wrong_key = b"-----BEGIN RSA PRIVATE KEY-----\r\nMIIEogIBAAKCAQB4qCFltuvHakZze86TUweU7E/SB3VLGEHAe7GJlBmrou9SSWsL\r\nH7E++157X6UqWFl54LOE9MeHZnoW7rZ+DxLKhk6NwAHTxXPnvw4CZlvUPC3OFxg3\r\nhEmNen6ojSM4sl4kYUIa7F+Q5uMEYaboxoBen9mbj4zzMGsG4aY/xBOb2ewrXQyL\r\nRh//tk1Px4ago+lUPisAvQVecz7/6KU4Xj4Lpv2z20f3cHlZX6bb7HlE1vixCMOf\r\nxvfC5SkWEGZMR/ZoWQUsoDkrDSITF/S3GtLfg083TgtCKaOF3mCT27sJ1og77npP\r\n0cH/qdlbdoFtdrRj3PvBpaj/TtXRhmdGcJBxAgMBAAECggEAYSq1Sp6XHo8dkV8B\r\nK2/QSURNu8y5zvIH8aUrgqo8Shb7OH9bryekrB3vJtgNwR5JYHdu2wHttcL3S4SO\r\nftJQxbyHgmxAjHUVNGqOM6yPA0o7cR70J7FnMoKVgdO3q68pVY7ll50IET9/T0X9\r\nDrTdKFb+/eILFsXFS1NpeSzExdsKq3zM0sP/vlJHHYVTmZDGaGEvny/eLAS+KAfG\r\nrKP96DeO4C/peXEJzALZ/mG1ReBB05Qp9Dx1xEC20yreRk5MnnBA5oiHVG5ZLOl9\r\nEEHINidqN+TMNSkxv67xMfQ6utNu5IpbklKv/4wqQOJOO50HZ+qBtSurTN573dky\r\nzslbCQKBgQDHDUBYyKN/v69VLmvNVcxTgrOcrdbqAfefJXb9C3dVXhS8/oRkCRU/\r\ndzxYWNT7hmQyWUKor/izh68rZ/M+bsTnlaa7IdAgyChzTfcZL/2pxG9pq05GF1Q4\r\nBSJ896ZEe3jEhbpJXRlWYvz7455svlxR0H8FooCTddTmkU3nsQSx0wKBgQCbLSa4\r\nyZs2QVstQQerNjxAtLi0IvV8cJkuvFoNC2Q21oqQc7BYU7NJL7uwriprZr5nwkCQ\r\nOFQXi4N3uqimNxuSng31ETfjFZPp+pjb8jf7Sce7cqU66xxR+anUzVZqBG1CJShx\r\nVxN7cWN33UZvIH34gA2Ax6AXNnJG42B5Gn1GKwKBgQCZ/oh/p4nGNXfiAK3qB6yy\r\nFvX6CwuvsqHt/8AUeKBz7PtCU+38roI/vXF0MBVmGky+HwxREQLpcdl1TVCERpIT\r\nUFXThI9OLUwOGI1IcTZf9tby+1LtKvM++8n4wGdjp9qAv6ylQV9u09pAzZItMwCd\r\nUx5SL6wlaQ2y60tIKk0lfQKBgBJS+56YmA6JGzY11qz+I5FUhfcnpauDNGOTdGLT\r\n9IqRPR2fu7RCdgpva4+KkZHLOTLReoRNUojRPb4WubGfEk93AJju5pWXR7c6k3Bt\r\novS2mrJk8GQLvXVksQxjDxBH44sLDkKMEM3j7uYJqDaZNKbyoCWT7TCwikAau5qx\r\naRevAoGAAKZV705dvrpJuyoHFZ66luANlrAwG/vNf6Q4mBEXB7guqMkokCsSkjqR\r\nhsD79E6q06zA0QzkLCavbCn5kMmDS/AbA80+B7El92iIN6d3jRdiNZiewkhlWhEG\r\nm4N0gQRfIu+rUjsS/4xk8UuQUT/Ossjn/hExi7ejpKdCc7N++bc=\r\n-----END RSA PRIVATE KEY-----"
         b = Bot(bot.token, private_key=wrong_key)
         passport_data = PassportData.de_json(RAW_PASSPORT_DATA, bot=b)
-        with pytest.raises(TelegramDecryptionError):
+        with pytest.raises(PassportDecryptionError):
             assert passport_data.decrypted_data
 
     def test_mocked_download_passport_file(self, passport_data, monkeypatch):

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -30,7 +30,7 @@ excluded = {
     'DispatcherHandlerStop',
     'Days',
     'telegram.deprecate',
-    'TelegramDecryptionError',
+    'PassportDecryptionError',
     'ContextTypes',
     'CallbackDataCache',
     'InvalidCallbackData',


### PR DESCRIPTION
The import policy (#2468) isn't decided for errors. So keeping it as it is (defined in `__all__`)