### PR TITLE
Add generic 'edited' update filter

### DIFF
--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -2319,4 +2319,6 @@ officedocument.wordprocessingml.document")``.
             :attr:`telegram.Update.edited_channel_post`
         channel_posts: Updates with either :attr:`telegram.Update.channel_post` or
             :attr:`telegram.Update.edited_channel_post`
+        edited: Updates with either :attr:`telegram.Update.edited_message` or
+            :attr:`telegram.Update.edited_channel_post`
     """

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1973,6 +1973,7 @@ class TestFilters:
         assert not Filters.update.channel_post(update)
         assert not Filters.update.edited_channel_post(update)
         assert not Filters.update.channel_posts(update)
+        assert not Filters.update.edited(update)
         assert Filters.update(update)
 
     def test_update_type_edited_message(self, update):
@@ -1983,6 +1984,7 @@ class TestFilters:
         assert not Filters.update.channel_post(update)
         assert not Filters.update.edited_channel_post(update)
         assert not Filters.update.channel_posts(update)
+        assert Filters.update.edited(update)
         assert Filters.update(update)
 
     def test_update_type_channel_post(self, update):
@@ -1993,6 +1995,7 @@ class TestFilters:
         assert Filters.update.channel_post(update)
         assert not Filters.update.edited_channel_post(update)
         assert Filters.update.channel_posts(update)
+        assert not Filters.update.edited(update)
         assert Filters.update(update)
 
     def test_update_type_edited_channel_post(self, update):
@@ -2003,6 +2006,7 @@ class TestFilters:
         assert not Filters.update.channel_post(update)
         assert Filters.update.edited_channel_post(update)
         assert Filters.update.channel_posts(update)
+        assert Filters.update.edited(update)
         assert Filters.update(update)
 
     def test_merged_short_circuit_and(self, update, base_class):


### PR DESCRIPTION
Added a filter `Filters.update.edited` working for both messages and channel posts.

Closes #2703