### PR TITLE
Make ILQ.answer raise ValueError rather than TypeError

### DIFF
--- a/telegram/inline/inlinequery.py
+++ b/telegram/inline/inlinequery.py
@@ -127,13 +127,18 @@ class InlineQuery(TelegramObject):
     ) -> bool:
         """Shortcut for::
 
-            bot.answer_inline_query(update.inline_query.id,
-                                    *args,
-                                    current_offset=self.offset if auto_pagination else None,
-                                    **kwargs)
+            bot.answer_inline_query(
+                update.inline_query.id,
+                *args,
+                current_offset=self.offset if auto_pagination else None,
+                **kwargs
+            )
 
         For the documentation of the arguments, please see
         :meth:`telegram.Bot.answer_inline_query`.
+
+        .. versionchanged:: 14.0
+            Raises :class:`ValueError` instead of :class:`TypeError`.
 
         Args:
             auto_pagination (:obj:`bool`, optional): If set to :obj:`True`, :attr:`offset` will be
@@ -141,12 +146,10 @@ class InlineQuery(TelegramObject):
                 Defaults to :obj:`False`.
 
         Raises:
-            TypeError: If both :attr:`current_offset` and :attr:`auto_pagination` are supplied.
+            ValueError: If both :attr:`current_offset` and :attr:`auto_pagination` are supplied.
         """
         if current_offset and auto_pagination:
-            # We raise TypeError instead of ValueError for backwards compatibility with versions
-            # which didn't check this here but let Python do the checking
-            raise TypeError('current_offset and auto_pagination are mutually exclusive!')
+            raise ValueError('current_offset and auto_pagination are mutually exclusive!')
         return self.bot.answer_inline_query(
             inline_query_id=self.id,
             current_offset=self.offset if auto_pagination else current_offset,

--- a/tests/test_inlinequery.py
+++ b/tests/test_inlinequery.py
@@ -92,7 +92,7 @@ class TestInlineQuery:
         assert inline_query.answer(results=[])
 
     def test_answer_error(self, inline_query):
-        with pytest.raises(TypeError, match='mutually exclusive'):
+        with pytest.raises(ValueError, match='mutually exclusive'):
             inline_query.answer(results=[], auto_pagination=True, current_offset='foobar')
 
     def test_answer_auto_pagination(self, monkeypatch, inline_query):


### PR DESCRIPTION
More or less deprecation …

### Checklist for PRs

- [x] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
