### PR TITLE
changing notifier event trigger

### DIFF
--- a/.github/workflows/example_notifier.yml
+++ b/.github/workflows/example_notifier.yml
@@ -1,6 +1,6 @@
 name: Warning maintainers
 on:
-  pull_request:
+  pull_request_target:
     paths: examples/**
 jobs:
   job:

--- a/.github/workflows/pre-commit_dependencies_notifier.yml
+++ b/.github/workflows/pre-commit_dependencies_notifier.yml
@@ -1,6 +1,6 @@
 name: Warning maintainers
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - requirements.txt
       - requirements-dev.txt

--- a/.github/workflows/readme_notifier.yml
+++ b/.github/workflows/readme_notifier.yml
@@ -1,6 +1,6 @@
 name: Warning maintainers
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - README.rst
       - README_RAW.rst


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool! Please have a look at the below checklist. It's here to help both you and the maintainers to remember some aspects. Make sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
-->

This changes the trigger to the [new *_target one](pull_request_target), which gives the forks enough rights to comment in their PR.

I tested the changes [on my fork](https://github.com/Poolitzer/python-telegram-bot/pulls), just for the example notifier, but since the code is the same for each workflow, this should be enough.