### PR TITLE
Feat: Disable Example notifier run on V14

### DIFF
--- a/.github/workflows/example_notifier.yml
+++ b/.github/workflows/example_notifier.yml
@@ -1,10 +1,10 @@
 name: Warning maintainers
 on:
-  pull_request_target:
-    paths: examples/**
   pull_request:
     branches-ignore:
       - V14
+  pull_request_target:
+    paths: examples/**
 jobs:
   job:
     runs-on: ubuntu-latest

--- a/.github/workflows/example_notifier.yml
+++ b/.github/workflows/example_notifier.yml
@@ -2,6 +2,9 @@ name: Warning maintainers
 on:
   pull_request_target:
     paths: examples/**
+  pull_request:
+    branches-ignore:
+      - V14
 jobs:
   job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Hi, I had the idea to disable the example notifier for V14. I imagine we will make a few changes to the examples and we reduce the "spam" from this workflow. We could extend this to other notifiers but Im not sure thats needed.
