### PR TITLE
Update setter error messages

### DIFF
--- a/telegram/ext/_conversationhandler.py
+++ b/telegram/ext/_conversationhandler.py
@@ -337,7 +337,9 @@ class ConversationHandler(Handler[Update, CCT]):
 
     @entry_points.setter
     def entry_points(self, value: object) -> NoReturn:
-        raise ValueError('You can not assign a new value to entry_points after initialization.')
+        raise AttributeError(
+            "You can not assign a new value to entry_points after initialization."
+        )
 
     @property
     def states(self) -> Dict[object, List[Handler]]:
@@ -349,7 +351,7 @@ class ConversationHandler(Handler[Update, CCT]):
 
     @states.setter
     def states(self, value: object) -> NoReturn:
-        raise ValueError('You can not assign a new value to states after initialization.')
+        raise AttributeError("You can not assign a new value to states after initialization.")
 
     @property
     def fallbacks(self) -> List[Handler]:
@@ -361,7 +363,7 @@ class ConversationHandler(Handler[Update, CCT]):
 
     @fallbacks.setter
     def fallbacks(self, value: object) -> NoReturn:
-        raise ValueError('You can not assign a new value to fallbacks after initialization.')
+        raise AttributeError("You can not assign a new value to fallbacks after initialization.")
 
     @property
     def allow_reentry(self) -> bool:
@@ -370,7 +372,9 @@ class ConversationHandler(Handler[Update, CCT]):
 
     @allow_reentry.setter
     def allow_reentry(self, value: object) -> NoReturn:
-        raise ValueError('You can not assign a new value to allow_reentry after initialization.')
+        raise AttributeError(
+            "You can not assign a new value to allow_reentry after initialization."
+        )
 
     @property
     def per_user(self) -> bool:
@@ -379,7 +383,7 @@ class ConversationHandler(Handler[Update, CCT]):
 
     @per_user.setter
     def per_user(self, value: object) -> NoReturn:
-        raise ValueError('You can not assign a new value to per_user after initialization.')
+        raise AttributeError("You can not assign a new value to per_user after initialization.")
 
     @property
     def per_chat(self) -> bool:
@@ -388,7 +392,7 @@ class ConversationHandler(Handler[Update, CCT]):
 
     @per_chat.setter
     def per_chat(self, value: object) -> NoReturn:
-        raise ValueError('You can not assign a new value to per_chat after initialization.')
+        raise AttributeError("You can not assign a new value to per_chat after initialization.")
 
     @property
     def per_message(self) -> bool:
@@ -397,7 +401,7 @@ class ConversationHandler(Handler[Update, CCT]):
 
     @per_message.setter
     def per_message(self, value: object) -> NoReturn:
-        raise ValueError('You can not assign a new value to per_message after initialization.')
+        raise AttributeError("You can not assign a new value to per_message after initialization.")
 
     @property
     def conversation_timeout(
@@ -411,8 +415,8 @@ class ConversationHandler(Handler[Update, CCT]):
 
     @conversation_timeout.setter
     def conversation_timeout(self, value: object) -> NoReturn:
-        raise ValueError(
-            'You can not assign a new value to conversation_timeout after initialization.'
+        raise AttributeError(
+            "You can not assign a new value to conversation_timeout after initialization."
         )
 
     @property
@@ -422,7 +426,7 @@ class ConversationHandler(Handler[Update, CCT]):
 
     @name.setter
     def name(self, value: object) -> NoReturn:
-        raise ValueError('You can not assign a new value to name after initialization.')
+        raise AttributeError("You can not assign a new value to name after initialization.")
 
     @property
     def map_to_parent(self) -> Optional[Dict[object, object]]:
@@ -434,7 +438,9 @@ class ConversationHandler(Handler[Update, CCT]):
 
     @map_to_parent.setter
     def map_to_parent(self, value: object) -> NoReturn:
-        raise ValueError('You can not assign a new value to map_to_parent after initialization.')
+        raise AttributeError(
+            "You can not assign a new value to map_to_parent after initialization."
+        )
 
     @property
     def persistence(self) -> Optional[BasePersistence]:

--- a/telegram/ext/_defaults.py
+++ b/telegram/ext/_defaults.py
@@ -119,10 +119,7 @@ class Defaults:
 
     @parse_mode.setter
     def parse_mode(self, value: object) -> NoReturn:
-        raise AttributeError(
-            "You can not assign a new value to defaults after because it would "
-            "not have any effect."
-        )
+        raise AttributeError("You can not assign a new value to parse_mode after initialization.")
 
     @property
     def explanation_parse_mode(self) -> Optional[str]:
@@ -134,8 +131,7 @@ class Defaults:
     @explanation_parse_mode.setter
     def explanation_parse_mode(self, value: object) -> NoReturn:
         raise AttributeError(
-            "You can not assign a new value to defaults after because it would "
-            "not have any effect."
+            "You can not assign a new value to explanation_parse_mode after initialization."
         )
 
     @property
@@ -148,8 +144,7 @@ class Defaults:
     @disable_notification.setter
     def disable_notification(self, value: object) -> NoReturn:
         raise AttributeError(
-            "You can not assign a new value to defaults after because it would "
-            "not have any effect."
+            "You can not assign a new value to disable_notification after initialization."
         )
 
     @property
@@ -162,8 +157,7 @@ class Defaults:
     @disable_web_page_preview.setter
     def disable_web_page_preview(self, value: object) -> NoReturn:
         raise AttributeError(
-            "You can not assign a new value to defaults after because it would "
-            "not have any effect."
+            "You can not assign a new value to disable_web_page_preview after initialization."
         )
 
     @property
@@ -176,8 +170,7 @@ class Defaults:
     @allow_sending_without_reply.setter
     def allow_sending_without_reply(self, value: object) -> NoReturn:
         raise AttributeError(
-            "You can not assign a new value to defaults after because it would "
-            "not have any effect."
+            "You can not assign a new value to allow_sending_without_reply after initialization."
         )
 
     @property
@@ -190,10 +183,7 @@ class Defaults:
 
     @timeout.setter
     def timeout(self, value: object) -> NoReturn:
-        raise AttributeError(
-            "You can not assign a new value to defaults after because it would "
-            "not have any effect."
-        )
+        raise AttributeError("You can not assign a new value to timeout after initialization.")
 
     @property
     def quote(self) -> Optional[bool]:
@@ -205,10 +195,7 @@ class Defaults:
 
     @quote.setter
     def quote(self, value: object) -> NoReturn:
-        raise AttributeError(
-            "You can not assign a new value to defaults after because it would "
-            "not have any effect."
-        )
+        raise AttributeError("You can not assign a new value to quote after initialization.")
 
     @property
     def tzinfo(self) -> pytz.BaseTzInfo:
@@ -219,10 +206,7 @@ class Defaults:
 
     @tzinfo.setter
     def tzinfo(self, value: object) -> NoReturn:
-        raise AttributeError(
-            "You can not assign a new value to defaults after because it would "
-            "not have any effect."
-        )
+        raise AttributeError("You can not assign a new value to tzinfo after initialization.")
 
     @property
     def run_async(self) -> bool:
@@ -234,10 +218,7 @@ class Defaults:
 
     @run_async.setter
     def run_async(self, value: object) -> NoReturn:
-        raise AttributeError(
-            "You can not assign a new value to defaults after because it would "
-            "not have any effect."
-        )
+        raise AttributeError("You can not assign a new value to run_async after initialization.")
 
     def __hash__(self) -> int:
         return hash(

--- a/tests/test_conversationhandler.py
+++ b/tests/test_conversationhandler.py
@@ -282,7 +282,7 @@ class TestConversationHandler:
             assert list(value.keys())[0] == attr
         else:
             assert getattr(ch, attr) == attr
-        with pytest.raises(ValueError, match=f'You can not assign a new value to {attr}'):
+        with pytest.raises(AttributeError, match=f'You can not assign a new value to {attr}'):
             setattr(ch, attr, True)
 
     def test_immutable_per_message(self):
@@ -299,7 +299,7 @@ class TestConversationHandler:
             map_to_parent='map_to_parent',
         )
         assert ch.per_message is False
-        with pytest.raises(ValueError, match='You can not assign a new value to per_message'):
+        with pytest.raises(AttributeError, match='You can not assign a new value to per_message'):
             ch.per_message = True
 
     def test_per_all_false(self):


### PR DESCRIPTION
Makes the `Defaults` property setter message more descriptive + changes `ValueError` to `AttributeError` for the setters in `ConversationHandler`