### PR TITLE
Improve performance of pylint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,8 @@ repos:
         files: ^(telegram|examples)/.*\.py$
         args:
           - --rcfile=setup.cfg
-          - --jobs=0
+          #  run pylint across multiple cpu cores to speed it up-
+          - --jobs=0  # See https://pylint.pycqa.org/en/latest/user_guide/run.html?#parallel-execution to know more
         additional_dependencies:
           - certifi
           - tornado>=6.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
         files: ^(telegram|examples)/.*\.py$
         args:
           - --rcfile=setup.cfg
+          - --jobs=0
         additional_dependencies:
           - certifi
           - tornado>=6.1


### PR DESCRIPTION
`pylint` used to run super quick, but a few months back it started to take 2+ mins on my machine. Apparently you can set the number of processors to speed it up. Setting it to 0 will auto detect no. of processors it can use. Much fast now! 😄 