### PR TITLE
Re-activate max caption length test

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2396,9 +2396,9 @@ class TestBot:
         my_rights = ChatAdministratorRights.all_rights()
         await bot.set_my_default_administrator_rights(my_rights, for_channels=True)
         my_admin_rights_ch = await bot.get_my_default_administrator_rights(for_channels=True)
-        # tg bug? is_anonymous, can_invite_users is False despite setting it True for channels:
+        assert my_admin_rights_ch.can_invite_users is my_rights.can_invite_users
+        # tg bug? is_anonymous is False despite setting it True for channels:
         assert my_admin_rights_ch.is_anonymous is not my_rights.is_anonymous
-        assert my_admin_rights_ch.can_invite_users is not my_rights.can_invite_users
 
         assert my_admin_rights_ch.can_manage_chat is my_rights.can_manage_chat
         assert my_admin_rights_ch.can_delete_messages is my_rights.can_delete_messages

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -103,7 +103,6 @@ class TestConstants:
             )
 
     @flaky(3, 1)
-    @pytest.mark.xfail(reason="Telegram apparently changed the limit without documenting it yet.")
     async def test_max_caption_length(self, bot, chat_id):
         good_caption = "a" * constants.MessageLimit.CAPTION_LENGTH
         with data_file("telegram.png").open("rb") as f:


### PR DESCRIPTION
Closes #3001. Apparently that was only a temporary issue.