### PR TITLE
Add `Dispatcher.add_handlers`

### DIFF
--- a/examples/deeplinking.py
+++ b/examples/deeplinking.py
@@ -87,7 +87,7 @@ def deep_linked_level_3(update: Update, context: CallbackContext.DEFAULT_TYPE) -
     )
 
 
-def deep_link_level_3_callback(update: Update, context: CallbackContext.DEFAULT_TYPE) -> None:
+def deep_link_level_3_button(update: Update, context: CallbackContext.DEFAULT_TYPE) -> None:
     """Answers CallbackQuery with deeplinking url."""
     bot = context.bot
     url = helpers.create_deep_linked_url(bot.username, USING_KEYBOARD)
@@ -114,30 +114,24 @@ def main() -> None:
     # https://core.telegram.org/bots#deep-linking
 
     # Register a deep-linking handler
-    dispatcher.add_handler(
-        CommandHandler("start", deep_linked_level_1, filters.Regex(CHECK_THIS_OUT))
-    )
+    level_1 = CommandHandler("start", deep_linked_level_1, filters.Regex(CHECK_THIS_OUT))
 
-    # This one works with a textual link instead of an URL
-    dispatcher.add_handler(CommandHandler("start", deep_linked_level_2, filters.Regex(SO_COOL)))
+    # This one works with a textual link instead of a URL
+    level_2 = CommandHandler("start", deep_linked_level_2, filters.Regex(SO_COOL))
 
     # We can also pass on the deep-linking payload
-    dispatcher.add_handler(
-        CommandHandler("start", deep_linked_level_3, filters.Regex(USING_ENTITIES))
-    )
+    level_3 = CommandHandler("start", deep_linked_level_3, filters.Regex(USING_ENTITIES))
 
     # Possible with inline keyboard buttons as well
-    dispatcher.add_handler(
-        CommandHandler("start", deep_linked_level_4, filters.Regex(USING_KEYBOARD))
-    )
+    level_4 = CommandHandler("start", deep_linked_level_4, filters.Regex(USING_KEYBOARD))
 
     # register callback handler for inline keyboard button
-    dispatcher.add_handler(
-        CallbackQueryHandler(deep_link_level_3_callback, pattern=KEYBOARD_CALLBACKDATA)
-    )
+    level_3_button = CallbackQueryHandler(deep_link_level_3_button, pattern=KEYBOARD_CALLBACKDATA)
+
+    start_handler = CommandHandler("start", start)
 
     # Make sure the deep-linking handlers occur *before* the normal /start handler.
-    dispatcher.add_handler(CommandHandler("start", start))
+    dispatcher.add_handlers([level_1, level_2, level_3, level_4, level_3_button, start_handler])
 
     # Start the Bot
     updater.start_polling()

--- a/examples/deeplinking.py
+++ b/examples/deeplinking.py
@@ -87,7 +87,7 @@ def deep_linked_level_3(update: Update, context: CallbackContext.DEFAULT_TYPE) -
     )
 
 
-def deep_link_level_3_button(update: Update, context: CallbackContext.DEFAULT_TYPE) -> None:
+def deep_link_level_3_callback(update: Update, context: CallbackContext.DEFAULT_TYPE) -> None:
     """Answers CallbackQuery with deeplinking url."""
     bot = context.bot
     url = helpers.create_deep_linked_url(bot.username, USING_KEYBOARD)
@@ -114,24 +114,30 @@ def main() -> None:
     # https://core.telegram.org/bots#deep-linking
 
     # Register a deep-linking handler
-    level_1 = CommandHandler("start", deep_linked_level_1, filters.Regex(CHECK_THIS_OUT))
+    dispatcher.add_handler(
+        CommandHandler("start", deep_linked_level_1, filters.Regex(CHECK_THIS_OUT))
+    )
 
-    # This one works with a textual link instead of a URL
-    level_2 = CommandHandler("start", deep_linked_level_2, filters.Regex(SO_COOL))
+    # This one works with a textual link instead of an URL
+    dispatcher.add_handler(CommandHandler("start", deep_linked_level_2, filters.Regex(SO_COOL)))
 
     # We can also pass on the deep-linking payload
-    level_3 = CommandHandler("start", deep_linked_level_3, filters.Regex(USING_ENTITIES))
+    dispatcher.add_handler(
+        CommandHandler("start", deep_linked_level_3, filters.Regex(USING_ENTITIES))
+    )
 
     # Possible with inline keyboard buttons as well
-    level_4 = CommandHandler("start", deep_linked_level_4, filters.Regex(USING_KEYBOARD))
+    dispatcher.add_handler(
+        CommandHandler("start", deep_linked_level_4, filters.Regex(USING_KEYBOARD))
+    )
 
     # register callback handler for inline keyboard button
-    level_3_button = CallbackQueryHandler(deep_link_level_3_button, pattern=KEYBOARD_CALLBACKDATA)
-
-    start_handler = CommandHandler("start", start)
+    dispatcher.add_handler(
+        CallbackQueryHandler(deep_link_level_3_callback, pattern=KEYBOARD_CALLBACKDATA)
+    )
 
     # Make sure the deep-linking handlers occur *before* the normal /start handler.
-    dispatcher.add_handlers([level_1, level_2, level_3, level_4, level_3_button, start_handler])
+    dispatcher.add_handler(CommandHandler("start", start))
 
     # Start the Bot
     updater.start_polling()

--- a/telegram/ext/_dispatcher.py
+++ b/telegram/ext/_dispatcher.py
@@ -36,11 +36,12 @@ from typing import (
     Generic,
     TypeVar,
     TYPE_CHECKING,
-    Sequence,
+    Tuple,
 )
 from uuid import uuid4
 
 from telegram import Update
+from telegram._utils.types import DVInput
 from telegram.error import TelegramError
 from telegram.ext import BasePersistence, ContextTypes, ExtBot
 from telegram.ext._handler import Handler
@@ -479,9 +480,9 @@ class Dispatcher(Generic[BT, CCT, UD, CD, BD, JQ, PT]):
         handled = False
         sync_modes = []
 
-        for group in sorted(self.handlers):  # lower -> higher groups
+        for handlers in self.handlers.values():
             try:
-                for handler in self.handlers[group]:
+                for handler in handlers:
                     check = handler.check_update(update)
                     if check is not None and check is not False:
                         if not context:
@@ -570,42 +571,52 @@ class Dispatcher(Generic[BT, CCT, UD, CD, BD, JQ, PT]):
 
         if group not in self.handlers:
             self.handlers[group] = []
+            self.handlers = dict(sorted(self.handlers.items()))  # lower -> higher groups
 
         self.handlers[group].append(handler)
 
     def add_handlers(
         self,
-        handlers: Union[Sequence[Handler], Dict[int, Sequence[Handler]]],
-        group: int = DEFAULT_GROUP,
+        handlers: Union[
+            Union[List[Handler], Tuple[Handler]], Dict[int, Union[List[Handler], Tuple[Handler]]]
+        ],
+        group: DVInput[int] = DefaultValue(0),
     ) -> None:
-        """Register multiple handlers at once. Priority/order of handlers matters.
+        """Registers multiple handlers at once. The order of the handlers in the passed
+        sequence(s) matters. See :meth:`add_handler` for details.
 
         .. versionadded:: 14.0
+        .. seealso:: :meth:`add_handler`
 
         Args:
-            handlers (Sequence[:obj:`telegram.ext.Handler`] | \
-                Dict[int, Sequence[:obj:`telegram.ext.Handler`]]): \
+            handlers (List[:obj:`telegram.ext.Handler`] | \
+                Dict[int, List[:obj:`telegram.ext.Handler`]]): \
                 Specify a sequence of handlers *or* a dictionary where the keys are groups and
                 values are handlers.
             group (:obj:`int`, optional): Specify which group the sequence of ``handlers``
                 should be added to. Defaults to ``0``.
 
-        .. seealso:: :meth:`add_handler`
         """
-        if isinstance(handlers, dict) and group != DEFAULT_GROUP:
+        if isinstance(handlers, dict) and not isinstance(group, DefaultValue):
             raise ValueError('The `group` argument can only be used with a sequence of handlers.')
 
-        if isinstance(handlers, list):
-            for handler in handlers:
-                self.add_handler(handler, group)
-
-        elif isinstance(handlers, dict):
+        if isinstance(handlers, dict):
             for handler_group, grp_handlers in handlers.items():
-                if not isinstance(grp_handlers, Sequence):
-                    raise ValueError(f'Handlers for group {handler_group} should be a sequence!')
+                if not isinstance(grp_handlers, (list, tuple)):
+                    raise ValueError(f'Handlers for group {handler_group} must be a list or tuple')
 
                 for handler in grp_handlers:
                     self.add_handler(handler, handler_group)
+
+        elif isinstance(handlers, (list, tuple)):
+            for handler in handlers:
+                self.add_handler(handler, DefaultValue.get_value(group))
+
+        else:
+            raise ValueError(
+                "The `handlers` argument must be a sequence of handlers or a "
+                "dictionary where the keys are groups and values are handlers."
+            )
 
     def remove_handler(self, handler: Handler, group: int = DEFAULT_GROUP) -> None:
         """Remove a handler from the specified group.

--- a/telegram/ext/_dispatcher.py
+++ b/telegram/ext/_dispatcher.py
@@ -99,7 +99,9 @@ class Dispatcher(Generic[BT, CCT, UD, CD, BD, JQ, PT]):
          :meth:`builder` (for convenience).
 
     .. versionchanged:: 14.0
-        Initialization is now done through the :class:`telegram.ext.DispatcherBuilder`.
+
+        * Initialization is now done through the :class:`telegram.ext.DispatcherBuilder`.
+        * Removed the attribute ``groups``.
 
     Attributes:
         bot (:class:`telegram.Bot`): The bot object that should be passed to the handlers.
@@ -119,10 +121,6 @@ class Dispatcher(Generic[BT, CCT, UD, CD, BD, JQ, PT]):
             :attr:`telegram.ext.Updater.exception_event`.
         handlers (Dict[:obj:`int`, List[:class:`telegram.ext.Handler`]]): A dictionary mapping each
             handler group to the list of handlers registered to that group.
-
-            .. seealso::
-                :meth:`add_handler`, :meth:`add_handlers`.
-        groups (List[:obj:`int`]): A list of all handler groups that have handlers registered.
 
             .. seealso::
                 :meth:`add_handler`, :meth:`add_handlers`.
@@ -150,7 +148,6 @@ class Dispatcher(Generic[BT, CCT, UD, CD, BD, JQ, PT]):
         'bot_data',
         '_update_persistence_lock',
         'handlers',
-        'groups',
         'error_handlers',
         'running',
         '__stop_event',
@@ -244,7 +241,6 @@ class Dispatcher(Generic[BT, CCT, UD, CD, BD, JQ, PT]):
             self.persistence = None
 
         self.handlers: Dict[int, List[Handler]] = {}
-        self.groups: List[int] = []
         self.error_handlers: Dict[Callable, Union[bool, DefaultValue]] = {}
 
         self.running = False
@@ -483,7 +479,7 @@ class Dispatcher(Generic[BT, CCT, UD, CD, BD, JQ, PT]):
         handled = False
         sync_modes = []
 
-        for group in self.groups:
+        for group in sorted(self.handlers):  # lower -> higher groups
             try:
                 for handler in self.handlers[group]:
                     check = handler.check_update(update)
@@ -574,8 +570,6 @@ class Dispatcher(Generic[BT, CCT, UD, CD, BD, JQ, PT]):
 
         if group not in self.handlers:
             self.handlers[group] = []
-            self.groups.append(group)
-            self.groups = sorted(self.groups)
 
         self.handlers[group].append(handler)
 
@@ -625,7 +619,6 @@ class Dispatcher(Generic[BT, CCT, UD, CD, BD, JQ, PT]):
             self.handlers[group].remove(handler)
             if not self.handlers[group]:
                 del self.handlers[group]
-                self.groups.remove(group)
 
     def update_persistence(self, update: object = None) -> None:
         """Update :attr:`user_data`, :attr:`chat_data` and :attr:`bot_data` in :attr:`persistence`.

--- a/telegram/ext/_dispatcher.py
+++ b/telegram/ext/_dispatcher.py
@@ -615,7 +615,7 @@ class Dispatcher(Generic[BT, CCT, UD, CD, BD, JQ, PT]):
         else:
             raise ValueError(
                 "The `handlers` argument must be a sequence of handlers or a "
-                "dictionary where the keys are groups and values are handlers."
+                "dictionary where the keys are groups and values are sequences of handlers."
             )
 
     def remove_handler(self, handler: Handler, group: int = DEFAULT_GROUP) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,7 +199,6 @@ def dp(_dp):
     _dp.bot_data = {}
     _dp.persistence = None
     _dp.handlers = {}
-    _dp.groups = []
     _dp.error_handlers = {}
     _dp.exception_event = Event()
     _dp.__stop_event = Event()

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -80,7 +80,7 @@ class TestDispatcher:
         self.count += 1
 
     def callback_set_count(self, count):
-        def callback(bot, update):
+        def callback(update, context):
             self.count = count
 
         return callback
@@ -412,6 +412,60 @@ class TestDispatcher:
         dp.update_queue.put(self.message_update)
         sleep(0.1)
         assert self.count == 3
+
+    def test_add_handlers_complex(self, dp):
+        """Tests both add_handler & add_handlers together & confirms the correct insertion order"""
+        msg_handler_set_count = MessageHandler(filters.TEXT, self.callback_set_count(1))
+        msg_handler_inc_count = MessageHandler(filters.PHOTO, self.callback_increase_count)
+
+        dp.add_handler(msg_handler_set_count, 1)
+        dp.add_handlers([msg_handler_inc_count, msg_handler_inc_count], 1)
+
+        photo_update = Update(2, message=Message(2, None, None, photo=True))
+        dp.update_queue.put(self.message_update)  # Putting updates in the queue calls the callback
+        dp.update_queue.put(photo_update)
+        sleep(0.1)  # sleep is required otherwise there is random behaviour
+
+        # Test if handler was added to correct group with correct order-
+        assert (
+            self.count == 2
+            and len(dp.handlers[1]) == 3
+            and dp.handlers[1][0].filters.name == 'filters.TEXT'
+        )
+
+        # Now lets test add_handlers when `handlers` is a dict-
+        dp.add_handlers(
+            handlers={
+                1: [
+                    MessageHandler(filters.USER, self.callback_increase_count),
+                    MessageHandler(filters.VOICE, self.callback_increase_count),
+                ],
+                -1: [MessageHandler(filters.CAPTION, self.callback_set_count(2))],
+            }
+        )
+
+        user_update = Update(3, message=Message(3, None, None, from_user=User(1, 's', True)))
+        voice_update = Update(4, message=Message(4, None, None, voice=True))
+        dp.update_queue.put(user_update)
+        dp.update_queue.put(voice_update)
+        sleep(0.1)
+
+        assert (
+            self.count == 4
+            and len(dp.handlers[1]) == 5
+            and dp.handlers[1][-1].filters.name == 'filters.VOICE'
+        )
+
+        dp.update_queue.put(Update(5, message=Message(5, None, None, caption='cap')))
+        sleep(0.1)
+
+        assert self.count == 2 and len(dp.handlers[-1]) == 1
+
+        # Now lets test the errors which can be produced-
+        with pytest.raises(ValueError, match="The `group` argument"):
+            dp.add_handlers({2: [msg_handler_set_count]}, group=3)
+        with pytest.raises(ValueError, match="Handlers for group 3"):
+            dp.add_handlers({3: msg_handler_set_count})
 
     def test_add_handler_errors(self, dp):
         handler = 'not a handler'


### PR DESCRIPTION
Closes #2821 
Also removes redundant `Dispatcher.groups` attribute (as pointed out by @david-shiko)

### Checklist for PRs

- [x] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests