### PR TITLE
Make ComH init error message more precise

### DIFF
--- a/telegram/ext/_commandhandler.py
+++ b/telegram/ext/_commandhandler.py
@@ -97,7 +97,7 @@ class CommandHandler(Handler[Update, CCT]):
             self.command = [x.lower() for x in command]
         for comm in self.command:
             if not re.match(r'^[\da-z_]{1,32}$', comm):
-                raise ValueError('Command is not a valid bot command')
+                raise ValueError(f'Command `{comm}` is not a valid bot command')
 
         self.filters = filters if filters is not None else filters_module.UpdateType.MESSAGES
 

--- a/tests/test_commandhandler.py
+++ b/tests/test_commandhandler.py
@@ -173,7 +173,9 @@ class TestCommandHandler(BaseTest):
         ids=['too long', 'invalid letter', 'invalid characters'],
     )
     def test_invalid_commands(self, cmd):
-        with pytest.raises(ValueError, match='not a valid bot command'):
+        with pytest.raises(
+            ValueError, match=f'`{re.escape(cmd.lower())}` is not a valid bot command'
+        ):
             CommandHandler(cmd, self.callback_basic)
 
     def test_command_list(self):


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool! Please have a look at the below checklist. It's here to help both you and the maintainers to remember some aspects. Make sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
-->

Supersedes #2707

### Checklist for PRs

- [ ] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [ ] Added new classes & modules to the docs
