### PR TITLE
to_true shortcut for ChatPermissions

### DIFF
--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -4802,7 +4802,8 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         Use this method to restrict a user in a supergroup. The bot must be an administrator in
         the supergroup for this to work and must have the appropriate admin rights. Pass
         :obj:`True` for all boolean parameters in :class:`telegram.ChatPermissions` to lift
-        restrictions from a user.
+        restrictions from a user, see
+        :meth:`telegram.ChatPermissions.all_true` for a shortcut.
 
         Args:
             chat_id (:obj:`int` | :obj:`str`): Unique identifier for the target chat or username

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -4832,11 +4832,11 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
             api_kwargs (:obj:`dict`, optional): Arbitrary keyword arguments to be passed to the
                 Telegram API.
 
-            Returns:
-                :obj:`bool`: On success, :obj:`True` is returned.
+        Returns:
+            :obj:`bool`: On success, :obj:`True` is returned.
 
-            Raises:
-                :class:`telegram.error.TelegramError`
+        Raises:
+            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             'chat_id': chat_id,

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -4801,9 +4801,9 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         """
         Use this method to restrict a user in a supergroup. The bot must be an administrator in
         the supergroup for this to work and must have the appropriate admin rights. Pass
-        :obj:`True` for all boolean parameters in :class:`telegram.ChatPermissions` to lift
-        restrictions from a user, see
-        :meth:`telegram.ChatPermissions.all_true` for a shortcut.
+        :obj:`True` for all boolean parameters to lift restrictions from a user.
+
+        .. seealso:: :meth:`telegram.ChatPermissions.all_permissions`
 
         Args:
             chat_id (:obj:`int` | :obj:`str`): Unique identifier for the target chat or username
@@ -4832,11 +4832,11 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
             api_kwargs (:obj:`dict`, optional): Arbitrary keyword arguments to be passed to the
                 Telegram API.
 
-        Returns:
-            :obj:`bool`: On success, :obj:`True` is returned.
+            Returns:
+                :obj:`bool`: On success, :obj:`True` is returned.
 
-        Raises:
-            :class:`telegram.error.TelegramError`
+            Raises:
+                :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             'chat_id': chat_id,

--- a/telegram/_chatpermissions.py
+++ b/telegram/_chatpermissions.py
@@ -128,6 +128,8 @@ class ChatPermissions(TelegramObject):
         This method returns the ChatPermissions object with all attributes set to :obj:`bool`.
         This is e.g. useful when unrestricting a ChatMember with
         :meth:`telegram.Bot.restrict_chat_member`.
+
+        .. versionadded:: 14.0
         """
         # we generate the object so we can set the attributes to True dynamically in case
         # there are more added later.

--- a/telegram/_chatpermissions.py
+++ b/telegram/_chatpermissions.py
@@ -123,12 +123,21 @@ class ChatPermissions(TelegramObject):
         )
 
     @classmethod
-    def all_true(cls) -> 'ChatPermissions':
+    def all_permissions(cls) -> 'ChatPermissions':
         """
-        This method returns the ChatPermissions object with all attributes set to :obj:`bool`.
+        This method returns the ChatPermissions object with all attributes set to :obj:`True`.
         This is e.g. useful when unrestricting a ChatMember with
         :meth:`telegram.Bot.restrict_chat_member`.
 
         .. versionadded:: 14.0
         """
         return cls(True, True, True, True, True, True, True, True)
+
+    @classmethod
+    def no_permissions(cls) -> 'ChatPermissions':
+        """
+        This method returns the ChatPermissions object with all attributes set to :obj:`False`.
+
+        .. versionadded:: 14.0
+        """
+        return cls(False, False, False, False, False, False, False, False)

--- a/telegram/_chatpermissions.py
+++ b/telegram/_chatpermissions.py
@@ -122,8 +122,8 @@ class ChatPermissions(TelegramObject):
             self.can_pin_messages,
         )
 
-    @staticmethod
-    def all_true() -> 'ChatPermissions':
+    @classmethod
+    def all_true(cls) -> 'ChatPermissions':
         """
         This method returns the ChatPermissions object with all attributes set to :obj:`bool`.
         This is e.g. useful when unrestricting a ChatMember with
@@ -131,11 +131,4 @@ class ChatPermissions(TelegramObject):
 
         .. versionadded:: 14.0
         """
-        # we generate the object so we can set the attributes to True dynamically in case
-        # there are more added later.
-        object_to_return = ChatPermissions()
-        # slots return us all attributes as a set of strings,
-        # which is exactly what we need to set them
-        for attribute in object_to_return.__slots__:
-            setattr(object_to_return, attribute, True)
-        return object_to_return
+        return cls(True, True, True, True, True, True, True, True)

--- a/telegram/_chatpermissions.py
+++ b/telegram/_chatpermissions.py
@@ -121,3 +121,19 @@ class ChatPermissions(TelegramObject):
             self.can_invite_users,
             self.can_pin_messages,
         )
+
+    @staticmethod
+    def all_true() -> 'ChatPermissions':
+        """
+        This method returns the ChatPermissions object with all attributes set to :obj:`bool`.
+        This is e.g. useful when unrestricting a ChatMember with
+        :meth:`telegram.Bot.restrict_chat_member`.
+        """
+        # we generate the object so we can set the attributes to True dynamically in case
+        # there are more added later.
+        object_to_return = ChatPermissions()
+        # slots return us all attributes as a set of strings,
+        # which is exactly what we need to set them
+        for attribute in object_to_return.__slots__:
+            setattr(object_to_return, attribute, True)
+        return object_to_return

--- a/telegram/_chatpermissions.py
+++ b/telegram/_chatpermissions.py
@@ -129,7 +129,7 @@ class ChatPermissions(TelegramObject):
         :obj:`True`. This is e.g. useful when unrestricting a chat member with
         :meth:`telegram.Bot.restrict_chat_member`.
 
-        .. versionadded:: 14.0
+        .. versionadded:: 20.0
         """
         return cls(True, True, True, True, True, True, True, True)
 
@@ -139,6 +139,6 @@ class ChatPermissions(TelegramObject):
         This method returns an :class:`ChatPermisisons` instance
         with all attributes set to :obj:`False`.
 
-        .. versionadded:: 14.0
+        .. versionadded:: 2.0
         """
         return cls(False, False, False, False, False, False, False, False)

--- a/telegram/_chatpermissions.py
+++ b/telegram/_chatpermissions.py
@@ -125,20 +125,21 @@ class ChatPermissions(TelegramObject):
     @classmethod
     def all_permissions(cls) -> 'ChatPermissions':
         """
-        This method returns an :class:`ChatPermisisons` instance with all attributes set to
-        :obj:`True`. This is e.g. useful when unrestricting a chat member with
+        This method returns an :class:`ChatPermissions` instance with all attributes
+        set to :obj:`True`. This is e.g. useful when unrestricting a chat member with
         :meth:`telegram.Bot.restrict_chat_member`.
 
         .. versionadded:: 20.0
+
         """
         return cls(True, True, True, True, True, True, True, True)
 
     @classmethod
     def no_permissions(cls) -> 'ChatPermissions':
         """
-        This method returns an :class:`ChatPermisisons` instance
+        This method returns an :class:`ChatPermissions` instance
         with all attributes set to :obj:`False`.
 
-        .. versionadded:: 2.0
+        .. versionadded:: 20.0
         """
         return cls(False, False, False, False, False, False, False, False)

--- a/telegram/_chatpermissions.py
+++ b/telegram/_chatpermissions.py
@@ -125,8 +125,8 @@ class ChatPermissions(TelegramObject):
     @classmethod
     def all_permissions(cls) -> 'ChatPermissions':
         """
-        This method returns the ChatPermissions object with all attributes set to :obj:`True`.
-        This is e.g. useful when unrestricting a chat member with
+        This method returns an :class:`ChatPermisisons` instance with all attributes set to
+        :obj:`True`. This is e.g. useful when unrestricting a chat member with
         :meth:`telegram.Bot.restrict_chat_member`.
 
         .. versionadded:: 14.0
@@ -136,7 +136,8 @@ class ChatPermissions(TelegramObject):
     @classmethod
     def no_permissions(cls) -> 'ChatPermissions':
         """
-        This method returns the ChatPermissions object with all attributes set to :obj:`False`.
+        This method returns an :class:`ChatPermisisons` instance
+        with all attributes set to :obj:`False`.
 
         .. versionadded:: 14.0
         """

--- a/telegram/_chatpermissions.py
+++ b/telegram/_chatpermissions.py
@@ -126,7 +126,7 @@ class ChatPermissions(TelegramObject):
     def all_permissions(cls) -> 'ChatPermissions':
         """
         This method returns the ChatPermissions object with all attributes set to :obj:`True`.
-        This is e.g. useful when unrestricting a ChatMember with
+        This is e.g. useful when unrestricting a chat member with
         :meth:`telegram.Bot.restrict_chat_member`.
 
         .. versionadded:: 14.0

--- a/tests/test_chatpermissions.py
+++ b/tests/test_chatpermissions.py
@@ -124,3 +124,13 @@ class TestChatPermissions:
 
         assert a != d
         assert hash(a) != hash(d)
+
+    def test_all_true(self):
+        f = ChatPermissions()
+        t = ChatPermissions.all_true()
+        # if the dirs are the same, the attributes will all be there
+        assert dir(f) == dir(t)
+        # now we just need to check that all attributes are True. to_dict gives them to us
+        # as a dict, mapping the attribute name to the value.
+        for key in t.to_dict().keys():
+            assert t[key] is True

--- a/tests/test_chatpermissions.py
+++ b/tests/test_chatpermissions.py
@@ -132,8 +132,8 @@ class TestChatPermissions:
         assert dir(f) == dir(t)
         # now we just need to check that all attributes are True. _id_attrs returns all values,
         # if a new one is added without defaulting to True, this will fail
-        for key in t._id_attrs:
-            assert key is True
+        for key in t.__slots__:
+            assert t[key] is True
         # and as a finisher, make sure the default is different.
         assert f != t
 
@@ -144,7 +144,7 @@ class TestChatPermissions:
         assert dir(f) == dir(t)
         # now we just need to check that all attributes are True. _id_attrs returns all values,
         # if a new one is added without defaulting to True, this will fail
-        for key in t._id_attrs:
-            assert key is False
+        for key in t.__slots__:
+            assert t[key] is False
         # and as a finisher, make sure the default is different.
         assert f != t

--- a/tests/test_chatpermissions.py
+++ b/tests/test_chatpermissions.py
@@ -125,14 +125,26 @@ class TestChatPermissions:
         assert a != d
         assert hash(a) != hash(d)
 
-    def test_all_true(self):
+    def test_all_permissions(self):
         f = ChatPermissions()
-        t = ChatPermissions.all_true()
+        t = ChatPermissions.all_permissions()
         # if the dirs are the same, the attributes will all be there
         assert dir(f) == dir(t)
         # now we just need to check that all attributes are True. _id_attrs returns all values,
         # if a new one is added without defaulting to True, this will fail
         for key in t._id_attrs:
             assert key is True
+        # and as a finisher, make sure the default is different.
+        assert f != t
+
+    def test_no_permissions(self):
+        f = ChatPermissions()
+        t = ChatPermissions.no_permissions()
+        # if the dirs are the same, the attributes will all be there
+        assert dir(f) == dir(t)
+        # now we just need to check that all attributes are True. _id_attrs returns all values,
+        # if a new one is added without defaulting to True, this will fail
+        for key in t._id_attrs:
+            assert key is False
         # and as a finisher, make sure the default is different.
         assert f != t

--- a/tests/test_chatpermissions.py
+++ b/tests/test_chatpermissions.py
@@ -130,7 +130,9 @@ class TestChatPermissions:
         t = ChatPermissions.all_true()
         # if the dirs are the same, the attributes will all be there
         assert dir(f) == dir(t)
-        # now we just need to check that all attributes are True. to_dict gives them to us
-        # as a dict, mapping the attribute name to the value.
-        for key in t.to_dict().keys():
-            assert t[key] is True
+        # now we just need to check that all attributes are True. _id_attrs returns all values,
+        # if a new one is added without defaulting to True, this will fail
+        for key in t._id_attrs:
+            assert key is True
+        # and as a finisher, make sure the default is different.
+        assert f != t


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool! Please have a look at the below checklist. It's here to help both you and the maintainers to remember some aspects. Make sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
-->

### Checklist for PRs

- [x] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)
- [x] Added new classes & modules to the docs


### If the PR contains API changes (otherwise, you can delete this passage)

* New classes:
    - [ ] Added `self._id_attrs` and corresponding documentation
    - [ ] `__init__` accepts `**_kwargs`
    
* Added new shortcuts:
    - [ ] In `Chat` & `User` for all methods that accept `chat/user_id`
    - [ ] In `Message` for all methods that accept `chat_id` and `message_id`
    - [ ] For new `Message` shortcuts: Added `quote` argument if methods accepts `reply_to_message_id`
    - [ ] In `CallbackQuery` for all methods that accept either `chat_id` and `message_id` or `inline_message_id`
    
* If relevant:

    - [ ] Added new constants at `telegram.constants` and shortcuts to them as class variables
    - [ ] Added new handlers for new update types
    - [ ] Added new filters for new message (sub)types
    - [ ] Added or updated documentation for the changed class(es) and/or method(s)
    - [ ] Updated the Bot API version number in all places: `README.rst` and `README_RAW.rst` (including the badge), as well as `telegram.constants.BOT_API_VERSION`
    - [ ] Added logic for arbitrary callback data in `tg.ext.Bot` for new methods that either accept a `reply_markup` in some form or have a return type that is/contains `telegram.Message`

This was a spontaneous idea and quickly done by me to avoid other work. No proper issue to close here.