### PR TITLE
Refactor conv warnings

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,6 +28,7 @@ Hey! You're PRing? Cool! Please have a look at the below checklist. It's here to
     - [ ] Link new and existing constants in docstrings instead of hard coded number and strings
     - [ ] Add new message types to `Message.effective_attachment`
     - [ ] Added new handlers for new update types
+      - [ ] Add the handlers to the warning loop in the `ConversationHandler`
     - [ ] Added new filters for new message (sub)types
     - [ ] Added or updated documentation for the changed class(es) and/or method(s)
     - [ ] Updated the Bot API version number in all places: `README.rst` and `README_RAW.rst` (including the badge), as well as `telegram.constants.BOT_API_VERSION`

--- a/telegram/ext/_conversationhandler.py
+++ b/telegram/ext/_conversationhandler.py
@@ -304,15 +304,15 @@ class ConversationHandler(Handler[Update, CCT]):
         for handler in all_handlers:
             if isinstance(handler, (StringCommandHandler, StringRegexHandler)):
                 warn(
-                    "The ConversationHandler does not work with non Telegram.Update type updates, "
-                    "and you shouldn't use this handler for Telegram Update types.",
+                    "The `ConversationHandler` only handles updates of type `telegram.Update`. "
+                    f"{handler.__class__.__name__} handles updates of type `str`.",
                     stacklevel=2,
                 )
             if isinstance(handler, PollHandler):
                 warn(
                     "PollHandler will never trigger in a conversation since it has no information "
                     "about the chat or the user who voted in it. Do you mean the "
-                    "'PollAnswerHandler'?",
+                    "`PollAnswerHandler`?",
                     stacklevel=2,
                 )
             # we can assume per_user is set. If its not, per_message has to be set, otherwise the
@@ -332,8 +332,8 @@ class ConversationHandler(Handler[Update, CCT]):
                 and self.per_chat
             ):
                 warn(
-                    "This Handler only has information about the user, so it wont ever be"
-                    " triggered if 'per_chat=True'." + per_faq_link,
+                    f"Updates handled by {handler.__class__.__name__} only have information about the user, so this handler wont ever be"
+                    " triggered if `per_chat=True`." + per_faq_link,
                     stacklevel=2,
                 )
 

--- a/telegram/ext/_conversationhandler.py
+++ b/telegram/ext/_conversationhandler.py
@@ -356,7 +356,7 @@ class ConversationHandler(Handler[Update, CCT]):
                     stacklevel=2,
                 )
 
-            elif self.conversation_timeout:
+            if self.conversation_timeout:
                 if isinstance(handler, self.__class__):
                     warn(
                         "Using `conversation_timeout` with nested conversations is currently not "
@@ -365,7 +365,7 @@ class ConversationHandler(Handler[Update, CCT]):
                         stacklevel=2,
                     )
 
-            elif self.run_async:
+            if self.run_async:
                 handler.run_async = True
 
     @property

--- a/telegram/ext/_conversationhandler.py
+++ b/telegram/ext/_conversationhandler.py
@@ -309,13 +309,13 @@ class ConversationHandler(Handler[Update, CCT]):
                     f"{handler.__class__.__name__} handles updates of type `str`.",
                     stacklevel=2,
                 )
-            if isinstance(handler, TypeHandler) and not issubclass(handler.type, Update):
+            elif isinstance(handler, TypeHandler) and not issubclass(handler.type, Update):
                 warn(
                     "The `ConversationHandler` only handles updates of type `telegram.Update`."
                     f" The TypeHandler is set to handle {handler.type.__name__}.",
                     stacklevel=2,
                 )
-            if isinstance(handler, PollHandler):
+            elif isinstance(handler, PollHandler):
                 warn(
                     "PollHandler will never trigger in a conversation since it has no information "
                     "about the chat or the user who voted in it. Do you mean the "
@@ -323,20 +323,16 @@ class ConversationHandler(Handler[Update, CCT]):
                     stacklevel=2,
                 )
 
-            if (
-                self.per_chat
-                and self.per_user
-                and (
-                    isinstance(
-                        handler,
-                        (
-                            ShippingQueryHandler,
-                            InlineQueryHandler,
-                            ChosenInlineResultHandler,
-                            PreCheckoutQueryHandler,
-                            PollAnswerHandler,
-                        ),
-                    )
+            elif self.per_chat and (
+                isinstance(
+                    handler,
+                    (
+                        ShippingQueryHandler,
+                        InlineQueryHandler,
+                        ChosenInlineResultHandler,
+                        PreCheckoutQueryHandler,
+                        PollAnswerHandler,
+                    ),
                 )
             ):
                 warn(
@@ -346,21 +342,19 @@ class ConversationHandler(Handler[Update, CCT]):
                     stacklevel=2,
                 )
 
-            if self.per_message:
-                if not isinstance(handler, CallbackQueryHandler):
-                    warn(
-                        "If 'per_message=True', all entry points, state handlers, and fallbacks"
-                        " must be 'CallbackQueryHandler', since no other handlers "
-                        f"have a message context.{per_faq_link}",
-                        stacklevel=2,
-                    )
-            else:
-                if isinstance(handler, CallbackQueryHandler):
-                    warn(
-                        "If 'per_message=False', 'CallbackQueryHandler' will not be "
-                        "tracked for every message." + per_faq_link,
-                        stacklevel=2,
-                    )
+            elif self.per_message and not isinstance(handler, CallbackQueryHandler):
+                warn(
+                    "If 'per_message=True', all entry points, state handlers, and fallbacks"
+                    " must be 'CallbackQueryHandler', since no other handlers "
+                    f"have a message context.{per_faq_link}",
+                    stacklevel=2,
+                )
+            elif isinstance(handler, CallbackQueryHandler):
+                warn(
+                    "If 'per_message=False', 'CallbackQueryHandler' will not be "
+                    "tracked for every message." + per_faq_link,
+                    stacklevel=2,
+                )
 
         if self.conversation_timeout:
             for handler in all_handlers:

--- a/telegram/ext/_conversationhandler.py
+++ b/telegram/ext/_conversationhandler.py
@@ -47,10 +47,6 @@ from telegram.ext import (
     InlineQueryHandler,
     StringCommandHandler,
     StringRegexHandler,
-    ShippingQueryHandler,
-    PreCheckoutQueryHandler,
-    PollHandler,
-    PollAnswerHandler,
 )
 from telegram._utils.warnings import warn
 from telegram.ext._utils.promise import Promise
@@ -245,6 +241,14 @@ class ConversationHandler(Handler[Update, CCT]):
         map_to_parent: Dict[object, object] = None,
         run_async: bool = False,
     ):
+        # these imports need to be here because of circular import error otherwise
+        from telegram.ext import (  # pylint: disable=import-outside-toplevel
+            ShippingQueryHandler,
+            PreCheckoutQueryHandler,
+            PollHandler,
+            PollAnswerHandler,
+        )
+
         self.run_async = run_async
 
         self._entry_points = entry_points
@@ -291,6 +295,12 @@ class ConversationHandler(Handler[Update, CCT]):
 
         # this loop is going to warn the user about handlers which can work unexpected
         # in conversations
+
+        # this link will be added to all warnings tied to per_* setting
+        per_faq_link = (
+            " Read this FAQ entry to learn more about the per_* settings https://git.io/JtcyU."
+        )
+
         for handler in all_handlers:
             if isinstance(handler, (StringCommandHandler, StringRegexHandler)):
                 warn(
@@ -323,7 +333,7 @@ class ConversationHandler(Handler[Update, CCT]):
             ):
                 warn(
                     "This Handler only has information about the user, so it wont ever be"
-                    " triggered if 'per_chat=True'.",
+                    " triggered if 'per_chat=True'." + per_faq_link,
                     stacklevel=2,
                 )
 
@@ -332,14 +342,14 @@ class ConversationHandler(Handler[Update, CCT]):
                     warn(
                         "If 'per_message=True', all entry points, state handlers, and fallbacks"
                         " must be 'CallbackQueryHandler', since no other handlers "
-                        "have a message context.",
+                        "have a message context." + per_faq_link,
                         stacklevel=2,
                     )
             else:
                 if isinstance(handler, CallbackQueryHandler):
                     warn(
                         "If 'per_message=False', 'CallbackQueryHandler' will not be "
-                        "tracked for every message.",
+                        "tracked for every message." + per_faq_link,
                         stacklevel=2,
                     )
 

--- a/telegram/ext/_conversationhandler.py
+++ b/telegram/ext/_conversationhandler.py
@@ -310,7 +310,7 @@ class ConversationHandler(Handler[Update, CCT]):
                 )
             if isinstance(handler, PollHandler):
                 warn(
-                    "PollHandler will never trigger in a Conversation since it has no information "
+                    "PollHandler will never trigger in a conversation since it has no information "
                     "about the chat or the user who voted in it. Do you mean the "
                     "'PollAnswerHandler'?",
                     stacklevel=2,
@@ -362,7 +362,6 @@ class ConversationHandler(Handler[Update, CCT]):
                         "differently from what you expect.",
                         stacklevel=2,
                     )
-                    break
 
         if self.run_async:
             for handler in all_handlers:

--- a/telegram/ext/_conversationhandler.py
+++ b/telegram/ext/_conversationhandler.py
@@ -356,14 +356,13 @@ class ConversationHandler(Handler[Update, CCT]):
                     stacklevel=2,
                 )
 
-            if self.conversation_timeout:
-                if isinstance(handler, self.__class__):
-                    warn(
-                        "Using `conversation_timeout` with nested conversations is currently not "
-                        "supported. You can still try to use it, but it will likely behave "
-                        "differently from what you expect.",
-                        stacklevel=2,
-                    )
+            if self.conversation_timeout and isinstance(handler, self.__class__):
+                warn(
+                    "Using `conversation_timeout` with nested conversations is currently not "
+                    "supported. You can still try to use it, but it will likely behave "
+                    "differently from what you expect.",
+                    stacklevel=2,
+                )
 
             if self.run_async:
                 handler.run_async = True

--- a/telegram/ext/_conversationhandler.py
+++ b/telegram/ext/_conversationhandler.py
@@ -299,7 +299,7 @@ class ConversationHandler(Handler[Update, CCT]):
 
         # this link will be added to all warnings tied to per_* setting
         per_faq_link = (
-            " Read this FAQ entry to learn more about the per_* settings https://git.io/JtcyU."
+            " Read this FAQ entry to learn more about the per_* settings: https://git.io/JtcyU."
         )
 
         for handler in all_handlers:
@@ -309,7 +309,7 @@ class ConversationHandler(Handler[Update, CCT]):
                     f"{handler.__class__.__name__} handles updates of type `str`.",
                     stacklevel=2,
                 )
-            if isinstance(handler, TypeHandler) and handler.type is not Update:
+            if isinstance(handler, TypeHandler) and not issubclass(handler.type, Update):
                 warn(
                     "The `ConversationHandler` only handles updates of type `telegram.Update`."
                     f" The TypeHandler is set to handle {handler.type.__name__}.",
@@ -341,7 +341,7 @@ class ConversationHandler(Handler[Update, CCT]):
             ):
                 warn(
                     f"Updates handled by {handler.__class__.__name__} only have information about "
-                    f"the user, so this handler wont ever be triggered if `per_chat=True`."
+                    f"the user, so this handler won't ever be triggered if `per_chat=True`."
                     + per_faq_link,
                     stacklevel=2,
                 )
@@ -351,7 +351,7 @@ class ConversationHandler(Handler[Update, CCT]):
                     warn(
                         "If 'per_message=True', all entry points, state handlers, and fallbacks"
                         " must be 'CallbackQueryHandler', since no other handlers "
-                        "have a message context." + per_faq_link,
+                        f"have a message context.{per_faq_link}",
                         stacklevel=2,
                     )
             else:

--- a/telegram/ext/_conversationhandler.py
+++ b/telegram/ext/_conversationhandler.py
@@ -356,8 +356,7 @@ class ConversationHandler(Handler[Update, CCT]):
                     stacklevel=2,
                 )
 
-        if self.conversation_timeout:
-            for handler in all_handlers:
+            elif self.conversation_timeout:
                 if isinstance(handler, self.__class__):
                     warn(
                         "Using `conversation_timeout` with nested conversations is currently not "
@@ -366,8 +365,7 @@ class ConversationHandler(Handler[Update, CCT]):
                         stacklevel=2,
                     )
 
-        if self.run_async:
-            for handler in all_handlers:
+            elif self.run_async:
                 handler.run_async = True
 
     @property

--- a/telegram/ext/_conversationhandler.py
+++ b/telegram/ext/_conversationhandler.py
@@ -338,7 +338,7 @@ class ConversationHandler(Handler[Update, CCT]):
                 warn(
                     f"Updates handled by {handler.__class__.__name__} only have information about "
                     f"the user, so this handler won't ever be triggered if `per_chat=True`."
-                    + per_faq_link,
+                    f"{per_faq_link}",
                     stacklevel=2,
                 )
 
@@ -349,10 +349,10 @@ class ConversationHandler(Handler[Update, CCT]):
                     f"have a message context.{per_faq_link}",
                     stacklevel=2,
                 )
-            elif isinstance(handler, CallbackQueryHandler):
+            elif not self.per_message and isinstance(handler, CallbackQueryHandler):
                 warn(
                     "If 'per_message=False', 'CallbackQueryHandler' will not be "
-                    "tracked for every message." + per_faq_link,
+                    f"tracked for every message.{per_faq_link}",
                     stacklevel=2,
                 )
 

--- a/tests/test_conversationhandler.py
+++ b/tests/test_conversationhandler.py
@@ -1420,28 +1420,28 @@ class TestConversationHandler:
         )
 
         per_faq_link = (
-            " Read this FAQ entry to learn more about the per_* settings https://git.io/JtcyU."
+            " Read this FAQ entry to learn more about the per_* settings: https://git.io/JtcyU."
         )
 
         assert str(recwarn[4].message) == (
             "Updates handled by ShippingQueryHandler only have information about the user,"
-            " so this handler wont ever be triggered if `per_chat=True`." + per_faq_link
+            " so this handler won't ever be triggered if `per_chat=True`." + per_faq_link
         )
         assert str(recwarn[5].message) == (
             "Updates handled by ChosenInlineResultHandler only have information about the user,"
-            " so this handler wont ever be triggered if `per_chat=True`." + per_faq_link
+            " so this handler won't ever be triggered if `per_chat=True`." + per_faq_link
         )
         assert str(recwarn[6].message) == (
             "Updates handled by InlineQueryHandler only have information about the user,"
-            " so this handler wont ever be triggered if `per_chat=True`." + per_faq_link
+            " so this handler won't ever be triggered if `per_chat=True`." + per_faq_link
         )
         assert str(recwarn[7].message) == (
             "Updates handled by PreCheckoutQueryHandler only have information about the user,"
-            " so this handler wont ever be triggered if `per_chat=True`." + per_faq_link
+            " so this handler won't ever be triggered if `per_chat=True`." + per_faq_link
         )
         assert str(recwarn[8].message) == (
             "Updates handled by PollAnswerHandler only have information about the user,"
-            " so this handler wont ever be triggered if `per_chat=True`." + per_faq_link
+            " so this handler won't ever be triggered if `per_chat=True`." + per_faq_link
         )
         assert str(recwarn[9].message) == (
             "If 'per_message=True', all entry points, state handlers, and fallbacks must be "

--- a/tests/test_conversationhandler.py
+++ b/tests/test_conversationhandler.py
@@ -1334,7 +1334,6 @@ class TestConversationHandler:
         assert handler.conversations.get((self.group.id, user1.id)) is None
         assert self.is_timeout
 
-    @pytest.mark.dev
     def test_handlers_generate_warning(self, recwarn):
         # this function tests all handler + per_* setting combinations.
 

--- a/tests/test_conversationhandler.py
+++ b/tests/test_conversationhandler.py
@@ -1453,6 +1453,9 @@ class TestConversationHandler:
             "every message." + per_faq_link
         )
 
+        for warning in recwarn:
+            assert warning.filename == __file__, "incorrect stacklevel!"
+
     def test_per_message_but_not_per_chat_warning(self, recwarn):
         ConversationHandler(
             entry_points=[CallbackQueryHandler(self.code, "code")],

--- a/tests/test_conversationhandler.py
+++ b/tests/test_conversationhandler.py
@@ -1335,7 +1335,9 @@ class TestConversationHandler:
         assert self.is_timeout
 
     def test_handlers_generate_warning(self, recwarn):
-        # this function tests all handler + per_* setting combinations.
+        """
+        this function tests all handler + per_* setting combinations.
+        """
 
         # the warning message action needs to be set to always,
         # otherwise only the first occurrence will be issued


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool! Please have a look at the below checklist. It's here to help both you and the maintainers to remember some aspects. Make sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
-->

### Checklist for PRs

- [ ] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)


This PR closes #2615.

I did make a decision while implementing this: I don't think it makes sense to break the for loops after one warning. The warnings menu will not show more then one unique warning anyway, and we swallow non unique ones this way or unique ones if the user changes their `filterwarning` method. 
