### PR TITLE
ConversionHandler - fix map_to_parent for promises

### DIFF
--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -649,11 +649,12 @@ class ConversationHandler(Handler[Update, CCT]):
                     self.logger.warning(
                         "Ignoring `conversation_timeout` because the Dispatcher has no JobQueue."
                     )
-        
-        new_state_str = new_state
+
         if isinstance(new_state, Promise):
             new_state_str = self._resolve_promise((new_state, new_state))
-        
+        else:
+            new_state_str = new_state
+
         if isinstance(self.map_to_parent, dict) and new_state_str in self.map_to_parent:
             self._update_state(self.END, conversation_key)
             if raise_dp_handler_stop:

--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -650,11 +650,12 @@ class ConversationHandler(Handler[Update, CCT]):
                         "Ignoring `conversation_timeout` because the Dispatcher has no JobQueue."
                     )
 
-        if isinstance(self.map_to_parent, dict) and new_state in self.map_to_parent:
+        new_state_str = self._resolve_promise((new_state, new_state)) if isinstance(new_state, Promise) else new_state
+        if isinstance(self.map_to_parent, dict) and new_state_str in self.map_to_parent:
             self._update_state(self.END, conversation_key)
             if raise_dp_handler_stop:
-                raise DispatcherHandlerStop(self.map_to_parent.get(new_state))
-            return self.map_to_parent.get(new_state)
+                raise DispatcherHandlerStop(self.map_to_parent.get(new_state_str))
+            return self.map_to_parent.get(new_state_str)
 
         self._update_state(new_state, conversation_key)
         if raise_dp_handler_stop:

--- a/telegram/ext/conversationhandler.py
+++ b/telegram/ext/conversationhandler.py
@@ -649,8 +649,11 @@ class ConversationHandler(Handler[Update, CCT]):
                     self.logger.warning(
                         "Ignoring `conversation_timeout` because the Dispatcher has no JobQueue."
                     )
-
-        new_state_str = self._resolve_promise((new_state, new_state)) if isinstance(new_state, Promise) else new_state
+        
+        new_state_str = new_state
+        if isinstance(new_state, Promise):
+            new_state_str = self._resolve_promise((new_state, new_state))
+        
         if isinstance(self.map_to_parent, dict) and new_state_str in self.map_to_parent:
             self._update_state(self.END, conversation_key)
             if raise_dp_handler_stop:


### PR DESCRIPTION
Fix error on mapping Promise-like new_state to parent state in ConversionHandler.

<!--
Hey! You're PRing? Cool! Please have a look at the below checklist. It's here to help both you and the maintainers to remember some aspects. Make sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
-->

### Checklist for PRs

- [x] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [x] Added myself alphabetically to `AUTHORS.rst` (optional)
- [x] Added new classes & modules to the docs


### If the PR contains API changes (otherwise, you can delete this passage)

* New classes:
    - [x] Added `self._id_attrs` and corresponding documentation
    - [x] `__init__` accepts `**_kwargs`
    
* Added new shortcuts:
    - [x] In `Chat` & `User` for all methods that accept `chat/user_id`
    - [x] In `Message` for all methods that accept `chat_id` and `message_id`
    - [x] For new `Message` shortcuts: Added `quote` argument if methods accepts `reply_to_message_id`
    - [x] In `CallbackQuery` for all methods that accept either `chat_id` and `message_id` or `inline_message_id`
    
* If relevant:

    - [x] Added new constants at `telegram.constants` and shortcuts to them as class variables
    - [x] Added new handlers for new update types
    - [x] Added new filters for new message (sub)types
    - [x] Added or updated documentation for the changed class(es) and/or method(s)
    - [x] Updated the Bot API version number in all places: `README.rst` and `README_RAW.rst` (including the badge), as well as `telegram.constants.BOT_API_VERSION`
    - [x] Added logic for arbitrary callback data in `tg.ext.Bot` for new methods that either accept a `reply_markup` in some form or have a return type that is/contains `telegram.Message`
