### PR TITLE
Fix of Bot.copy_message

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -39,6 +39,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `daimajia <https://github.com/daimajia>`_
 - `Daniel Reed <https://github.com/nmlorg>`_
 - `D David Livingston <https://github.com/daviddl9>`_
+- `DonalDuck004 <https://github.com/DonalDuck004>`_
 - `Eana Hufwe <https://github.com/blueset>`_
 - `Ehsan Online <https://github.com/ehsanonline>`_
 - `Eli Gao <https://github.com/eligao>`_

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -5296,7 +5296,7 @@ class Bot(TelegramObject):
             'disable_notification': disable_notification,
             'allow_sending_without_reply': allow_sending_without_reply,
         }
-        if caption:
+        if caption is not None:
             data['caption'] = caption
         if caption_entities:
             data['caption_entities'] = caption_entities

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2024,29 +2024,30 @@ class TestBot:
 
     @flaky(3, 1)
     @pytest.mark.parametrize('json_keyboard', [True, False])
-    def test_copy_message(self, monkeypatch, bot, chat_id, media_message, json_keyboard):
+    @pytest.mark.parametrize('caption', ["<b>Test</b>", '', None])
+    def test_copy_message(self, monkeypatch, bot, chat_id, media_message, json_keyboard, caption):
         keyboard = InlineKeyboardMarkup(
             [[InlineKeyboardButton(text="test", callback_data="test2")]]
         )
-
+ 
         def post(url, data, timeout):
             assert data["chat_id"] == chat_id
             assert data["from_chat_id"] == chat_id
             assert data["message_id"] == media_message.message_id
-            assert data["caption"] == "<b>Test</b>"
+            assert data.get("caption") == caption
             assert data["parse_mode"] == ParseMode.HTML
             assert data["reply_to_message_id"] == media_message.message_id
             assert data["reply_markup"] == keyboard.to_json()
             assert data["disable_notification"] is True
             assert data["caption_entities"] == [MessageEntity(MessageEntity.BOLD, 0, 4)]
             return data
-
+ 
         monkeypatch.setattr(bot.request, 'post', post)
         bot.copy_message(
             chat_id,
             from_chat_id=chat_id,
             message_id=media_message.message_id,
-            caption="<b>Test</b>",
+            caption=caption,
             caption_entities=[MessageEntity(MessageEntity.BOLD, 0, 4)],
             parse_mode=ParseMode.HTML,
             reply_to_message_id=media_message.message_id,

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2029,7 +2029,7 @@ class TestBot:
         keyboard = InlineKeyboardMarkup(
             [[InlineKeyboardButton(text="test", callback_data="test2")]]
         )
- 
+
         def post(url, data, timeout):
             assert data["chat_id"] == chat_id
             assert data["from_chat_id"] == chat_id
@@ -2041,7 +2041,7 @@ class TestBot:
             assert data["disable_notification"] is True
             assert data["caption_entities"] == [MessageEntity(MessageEntity.BOLD, 0, 4)]
             return data
- 
+
         monkeypatch.setattr(bot.request, 'post', post)
         bot.copy_message(
             chat_id,


### PR DESCRIPTION
When you pass "" as a caption to this method, the caption is not sent to the Telegram API, because the if on line 5299 does not allow it to insert it in the dict of data to be sent to the Telegram API