### PR TITLE
'Refactored by Sourcery'

### DIFF
--- a/examples/chatmemberbot.py
+++ b/examples/chatmemberbot.py
@@ -92,13 +92,12 @@ def track_chats(update: Update, context: CallbackContext) -> None:
         elif was_member and not is_member:
             logger.info("%s removed the bot from the group %s", cause_name, chat.title)
             context.bot_data.setdefault("group_ids", set()).discard(chat.id)
-    else:
-        if not was_member and is_member:
-            logger.info("%s added the bot to the channel %s", cause_name, chat.title)
-            context.bot_data.setdefault("channel_ids", set()).add(chat.id)
-        elif was_member and not is_member:
-            logger.info("%s removed the bot from the channel %s", cause_name, chat.title)
-            context.bot_data.setdefault("channel_ids", set()).discard(chat.id)
+    elif not was_member and is_member:
+        logger.info("%s added the bot to the channel %s", cause_name, chat.title)
+        context.bot_data.setdefault("channel_ids", set()).add(chat.id)
+    elif was_member and not is_member:
+        logger.info("%s removed the bot from the channel %s", cause_name, chat.title)
+        context.bot_data.setdefault("channel_ids", set()).discard(chat.id)
 
 
 def show_chats(update: Update, context: CallbackContext) -> None:

--- a/examples/pollbot.py
+++ b/examples/pollbot.py
@@ -74,12 +74,13 @@ def receive_poll_answer(update: Update, context: CallbackContext) -> None:
     except KeyError:
         return
     selected_options = answer.option_ids
-    answer_string = ""
-    for question_id in selected_options:
-        if question_id != selected_options[-1]:
-            answer_string += questions[question_id] + " and "
-        else:
-            answer_string += questions[question_id]
+    answer_string = "".join(
+        questions[question_id] + " and "
+        if question_id != selected_options[-1]
+        else questions[question_id]
+        for question_id in selected_options
+    )
+
     context.bot.send_message(
         context.bot_data[poll_id]["chat_id"],
         f"{update.effective_user.mention_html()} feels {answer_string}!",

--- a/telegram/base.py
+++ b/telegram/base.py
@@ -122,11 +122,7 @@ class TelegramObject:
 
             value = getattr(self, key, None)
             if value is not None:
-                if hasattr(value, 'to_dict'):
-                    data[key] = value.to_dict()
-                else:
-                    data[key] = value
-
+                data[key] = value.to_dict() if hasattr(value, 'to_dict') else value
         if data.get('from_user'):
             data['from'] = data.pop('from_user', None)
         return data

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -563,9 +563,9 @@ class Bot(TelegramObject):
         """
         data: JSONDict = {'chat_id': chat_id, 'message_id': message_id}
 
-        result = self._post('deleteMessage', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'deleteMessage', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     @log
     def forward_message(
@@ -1567,7 +1567,7 @@ class Bot(TelegramObject):
             :class:`telegram.error.TelegramError`
 
         """
-        if not ((latitude is not None and longitude is not None) or location):
+        if (latitude is None or longitude is None) and not location:
             raise ValueError(
                 "Either location or latitude and longitude must be passed as argument."
             )
@@ -2028,9 +2028,9 @@ class Bot(TelegramObject):
         """
         data: JSONDict = {'chat_id': chat_id, 'action': action}
 
-        result = self._post('sendChatAction', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'sendChatAction', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     def _effective_inline_results(  # pylint: disable=R0201
         self,
@@ -2053,11 +2053,7 @@ class Bot(TelegramObject):
 
         if current_offset is not None:
             # Convert the string input to integer
-            if current_offset == '':
-                current_offset_int = 0
-            else:
-                current_offset_int = int(current_offset)
-
+            current_offset_int = 0 if current_offset == '' else int(current_offset)
             # for now set to empty string, stating that there are no more results
             # might change later
             next_offset = ''
@@ -2071,18 +2067,17 @@ class Bot(TelegramObject):
                     # the callback *might* return more results on the next call, so we increment
                     # the page count
                     next_offset = str(current_offset_int + 1)
+            elif len(results) > (current_offset_int + 1) * MAX_INLINE_QUERY_RESULTS:
+                # we expect more results for the next page
+                next_offset_int = current_offset_int + 1
+                next_offset = str(next_offset_int)
+                effective_results = results[
+                    current_offset_int
+                    * MAX_INLINE_QUERY_RESULTS : next_offset_int
+                    * MAX_INLINE_QUERY_RESULTS
+                ]
             else:
-                if len(results) > (current_offset_int + 1) * MAX_INLINE_QUERY_RESULTS:
-                    # we expect more results for the next page
-                    next_offset_int = current_offset_int + 1
-                    next_offset = str(next_offset_int)
-                    effective_results = results[
-                        current_offset_int
-                        * MAX_INLINE_QUERY_RESULTS : next_offset_int
-                        * MAX_INLINE_QUERY_RESULTS
-                    ]
-                else:
-                    effective_results = results[current_offset_int * MAX_INLINE_QUERY_RESULTS :]
+                effective_results = results[current_offset_int * MAX_INLINE_QUERY_RESULTS :]
         else:
             effective_results = results  # type: ignore[assignment]
 
@@ -2164,12 +2159,8 @@ class Bot(TelegramObject):
 
         @no_type_check
         def _set_defaults(res):
-            # pylint: disable=W0212
             if hasattr(res, 'parse_mode') and res.parse_mode == DEFAULT_NONE:
-                if self.defaults:
-                    res.parse_mode = self.defaults.parse_mode
-                else:
-                    res.parse_mode = None
+                res.parse_mode = self.defaults.parse_mode if self.defaults else None
             if hasattr(res, 'input_message_content') and res.input_message_content:
                 if (
                     hasattr(res.input_message_content, 'parse_mode')
@@ -2412,9 +2403,9 @@ class Bot(TelegramObject):
         if revoke_messages is not None:
             data['revoke_messages'] = revoke_messages
 
-        result = self._post('banChatMember', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'banChatMember', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     @log
     def ban_chat_sender_chat(
@@ -2451,9 +2442,9 @@ class Bot(TelegramObject):
         """
         data: JSONDict = {'chat_id': chat_id, 'sender_chat_id': sender_chat_id}
 
-        result = self._post('banChatSenderChat', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'banChatSenderChat', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     @log
     def unban_chat_member(
@@ -2495,9 +2486,9 @@ class Bot(TelegramObject):
         if only_if_banned is not None:
             data['only_if_banned'] = only_if_banned
 
-        result = self._post('unbanChatMember', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'unbanChatMember', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     @log
     def unban_chat_sender_chat(
@@ -2532,9 +2523,9 @@ class Bot(TelegramObject):
         """
         data: JSONDict = {'chat_id': chat_id, 'sender_chat_id': sender_chat_id}
 
-        result = self._post('unbanChatSenderChat', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'unbanChatSenderChat', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     @log
     def answer_callback_query(
@@ -2595,9 +2586,9 @@ class Bot(TelegramObject):
         if cache_time is not None:
             data['cache_time'] = cache_time
 
-        result = self._post('answerCallbackQuery', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'answerCallbackQuery', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     @log
     def edit_message_text(
@@ -3046,9 +3037,7 @@ class Bot(TelegramObject):
         if drop_pending_updates:
             data['drop_pending_updates'] = drop_pending_updates
 
-        result = self._post('setWebhook', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post('setWebhook', data, timeout=timeout, api_kwargs=api_kwargs)
 
     @log
     def delete_webhook(
@@ -3082,9 +3071,9 @@ class Bot(TelegramObject):
         if drop_pending_updates:
             data['drop_pending_updates'] = drop_pending_updates
 
-        result = self._post('deleteWebhook', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'deleteWebhook', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     @log
     def leave_chat(
@@ -3113,9 +3102,7 @@ class Bot(TelegramObject):
         """
         data: JSONDict = {'chat_id': chat_id}
 
-        result = self._post('leaveChat', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post('leaveChat', data, timeout=timeout, api_kwargs=api_kwargs)
 
     @log
     def get_chat(
@@ -3234,9 +3221,9 @@ class Bot(TelegramObject):
         """
         data: JSONDict = {'chat_id': chat_id}
 
-        result = self._post('getChatMemberCount', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'getChatMemberCount', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     @log
     def get_chat_member(
@@ -3300,9 +3287,9 @@ class Bot(TelegramObject):
         """
         data: JSONDict = {'chat_id': chat_id, 'sticker_set_name': sticker_set_name}
 
-        result = self._post('setChatStickerSet', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'setChatStickerSet', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     @log
     def delete_chat_sticker_set(
@@ -3330,9 +3317,9 @@ class Bot(TelegramObject):
         """
         data: JSONDict = {'chat_id': chat_id}
 
-        result = self._post('deleteChatStickerSet', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'deleteChatStickerSet', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     def get_webhook_info(
         self, timeout: ODVInput[float] = DEFAULT_NONE, api_kwargs: JSONDict = None
@@ -3718,9 +3705,9 @@ class Bot(TelegramObject):
         if error_message is not None:
             data['error_message'] = error_message
 
-        result = self._post('answerShippingQuery', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'answerShippingQuery', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     @log
     def answer_pre_checkout_query(  # pylint: disable=C0103
@@ -3777,9 +3764,9 @@ class Bot(TelegramObject):
         if error_message is not None:
             data['error_message'] = error_message
 
-        result = self._post('answerPreCheckoutQuery', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'answerPreCheckoutQuery', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     @log
     def restrict_chat_member(
@@ -3838,9 +3825,9 @@ class Bot(TelegramObject):
                 )
             data['until_date'] = until_date
 
-        result = self._post('restrictChatMember', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'restrictChatMember', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     @log
     def promote_chat_member(
@@ -3940,9 +3927,9 @@ class Bot(TelegramObject):
         if can_manage_voice_chats is not None:
             data['can_manage_voice_chats'] = can_manage_voice_chats
 
-        result = self._post('promoteChatMember', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'promoteChatMember', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     @log
     def set_chat_permissions(
@@ -3976,9 +3963,9 @@ class Bot(TelegramObject):
         """
         data: JSONDict = {'chat_id': chat_id, 'permissions': permissions.to_dict()}
 
-        result = self._post('setChatPermissions', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'setChatPermissions', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     @log
     def set_chat_administrator_custom_title(
@@ -4014,11 +4001,12 @@ class Bot(TelegramObject):
         """
         data: JSONDict = {'chat_id': chat_id, 'user_id': user_id, 'custom_title': custom_title}
 
-        result = self._post(
-            'setChatAdministratorCustomTitle', data, timeout=timeout, api_kwargs=api_kwargs
+        return self._post(
+            'setChatAdministratorCustomTitle',
+            data,
+            timeout=timeout,
+            api_kwargs=api_kwargs,
         )
-
-        return result  # type: ignore[return-value]
 
     @log
     def export_chat_invite_link(
@@ -4057,9 +4045,9 @@ class Bot(TelegramObject):
         """
         data: JSONDict = {'chat_id': chat_id}
 
-        result = self._post('exportChatInviteLink', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'exportChatInviteLink', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     @log
     def create_chat_invite_link(
@@ -4291,9 +4279,9 @@ class Bot(TelegramObject):
         """
         data: JSONDict = {'chat_id': chat_id, 'user_id': user_id}
 
-        result = self._post('approveChatJoinRequest', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'approveChatJoinRequest', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     @log
     def decline_chat_join_request(
@@ -4328,9 +4316,9 @@ class Bot(TelegramObject):
         """
         data: JSONDict = {'chat_id': chat_id, 'user_id': user_id}
 
-        result = self._post('declineChatJoinRequest', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'declineChatJoinRequest', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     @log
     def set_chat_photo(
@@ -4367,9 +4355,7 @@ class Bot(TelegramObject):
         """
         data: JSONDict = {'chat_id': chat_id, 'photo': parse_file_input(photo)}
 
-        result = self._post('setChatPhoto', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post('setChatPhoto', data, timeout=timeout, api_kwargs=api_kwargs)
 
     @log
     def delete_chat_photo(
@@ -4401,9 +4387,9 @@ class Bot(TelegramObject):
         """
         data: JSONDict = {'chat_id': chat_id}
 
-        result = self._post('deleteChatPhoto', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'deleteChatPhoto', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     @log
     def set_chat_title(
@@ -4437,9 +4423,7 @@ class Bot(TelegramObject):
         """
         data: JSONDict = {'chat_id': chat_id, 'title': title}
 
-        result = self._post('setChatTitle', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post('setChatTitle', data, timeout=timeout, api_kwargs=api_kwargs)
 
     @log
     def set_chat_description(
@@ -4473,9 +4457,9 @@ class Bot(TelegramObject):
         """
         data: JSONDict = {'chat_id': chat_id, 'description': description}
 
-        result = self._post('setChatDescription', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'setChatDescription', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     @log
     def pin_chat_message(
@@ -4758,9 +4742,9 @@ class Bot(TelegramObject):
             # message here, which isn't json dumped by utils.request
             data['mask_position'] = mask_position.to_json()
 
-        result = self._post('createNewStickerSet', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'createNewStickerSet', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     @log
     def add_sticker_to_set(
@@ -4838,9 +4822,9 @@ class Bot(TelegramObject):
             # message here, which isn't json dumped by utils.request
             data['mask_position'] = mask_position.to_json()
 
-        result = self._post('addStickerToSet', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'addStickerToSet', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     @log
     def set_sticker_position_in_set(
@@ -4870,11 +4854,9 @@ class Bot(TelegramObject):
         """
         data: JSONDict = {'sticker': sticker, 'position': position}
 
-        result = self._post(
+        return self._post(
             'setStickerPositionInSet', data, timeout=timeout, api_kwargs=api_kwargs
         )
-
-        return result  # type: ignore[return-value]
 
     @log
     def delete_sticker_from_set(
@@ -4902,9 +4884,9 @@ class Bot(TelegramObject):
         """
         data: JSONDict = {'sticker': sticker}
 
-        result = self._post('deleteStickerFromSet', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'deleteStickerFromSet', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     @log
     def set_sticker_set_thumb(
@@ -4954,9 +4936,9 @@ class Bot(TelegramObject):
         if thumb is not None:
             data['thumb'] = parse_file_input(thumb)
 
-        result = self._post('setStickerSetThumb', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'setStickerSetThumb', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     @log
     def set_passport_data_errors(
@@ -4995,9 +4977,9 @@ class Bot(TelegramObject):
         """
         data: JSONDict = {'user_id': user_id, 'errors': [error.to_dict() for error in errors]}
 
-        result = self._post('setPassportDataErrors', data, timeout=timeout, api_kwargs=api_kwargs)
-
-        return result  # type: ignore[return-value]
+        return self._post(
+            'setPassportDataErrors', data, timeout=timeout, api_kwargs=api_kwargs
+        )
 
     @log
     def send_poll(

--- a/telegram/error.py
+++ b/telegram/error.py
@@ -31,11 +31,7 @@ def _lstrip_str(in_s: str, lstr: str) -> str:
         :obj:`str`: The stripped string.
 
     """
-    if in_s.startswith(lstr):
-        res = in_s[len(lstr) :]
-    else:
-        res = in_s
-    return res
+    return in_s[len(lstr) :] if in_s.startswith(lstr) else in_s
 
 
 class TelegramError(Exception):

--- a/telegram/ext/__init__.py
+++ b/telegram/ext/__init__.py
@@ -19,6 +19,7 @@
 # pylint: disable=C0413
 """Extensions over the Telegram Bot API to facilitate bot making"""
 
+
 from .extbot import ExtBot
 from .basepersistence import BasePersistence
 from .picklepersistence import PicklePersistence
@@ -34,9 +35,7 @@ from .dispatcher import Dispatcher, DispatcherHandlerStop, run_async
 try:
     del Dispatcher.__slots__
 except AttributeError as exc:
-    if str(exc) == '__slots__':
-        pass
-    else:
+    if str(exc) != '__slots__':
         raise exc
 
 from .jobqueue import JobQueue, Job

--- a/telegram/ext/callbackqueryhandler.py
+++ b/telegram/ext/callbackqueryhandler.py
@@ -188,18 +188,17 @@ class CallbackQueryHandler(Handler[Update, CCT]):
         """
         if isinstance(update, Update) and update.callback_query:
             callback_data = update.callback_query.data
-            if self.pattern:
-                if callback_data is None:
-                    return False
-                if isinstance(self.pattern, type):
-                    return isinstance(callback_data, self.pattern)
-                if callable(self.pattern):
-                    return self.pattern(callback_data)
-                match = re.match(self.pattern, callback_data)
-                if match:
-                    return match
-            else:
+            if not self.pattern:
                 return True
+            if callback_data is None:
+                return False
+            if isinstance(self.pattern, type):
+                return isinstance(callback_data, self.pattern)
+            if callable(self.pattern):
+                return self.pattern(callback_data)
+            match = re.match(self.pattern, callback_data)
+            if match:
+                return match
         return None
 
     def collect_optional_args(

--- a/telegram/ext/commandhandler.py
+++ b/telegram/ext/commandhandler.py
@@ -403,10 +403,7 @@ class PrefixHandler(CommandHandler):
 
     @prefix.setter
     def prefix(self, prefix: Union[str, List[str]]) -> None:
-        if isinstance(prefix, str):
-            self._prefix = [prefix.lower()]
-        else:
-            self._prefix = prefix
+        self._prefix = [prefix.lower()] if isinstance(prefix, str) else prefix
         self._build_commands()
 
     @property  # type: ignore[override]
@@ -421,10 +418,7 @@ class PrefixHandler(CommandHandler):
 
     @command.setter
     def command(self, command: Union[str, List[str]]) -> None:
-        if isinstance(command, str):
-            self._command = [command.lower()]
-        else:
-            self._command = command
+        self._command = [command.lower()] if isinstance(command, str) else command
         self._build_commands()
 
     def _build_commands(self) -> None:

--- a/telegram/ext/dispatcher.py
+++ b/telegram/ext/dispatcher.py
@@ -502,7 +502,7 @@ class Dispatcher(Generic[CCT, UD, CD, BD]):
         total = len(threads)
 
         # Stop all threads in the thread pool by put()ting one non-tuple per thread
-        for i in range(total):
+        for _ in range(total):
             self.__async_queue.put(None)
 
         for i, thr in enumerate(threads):
@@ -663,79 +663,73 @@ class Dispatcher(Generic[CCT, UD, CD, BD]):
             self.__update_persistence(update)
 
     def __update_persistence(self, update: object = None) -> None:
-        if self.persistence:
-            # We use list() here in order to decouple chat_ids from self.chat_data, as dict view
-            # objects will change, when the dict does and we want to loop over chat_ids
-            chat_ids = list(self.chat_data.keys())
-            user_ids = list(self.user_data.keys())
+        if not self.persistence:
+            return
+        # We use list() here in order to decouple chat_ids from self.chat_data, as dict view
+        # objects will change, when the dict does and we want to loop over chat_ids
+        chat_ids = list(self.chat_data.keys())
+        user_ids = list(self.user_data.keys())
 
-            if isinstance(update, Update):
-                if update.effective_chat:
-                    chat_ids = [update.effective_chat.id]
-                else:
-                    chat_ids = []
-                if update.effective_user:
-                    user_ids = [update.effective_user.id]
-                else:
-                    user_ids = []
-
-            if self.persistence.store_callback_data:
-                self.bot = cast(telegram.ext.extbot.ExtBot, self.bot)
+        if isinstance(update, Update):
+            chat_ids = [update.effective_chat.id] if update.effective_chat else []
+            user_ids = [update.effective_user.id] if update.effective_user else []
+        if self.persistence.store_callback_data:
+            self.bot = cast(telegram.ext.extbot.ExtBot, self.bot)
+            try:
+                self.persistence.update_callback_data(
+                    self.bot.callback_data_cache.persistence_data
+                )
+            except Exception as exc:
                 try:
-                    self.persistence.update_callback_data(
-                        self.bot.callback_data_cache.persistence_data
+                    self.dispatch_error(update, exc)
+                except Exception:
+                    message = (
+                        'Saving callback data raised an error and an '
+                        'uncaught error was raised while handling '
+                        'the error with an error_handler'
                     )
-                except Exception as exc:
-                    try:
-                        self.dispatch_error(update, exc)
-                    except Exception:
-                        message = (
-                            'Saving callback data raised an error and an '
-                            'uncaught error was raised while handling '
-                            'the error with an error_handler'
-                        )
-                        self.logger.exception(message)
-            if self.persistence.store_bot_data:
+                    self.logger.exception(message)
+        if self.persistence.store_bot_data:
+            try:
+                self.persistence.update_bot_data(self.bot_data)
+            except Exception as exc:
                 try:
-                    self.persistence.update_bot_data(self.bot_data)
+                    self.dispatch_error(update, exc)
+                except Exception:
+                    message = (
+                        'Saving bot data raised an error and an '
+                        'uncaught error was raised while handling '
+                        'the error with an error_handler'
+                    )
+                    self.logger.exception(message)
+        if self.persistence.store_chat_data:
+            for chat_id in chat_ids:
+                try:
+                    self.persistence.update_chat_data(chat_id, self.chat_data[chat_id])
                 except Exception as exc:
                     try:
                         self.dispatch_error(update, exc)
                     except Exception:
                         message = (
-                            'Saving bot data raised an error and an '
+                            'Saving chat data raised an error and an '
                             'uncaught error was raised while handling '
                             'the error with an error_handler'
                         )
                         self.logger.exception(message)
-            if self.persistence.store_chat_data:
-                for chat_id in chat_ids:
+        if self.persistence.store_user_data:
+            for user_id in user_ids:
+                try:
+                    self.persistence.update_user_data(user_id, self.user_data[user_id])
+                except Exception as exc:
                     try:
-                        self.persistence.update_chat_data(chat_id, self.chat_data[chat_id])
-                    except Exception as exc:
-                        try:
-                            self.dispatch_error(update, exc)
-                        except Exception:
-                            message = (
-                                'Saving chat data raised an error and an '
-                                'uncaught error was raised while handling '
-                                'the error with an error_handler'
-                            )
-                            self.logger.exception(message)
-            if self.persistence.store_user_data:
-                for user_id in user_ids:
-                    try:
-                        self.persistence.update_user_data(user_id, self.user_data[user_id])
-                    except Exception as exc:
-                        try:
-                            self.dispatch_error(update, exc)
-                        except Exception:
-                            message = (
-                                'Saving user data raised an error and an '
-                                'uncaught error was raised while handling '
-                                'the error with an error_handler'
-                            )
-                            self.logger.exception(message)
+                        self.dispatch_error(update, exc)
+                    except Exception:
+                        message = (
+                            'Saving user data raised an error and an '
+                            'uncaught error was raised while handling '
+                            'the error with an error_handler'
+                        )
+                        self.logger.exception(message)
 
     def add_error_handler(
         self,
@@ -808,11 +802,10 @@ class Dispatcher(Generic[CCT, UD, CD, BD]):
                         self.run_async(callback, update, context, update=update)
                     else:
                         callback(update, context)
+                elif run_async:
+                    self.run_async(callback, self.bot, update, error, update=update)
                 else:
-                    if run_async:
-                        self.run_async(callback, self.bot, update, error, update=update)
-                    else:
-                        callback(self.bot, update, error)
+                    callback(self.bot, update, error)
 
         else:
             self.logger.exception(

--- a/telegram/ext/inlinequeryhandler.py
+++ b/telegram/ext/inlinequeryhandler.py
@@ -178,13 +178,12 @@ class InlineQueryHandler(Handler[Update, CCT]):
                 update.inline_query.chat_type not in self.chat_types
             ):
                 return False
-            if self.pattern:
-                if update.inline_query.query:
-                    match = re.match(self.pattern, update.inline_query.query)
-                    if match:
-                        return match
-            else:
+            if not self.pattern:
                 return True
+            if update.inline_query.query:
+                match = re.match(self.pattern, update.inline_query.query)
+                if match:
+                    return match
         return None
 
     def collect_optional_args(

--- a/telegram/ext/messagehandler.py
+++ b/telegram/ext/messagehandler.py
@@ -145,7 +145,7 @@ class MessageHandler(Handler[Update, CCT]):
             pass_chat_data=pass_chat_data,
             run_async=run_async,
         )
-        if message_updates is False and channel_post_updates is False and edited_updates is False:
+        if not message_updates and not channel_post_updates and not edited_updates:
             raise ValueError(
                 'message_updates, channel_post_updates and edited_updates are all False'
             )
@@ -159,7 +159,7 @@ class MessageHandler(Handler[Update, CCT]):
                 TelegramDeprecationWarning,
                 stacklevel=2,
             )
-            if message_updates is False:
+            if not message_updates:
                 self.filters &= ~Filters.update.message
 
         if channel_post_updates is not None:
@@ -168,7 +168,7 @@ class MessageHandler(Handler[Update, CCT]):
                 TelegramDeprecationWarning,
                 stacklevel=2,
             )
-            if channel_post_updates is False:
+            if not channel_post_updates:
                 self.filters &= ~Filters.update.channel_post
 
         if edited_updates is not None:
@@ -177,7 +177,7 @@ class MessageHandler(Handler[Update, CCT]):
                 TelegramDeprecationWarning,
                 stacklevel=2,
             )
-            if edited_updates is False:
+            if not edited_updates:
                 self.filters &= ~(
                     Filters.update.edited_message | Filters.update.edited_channel_post
                 )

--- a/telegram/files/file.py
+++ b/telegram/files/file.py
@@ -134,12 +134,7 @@ class File(TelegramObject):
 
         local_file = is_local_file(self.file_path)
 
-        if local_file:
-            url = self.file_path
-        else:
-            # Convert any UTF-8 char into a url encoded ASCII string.
-            url = self._get_encoded_url()
-
+        url = self.file_path if local_file else self._get_encoded_url()
         if out:
             if local_file:
                 with open(url, 'rb') as file:

--- a/telegram/files/inputfile.py
+++ b/telegram/files/inputfile.py
@@ -56,10 +56,7 @@ class InputFile:
 
     def __init__(self, obj: Union[IO, bytes], filename: str = None, attach: bool = None):
         self.filename = None
-        if isinstance(obj, bytes):
-            self.input_file_content = obj
-        else:
-            self.input_file_content = obj.read()
+        self.input_file_content = obj if isinstance(obj, bytes) else obj.read()
         self.attach = 'attached' + uuid4().hex if attach else None
 
         if filename:

--- a/telegram/games/game.py
+++ b/telegram/games/game.py
@@ -183,4 +183,4 @@ class Game(TelegramObject):
         }
 
     def __hash__(self) -> int:
-        return hash((self.title, self.description, tuple(p for p in self.photo)))
+        return hash((self.title, self.description, tuple(self.photo)))

--- a/telegram/inline/inlinekeyboardmarkup.py
+++ b/telegram/inline/inlinekeyboardmarkup.py
@@ -135,4 +135,4 @@ class InlineKeyboardMarkup(ReplyMarkup):
         return cls(button_grid, **kwargs)
 
     def __hash__(self) -> int:
-        return hash(tuple(tuple(button for button in row) for row in self.inline_keyboard))
+        return hash(tuple(tuple(row) for row in self.inline_keyboard))

--- a/telegram/replykeyboardmarkup.py
+++ b/telegram/replykeyboardmarkup.py
@@ -283,7 +283,7 @@ class ReplyKeyboardMarkup(ReplyMarkup):
     def __hash__(self) -> int:
         return hash(
             (
-                tuple(tuple(button for button in row) for row in self.keyboard),
+                tuple(tuple(row) for row in self.keyboard),
                 self.resize_keyboard,
                 self.one_time_keyboard,
                 self.selective,

--- a/telegram/userprofilephotos.py
+++ b/telegram/userprofilephotos.py
@@ -76,4 +76,4 @@ class UserProfilePhotos(TelegramObject):
         return data
 
     def __hash__(self) -> int:
-        return hash(tuple(tuple(p for p in photo) for photo in self.photos))
+        return hash(tuple(tuple(photo) for photo in self.photos))

--- a/telegram/utils/helpers.py
+++ b/telegram/utils/helpers.py
@@ -131,11 +131,12 @@ def parse_file_input(
     if isinstance(file_input, str) and file_input.startswith('file://'):
         return file_input
     if isinstance(file_input, (str, Path)):
-        if is_local_file(file_input):
-            out = Path(file_input).absolute().as_uri()
-        else:
-            out = file_input  # type: ignore[assignment]
-        return out
+        return (
+            Path(file_input).absolute().as_uri()
+            if is_local_file(file_input)
+            else file_input
+        )
+
     if isinstance(file_input, bytes):
         return InputFile(file_input, attach=attach, filename=filename)
     if InputFile.is_file(file_input):
@@ -162,7 +163,7 @@ def escape_markdown(text: str, version: int = 1, entity_type: str = None) -> str
     if int(version) == 1:
         escape_chars = r'_*`['
     elif int(version) == 2:
-        if entity_type in ['pre', 'code']:
+        if entity_type in {'pre', 'code'}:
             escape_chars = r'\`'
         elif entity_type == 'text_link':
             escape_chars = r'\)'
@@ -423,11 +424,7 @@ def create_deep_linked_url(bot_username: str, payload: str = None, group: bool =
             "URLs: A-Z, a-z, 0-9, _ and -"
         )
 
-    if group:
-        key = 'startgroup'
-    else:
-        key = 'start'
-
+    key = 'startgroup' if group else 'start'
     return f'{base_url}?{key}={payload}'
 
 

--- a/telegram/utils/request.py
+++ b/telegram/utils/request.py
@@ -168,13 +168,7 @@ class Request:
             'SOCKSProxyManager',  # noqa: F821
             urllib3.ProxyManager,
         ] = None  # type: ignore
-        if not proxy_url:
-            if appengine.is_appengine_sandbox():
-                # Use URLFetch service if running in App Engine
-                self._con_pool = appengine.AppEngineManager()
-            else:
-                self._con_pool = urllib3.PoolManager(**kwargs)
-        else:
+        if proxy_url:
             kwargs.update(urllib3_proxy_kwargs)
             if proxy_url.startswith('socks'):
                 try:
@@ -191,6 +185,12 @@ class Request:
                     mgr.proxy_headers.update(auth_hdrs)
 
                 self._con_pool = mgr
+
+        elif appengine.is_appengine_sandbox():
+            # Use URLFetch service if running in App Engine
+            self._con_pool = appengine.AppEngineManager()
+        else:
+            self._con_pool = urllib3.PoolManager(**kwargs)
 
     def __setattr__(self, key: str, value: object) -> None:
         set_new_attribute_deprecated(self, key, value)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -209,16 +209,14 @@ def updater(bot):
 
 @pytest.fixture(scope='function')
 def thumb_file():
-    f = open('tests/data/thumb.jpg', 'rb')
-    yield f
-    f.close()
+    with open('tests/data/thumb.jpg', 'rb') as f:
+        yield f
 
 
 @pytest.fixture(scope='class')
 def class_thumb_file():
-    f = open('tests/data/thumb.jpg', 'rb')
-    yield f
-    f.close()
+    with open('tests/data/thumb.jpg', 'rb') as f:
+        yield f
 
 
 def pytest_configure(config):
@@ -429,24 +427,26 @@ def check_shortcut_signature(
     # all
     for kwarg in effective_shortcut_args:
         if bot_sig.parameters[kwarg].annotation != shortcut_sig.parameters[kwarg].annotation:
-            if isinstance(bot_sig.parameters[kwarg].annotation, type):
-                if bot_sig.parameters[kwarg].annotation.__name__ != str(
-                    shortcut_sig.parameters[kwarg].annotation
-                ):
-                    raise Exception(
-                        f'For argument {kwarg} I expected {bot_sig.parameters[kwarg].annotation}, '
-                        f'but got {shortcut_sig.parameters[kwarg].annotation}'
-                    )
-            else:
+            if not isinstance(bot_sig.parameters[kwarg].annotation, type):
                 raise Exception(
                     f'For argument {kwarg} I expected {bot_sig.parameters[kwarg].annotation}, but '
                     f'got {shortcut_sig.parameters[kwarg].annotation}'
                 )
 
+            if bot_sig.parameters[kwarg].annotation.__name__ != str(
+                shortcut_sig.parameters[kwarg].annotation
+            ):
+                raise Exception(
+                    f'For argument {kwarg} I expected {bot_sig.parameters[kwarg].annotation}, '
+                    f'but got {shortcut_sig.parameters[kwarg].annotation}'
+                )
     bot_method_sig = inspect.signature(bot_method)
     shortcut_sig = inspect.signature(shortcut)
     for arg in expected_args:
-        if not shortcut_sig.parameters[arg].default == bot_method_sig.parameters[arg].default:
+        if (
+            shortcut_sig.parameters[arg].default
+            != bot_method_sig.parameters[arg].default
+        ):
             raise Exception(
                 f'Default for argument {arg} does not match the default of the Bot method.'
             )
@@ -500,7 +500,7 @@ def check_shortcut_call(
         received_kwargs = {
             name for name, value in kw.items() if name in ignored_args or value == name
         }
-        if not received_kwargs == expected_args:
+        if received_kwargs != expected_args:
             raise Exception(
                 f'{orig_bot_method.__name__} did not receive correct value for the parameters '
                 f'{expected_args - received_kwargs}'

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -30,9 +30,8 @@ from tests.conftest import check_shortcut_call, check_shortcut_signature, check_
 
 @pytest.fixture(scope='function')
 def animation_file():
-    f = open('tests/data/game.gif', 'rb')
-    yield f
-    f.close()
+    with open('tests/data/game.gif', 'rb') as f:
+        yield f
 
 
 @pytest.fixture(scope='class')

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -29,9 +29,8 @@ from tests.conftest import check_shortcut_call, check_shortcut_signature, check_
 
 @pytest.fixture(scope='function')
 def audio_file():
-    f = open('tests/data/telegram.mp3', 'rb')
-    yield f
-    f.close()
+    with open('tests/data/telegram.mp3', 'rb') as f:
+        yield f
 
 
 @pytest.fixture(scope='class')

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1723,7 +1723,7 @@ class TestBot:
         with pytest.raises(ValueError, match="`member_limit` can't be specified"):
             bot.create_chat_invite_link(**data)
 
-        data.update({'invite_link': 'https://invite.link'})
+        data['invite_link'] = 'https://invite.link'
         with pytest.raises(ValueError, match="`member_limit` can't be specified"):
             bot.edit_chat_invite_link(**data)
 

--- a/tests/test_callbackdatacache.py
+++ b/tests/test_callbackdatacache.py
@@ -384,4 +384,4 @@ class TestCallbackDataCache:
         callback_data = [
             list(data[2].values())[0] for data in callback_data_cache.persistence_data[0]
         ]
-        assert callback_data == list(str(i) for i in range(50, 100))
+        assert callback_data == [str(i) for i in range(50, 100)]

--- a/tests/test_callbackquery.py
+++ b/tests/test_callbackquery.py
@@ -264,8 +264,7 @@ class TestCallbackQuery:
 
     def test_stop_message_live_location(self, monkeypatch, callback_query):
         def make_assertion(*_, **kwargs):
-            ids = self.check_passed_ids(callback_query, kwargs)
-            return ids
+            return self.check_passed_ids(callback_query, kwargs)
 
         assert check_shortcut_signature(
             CallbackQuery.stop_message_live_location,

--- a/tests/test_chatphoto.py
+++ b/tests/test_chatphoto.py
@@ -31,9 +31,8 @@ from tests.conftest import (
 
 @pytest.fixture(scope='function')
 def chatphoto_file():
-    f = open('tests/data/telegram.jpg', 'rb')
-    yield f
-    f.close()
+    with open('tests/data/telegram.jpg', 'rb') as f:
+        yield f
 
 
 @pytest.fixture(scope='function')

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -135,12 +135,13 @@ class TestDispatcher:
                 context.my_flag = True
 
         def two(update, context):
-            if update.message.text == 'test':
-                if not hasattr(context, 'my_flag'):
-                    pytest.fail()
-            else:
-                if hasattr(context, 'my_flag'):
-                    pytest.fail()
+            if (
+                update.message.text == 'test'
+                and not hasattr(context, 'my_flag')
+                or update.message.text != 'test'
+                and hasattr(context, 'my_flag')
+            ):
+                pytest.fail()
 
         cdp.add_handler(MessageHandler(Filters.regex('test'), one), group=1)
         cdp.add_handler(MessageHandler(None, two), group=2)

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -30,9 +30,8 @@ from tests.conftest import check_shortcut_signature, check_shortcut_call, check_
 
 @pytest.fixture(scope='function')
 def document_file():
-    f = open('tests/data/telegram.png', 'rb')
-    yield f
-    f.close()
+    with open('tests/data/telegram.png', 'rb') as f:
+        yield f
 
 
 @pytest.fixture(scope='class')

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -168,7 +168,9 @@ class TestHelpers:
         # test for a time of day that is still to come, and one in the past
         time_future, time_past = dtm.time(hour + hour_delta), dtm.time(hour - hour_delta)
         assert helpers.to_float_timestamp(time_future, ref_t) == ref_t + 60 * 60 * hour_delta
-        assert helpers.to_float_timestamp(time_past, ref_t) == ref_t + 60 * 60 * (24 - hour_delta)
+        assert helpers.to_float_timestamp(time_past, ref_t) == ref_t + 60 ** 2 * (
+            24 - hour_delta
+        )
 
     def test_to_float_timestamp_time_of_day_timezone(self, timezone):
         """Conversion from timezone-aware time-of-day specification to timestamp"""

--- a/tests/test_inputfile.py
+++ b/tests/test_inputfile.py
@@ -38,11 +38,7 @@ class TestInputFile:
         assert len(recwarn) == 1 and 'custom' in str(recwarn[0].message), recwarn.list
 
     def test_subprocess_pipe(self):
-        if sys.platform == 'win32':
-            cmd = ['type', self.png]
-        else:
-            cmd = ['cat', self.png]
-
+        cmd = ['type', self.png] if sys.platform == 'win32' else ['cat', self.png]
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=(sys.platform == 'win32'))
         in_file = InputFile(proc.stdout)
 

--- a/tests/test_jobqueue.py
+++ b/tests/test_jobqueue.py
@@ -443,7 +443,7 @@ class TestJobQueue:
 
     def test_job_lt_eq(self, job_queue):
         job = job_queue.run_repeating(self.job_run_once, 0.02)
-        assert not job == job_queue
+        assert job != job_queue
         assert not job < job
 
     def test_dispatch_error(self, job_queue, dp):

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -134,8 +134,7 @@ class TestLocation:
     # TODO: Needs improvement with in inline sent live location.
     def test_stop_live_inline_message(self, monkeypatch, bot):
         def test(url, data, **kwargs):
-            id_ = data['inline_message_id'] == 1234
-            return id_
+            return data['inline_message_id'] == 1234
 
         monkeypatch.setattr(bot.request, 'post', test)
         assert bot.stop_message_live_location(inline_message_id=1234)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -630,7 +630,7 @@ class TestMessage:
         message.chat.id = _id
         message.chat.type = _type
         # The leading - for group ids/ -100 for supergroup ids isn't supposed to be in the link
-        assert message.link == f'https://t.me/c/{3}/{message.message_id}'
+        assert message.link == f'https://t.me/c/3/{message.message_id}'
 
     @pytest.mark.parametrize('_id, username', argvalues=[(None, 'username'), (-3, None)])
     def test_link_private_chats(self, message, _id, username):

--- a/tests/test_messageentity.py
+++ b/tests/test_messageentity.py
@@ -24,15 +24,11 @@ from telegram import MessageEntity, User
 @pytest.fixture(scope="class", params=MessageEntity.ALL_TYPES)
 def message_entity(request):
     type_ = request.param
-    url = None
-    if type_ == MessageEntity.TEXT_LINK:
-        url = 't.me'
+    url = 't.me' if type_ == MessageEntity.TEXT_LINK else None
     user = None
     if type_ == MessageEntity.TEXT_MENTION:
         user = User(1, 'test_user', False)
-    language = None
-    if type == MessageEntity.PRE:
-        language = "python"
+    language = "python" if type == MessageEntity.PRE else None
     return MessageEntity(type, 1, 3, url=url, user=user, language=language)
 
 

--- a/tests/test_official.py
+++ b/tests/test_official.py
@@ -52,10 +52,10 @@ def parse_table(h4):
     table = find_next_sibling_until(h4, 'table', h4.find_next_sibling('h4'))
     if not table:
         return []
-    t = []
-    for tr in table.find_all('tr')[1:]:
-        t.append([td.text for td in tr.find_all('td')])
-    return t
+    return [
+        [td.text for td in tr.find_all('td')]
+        for tr in table.find_all('tr')[1:]
+    ]
 
 
 def check_method(h4):

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -355,23 +355,23 @@ class TestBasePersistence:
         dp = updater.dispatcher
 
         def callback_known_user(update, context):
-            if not context.user_data['test1'] == 'test2':
+            if context.user_data['test1'] != 'test2':
                 pytest.fail('user_data corrupt')
-            if not context.bot_data == bot_data:
+            if context.bot_data != bot_data:
                 pytest.fail('bot_data corrupt')
 
         def callback_known_chat(update, context):
-            if not context.chat_data['test3'] == 'test4':
+            if context.chat_data['test3'] != 'test4':
                 pytest.fail('chat_data corrupt')
-            if not context.bot_data == bot_data:
+            if context.bot_data != bot_data:
                 pytest.fail('bot_data corrupt')
 
         def callback_unknown_user_or_chat(update, context):
-            if not context.user_data == {}:
+            if context.user_data != {}:
                 pytest.fail('user_data corrupt')
-            if not context.chat_data == {}:
+            if context.chat_data != {}:
                 pytest.fail('chat_data corrupt')
-            if not context.bot_data == bot_data:
+            if context.bot_data != bot_data:
                 pytest.fail('bot_data corrupt')
             context.user_data[1] = 'test7'
             context.chat_data[2] = 'test8'
@@ -486,29 +486,25 @@ class TestBasePersistence:
             if store_user_data:
                 if context.user_data.get('refreshed') != update.effective_user.id:
                     self.test_flag = 'user_data was not refreshed'
-            else:
-                if 'refreshed' in context.user_data:
-                    self.test_flag = 'user_data was wrongly refreshed'
+            elif 'refreshed' in context.user_data:
+                self.test_flag = 'user_data was wrongly refreshed'
             if store_chat_data:
                 if context.chat_data.get('refreshed') != update.effective_chat.id:
                     self.test_flag = 'chat_data was not refreshed'
-            else:
-                if 'refreshed' in context.chat_data:
-                    self.test_flag = 'chat_data was wrongly refreshed'
+            elif 'refreshed' in context.chat_data:
+                self.test_flag = 'chat_data was wrongly refreshed'
             if store_bot_data:
                 if context.bot_data.get('refreshed') != 1:
                     self.test_flag = 'bot_data was not refreshed'
-            else:
-                if 'refreshed' in context.bot_data:
-                    self.test_flag = 'bot_data was wrongly refreshed'
+            elif 'refreshed' in context.bot_data:
+                self.test_flag = 'bot_data was wrongly refreshed'
 
         def callback_without_user_and_chat(_, context):
             if store_bot_data:
                 if context.bot_data.get('refreshed') != 1:
                     self.test_flag = 'bot_data was not refreshed'
-            else:
-                if 'refreshed' in context.bot_data:
-                    self.test_flag = 'bot_data was wrongly refreshed'
+            elif 'refreshed' in context.bot_data:
+                self.test_flag = 'bot_data was wrongly refreshed'
 
         with_user_and_chat = MessageHandler(
             Filters.user(user_id=12345),
@@ -1338,10 +1334,10 @@ class TestPicklePersistence:
     def test_updating_multi_file(self, pickle_persistence, good_pickle_files):
         user_data = pickle_persistence.get_user_data()
         user_data[12345]['test3']['test4'] = 'test6'
-        assert not pickle_persistence.user_data == user_data
+        assert pickle_persistence.user_data != user_data
         pickle_persistence.update_user_data(12345, user_data[12345])
         user_data[12345]['test3']['test4'] = 'test7'
-        assert not pickle_persistence.user_data == user_data
+        assert pickle_persistence.user_data != user_data
         pickle_persistence.update_user_data(12345, user_data[12345])
         assert pickle_persistence.user_data == user_data
         with open('pickletest_user_data', 'rb') as f:
@@ -1350,10 +1346,10 @@ class TestPicklePersistence:
 
         chat_data = pickle_persistence.get_chat_data()
         chat_data[-12345]['test3']['test4'] = 'test6'
-        assert not pickle_persistence.chat_data == chat_data
+        assert pickle_persistence.chat_data != chat_data
         pickle_persistence.update_chat_data(-12345, chat_data[-12345])
         chat_data[-12345]['test3']['test4'] = 'test7'
-        assert not pickle_persistence.chat_data == chat_data
+        assert pickle_persistence.chat_data != chat_data
         pickle_persistence.update_chat_data(-12345, chat_data[-12345])
         assert pickle_persistence.chat_data == chat_data
         with open('pickletest_chat_data', 'rb') as f:
@@ -1362,10 +1358,10 @@ class TestPicklePersistence:
 
         bot_data = pickle_persistence.get_bot_data()
         bot_data['test3']['test4'] = 'test6'
-        assert not pickle_persistence.bot_data == bot_data
+        assert pickle_persistence.bot_data != bot_data
         pickle_persistence.update_bot_data(bot_data)
         bot_data['test3']['test4'] = 'test7'
-        assert not pickle_persistence.bot_data == bot_data
+        assert pickle_persistence.bot_data != bot_data
         pickle_persistence.update_bot_data(bot_data)
         assert pickle_persistence.bot_data == bot_data
         with open('pickletest_bot_data', 'rb') as f:
@@ -1374,10 +1370,10 @@ class TestPicklePersistence:
 
         callback_data = pickle_persistence.get_callback_data()
         callback_data[1]['test3'] = 'test4'
-        assert not pickle_persistence.callback_data == callback_data
+        assert pickle_persistence.callback_data != callback_data
         pickle_persistence.update_callback_data(callback_data)
         callback_data[1]['test3'] = 'test5'
-        assert not pickle_persistence.callback_data == callback_data
+        assert pickle_persistence.callback_data != callback_data
         pickle_persistence.update_callback_data(callback_data)
         assert pickle_persistence.callback_data == callback_data
         with open('pickletest_callback_data', 'rb') as f:
@@ -1386,7 +1382,7 @@ class TestPicklePersistence:
 
         conversation1 = pickle_persistence.get_conversations('name1')
         conversation1[(123, 123)] = 5
-        assert not pickle_persistence.conversations['name1'] == conversation1
+        assert pickle_persistence.conversations['name1'] != conversation1
         pickle_persistence.update_conversation('name1', (123, 123), 5)
         assert pickle_persistence.conversations['name1'] == conversation1
         assert pickle_persistence.get_conversations('name1') == conversation1
@@ -1404,10 +1400,10 @@ class TestPicklePersistence:
 
         user_data = pickle_persistence.get_user_data()
         user_data[12345]['test3']['test4'] = 'test6'
-        assert not pickle_persistence.user_data == user_data
+        assert pickle_persistence.user_data != user_data
         pickle_persistence.update_user_data(12345, user_data[12345])
         user_data[12345]['test3']['test4'] = 'test7'
-        assert not pickle_persistence.user_data == user_data
+        assert pickle_persistence.user_data != user_data
         pickle_persistence.update_user_data(12345, user_data[12345])
         assert pickle_persistence.user_data == user_data
         with open('pickletest', 'rb') as f:
@@ -1416,10 +1412,10 @@ class TestPicklePersistence:
 
         chat_data = pickle_persistence.get_chat_data()
         chat_data[-12345]['test3']['test4'] = 'test6'
-        assert not pickle_persistence.chat_data == chat_data
+        assert pickle_persistence.chat_data != chat_data
         pickle_persistence.update_chat_data(-12345, chat_data[-12345])
         chat_data[-12345]['test3']['test4'] = 'test7'
-        assert not pickle_persistence.chat_data == chat_data
+        assert pickle_persistence.chat_data != chat_data
         pickle_persistence.update_chat_data(-12345, chat_data[-12345])
         assert pickle_persistence.chat_data == chat_data
         with open('pickletest', 'rb') as f:
@@ -1428,10 +1424,10 @@ class TestPicklePersistence:
 
         bot_data = pickle_persistence.get_bot_data()
         bot_data['test3']['test4'] = 'test6'
-        assert not pickle_persistence.bot_data == bot_data
+        assert pickle_persistence.bot_data != bot_data
         pickle_persistence.update_bot_data(bot_data)
         bot_data['test3']['test4'] = 'test7'
-        assert not pickle_persistence.bot_data == bot_data
+        assert pickle_persistence.bot_data != bot_data
         pickle_persistence.update_bot_data(bot_data)
         assert pickle_persistence.bot_data == bot_data
         with open('pickletest', 'rb') as f:
@@ -1440,10 +1436,10 @@ class TestPicklePersistence:
 
         callback_data = pickle_persistence.get_callback_data()
         callback_data[1]['test3'] = 'test4'
-        assert not pickle_persistence.callback_data == callback_data
+        assert pickle_persistence.callback_data != callback_data
         pickle_persistence.update_callback_data(callback_data)
         callback_data[1]['test3'] = 'test5'
-        assert not pickle_persistence.callback_data == callback_data
+        assert pickle_persistence.callback_data != callback_data
         pickle_persistence.update_callback_data(callback_data)
         assert pickle_persistence.callback_data == callback_data
         with open('pickletest', 'rb') as f:
@@ -1452,7 +1448,7 @@ class TestPicklePersistence:
 
         conversation1 = pickle_persistence.get_conversations('name1')
         conversation1[(123, 123)] = 5
-        assert not pickle_persistence.conversations['name1'] == conversation1
+        assert pickle_persistence.conversations['name1'] != conversation1
         pickle_persistence.update_conversation('name1', (123, 123), 5)
         assert pickle_persistence.conversations['name1'] == conversation1
         assert pickle_persistence.get_conversations('name1') == conversation1
@@ -1487,58 +1483,58 @@ class TestPicklePersistence:
 
         user_data = pickle_persistence.get_user_data()
         user_data[54321]['test9'] = 'test 10'
-        assert not pickle_persistence.user_data == user_data
+        assert pickle_persistence.user_data != user_data
 
         pickle_persistence.update_user_data(54321, user_data[54321])
         assert pickle_persistence.user_data == user_data
 
         with open('pickletest_user_data', 'rb') as f:
             user_data_test = defaultdict(dict, pickle.load(f))
-        assert not user_data_test == user_data
+        assert user_data_test != user_data
 
         chat_data = pickle_persistence.get_chat_data()
         chat_data[54321]['test9'] = 'test 10'
-        assert not pickle_persistence.chat_data == chat_data
+        assert pickle_persistence.chat_data != chat_data
 
         pickle_persistence.update_chat_data(54321, chat_data[54321])
         assert pickle_persistence.chat_data == chat_data
 
         with open('pickletest_chat_data', 'rb') as f:
             chat_data_test = defaultdict(dict, pickle.load(f))
-        assert not chat_data_test == chat_data
+        assert chat_data_test != chat_data
 
         bot_data = pickle_persistence.get_bot_data()
         bot_data['test6'] = 'test 7'
-        assert not pickle_persistence.bot_data == bot_data
+        assert pickle_persistence.bot_data != bot_data
 
         pickle_persistence.update_bot_data(bot_data)
         assert pickle_persistence.bot_data == bot_data
 
         with open('pickletest_bot_data', 'rb') as f:
             bot_data_test = pickle.load(f)
-        assert not bot_data_test == bot_data
+        assert bot_data_test != bot_data
 
         callback_data = pickle_persistence.get_callback_data()
         callback_data[1]['test3'] = 'test4'
-        assert not pickle_persistence.callback_data == callback_data
+        assert pickle_persistence.callback_data != callback_data
 
         pickle_persistence.update_callback_data(callback_data)
         assert pickle_persistence.callback_data == callback_data
 
         with open('pickletest_callback_data', 'rb') as f:
             callback_data_test = pickle.load(f)
-        assert not callback_data_test == callback_data
+        assert callback_data_test != callback_data
 
         conversation1 = pickle_persistence.get_conversations('name1')
         conversation1[(123, 123)] = 5
-        assert not pickle_persistence.conversations['name1'] == conversation1
+        assert pickle_persistence.conversations['name1'] != conversation1
 
         pickle_persistence.update_conversation('name1', (123, 123), 5)
         assert pickle_persistence.conversations['name1'] == conversation1
 
         with open('pickletest_conversations', 'rb') as f:
             conversations_test = defaultdict(dict, pickle.load(f))
-        assert not conversations_test['name1'] == conversation1
+        assert conversations_test['name1'] != conversation1
 
         pickle_persistence.flush()
         with open('pickletest_user_data', 'rb') as f:
@@ -1566,48 +1562,48 @@ class TestPicklePersistence:
 
         user_data = pickle_persistence.get_user_data()
         user_data[54321]['test9'] = 'test 10'
-        assert not pickle_persistence.user_data == user_data
+        assert pickle_persistence.user_data != user_data
         pickle_persistence.update_user_data(54321, user_data[54321])
         assert pickle_persistence.user_data == user_data
         with open('pickletest', 'rb') as f:
             user_data_test = defaultdict(dict, pickle.load(f)['user_data'])
-        assert not user_data_test == user_data
+        assert user_data_test != user_data
 
         chat_data = pickle_persistence.get_chat_data()
         chat_data[54321]['test9'] = 'test 10'
-        assert not pickle_persistence.chat_data == chat_data
+        assert pickle_persistence.chat_data != chat_data
         pickle_persistence.update_chat_data(54321, chat_data[54321])
         assert pickle_persistence.chat_data == chat_data
         with open('pickletest', 'rb') as f:
             chat_data_test = defaultdict(dict, pickle.load(f)['chat_data'])
-        assert not chat_data_test == chat_data
+        assert chat_data_test != chat_data
 
         bot_data = pickle_persistence.get_bot_data()
         bot_data['test6'] = 'test 7'
-        assert not pickle_persistence.bot_data == bot_data
+        assert pickle_persistence.bot_data != bot_data
         pickle_persistence.update_bot_data(bot_data)
         assert pickle_persistence.bot_data == bot_data
         with open('pickletest', 'rb') as f:
             bot_data_test = pickle.load(f)['bot_data']
-        assert not bot_data_test == bot_data
+        assert bot_data_test != bot_data
 
         callback_data = pickle_persistence.get_callback_data()
         callback_data[1]['test3'] = 'test4'
-        assert not pickle_persistence.callback_data == callback_data
+        assert pickle_persistence.callback_data != callback_data
         pickle_persistence.update_callback_data(callback_data)
         assert pickle_persistence.callback_data == callback_data
         with open('pickletest', 'rb') as f:
             callback_data_test = pickle.load(f)['callback_data']
-        assert not callback_data_test == callback_data
+        assert callback_data_test != callback_data
 
         conversation1 = pickle_persistence.get_conversations('name1')
         conversation1[(123, 123)] = 5
-        assert not pickle_persistence.conversations['name1'] == conversation1
+        assert pickle_persistence.conversations['name1'] != conversation1
         pickle_persistence.update_conversation('name1', (123, 123), 5)
         assert pickle_persistence.conversations['name1'] == conversation1
         with open('pickletest', 'rb') as f:
             conversations_test = defaultdict(dict, pickle.load(f)['conversations'])
-        assert not conversations_test['name1'] == conversation1
+        assert conversations_test['name1'] != conversation1
 
         pickle_persistence.flush()
         with open('pickletest', 'rb') as f:
@@ -1633,13 +1629,13 @@ class TestPicklePersistence:
         bot.callback_data_cache.clear_callback_queries()
 
         def first(update, context):
-            if not context.user_data == {}:
+            if context.user_data != {}:
                 pytest.fail()
-            if not context.chat_data == {}:
+            if context.chat_data != {}:
                 pytest.fail()
-            if not context.bot_data == bot_data:
+            if context.bot_data != bot_data:
                 pytest.fail()
-            if not context.bot.callback_data_cache.persistence_data == ([], {}):
+            if context.bot.callback_data_cache.persistence_data != ([], {}):
                 pytest.fail()
             context.user_data['test1'] = 'test2'
             context.chat_data['test3'] = 'test4'
@@ -1647,13 +1643,16 @@ class TestPicklePersistence:
             context.bot.callback_data_cache._callback_queries['test1'] = 'test0'
 
         def second(update, context):
-            if not context.user_data['test1'] == 'test2':
+            if context.user_data['test1'] != 'test2':
                 pytest.fail()
-            if not context.chat_data['test3'] == 'test4':
+            if context.chat_data['test3'] != 'test4':
                 pytest.fail()
-            if not context.bot_data['test1'] == 'test0':
+            if context.bot_data['test1'] != 'test0':
                 pytest.fail()
-            if not context.bot.callback_data_cache.persistence_data == ([], {'test1': 'test0'}):
+            if context.bot.callback_data_cache.persistence_data != (
+                [],
+                {'test1': 'test0'},
+            ):
                 pytest.fail()
 
         h1 = MessageHandler(None, first, pass_user_data=True, pass_chat_data=True)
@@ -2139,36 +2138,36 @@ class TestDictPersistence:
 
         user_data = dict_persistence.get_user_data()
         user_data[12345]['test3']['test4'] = 'test6'
-        assert not dict_persistence.user_data == user_data
-        assert not dict_persistence.user_data_json == json.dumps(user_data)
+        assert dict_persistence.user_data != user_data
+        assert dict_persistence.user_data_json != json.dumps(user_data)
         dict_persistence.update_user_data(12345, user_data[12345])
         user_data[12345]['test3']['test4'] = 'test7'
-        assert not dict_persistence.user_data == user_data
-        assert not dict_persistence.user_data_json == json.dumps(user_data)
+        assert dict_persistence.user_data != user_data
+        assert dict_persistence.user_data_json != json.dumps(user_data)
         dict_persistence.update_user_data(12345, user_data[12345])
         assert dict_persistence.user_data == user_data
         assert dict_persistence.user_data_json == json.dumps(user_data)
 
         chat_data = dict_persistence.get_chat_data()
         chat_data[-12345]['test3']['test4'] = 'test6'
-        assert not dict_persistence.chat_data == chat_data
-        assert not dict_persistence.chat_data_json == json.dumps(chat_data)
+        assert dict_persistence.chat_data != chat_data
+        assert dict_persistence.chat_data_json != json.dumps(chat_data)
         dict_persistence.update_chat_data(-12345, chat_data[-12345])
         chat_data[-12345]['test3']['test4'] = 'test7'
-        assert not dict_persistence.chat_data == chat_data
-        assert not dict_persistence.chat_data_json == json.dumps(chat_data)
+        assert dict_persistence.chat_data != chat_data
+        assert dict_persistence.chat_data_json != json.dumps(chat_data)
         dict_persistence.update_chat_data(-12345, chat_data[-12345])
         assert dict_persistence.chat_data == chat_data
         assert dict_persistence.chat_data_json == json.dumps(chat_data)
 
         bot_data = dict_persistence.get_bot_data()
         bot_data['test3']['test4'] = 'test6'
-        assert not dict_persistence.bot_data == bot_data
-        assert not dict_persistence.bot_data_json == json.dumps(bot_data)
+        assert dict_persistence.bot_data != bot_data
+        assert dict_persistence.bot_data_json != json.dumps(bot_data)
         dict_persistence.update_bot_data(bot_data)
         bot_data['test3']['test4'] = 'test7'
-        assert not dict_persistence.bot_data == bot_data
-        assert not dict_persistence.bot_data_json == json.dumps(bot_data)
+        assert dict_persistence.bot_data != bot_data
+        assert dict_persistence.bot_data_json != json.dumps(bot_data)
         dict_persistence.update_bot_data(bot_data)
         assert dict_persistence.bot_data == bot_data
         assert dict_persistence.bot_data_json == json.dumps(bot_data)
@@ -2176,20 +2175,20 @@ class TestDictPersistence:
         callback_data = dict_persistence.get_callback_data()
         callback_data[1]['test3'] = 'test4'
         callback_data[0][0][2]['button2'] = 'test41'
-        assert not dict_persistence.callback_data == callback_data
-        assert not dict_persistence.callback_data_json == json.dumps(callback_data)
+        assert dict_persistence.callback_data != callback_data
+        assert dict_persistence.callback_data_json != json.dumps(callback_data)
         dict_persistence.update_callback_data(callback_data)
         callback_data[1]['test3'] = 'test5'
         callback_data[0][0][2]['button2'] = 'test42'
-        assert not dict_persistence.callback_data == callback_data
-        assert not dict_persistence.callback_data_json == json.dumps(callback_data)
+        assert dict_persistence.callback_data != callback_data
+        assert dict_persistence.callback_data_json != json.dumps(callback_data)
         dict_persistence.update_callback_data(callback_data)
         assert dict_persistence.callback_data == callback_data
         assert dict_persistence.callback_data_json == json.dumps(callback_data)
 
         conversation1 = dict_persistence.get_conversations('name1')
         conversation1[(123, 123)] = 5
-        assert not dict_persistence.conversations['name1'] == conversation1
+        assert dict_persistence.conversations['name1'] != conversation1
         dict_persistence.update_conversation('name1', (123, 123), 5)
         assert dict_persistence.conversations['name1'] == conversation1
         conversations['name1'][(123, 123)] = 5
@@ -2210,13 +2209,13 @@ class TestDictPersistence:
         dp = u.dispatcher
 
         def first(update, context):
-            if not context.user_data == {}:
+            if context.user_data != {}:
                 pytest.fail()
-            if not context.chat_data == {}:
+            if context.chat_data != {}:
                 pytest.fail()
-            if not context.bot_data == {}:
+            if context.bot_data != {}:
                 pytest.fail()
-            if not context.bot.callback_data_cache.persistence_data == ([], {}):
+            if context.bot.callback_data_cache.persistence_data != ([], {}):
                 pytest.fail()
             context.user_data['test1'] = 'test2'
             context.chat_data[3] = 'test4'
@@ -2224,13 +2223,16 @@ class TestDictPersistence:
             context.bot.callback_data_cache._callback_queries['test1'] = 'test0'
 
         def second(update, context):
-            if not context.user_data['test1'] == 'test2':
+            if context.user_data['test1'] != 'test2':
                 pytest.fail()
-            if not context.chat_data[3] == 'test4':
+            if context.chat_data[3] != 'test4':
                 pytest.fail()
-            if not context.bot_data['test1'] == 'test0':
+            if context.bot_data['test1'] != 'test0':
                 pytest.fail()
-            if not context.bot.callback_data_cache.persistence_data == ([], {'test1': 'test0'}):
+            if context.bot.callback_data_cache.persistence_data != (
+                [],
+                {'test1': 'test0'},
+            ):
                 pytest.fail()
 
         h1 = MessageHandler(Filters.all, first)

--- a/tests/test_photo.py
+++ b/tests/test_photo.py
@@ -35,9 +35,8 @@ from tests.conftest import (
 
 @pytest.fixture(scope='function')
 def photo_file():
-    f = open('tests/data/telegram.jpg', 'rb')
-    yield f
-    f.close()
+    with open('tests/data/telegram.jpg', 'rb') as f:
+        yield f
 
 
 @pytest.fixture(scope='class')

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -43,10 +43,7 @@ def test_class_has_slots_and_dict(mro_slots):
 
     for path in tg_paths:
         # windows uses backslashes:
-        if os.name == 'nt':
-            split_path = path.split('\\')
-        else:
-            split_path = path.split('/')
+        split_path = path.split('\\') if os.name == 'nt' else path.split('/')
         mod_name = f"telegram{'.ext.' if split_path[1] == 'ext' else '.'}{split_path[-1][:-3]}"
         spec = importlib.util.spec_from_file_location(mod_name, path)
         module = importlib.util.module_from_spec(spec)

--- a/tests/test_sticker.py
+++ b/tests/test_sticker.py
@@ -30,9 +30,8 @@ from tests.conftest import check_shortcut_call, check_shortcut_signature, check_
 
 @pytest.fixture(scope='function')
 def sticker_file():
-    f = open('tests/data/telegram.webp', 'rb')
-    yield f
-    f.close()
+    with open('tests/data/telegram.webp', 'rb') as f:
+        yield f
 
 
 @pytest.fixture(scope='class')
@@ -43,9 +42,8 @@ def sticker(bot, chat_id):
 
 @pytest.fixture(scope='function')
 def animated_sticker_file():
-    f = open('tests/data/telegram_animated_sticker.tgs', 'rb')
-    yield f
-    f.close()
+    with open('tests/data/telegram_animated_sticker.tgs', 'rb') as f:
+        yield f
 
 
 @pytest.fixture(scope='class')
@@ -337,9 +335,8 @@ def animated_sticker_set(bot):
 
 @pytest.fixture(scope='function')
 def sticker_set_thumb_file():
-    f = open('tests/data/sticker_set_thumb.png', 'rb')
-    yield f
-    f.close()
+    with open('tests/data/sticker_set_thumb.png', 'rb') as f:
+        yield f
 
 
 class TestStickerSet:

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -212,7 +212,7 @@ class TestUpdater:
         # that depends on this distinction works
         if ext_bot and not isinstance(updater.bot, ExtBot):
             updater.bot = ExtBot(updater.bot.token)
-        if not ext_bot and not type(updater.bot) is Bot:
+        if not ext_bot and type(updater.bot) is not Bot:
             updater.bot = Bot(updater.bot.token)
 
         q = Queue()

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -30,9 +30,8 @@ from tests.conftest import check_shortcut_call, check_shortcut_signature, check_
 
 @pytest.fixture(scope='function')
 def video_file():
-    f = open('tests/data/telegram.mp4', 'rb')
-    yield f
-    f.close()
+    with open('tests/data/telegram.mp4', 'rb') as f:
+        yield f
 
 
 @pytest.fixture(scope='class')

--- a/tests/test_videonote.py
+++ b/tests/test_videonote.py
@@ -29,9 +29,8 @@ from tests.conftest import check_shortcut_call, check_shortcut_signature, check_
 
 @pytest.fixture(scope='function')
 def video_note_file():
-    f = open('tests/data/telegram2.mp4', 'rb')
-    yield f
-    f.close()
+    with open('tests/data/telegram2.mp4', 'rb') as f:
+        yield f
 
 
 @pytest.fixture(scope='class')

--- a/tests/test_voice.py
+++ b/tests/test_voice.py
@@ -30,9 +30,8 @@ from tests.conftest import check_shortcut_call, check_shortcut_signature, check_
 
 @pytest.fixture(scope='function')
 def voice_file():
-    f = open('tests/data/telegram.ogg', 'rb')
-    yield f
-    f.close()
+    with open('tests/data/telegram.ogg', 'rb') as f:
+        yield f
 
 
 @pytest.fixture(scope='class')


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool! Please have a look at the below checklist. It's here to help both you and the maintainers to remember some aspects. Make sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
-->

### Checklist for PRs

- [ ] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [ ] Created new or adapted existing unit tests
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)
- [ ] Added new classes & modules to the docs


### If the PR contains API changes (otherwise, you can delete this passage)

* New classes:
    - [ ] Added `self._id_attrs` and corresponding documentation
    - [ ] `__init__` accepts `**_kwargs`
    
* Added new shortcuts:
    - [ ] In `Chat` & `User` for all methods that accept `chat/user_id`
    - [ ] In `Message` for all methods that accept `chat_id` and `message_id`
    - [ ] For new `Message` shortcuts: Added `quote` argument if methods accepts `reply_to_message_id`
    - [ ] In `CallbackQuery` for all methods that accept either `chat_id` and `message_id` or `inline_message_id`
    
* If relevant:

    - [ ] Added new constants at `telegram.constants` and shortcuts to them as class variables
    - [ ] Added new handlers for new update types
    - [ ] Added new filters for new message (sub)types
    - [ ] Added or updated documentation for the changed class(es) and/or method(s)
    - [ ] Updated the Bot API version number in all places: `README.rst` and `README_RAW.rst` (including the badge), as well as `telegram.constants.BOT_API_VERSION`
    - [ ] Added logic for arbitrary callback data in `tg.ext.Bot` for new methods that either accept a `reply_markup` in some form or have a return type that is/contains `telegram.Message`
