### PR TITLE
adding permissions to workflow

### DIFF
--- a/.github/workflows/example_notifier.yml
+++ b/.github/workflows/example_notifier.yml
@@ -2,6 +2,8 @@ name: Warning maintainers
 on:
   pull_request_target:
     paths: examples/**
+permissions:
+ pull-requests: write
 jobs:
   job:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-commit_dependencies_notifier.yml
+++ b/.github/workflows/pre-commit_dependencies_notifier.yml
@@ -5,6 +5,8 @@ on:
       - requirements.txt
       - requirements-dev.txt
       - .pre-commit-config.yaml
+permissions:
+ pull-requests: write
 jobs:
   job:
     runs-on: ubuntu-latest

--- a/.github/workflows/readme_notifier.yml
+++ b/.github/workflows/readme_notifier.yml
@@ -4,6 +4,8 @@ on:
     paths:
       - README.rst
       - README_RAW.rst
+permissions:
+ pull-requests: write
 jobs:
   job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
While doing the rewrite of my action today, I stumbled upon [a new way to give permissions to action tokens](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions). We had the issue that people who don't have write access to our repo (so those who came from forks) didn't generate tokens with write access to the pull request. This generated in my action failing with the `Resource not accessible by integration` error, see Poolitzer/python-telegram-bot/pull/2 or the actual errror https://github.com/Poolitzer/python-telegram-bot/runs/6211635584?check_suite_focus=true or https://github.com/python-telegram-bot/python-telegram-bot/runs/6189881374?check_suite_focus=true.

This was unfixable without exposing a token to the public. But with this new setting, we are all good \o/. See https://github.com/Poolitzer/python-telegram-bot/pull/3.

I see no downside to this change.