### PR TITLE
Add `Dispatcher/Persistence.drop_chat/user_data`

### DIFF
--- a/telegram/ext/_basepersistence.py
+++ b/telegram/ext/_basepersistence.py
@@ -532,7 +532,7 @@ class BasePersistence(Generic[UD, CD, BD], ABC):
 
         Args:
             data (Optional[Tuple[List[Tuple[:obj:`str`, :obj:`float`, \
-                Dict[:obj:`str`, :obj:`Any`]]], Dict[:obj:`str`, :obj:`str`]]):
+                Dict[:obj:`str`, :obj:`Any`]]], Dict[:obj:`str`, :obj:`str`]]]):
                 The relevant data to restore :class:`telegram.ext.CallbackDataCache`.
         """
 

--- a/telegram/ext/_basepersistence.py
+++ b/telegram/ext/_basepersistence.py
@@ -457,7 +457,7 @@ class BasePersistence(Generic[UD, CD, BD], ABC):
 
         Returns:
             Optional[Tuple[List[Tuple[:obj:`str`, :obj:`float`, \
-                Dict[:obj:`str`, :obj:`Any`]]], Dict[:obj:`str`, :obj:`str`]]:
+                Dict[:obj:`str`, :obj:`Any`]]], Dict[:obj:`str`, :obj:`str`]]]:
                 The restored meta data or :obj:`None`, if no data was stored.
         """
 

--- a/telegram/ext/_basepersistence.py
+++ b/telegram/ext/_basepersistence.py
@@ -541,6 +541,8 @@ class BasePersistence(Generic[UD, CD, BD], ABC):
         """Will be called by the :class:`telegram.ext.Dispatcher`, when using
         :meth:`~telegram.ext.Dispatcher.drop_chat_data`.
 
+        .. versionadded:: 14.0
+
         Args:
             chat_id (:obj:`int`): The chat id to delete from the persistence.
         """
@@ -549,6 +551,8 @@ class BasePersistence(Generic[UD, CD, BD], ABC):
     def drop_user_data(self, user_id: int) -> None:
         """Will be called by the :class:`telegram.ext.Dispatcher`, when using
         :meth:`~telegram.ext.Dispatcher.drop_user_data`.
+
+        .. versionadded:: 14.0
 
         Args:
             user_id (:obj:`int`): The user id to delete from the persistence.

--- a/telegram/ext/_basepersistence.py
+++ b/telegram/ext/_basepersistence.py
@@ -521,6 +521,40 @@ class BasePersistence(Generic[UD, CD, BD], ABC):
         """
 
     @abstractmethod
+    def update_callback_data(self, data: CDCData) -> None:
+        """Will be called by the :class:`telegram.ext.Dispatcher` after a handler has
+        handled an update.
+
+        .. versionadded:: 13.6
+
+        .. versionchanged:: 14.0
+           Changed this method into an ``@abstractmethod``.
+
+        Args:
+            data (Optional[Tuple[List[Tuple[:obj:`str`, :obj:`float`, \
+                Dict[:obj:`str`, :obj:`Any`]]], Dict[:obj:`str`, :obj:`str`]]):
+                The relevant data to restore :class:`telegram.ext.CallbackDataCache`.
+        """
+
+    @abstractmethod
+    def drop_chat_data(self, chat_id: int) -> None:
+        """Will be called by the :class:`telegram.ext.Dispatcher`, when using
+        :meth:`~telegram.ext.Dispatcher.drop_chat_data`.
+
+        Args:
+            chat_id (:obj:`int`): The chat id to delete from the persistence.
+        """
+
+    @abstractmethod
+    def drop_user_data(self, user_id: int) -> None:
+        """Will be called by the :class:`telegram.ext.Dispatcher`, when using
+        :meth:`~telegram.ext.Dispatcher.drop_user_data`.
+
+        Args:
+            user_id (:obj:`int`): The user id to delete from the persistence.
+        """
+
+    @abstractmethod
     def refresh_user_data(self, user_id: int, user_data: UD) -> None:
         """Will be called by the :class:`telegram.ext.Dispatcher` before passing the
         :attr:`user_data` to a callback. Can be used to update data stored in :attr:`user_data`
@@ -568,22 +602,6 @@ class BasePersistence(Generic[UD, CD, BD], ABC):
         Args:
             bot_data (:obj:`dict` | :attr:`telegram.ext.ContextTypes.bot_data`):
                 The ``bot_data``.
-        """
-
-    @abstractmethod
-    def update_callback_data(self, data: CDCData) -> None:
-        """Will be called by the :class:`telegram.ext.Dispatcher` after a handler has
-        handled an update.
-
-        .. versionadded:: 13.6
-
-        .. versionchanged:: 14.0
-           Changed this method into an ``@abstractmethod``.
-
-        Args:
-            data (Optional[Tuple[List[Tuple[:obj:`str`, :obj:`float`, \
-                Dict[:obj:`str`, :obj:`Any`]]], Dict[:obj:`str`, :obj:`str`]]):
-                The relevant data to restore :class:`telegram.ext.CallbackDataCache`.
         """
 
     @abstractmethod

--- a/telegram/ext/_dictpersistence.py
+++ b/telegram/ext/_dictpersistence.py
@@ -361,6 +361,30 @@ class DictPersistence(BasePersistence):
         self._callback_data = (data[0], data[1].copy())
         self._callback_data_json = None
 
+    def drop_chat_data(self, chat_id: int) -> None:
+        """Will delete the specified key from the :attr:`chat_data`.
+
+        Args:
+            chat_id (:obj:`int`): The chat id to delete from the persistence.
+        """
+        if self._chat_data is None:
+            self._chat_data = defaultdict(dict)
+        else:
+            del self._chat_data[chat_id]
+            self._chat_data_json = None
+
+    def drop_user_data(self, user_id: int) -> None:
+        """Will delete the specified key from the :attr:`user_data`.
+
+        Args:
+            user_id (:obj:`int`): The user id to delete from the persistence.
+        """
+        if self._user_data is None:
+            self._user_data = defaultdict(dict)
+        else:
+            del self._user_data[user_id]
+            self._user_data_json = None
+
     def refresh_user_data(self, user_id: int, user_data: Dict) -> None:
         """Does nothing.
 

--- a/telegram/ext/_dictpersistence.py
+++ b/telegram/ext/_dictpersistence.py
@@ -364,6 +364,8 @@ class DictPersistence(BasePersistence):
     def drop_chat_data(self, chat_id: int) -> None:
         """Will delete the specified key from the :attr:`chat_data`.
 
+        .. versionadded:: 14.0
+
         Args:
             chat_id (:obj:`int`): The chat id to delete from the persistence.
         """
@@ -375,6 +377,8 @@ class DictPersistence(BasePersistence):
 
     def drop_user_data(self, user_id: int) -> None:
         """Will delete the specified key from the :attr:`user_data`.
+
+        .. versionadded:: 14.0
 
         Args:
             user_id (:obj:`int`): The user id to delete from the persistence.

--- a/telegram/ext/_dictpersistence.py
+++ b/telegram/ext/_dictpersistence.py
@@ -370,10 +370,9 @@ class DictPersistence(BasePersistence):
             chat_id (:obj:`int`): The chat id to delete from the persistence.
         """
         if self._chat_data is None:
-            self._chat_data = defaultdict(dict)
-        else:
-            del self._chat_data[chat_id]
-            self._chat_data_json = None
+            return
+        self._chat_data.pop(chat_id, None)
+        self._chat_data_json = None
 
     def drop_user_data(self, user_id: int) -> None:
         """Will delete the specified key from the :attr:`user_data`.
@@ -384,10 +383,9 @@ class DictPersistence(BasePersistence):
             user_id (:obj:`int`): The user id to delete from the persistence.
         """
         if self._user_data is None:
-            self._user_data = defaultdict(dict)
-        else:
-            del self._user_data[user_id]
-            self._user_data_json = None
+            return
+        self._user_data.pop(user_id, None)
+        self._user_data_json = None
 
     def refresh_user_data(self, user_id: int, user_data: Dict) -> None:
         """Does nothing.

--- a/telegram/ext/_dispatcher.py
+++ b/telegram/ext/_dispatcher.py
@@ -683,7 +683,8 @@ class Dispatcher(Generic[BT, CCT, UD, CD, BD, JQ, PT]):
         """
         del self._chat_data[chat_id]
 
-        self.update_persistence()
+        if self.persistence:
+            self.persistence.drop_chat_data(chat_id)
 
     def drop_user_data(self, user_id: int) -> None:
         """Used for deleting a key from the :attr:`user_data`.
@@ -696,7 +697,8 @@ class Dispatcher(Generic[BT, CCT, UD, CD, BD, JQ, PT]):
         """
         del self._user_data[user_id]
 
-        self.update_persistence()
+        if self.persistence:
+            self.persistence.drop_user_data(user_id)
 
     def update_persistence(self, update: object = None) -> None:
         """Update :attr:`user_data`, :attr:`chat_data` and :attr:`bot_data` in :attr:`persistence`.

--- a/telegram/ext/_dispatcher.py
+++ b/telegram/ext/_dispatcher.py
@@ -326,13 +326,15 @@ class Dispatcher(Generic[BT, CCT, UD, CD, BD, JQ, PT]):
 
     def _set_chat_data(self, data: DefaultDict[int, CD]) -> None:
         """Used for assigning a new value to the underlying chat_data dictionary. Also updates
-        the read-only mapping."""
+        the read-only mapping.
+        """
         self._chat_data = data
         self.chat_data = MappingProxyType(self._chat_data)
 
     def _set_user_data(self, data: DefaultDict[int, UD]) -> None:
         """Used for assigning a new value to the underlying user_data dictionary. Also updates
-        the read-only mapping."""
+        the read-only mapping.
+        """
         self._user_data = data
         self.user_data = MappingProxyType(self._user_data)
 
@@ -670,67 +672,29 @@ class Dispatcher(Generic[BT, CCT, UD, CD, BD, JQ, PT]):
             if not self.handlers[group]:
                 del self.handlers[group]
 
-    def drop_chat_data(self, chat_id: int = None, all_empty_entries: bool = False) -> None:
+    def drop_chat_data(self, chat_id: int) -> None:
         """Used for deleting a key from the :attr:`chat_data`.
 
         .. versionadded:: 14.0
 
         Args:
-            chat_id (:obj:`int`, optional): The chat id to delete from the persistence. The entry
-                will be deleted even if it is not empty. Mutually exclusive with
-                ``all_empty_entries``.
-            all_empty_entries (:obj:`bool`, optional): If :obj:`True`, all entries which evaluates
-                to :obj:`False` in a boolean context in :attr:`chat_data` will be deleted.
-                Mutually exclusive with ``chat_id``.
-
-        Raises:
-            :exc:`ValueError`: When both ``chat_id`` and ``all_empty_entries`` are
-                provided, or none of them are passed.
+            chat_id (:obj:`int`): The chat id to delete from the persistence. The entry
+                will be deleted even if it is not empty.
         """
-        if not bool(chat_id) ^ bool(all_empty_entries):
-            raise ValueError("You must pass either `chat_id` or `all_empty_entries`.")
-
-        if chat_id:
-            del self._chat_data[chat_id]
-
-        elif all_empty_entries:
-            chat_ids = list(self._chat_data.keys())
-
-            for _id in chat_ids:
-                if not bool(self._chat_data[_id]):
-                    del self._chat_data[_id]
+        del self._chat_data[chat_id]
 
         self.update_persistence()
 
-    def drop_user_data(self, user_id: int = None, all_empty_entries: bool = False) -> None:
+    def drop_user_data(self, user_id: int) -> None:
         """Used for deleting a key from the :attr:`user_data`.
 
         .. versionadded:: 14.0
 
         Args:
-            user_id (:obj:`int`, optional): The user id to delete from the persistence. The entry
-                will be deleted even if it is not empty. Mutually exclusive with
-                ``all_empty_entries``.
-            all_empty_entries (:obj:`bool`, optional): If :obj:`True`, all entries which evaluates
-                to :obj:`False` in a boolean context in :attr:`user_data` will be deleted.
-                Mutually exclusive with ``user_id``.
-
-        Raises:
-            :exc:`ValueError`: When both ``user_id`` and ``all_empty_entries`` are
-                provided, or none of them are passed.
+            user_id (:obj:`int`): The user id to delete from the persistence. The entry
+                will be deleted even if it is not empty.
         """
-        if not bool(user_id) ^ bool(all_empty_entries):
-            raise ValueError("You must pass either `user_id` or `all_empty_entries`.")
-
-        if user_id:
-            del self._user_data[user_id]
-
-        elif all_empty_entries:
-            user_ids = list(self._user_data.keys())
-
-            for u_id in user_ids:
-                if not bool(self._user_data[u_id]):
-                    del self._user_data[u_id]
+        del self._user_data[user_id]
 
         self.update_persistence()
 
@@ -748,8 +712,8 @@ class Dispatcher(Generic[BT, CCT, UD, CD, BD, JQ, PT]):
         if self.persistence:
             # We use list() here in order to decouple chat_ids from self._chat_data, as dict view
             # objects will change, when the dict does and we want to loop over chat_ids
-            chat_ids = list(self._chat_data.keys())
-            user_ids = list(self._user_data.keys())
+            chat_ids = list(self.chat_data.keys())
+            user_ids = list(self.user_data.keys())
 
             if isinstance(update, Update):
                 if update.effective_chat:
@@ -778,13 +742,13 @@ class Dispatcher(Generic[BT, CCT, UD, CD, BD, JQ, PT]):
             if self.persistence.store_data.chat_data:
                 for chat_id in chat_ids:
                     try:
-                        self.persistence.update_chat_data(chat_id, self._chat_data[chat_id])
+                        self.persistence.update_chat_data(chat_id, self.chat_data[chat_id])
                     except Exception as exc:
                         self.dispatch_error(update, exc)
             if self.persistence.store_data.user_data:
                 for user_id in user_ids:
                     try:
-                        self.persistence.update_user_data(user_id, self._user_data[user_id])
+                        self.persistence.update_user_data(user_id, self.user_data[user_id])
                     except Exception as exc:
                         self.dispatch_error(update, exc)
 

--- a/telegram/ext/_dispatcher.py
+++ b/telegram/ext/_dispatcher.py
@@ -668,7 +668,6 @@ class Dispatcher(Generic[BT, CCT, UD, CD, BD, JQ, PT]):
             :exc:`ValueError`: When both :paramref:`chat_id` and :paramref:`all_empty_entries` are
                 provided, or none of them are passed.
         """
-
         if chat_id and all_empty_entries:
             raise ValueError("You must pass either `chat_id` or `all_empty_entries` not both.")
 
@@ -705,7 +704,6 @@ class Dispatcher(Generic[BT, CCT, UD, CD, BD, JQ, PT]):
             :exc:`ValueError`: When both :paramref:`user_id` and :paramref:`all_empty_entries` are
                 provided, or none of them are passed.
         """
-
         if user_id and all_empty_entries:
             raise ValueError("You must pass either `user_id` or `all_empty_entries` not both.")
 

--- a/telegram/ext/_picklepersistence.py
+++ b/telegram/ext/_picklepersistence.py
@@ -402,9 +402,8 @@ class PicklePersistence(BasePersistence[UD, CD, BD]):
             chat_id (:obj:`int`): The chat id to delete from the persistence.
         """
         if self.chat_data is None:
-            self.chat_data = defaultdict(self.context_types.chat_data)
-        else:
-            del self.chat_data[chat_id]
+            return
+        self.chat_data.pop(chat_id, None)  # type: ignore[arg-type]
 
         if not self.on_flush:
             if not self.single_file:
@@ -422,9 +421,8 @@ class PicklePersistence(BasePersistence[UD, CD, BD]):
             user_id (:obj:`int`): The user id to delete from the persistence.
         """
         if self.user_data is None:
-            self.user_data = defaultdict(self.context_types.user_data)
-        else:
-            del self.user_data[user_id]
+            return
+        self.user_data.pop(user_id, None)  # type: ignore[arg-type]
 
         if not self.on_flush:
             if not self.single_file:

--- a/telegram/ext/_picklepersistence.py
+++ b/telegram/ext/_picklepersistence.py
@@ -396,6 +396,8 @@ class PicklePersistence(BasePersistence[UD, CD, BD]):
         """Will delete the specified key from the :attr:`chat_data` and depending on
         :attr:`on_flush` save the pickle file.
 
+        .. versionadded:: 14.0
+
         Args:
             chat_id (:obj:`int`): The chat id to delete from the persistence.
         """
@@ -413,6 +415,8 @@ class PicklePersistence(BasePersistence[UD, CD, BD]):
     def drop_user_data(self, user_id: int) -> None:
         """Will delete the specified key from the :attr:`user_data` and depending on
         :attr:`on_flush` save the pickle file.
+
+        .. versionadded:: 14.0
 
         Args:
             user_id (:obj:`int`): The user id to delete from the persistence.

--- a/telegram/ext/_picklepersistence.py
+++ b/telegram/ext/_picklepersistence.py
@@ -392,6 +392,42 @@ class PicklePersistence(BasePersistence[UD, CD, BD]):
             else:
                 self._dump_singlefile()
 
+    def drop_chat_data(self, chat_id: int) -> None:
+        """Will delete the specified key from the :attr:`chat_data` and depending on
+        :attr:`on_flush` save the pickle file.
+
+        Args:
+            chat_id (:obj:`int`): The chat id to delete from the persistence.
+        """
+        if self.chat_data is None:
+            self.chat_data = defaultdict(self.context_types.chat_data)
+        else:
+            del self.chat_data[chat_id]
+
+        if not self.on_flush:
+            if not self.single_file:
+                self._dump_file(Path(f"{self.filepath}_chat_data"), self.chat_data)
+            else:
+                self._dump_singlefile()
+
+    def drop_user_data(self, user_id: int) -> None:
+        """Will delete the specified key from the :attr:`user_data` and depending on
+        :attr:`on_flush` save the pickle file.
+
+        Args:
+            user_id (:obj:`int`): The user id to delete from the persistence.
+        """
+        if self.user_data is None:
+            self.user_data = defaultdict(self.context_types.user_data)
+        else:
+            del self.user_data[user_id]
+
+        if not self.on_flush:
+            if not self.single_file:
+                self._dump_file(Path(f"{self.filepath}_user_data"), self.user_data)
+            else:
+                self._dump_singlefile()
+
     def refresh_user_data(self, user_id: int, user_data: UD) -> None:
         """Does nothing.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -194,10 +194,9 @@ def dp(_dp):
     # Reset the dispatcher first
     while not _dp.update_queue.empty():
         _dp.update_queue.get(False)
-    _dp._chat_data = defaultdict(dict)
-    _dp._user_data = defaultdict(dict)
+    _dp._set_chat_data(defaultdict(dict))
+    _dp._set_user_data(defaultdict(dict))
     _dp.bot_data = {}
-    _dp.persistence = None
     _dp.handlers = {}
     _dp.error_handlers = {}
     _dp.exception_event = Event()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ from queue import Queue
 from threading import Thread, Event
 from time import sleep
 from typing import Callable, List, Iterable, Any
+from types import MappingProxyType
 
 import pytest
 import pytz
@@ -194,8 +195,10 @@ def dp(_dp):
     # Reset the dispatcher first
     while not _dp.update_queue.empty():
         _dp.update_queue.get(False)
-    _dp._set_chat_data(defaultdict(dict))
-    _dp._set_user_data(defaultdict(dict))
+    _dp._chat_data = defaultdict(dict)
+    _dp._user_data = defaultdict(dict)
+    _dp.chat_data = MappingProxyType(_dp._chat_data)  # Rebuild the mapping so it updates
+    _dp.user_data = MappingProxyType(_dp._user_data)
     _dp.bot_data = {}
     _dp.handlers = {}
     _dp.error_handlers = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -194,8 +194,8 @@ def dp(_dp):
     # Reset the dispatcher first
     while not _dp.update_queue.empty():
         _dp.update_queue.get(False)
-    _dp.chat_data = defaultdict(dict)
-    _dp.user_data = defaultdict(dict)
+    _dp._chat_data = defaultdict(dict)
+    _dp._user_data = defaultdict(dict)
     _dp.bot_data = {}
     _dp.persistence = None
     _dp.handlers = {}

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -76,9 +76,8 @@ class TestAnimation:
         assert animation.file_unique_id != ''
 
     def test_expected_values(self, animation):
-        assert animation.file_size == self.file_size
         assert animation.mime_type == self.mime_type
-        assert animation.file_name == self.file_name
+        assert animation.file_name.startswith('game.gif') == self.file_name.startswith('game.gif')
         assert isinstance(animation.thumb, PhotoSize)
 
     @flaky(3, 1)
@@ -122,7 +121,6 @@ class TestAnimation:
     def test_get_and_download(self, bot, animation):
         new_file = bot.get_file(animation.file_id)
 
-        assert new_file.file_size == self.file_size
         assert new_file.file_id == animation.file_id
         assert new_file.file_path.startswith('https://')
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -879,6 +879,54 @@ class TestDispatcher:
         assert not dp.persistence.test_flag_user_data
         assert dp.persistence.test_flag_chat_data
 
+    @pytest.mark.parametrize(
+        "remove_all,c_id,expected",
+        [
+            (True, 123, None),
+            (None, None, None),
+            (True, None, {321: {'not_empty': 'no'}, 222: "remove_me"}),
+            (False, 321, {123: [], 222: "remove_me"}),
+            (False, 111, None),
+        ],
+    )
+    def test_drop_chat_data(self, dp, remove_all, c_id, expected):
+        dp.chat_data = {123: [], 321: {'not_empty': 'no'}, 222: "remove_me"}
+
+        if (remove_all and c_id) or (not remove_all and not c_id):
+            with pytest.raises(ValueError, match="You must pass either"):
+                dp.drop_chat_data(c_id, all_empty_entries=remove_all)
+        else:
+            if c_id is not None and c_id not in dp.chat_data:
+                with pytest.raises(ValueError, match="The specified"):
+                    dp.drop_chat_data(c_id)
+            else:
+                dp.drop_chat_data(c_id, all_empty_entries=remove_all)
+                assert dp.chat_data == expected
+
+    @pytest.mark.parametrize(
+        "remove_all,u_id,expected",
+        [
+            (True, 123, None),
+            (None, None, None),
+            (True, None, {321: {'not_empty': 'no'}, 222: "remove_me"}),
+            (False, 321, {123: [], 222: "remove_me"}),
+            (False, 111, None),
+        ],
+    )
+    def test_drop_user_data(self, dp, remove_all, u_id, expected):
+        dp.user_data = {123: [], 321: {'not_empty': 'no'}, 222: "remove_me"}
+
+        if (remove_all and u_id) or (not remove_all and not u_id):
+            with pytest.raises(ValueError, match="You must pass either"):
+                dp.drop_user_data(u_id, all_empty_entries=remove_all)
+        else:
+            if u_id is not None and u_id not in dp.user_data:
+                with pytest.raises(ValueError, match="The specified"):
+                    dp.drop_user_data(u_id)
+            else:
+                dp.drop_user_data(u_id, all_empty_entries=remove_all)
+                assert dp.user_data == expected
+
     def test_update_persistence_once_per_update(self, monkeypatch, dp):
         def update_persistence(*args, **kwargs):
             self.count += 1

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -889,66 +889,34 @@ class TestDispatcher:
         assert dp.persistence.test_flag_chat_data
 
     @pytest.mark.parametrize(
-        "remove_all,c_id,expected",
-        [
-            (True, 123, None),
-            (None, None, None),
-            (True, None, {321: {'not_empty': 'no'}, 222: "remove_me"}),
-            (False, 321, {123: [], 222: "remove_me"}),
-            (False, 111, None),
-        ],
-        ids=[
-            "Passing all parameters (error)",
-            "Passing no parameters (error)",
-            "test all_empty removal",
-            "test chat_id removal",
-            "test no key in data (error)",
-        ],
+        "c_id,expected",
+        [(321, {123: [], 222: "remove_me"}), (111, None)],
+        ids=["test chat_id removal", "test no key in data (error)"],
     )
-    def test_drop_chat_data(self, dp, remove_all, c_id, expected):
+    def test_drop_chat_data(self, dp, c_id, expected):
         dp._chat_data.update({123: [], 321: {'not_empty': 'no'}, 222: "remove_me"})
 
-        if (remove_all and c_id) or (not remove_all and not c_id):
-            with pytest.raises(ValueError, match="You must pass either"):
-                dp.drop_chat_data(c_id, all_empty_entries=remove_all)
+        if c_id is not None and c_id not in dp.chat_data:
+            with pytest.raises(KeyError):
+                dp.drop_chat_data(c_id)
         else:
-            if c_id is not None and c_id not in dp.chat_data:
-                with pytest.raises(KeyError):
-                    dp.drop_chat_data(c_id)
-            else:
-                dp.drop_chat_data(c_id, all_empty_entries=remove_all)
-                assert dp.chat_data == expected
+            dp.drop_chat_data(c_id)
+            assert dp.chat_data == expected
 
     @pytest.mark.parametrize(
-        "remove_all,u_id,expected",
-        [
-            (True, 123, None),
-            (None, None, None),
-            (True, None, {321: {'not_empty': 'no'}, 222: "remove_me"}),
-            (False, 321, {123: [], 222: "remove_me"}),
-            (False, 111, None),
-        ],
-        ids=[
-            "Passing all parameters (error)",
-            "Passing no parameters (error)",
-            "test all_empty removal",
-            "test chat_id removal",
-            "test no key in data (error)",
-        ],
+        "u_id,expected",
+        [(321, {123: [], 222: "remove_me"}), (111, None)],
+        ids=["test user_id removal", "test no key in data (error)"],
     )
-    def test_drop_user_data(self, dp, remove_all, u_id, expected):
+    def test_drop_user_data(self, dp, u_id, expected):
         dp._user_data.update({123: [], 321: {'not_empty': 'no'}, 222: "remove_me"})
 
-        if (remove_all and u_id) or (not remove_all and not u_id):
-            with pytest.raises(ValueError, match="You must pass either"):
-                dp.drop_user_data(u_id, all_empty_entries=remove_all)
+        if u_id is not None and u_id not in dp.user_data:
+            with pytest.raises(KeyError):
+                dp.drop_user_data(u_id)
         else:
-            if u_id is not None and u_id not in dp.user_data:
-                with pytest.raises(KeyError):
-                    dp.drop_user_data(u_id)
-            else:
-                dp.drop_user_data(u_id, all_empty_entries=remove_all)
-                assert dp.user_data == expected
+            dp.drop_user_data(u_id)
+            assert dp.user_data == expected
 
     def test_update_persistence_once_per_update(self, monkeypatch, dp):
         def update_persistence(*args, **kwargs):

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -125,6 +125,15 @@ class TestDispatcher:
         )
         assert recwarn[0].filename == __file__, "stacklevel is incorrect!"
 
+    @pytest.mark.parametrize("data", ["chat_data", "user_data"])
+    def test_chat_user_data_read_only(self, dp, data):
+        read_only_data = getattr(dp, data)
+        writable_data = getattr(dp, f"_{data}")
+        writable_data[123] = 321
+        assert read_only_data == writable_data
+        with pytest.raises(TypeError):
+            read_only_data[111] = 123
+
     @pytest.mark.parametrize(
         'builder',
         (DispatcherBuilder(), UpdaterBuilder()),
@@ -890,7 +899,7 @@ class TestDispatcher:
         ],
     )
     def test_drop_chat_data(self, dp, remove_all, c_id, expected):
-        dp.chat_data = {123: [], 321: {'not_empty': 'no'}, 222: "remove_me"}
+        dp._chat_data = {123: [], 321: {'not_empty': 'no'}, 222: "remove_me"}
 
         if (remove_all and c_id) or (not remove_all and not c_id):
             with pytest.raises(ValueError, match="You must pass either"):
@@ -914,7 +923,7 @@ class TestDispatcher:
         ],
     )
     def test_drop_user_data(self, dp, remove_all, u_id, expected):
-        dp.user_data = {123: [], 321: {'not_empty': 'no'}, 222: "remove_me"}
+        dp._user_data = {123: [], 321: {'not_empty': 'no'}, 222: "remove_me"}
 
         if (remove_all and u_id) or (not remove_all and not u_id):
             with pytest.raises(ValueError, match="You must pass either"):

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -908,33 +908,23 @@ class TestDispatcher:
 
     @pytest.mark.parametrize(
         "c_id,expected",
-        [(321, {123: [], 222: "remove_me"}), (111, None)],
-        ids=["test chat_id removal", "test no key in data (error)"],
+        [(321, {222: "remove_me"}), (111, {321: {'not_empty': 'no'}, 222: "remove_me"})],
+        ids=["test chat_id removal", "test no key in data (no error)"],
     )
     def test_drop_chat_data(self, dp, c_id, expected):
-        dp._chat_data.update({123: [], 321: {'not_empty': 'no'}, 222: "remove_me"})
-
-        if c_id is not None and c_id not in dp.chat_data:
-            with pytest.raises(KeyError):
-                dp.drop_chat_data(c_id)
-        else:
-            dp.drop_chat_data(c_id)
-            assert dp.chat_data == expected
+        dp._chat_data.update({321: {'not_empty': 'no'}, 222: "remove_me"})
+        dp.drop_chat_data(c_id)
+        assert dp.chat_data == expected
 
     @pytest.mark.parametrize(
         "u_id,expected",
-        [(321, {123: [], 222: "remove_me"}), (111, None)],
-        ids=["test user_id removal", "test no key in data (error)"],
+        [(321, {222: "remove_me"}), (111, {321: {'not_empty': 'no'}, 222: "remove_me"})],
+        ids=["test user_id removal", "test no key in data (no error)"],
     )
     def test_drop_user_data(self, dp, u_id, expected):
-        dp._user_data.update({123: [], 321: {'not_empty': 'no'}, 222: "remove_me"})
-
-        if u_id is not None and u_id not in dp.user_data:
-            with pytest.raises(KeyError):
-                dp.drop_user_data(u_id)
-        else:
-            dp.drop_user_data(u_id)
-            assert dp.user_data == expected
+        dp._user_data.update({321: {'not_empty': 'no'}, 222: "remove_me"})
+        dp.drop_user_data(u_id)
+        assert dp.user_data == expected
 
     def test_update_persistence_once_per_update(self, monkeypatch, dp):
         def update_persistence(*args, **kwargs):

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -897,16 +897,23 @@ class TestDispatcher:
             (False, 321, {123: [], 222: "remove_me"}),
             (False, 111, None),
         ],
+        ids=[
+            "Passing all parameters (error)",
+            "Passing no parameters (error)",
+            "test all_empty removal",
+            "test chat_id removal",
+            "test no key in data (error)",
+        ],
     )
     def test_drop_chat_data(self, dp, remove_all, c_id, expected):
-        dp._chat_data = {123: [], 321: {'not_empty': 'no'}, 222: "remove_me"}
+        dp._chat_data.update({123: [], 321: {'not_empty': 'no'}, 222: "remove_me"})
 
         if (remove_all and c_id) or (not remove_all and not c_id):
             with pytest.raises(ValueError, match="You must pass either"):
                 dp.drop_chat_data(c_id, all_empty_entries=remove_all)
         else:
             if c_id is not None and c_id not in dp.chat_data:
-                with pytest.raises(ValueError, match="The specified"):
+                with pytest.raises(KeyError):
                     dp.drop_chat_data(c_id)
             else:
                 dp.drop_chat_data(c_id, all_empty_entries=remove_all)
@@ -921,16 +928,23 @@ class TestDispatcher:
             (False, 321, {123: [], 222: "remove_me"}),
             (False, 111, None),
         ],
+        ids=[
+            "Passing all parameters (error)",
+            "Passing no parameters (error)",
+            "test all_empty removal",
+            "test chat_id removal",
+            "test no key in data (error)",
+        ],
     )
     def test_drop_user_data(self, dp, remove_all, u_id, expected):
-        dp._user_data = {123: [], 321: {'not_empty': 'no'}, 222: "remove_me"}
+        dp._user_data.update({123: [], 321: {'not_empty': 'no'}, 222: "remove_me"})
 
         if (remove_all and u_id) or (not remove_all and not u_id):
             with pytest.raises(ValueError, match="You must pass either"):
                 dp.drop_user_data(u_id, all_empty_entries=remove_all)
         else:
             if u_id is not None and u_id not in dp.user_data:
-                with pytest.raises(ValueError, match="The specified"):
+                with pytest.raises(KeyError):
                     dp.drop_user_data(u_id)
             else:
                 dp.drop_user_data(u_id, all_empty_entries=remove_all)

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -630,6 +630,12 @@ class TestDispatcher:
             def update_bot_data(self, data):
                 raise Exception
 
+            def drop_chat_data(self, chat_id):
+                pass
+
+            def drop_user_data(self, user_id):
+                pass
+
             def get_chat_data(self):
                 return defaultdict(dict)
 
@@ -756,6 +762,12 @@ class TestDispatcher:
             def update_user_data(self, user_id, data):
                 self.update(data)
 
+            def drop_user_data(self, user_id):
+                pass
+
+            def drop_chat_data(self, chat_id):
+                pass
+
             def get_chat_data(self):
                 pass
 
@@ -832,6 +844,12 @@ class TestDispatcher:
                 self.test_flag_user_data = True
 
             def update_conversation(self, name, key, new_state):
+                pass
+
+            def drop_chat_data(self, chat_id):
+                pass
+
+            def drop_user_data(self, user_id):
                 pass
 
             def get_conversations(self, name):

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -50,14 +50,14 @@ from telegram.ext import (
     JobQueue,
     ContextTypes,
 )
+from telegram.ext._callbackdatacache import _KeyboardData
 
 
 @pytest.fixture(autouse=True)
-def change_directory(tmp_path):
+def change_directory(tmp_path: Path):
     orig_dir = Path.cwd()
-    # Switch to a temporary directory so we don't have to worry about cleaning up files
-    # (str() for py<3.6)
-    os.chdir(str(tmp_path))
+    # Switch to a temporary directory, so we don't have to worry about cleaning up files
+    os.chdir(tmp_path)
     yield
     # Go back to original directory
     os.chdir(orig_dir)
@@ -97,6 +97,12 @@ class OwnPersistence(BasePersistence):
         raise NotImplementedError
 
     def get_callback_data(self):
+        raise NotImplementedError
+
+    def drop_user_data(self, user_id):
+        raise NotImplementedError
+
+    def drop_chat_data(self, chat_id):
         raise NotImplementedError
 
     def refresh_user_data(self, user_id, user_data):
@@ -158,6 +164,12 @@ def bot_persistence():
 
         def update_callback_data(self, data):
             self.callback_data = data
+
+        def drop_user_data(self, user_id):
+            pass
+
+        def drop_chat_data(self, chat_id):
+            pass
 
         def update_conversation(self, name, key, new_state):
             raise NotImplementedError
@@ -257,7 +269,7 @@ class TestBasePersistence:
         with pytest.raises(
             TypeError,
             match=(
-                'flush, get_bot_data, get_callback_data, '
+                'drop_chat_data, drop_user_data, flush, get_bot_data, get_callback_data, '
                 'get_chat_data, get_conversations, '
                 'get_user_data, refresh_bot_data, refresh_chat_data, '
                 'refresh_user_data, update_bot_data, update_callback_data, '
@@ -339,7 +351,7 @@ class TestBasePersistence:
         u.dispatcher.chat_data[442233]['test5'] = 'test6'
         assert u.dispatcher.chat_data[442233]['test5'] == 'test6'
 
-    @pytest.mark.parametrize('run_async', [True, False], ids=['synchronous', 'run_async'])
+    @pytest.mark.parametrize('run_async', [True, False], ids=['run_async', 'synchronous'])
     def test_dispatcher_integration_handlers(
         self,
         dp,
@@ -368,8 +380,6 @@ class TestBasePersistence:
         base_persistence.get_chat_data = get_chat_data
         base_persistence.get_bot_data = get_bot_data
         base_persistence.get_callback_data = get_callback_data
-        # base_persistence.update_chat_data = lambda x: x
-        # base_persistence.update_user_data = lambda x: x
         base_persistence.refresh_bot_data = lambda x: x
         base_persistence.refresh_chat_data = lambda x, y: x
         base_persistence.refresh_user_data = lambda x, y: x
@@ -383,7 +393,7 @@ class TestBasePersistence:
                 pytest.fail('bot_data corrupt')
 
         def callback_known_chat(update, context):
-            if not context.chat_data['test3'] == 'test4':
+            if not context.chat_data[3] == 'test4':
                 pytest.fail('chat_data corrupt')
             if not context.bot_data == bot_data:
                 pytest.fail('bot_data corrupt')
@@ -398,20 +408,17 @@ class TestBasePersistence:
             context.user_data[1] = 'test7'
             context.chat_data[2] = 'test8'
             context.bot_data['test0'] = 'test0'
-            context.bot.callback_data_cache.put('test0')
+            # Let's now delete user1 and chat1
+            context.dispatcher.drop_chat_data(-67890)
+            context.dispatcher.drop_user_data(12345)
+            # Test setting new keyboard callback data-
+            context.bot.callback_data_cache._keyboard_data['id'] = _KeyboardData(
+                'id', button_data={'button3': 'test3'}
+            )
 
-        known_user = MessageHandler(
-            filters.User(user_id=12345),
-            callback_known_user,
-        )
-        known_chat = MessageHandler(
-            filters.Chat(chat_id=-67890),
-            callback_known_chat,
-        )
-        unknown = MessageHandler(
-            filters.ALL,
-            callback_unknown_user_or_chat,
-        )
+        known_user = MessageHandler(filters.User(user_id=12345), callback_known_user)  # user1
+        known_chat = MessageHandler(filters.Chat(chat_id=-67890), callback_known_chat)  # chat1
+        unknown = MessageHandler(filters.ALL, callback_unknown_user_or_chat)  # user2 and chat2
         dp.add_handler(known_user)
         dp.add_handler(known_chat)
         dp.add_handler(unknown)
@@ -420,51 +427,64 @@ class TestBasePersistence:
         chat1 = Chat(id=-67890, type='group')
         chat2 = Chat(id=-987654, type='group')
         m = Message(1, None, chat2, from_user=user1)
-        u = Update(0, m)
-        with caplog.at_level(logging.ERROR):
-            dp.process_update(u)
-        rec = caplog.records[-1]
-        assert rec.getMessage() == 'No error handlers are registered, logging exception.'
-        assert rec.levelname == 'ERROR'
-        rec = caplog.records[-2]
-        assert rec.getMessage() == 'No error handlers are registered, logging exception.'
-        assert rec.levelname == 'ERROR'
-        rec = caplog.records[-3]
-        assert rec.getMessage() == 'No error handlers are registered, logging exception.'
-        assert rec.levelname == 'ERROR'
+        u_known_user = Update(0, m)
+        dp.process_update(u_known_user)
+        # 4 errors which arise since update_*_data are raising NotImplementedError here.
+        assert len(caplog.records) == 4
         m.from_user = user2
         m.chat = chat1
-        u = Update(1, m)
-        dp.process_update(u)
+        u_known_chat = Update(1, m)
+        dp.process_update(u_known_chat)
         m.chat = chat2
-        u = Update(2, m)
+        u_unknown_user_or_chat = Update(2, m)
 
         def save_bot_data(data):
             if 'test0' not in data:
                 pytest.fail()
 
-        def save_chat_data(data):
-            if -987654 not in data:
+        def save_chat_data(_id, data):
+            if 2 not in data:  # data should be: {2: 'test8'}
                 pytest.fail()
 
-        def save_user_data(data):
-            if 54321 not in data:
+        def save_user_data(_id, data):
+            if 1 not in data:  # data should be: {1: 'test7'}
                 pytest.fail()
 
         def save_callback_data(data):
-            if not assert_data_in_cache(dp.bot.callback_data, 'test0'):
+            if not assert_data_in_cache(dp.bot.callback_data_cache, 'test3'):
                 pytest.fail()
+
+        # Functions to check deletion-
+        def delete_user_data(user_id):
+            if 12345 != user_id:
+                pytest.fail("The id being deleted is not of user1's")
+            user_data.pop(user_id, None)
+
+        def delete_chat_data(chat_id):
+            if -67890 != chat_id:
+                pytest.fail("The chat id being deleted is not of chat1's")
+            chat_data.pop(chat_id, None)
 
         base_persistence.update_chat_data = save_chat_data
         base_persistence.update_user_data = save_user_data
         base_persistence.update_bot_data = save_bot_data
         base_persistence.update_callback_data = save_callback_data
-        dp.process_update(u)
+        base_persistence.drop_chat_data = delete_chat_data
+        base_persistence.drop_user_data = delete_user_data
+        dp.process_update(u_unknown_user_or_chat)
 
+        # Test callback_unknown_user_or_chat worked correctly-
         assert dp.user_data[54321][1] == 'test7'
         assert dp.chat_data[-987654][2] == 'test8'
         assert dp.bot_data['test0'] == 'test0'
-        assert assert_data_in_cache(dp.bot.callback_data_cache, 'test0')
+        assert assert_data_in_cache(dp.bot.callback_data_cache, 'test3')
+        assert 12345 not in dp.user_data  # Tests if dp.drop_user_data worked or not
+        assert -67890 not in dp.chat_data
+        assert len(caplog.records) == 8  # Errors double since new update is processed.
+        for r in caplog.records:
+            assert issubclass(r.exc_info[0], NotImplementedError)
+            assert r.getMessage() == 'No error handlers are registered, logging exception.'
+            assert r.levelname == 'ERROR'
 
     @pytest.mark.parametrize(
         'store_user_data', [True, False], ids=['store_user_data-True', 'store_user_data-False']
@@ -475,7 +495,7 @@ class TestBasePersistence:
     @pytest.mark.parametrize(
         'store_bot_data', [True, False], ids=['store_bot_data-True', 'store_bot_data-False']
     )
-    @pytest.mark.parametrize('run_async', [True, False], ids=['synchronous', 'run_async'])
+    @pytest.mark.parametrize('run_async', [True, False], ids=['run_async', 'synchronous'])
     def test_persistence_dispatcher_integration_refresh_data(
         self,
         dp,
@@ -1043,13 +1063,9 @@ class TestPicklePersistence:
 
     def test_no_files_present_multi_file(self, pickle_persistence):
         assert pickle_persistence.get_user_data() == defaultdict(dict)
-        assert pickle_persistence.get_user_data() == defaultdict(dict)
         assert pickle_persistence.get_chat_data() == defaultdict(dict)
-        assert pickle_persistence.get_chat_data() == defaultdict(dict)
-        assert pickle_persistence.get_bot_data() == {}
         assert pickle_persistence.get_bot_data() == {}
         assert pickle_persistence.get_callback_data() is None
-        assert pickle_persistence.get_conversations('noname') == {}
         assert pickle_persistence.get_conversations('noname') == {}
 
     def test_no_files_present_single_file(self, pickle_persistence):
@@ -1342,6 +1358,8 @@ class TestPicklePersistence:
         with Path('pickletest_user_data').open('rb') as f:
             user_data_test = defaultdict(dict, pickle.load(f))
         assert user_data_test == user_data
+        pickle_persistence.drop_user_data(67890)
+        assert 67890 not in pickle_persistence.get_user_data()
 
         chat_data = pickle_persistence.get_chat_data()
         chat_data[-12345]['test3']['test4'] = 'test6'
@@ -1354,6 +1372,8 @@ class TestPicklePersistence:
         with Path('pickletest_chat_data').open('rb') as f:
             chat_data_test = defaultdict(dict, pickle.load(f))
         assert chat_data_test == chat_data
+        pickle_persistence.drop_chat_data(-67890)
+        assert -67890 not in pickle_persistence.get_chat_data()
 
         bot_data = pickle_persistence.get_bot_data()
         bot_data['test3']['test4'] = 'test6'
@@ -1408,6 +1428,8 @@ class TestPicklePersistence:
         with Path('pickletest').open('rb') as f:
             user_data_test = defaultdict(dict, pickle.load(f)['user_data'])
         assert user_data_test == user_data
+        pickle_persistence.drop_user_data(67890)
+        assert 67890 not in pickle_persistence.get_user_data()
 
         chat_data = pickle_persistence.get_chat_data()
         chat_data[-12345]['test3']['test4'] = 'test6'
@@ -1420,6 +1442,8 @@ class TestPicklePersistence:
         with Path('pickletest').open('rb') as f:
             chat_data_test = defaultdict(dict, pickle.load(f)['chat_data'])
         assert chat_data_test == chat_data
+        pickle_persistence.drop_chat_data(-67890)
+        assert -67890 not in pickle_persistence.get_chat_data()
 
         bot_data = pickle_persistence.get_bot_data()
         bot_data['test3']['test4'] = 'test6'
@@ -2132,6 +2156,8 @@ class TestDictPersistence:
         dict_persistence.update_user_data(12345, user_data[12345])
         assert dict_persistence.user_data == user_data
         assert dict_persistence.user_data_json == json.dumps(user_data)
+        dict_persistence.drop_user_data(67890)
+        assert 67890 not in dict_persistence.user_data
 
         chat_data = dict_persistence.get_chat_data()
         chat_data[-12345]['test3']['test4'] = 'test6'
@@ -2144,6 +2170,8 @@ class TestDictPersistence:
         dict_persistence.update_chat_data(-12345, chat_data[-12345])
         assert dict_persistence.chat_data == chat_data
         assert dict_persistence.chat_data_json == json.dumps(chat_data)
+        dict_persistence.drop_chat_data(-67890)
+        assert -67890 not in dict_persistence.chat_data
 
         bot_data = dict_persistence.get_bot_data()
         bot_data['test3']['test4'] = 'test6'

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1931,6 +1931,12 @@ class TestPicklePersistence:
 
         persistence.user_data = None
         persistence.chat_data = None
+        persistence.drop_user_data(123)
+        persistence.drop_chat_data(123)
+        assert isinstance(persistence.get_user_data(), defaultdict)
+        assert isinstance(persistence.get_chat_data(), defaultdict)
+        persistence.user_data = None
+        persistence.chat_data = None
         persistence.update_user_data(1, ud(1))
         persistence.update_chat_data(1, cd(1))
         persistence.update_bot_data(bd(1))
@@ -2158,6 +2164,9 @@ class TestDictPersistence:
         assert dict_persistence.user_data_json == json.dumps(user_data)
         dict_persistence.drop_user_data(67890)
         assert 67890 not in dict_persistence.user_data
+        dict_persistence._user_data = None
+        dict_persistence.drop_user_data(123)
+        assert isinstance(dict_persistence.get_user_data(), defaultdict)
 
         chat_data = dict_persistence.get_chat_data()
         chat_data[-12345]['test3']['test4'] = 'test6'
@@ -2172,6 +2181,9 @@ class TestDictPersistence:
         assert dict_persistence.chat_data_json == json.dumps(chat_data)
         dict_persistence.drop_chat_data(-67890)
         assert -67890 not in dict_persistence.chat_data
+        dict_persistence._chat_data = None
+        dict_persistence.drop_chat_data(123)
+        assert isinstance(dict_persistence.get_chat_data(), defaultdict)
 
         bot_data = dict_persistence.get_bot_data()
         bot_data['test3']['test4'] = 'test6'


### PR DESCRIPTION
Closes #2732 

### Checklist for PRs

- [x] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests

Breaking changes:
- `dp.chat/user_data` is now read only
- `BasePersistence.drop_chat/user_data` is an abstractmethod