### PR TITLE
hashtags fixed in markdownV2

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -99,6 +99,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Sascha <https://github.com/saschalalala>`_
 - `Shelomentsev D <https://github.com/shelomentsevd>`_
 - `Simon Schürrle <https://github.com/SitiSchu>`_
+- `SReza SMohseni <https://github.com/srezasm>`_
 - `sooyhwang <https://github.com/sooyhwang>`_
 - `syntx <https://github.com/syntx>`_
 - `thodnev <https://github.com/thodnev>`_

--- a/telegram/utils/helpers.py
+++ b/telegram/utils/helpers.py
@@ -167,11 +167,11 @@ def escape_markdown(text: str, version: int = 1, entity_type: str = None) -> str
         elif entity_type == 'text_link':
             escape_chars = r'\)'
         else:
-            escape_chars = r'_*[]()~`>#+-=|{}.!'
+            escape_chars = r'_*[]()~`>+-=|{}.!'
     else:
         raise ValueError('Markdown version must be either 1 or 2!')
 
-    return re.sub(f'([{re.escape(escape_chars)}])', r'\\\1', text)
+    return re.sub(f'([{re.escape(escape_chars)}])', r'\\\1', text.replace('#', r'\\%23\\'))
 
 
 # -------- date/time related helpers --------

--- a/telegram/utils/helpers.py
+++ b/telegram/utils/helpers.py
@@ -171,7 +171,7 @@ def escape_markdown(text: str, version: int = 1, entity_type: str = None) -> str
     else:
         raise ValueError('Markdown version must be either 1 or 2!')
 
-    return re.sub(f'([{re.escape(escape_chars)}])', r'\\\1', text.replace('#', r'\\%23\\'))
+    return re.sub(f'([{re.escape(escape_chars)}])', r'\\\1', text.replace('#', '\\%23\\'))
 
 
 # -------- date/time related helpers --------


### PR DESCRIPTION
# Fixed hashtags for markdownV2 format.
Apparently, markdownV2 doesn't handle hashtags with the preceding '\\' character. Through a chat with one of the telegram assistants I figured that the problem will be fixed by replacing the '#' with '\%23\'. each '\\' is just a backslash and '%23' represents the '#' character in HTML format.