### PR TITLE
add Linkcheck to doc ci

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -263,18 +263,18 @@ break the API classes. For example:
         self.last_name = last_name
 
 
-.. _`Code of Conduct`: https://www.python.org/psf/codeofconduct/
+.. _`Code of Conduct`: https://www.python.org/psf/conduct/
 .. _`issue tracker`: https://github.com/python-telegram-bot/python-telegram-bot/issues
 .. _`Telegram group`: https://telegram.me/pythontelegrambotgroup
-.. _`PEP 8 Style Guide`: https://www.python.org/dev/peps/pep-0008/
-.. _`sphinx`: http://sphinx-doc.org
-.. _`Google Python Style Guide`: http://google.github.io/styleguide/pyguide.html
+.. _`PEP 8 Style Guide`: https://peps.python.org/pep-0008/
+.. _`sphinx`: https://www.sphinx-doc.org/en/master
+.. _`Google Python Style Guide`: https://google.github.io/styleguide/pyguide.html
 .. _`Google Python Style Docstrings`: https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html
-.. _AUTHORS.rst: ../AUTHORS.rst
+.. _AUTHORS.rst: https://github.com/python-telegram-bot/python-telegram-bot/blob/master/AUTHORS.rst
 .. _`MyPy`: https://mypy.readthedocs.io/en/stable/index.html
 .. _`here`: https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html
 .. _`Black`: https://black.readthedocs.io/en/stable/index.html
-.. _`popular editors`: https://black.readthedocs.io/en/stable/editor_integration.html
+.. _`popular editors`: https://black.readthedocs.io/en/stable/integrations/editors.html
 .. _`RTD`: https://python-telegram-bot.readthedocs.io/
 .. _`RTD build`: https://python-telegram-bot.readthedocs.io/en/doc-fixes
 .. _`CSI`: https://standards.mousepawmedia.com/en/stable/csi.html

--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -3,9 +3,6 @@ on:
   schedule:
     # First day of month at 05:46 in every 2nd month
     - cron: '46 5 1 */2 *'
-  push:
-    branches:
-      - linkcheck
 
 jobs:
   test-sphinx-build:

--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -1,13 +1,11 @@
 name: Test Documentation Build
 on:
-  pull_request:
-    branches:
-      - master
-      - doc-fixes
+  schedule:
+    # First day of month at 05:46 in every 2nd month
+    - cron: '46 5 1 */2 *'
   push:
-    branches: 
-      - master
-      - doc-fixes
+    branches:
+      - linkcheck
 
 jobs:
   test-sphinx-build:

--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test-sphinx-build:
-    name: test-sphinx-build
+    name: test-sphinx-linkcheck
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
@@ -18,9 +18,6 @@ jobs:
       fail-fast: False
     steps:
       - uses: actions/checkout@v3
-      - name: Initialize vendored libs
-        run:
-          git submodule update --init --recursive
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -1,4 +1,4 @@
-name: Test Documentation Build
+name: Check Links in Documentation
 on:
   schedule:
     # First day of month at 05:46 in every 2nd month
@@ -32,4 +32,4 @@ jobs:
           python -W ignore -m pip install -r requirements-dev.txt
           python -W ignore -m pip install -r docs/requirements-docs.txt
       - name: Build docs
-        run: sphinx-build docs/source docs/build/html -W --keep-going -j auto
+        run: sphinx-build docs/source docs/build/html -W --keep-going -j auto -b linkcheck

--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -31,5 +31,5 @@ jobs:
           python -W ignore -m pip install -r requirements.txt
           python -W ignore -m pip install -r requirements-dev.txt
           python -W ignore -m pip install -r docs/requirements-docs.txt
-      - name: Build docs
+      - name: Check Links
         run: sphinx-build docs/source docs/build/html -W --keep-going -j auto -b linkcheck

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,9 +20,6 @@ jobs:
       fail-fast: False
     steps:
       - uses: actions/checkout@v3
-      - name: Initialize vendored libs
-        run:
-          git submodule update --init --recursive
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
         with:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1520,7 +1520,7 @@ Changes
 - Lots of small improvements to our tests and documentation.
 
 
-.. _`see docs`: http://python-telegram-bot.readthedocs.io/en/stable/telegram.ext.dispatcher.html#telegram.ext.Dispatcher.add_handler
+.. _`see docs`: https://python-telegram-bot.readthedocs.io/en/stable/telegram.ext.dispatcher.html#telegram.ext.Dispatcher.add_handler
 .. _`#777`: https://github.com/python-telegram-bot/python-telegram-bot/pull/777
 .. _`#806`: https://github.com/python-telegram-bot/python-telegram-bot/pull/806
 .. _`#766`: https://github.com/python-telegram-bot/python-telegram-bot/pull/766
@@ -1762,7 +1762,7 @@ Pre-version 7.0
 
 - Implement Bot API 2.0
 - Almost complete recode of ``Dispatcher``
-- Please read the `Transistion Guide to 4.0 <https://github.com/python-telegram-bot/python-telegram-bot/wiki/Transistion-guide-to-Version-4.0>`_
+- Please read the `Transistion Guide to 4.0 <https://github.com/python-telegram-bot/python-telegram-bot/wiki/Transition-guide-to-Version-4.0>`_
 
 **2016-03-22**
 

--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -49,4 +49,4 @@ Project maintainers who do not follow or enforce the Code of Conduct in good fai
 Attribution
 ===========
 
-This Code of Conduct is adapted from the `Contributor Covenant <http://contributor-covenant.org>`_, version 1.4, available at `http://contributor-covenant.org/version/1/4 <http://contributor-covenant.org/version/1/4/>`_.
+This Code of Conduct is adapted from the `Contributor Covenant <https://www.contributor-covenant.org>`_, version 1.4, available at `https://www.contributor-covenant.org/version/1/4 <https://www.contributor-covenant.org/version/1/4/>`_.

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
 
 .. image:: https://raw.githubusercontent.com/python-telegram-bot/logos/master/logo-text/png/ptb-logo-text_768.png
    :align: center
-   :target: https://python-telegram-bot.io
+   :target: https://python-telegram-bot.org
    :alt: python-telegram-bot Logo
 
 .. image:: https://img.shields.io/pypi/v/python-telegram-bot.svg

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
 ..
     Make sure to apply any changes to this file to README_RAW.rst as well!
 
-.. image:: https://github.com/python-telegram-bot/logos/blob/master/logo-text/png/ptb-logo-text_768.png?raw=true
+.. image:: https://raw.githubusercontent.com/python-telegram-bot/logos/master/logo-text/png/ptb-logo-text_768.png
    :align: center
-   :target: https://python-telegram-bot.org
+   :target: https://python-telegram-bot.io
    :alt: python-telegram-bot Logo
 
 .. image:: https://img.shields.io/pypi/v/python-telegram-bot.svg
@@ -34,16 +34,16 @@
    :target: https://github.com/python-telegram-bot/python-telegram-bot/
    :alt: Github Actions workflow
 
-.. image:: https://codecov.io/gh/python-telegram-bot/python-telegram-bot/branch/master/graph/badge.svg
-   :target: https://codecov.io/gh/python-telegram-bot/python-telegram-bot
+.. image:: https://app.codecov.io/gh/python-telegram-bot/python-telegram-bot/branch/master/graph/badge.svg
+   :target: https://app.codecov.io/gh/python-telegram-bot/python-telegram-bot
    :alt: Code coverage
 
-.. image:: http://isitmaintained.com/badge/resolution/python-telegram-bot/python-telegram-bot.svg
-   :target: http://isitmaintained.com/project/python-telegram-bot/python-telegram-bot
+.. image:: https://isitmaintained.com/badge/resolution/python-telegram-bot/python-telegram-bot.svg
+   :target: https://isitmaintained.com/project/python-telegram-bot/python-telegram-bot
    :alt: Median time to resolve an issue
 
 .. image:: https://api.codacy.com/project/badge/Grade/99d901eaa09b44b4819aec05c330c968
-   :target: https://www.codacy.com/app/python-telegram-bot/python-telegram-bot?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=python-telegram-bot/python-telegram-bot&amp;utm_campaign=Badge_Grade
+   :target: https://app.codacy.com/gh/python-telegram-bot/python-telegram-bot/dashboard
    :alt: Code quality: Codacy
 
 .. image:: https://deepsource.io/gh/python-telegram-bot/python-telegram-bot.svg/?label=active+issues
@@ -136,7 +136,7 @@ Optional Dependencies
 
 PTB can be installed with optional dependencies:
 
-* ``pip install python-telegram-bot[passport]`` installs the `cryptography>=3.0 <https://cryptography.io>`_ library. Use this, if you want to use Telegram Passport related functionality.
+* ``pip install python-telegram-bot[passport]`` installs the `cryptography>=3.0 <https://cryptography.io/en/stable>`_ library. Use this, if you want to use Telegram Passport related functionality.
 * ``pip install python-telegram-bot[json]`` installs the `ujson>=4.0.0 <https://pypi.org/project/ujson/>`_ library. It will then be used for JSON de- & encoding, which can bring speed up compared to the standard `json <https://docs.python.org/3/library/json.html>`_ library.
 * ``pip install python-telegram-bot[socks]`` installs ``httpx[socks]``. Use this, if you want to work behind a Socks5 server.
 

--- a/README_RAW.rst
+++ b/README_RAW.rst
@@ -34,16 +34,16 @@
    :target: https://github.com/python-telegram-bot/python-telegram-bot/
    :alt: Github Actions workflow
 
-.. image:: https://codecov.io/gh/python-telegram-bot/python-telegram-bot/branch/master/graph/badge.svg
-   :target: https://codecov.io/gh/python-telegram-bot/python-telegram-bot
+.. image:: https://app.codecov.io/gh/python-telegram-bot/python-telegram-bot/branch/master/graph/badge.svg
+   :target: https://app.codecov.io/gh/python-telegram-bot/python-telegram-bot
    :alt: Code coverage
 
-.. image:: http://isitmaintained.com/badge/resolution/python-telegram-bot/python-telegram-bot.svg
-   :target: http://isitmaintained.com/project/python-telegram-bot/python-telegram-bot
+.. image:: https://isitmaintained.com/badge/resolution/python-telegram-bot/python-telegram-bot.svg
+   :target: https://isitmaintained.com/project/python-telegram-bot/python-telegram-bot
    :alt: Median time to resolve an issue
 
 .. image:: https://api.codacy.com/project/badge/Grade/99d901eaa09b44b4819aec05c330c968
-   :target: https://www.codacy.com/app/python-telegram-bot/python-telegram-bot?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=python-telegram-bot/python-telegram-bot&amp;utm_campaign=Badge_Grade
+   :target: https://app.codacy.com/gh/python-telegram-bot/python-telegram-bot/dashboard
    :alt: Code quality: Codacy
 
 .. image:: https://deepsource.io/gh/python-telegram-bot/python-telegram-bot.svg/?label=active+issues
@@ -134,7 +134,7 @@ Optional Dependencies
 
 ``python-telegram-bot-raw`` can be installed with optional dependencies:
 
-* ``pip install python-telegram-bot[passport]`` installs the `cryptography <https://cryptography.io>`_ library. Use this, if you want to use Telegram Passport related functionality.
+* ``pip install python-telegram-bot[passport]`` installs the `cryptography <https://cryptography.io/en/stable>`_ library. Use this, if you want to use Telegram Passport related functionality.
 * ``pip install python-telegram-bot[json]`` installs the `ujson <https://pypi.org/project/ujson/>`_ library. It will then be used for JSON de- & encoding, which can bring speed up compared to the standard `json <https://docs.python.org/3/library/json.html>`_ library.
 * ``pip install python-telegram-bot[socks]`` installs the `PySocks <https://pypi.org/project/PySocks/>`_ library. Use this, if you want to work behind a Socks5 server.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -99,6 +99,27 @@ release = "20.0a0"  # telegram.__version__
 # Usually you set "language" from the command line for these cases.
 language = None
 
+# Linkcheck settings
+
+linkcheck_ignore = [
+    # Let's not check issue/PR links - that's wasted resources
+    r"http(s)://github\.com/python-telegram-bot/python-telegram-bot/(issues|pull)/\d+/?",
+    # For some reason linkcheck has a problem with these two:
+    re.escape("https://github.com/python-telegram-bot/python-telegram-bot/discussions/new"),
+    re.escape("https://github.com/python-telegram-bot/python-telegram-bot/issues/new"),
+    # Anchors are apparently inserted by GitHub dynamically, so let's skip checking them
+    "https://github.com/python-telegram-bot/python-telegram-bot/tree/master/examples#",
+    r"https://github\.com/python-telegram-bot/python-telegram-bot/wiki/[\w\-_,]+\#",
+]
+linkcheck_allowed_redirects = {
+    # Redirects to the default version are okay
+    r"https://python-telegram-bot\.readthedocs\.io/.*": r"https://python-telegram-bot\.readthedocs\.io/en/[\w\d\.]+/.*",
+    # pre-commit.ci always redirects to the latest run
+    re.escape(
+        "https://results.pre-commit.ci/latest/github/python-telegram-bot/python-telegram-bot/master"
+    ): r"https://results\.pre-commit\.ci/run/github/.*",
+}
+
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
 # today = ''

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -2245,7 +2245,7 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
             google_place_id (:obj:`str`, optional): Google Places identifier of the venue.
             google_place_type (:obj:`str`, optional): Google Places type of the venue. (See
                 `supported types \
-                <https://developers.google.com/places/web-service/supported_types>`_.)
+                <https://developers.google.com/maps/documentation/places/web-service/supported_types>`_.)
             venue (:class:`telegram.Venue`, optional): The venue to send.
             disable_notification (:obj:`bool`, optional): Sends the message silently. Users will
                 receive a notification with no sound.
@@ -3726,7 +3726,8 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
                 integration.
             certificate (:term:`file object`): Upload your public key certificate so that the root
                 certificate in use can be checked. See our self-signed guide for details.
-                (https://goo.gl/rw7w6Y)
+                (https://github.com/python-telegram-bot/python-telegram-bot/wiki/Webhooks#\
+                creating-a-self-signed-certificate-using-openssl)
             ip_address (:obj:`str`, optional): The fixed IP address which will be used to send
                 webhook requests instead of the IP address resolved through DNS.
             max_connections (:obj:`int`, optional): Maximum allowed number of simultaneous HTTPS

--- a/telegram/_files/venue.py
+++ b/telegram/_files/venue.py
@@ -47,7 +47,8 @@ class Venue(TelegramObject):
             "arts_entertainment/default", "arts_entertainment/aquarium" or "food/icecream".)
         google_place_id (:obj:`str`, optional): Google Places identifier of the venue.
         google_place_type (:obj:`str`, optional): Google Places type of the venue. (See
-            `supported types <https://developers.google.com/places/web-service/supported_types>`_.)
+            `supported types <https://developers.google.com/maps/documentation/places/web-service\
+            /supported_types>`_.)
         **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
     Attributes:

--- a/telegram/_inline/inlinequeryresultvenue.py
+++ b/telegram/_inline/inlinequeryresultvenue.py
@@ -50,7 +50,8 @@ class InlineQueryResultVenue(InlineQueryResult):
             "food/icecream".)
         google_place_id (:obj:`str`, optional): Google Places identifier of the venue.
         google_place_type (:obj:`str`, optional): Google Places type of the venue. (See
-            `supported types <https://developers.google.com/places/web-service/supported_types>`_.)
+            `supported types <https://developers.google.com/maps/documentation/places/web-service\
+            /supported_types>`_.)
         reply_markup (:class:`telegram.InlineKeyboardMarkup`, optional): Inline keyboard attached
             to the message.
         input_message_content (:class:`telegram.InputMessageContent`, optional): Content of the

--- a/telegram/_inline/inputvenuemessagecontent.py
+++ b/telegram/_inline/inputvenuemessagecontent.py
@@ -45,7 +45,8 @@ class InputVenueMessageContent(InputMessageContent):
             "food/icecream".)
         google_place_id (:obj:`str`, optional): Google Places identifier of the venue.
         google_place_type (:obj:`str`, optional): Google Places type of the venue. (See
-            `supported types <https://developers.google.com/places/web-service/supported_types>`_.)
+            `supported types <https://developers.google.com/maps/documentation/places/web-service\
+            /supported_types>`_.)
         **kwargs (:obj:`dict`): Arbitrary keyword arguments.
 
     Attributes:

--- a/telegram/ext/_application.py
+++ b/telegram/ext/_application.py
@@ -658,9 +658,10 @@ class Application(Generic[BT, CCT, UD, CD, BD, JQ], AbstractAsyncContextManager)
 
         If :paramref:`cert`
         and :paramref:`key` are not provided, the webhook will be started directly on
-        ``http://listen:port/url_path``, so SSL can be handled by another
+        ````http://listen:port/url_path````, so SSL can be handled by another
         application. Else, the webhook will be started on
-        ``https://listen:port/url_path``. Also calls :meth:`telegram.Bot.set_webhook` as required.
+        ````https://listen:port/url_path````. Also calls :meth:`telegram.Bot.set_webhook` as
+        required.
 
         .. seealso::
             :meth:`initialize`, :meth:`start`, :meth:`stop`, :meth:`shutdown`

--- a/telegram/ext/_application.py
+++ b/telegram/ext/_application.py
@@ -658,9 +658,9 @@ class Application(Generic[BT, CCT, UD, CD, BD, JQ], AbstractAsyncContextManager)
 
         If :paramref:`cert`
         and :paramref:`key` are not provided, the webhook will be started directly on
-        ````http://listen:port/url_path````, so SSL can be handled by another
+        ``http://listen:port/url_path``, so SSL can be handled by another
         application. Else, the webhook will be started on
-        ````https://listen:port/url_path````. Also calls :meth:`telegram.Bot.set_webhook` as
+        ``https://listen:port/url_path``. Also calls :meth:`telegram.Bot.set_webhook` as
         required.
 
         .. seealso::

--- a/telegram/ext/_updater.py
+++ b/telegram/ext/_updater.py
@@ -369,9 +369,9 @@ class Updater(AbstractAsyncContextManager):
         """
         Starts a small http server to listen for updates via webhook. If :paramref:`cert`
         and :paramref:`key` are not provided, the webhook will be started directly on
-        http://listen:port/url_path, so SSL can be handled by another
+        ``http://listen:port/url_path``, so SSL can be handled by another
         application. Else, the webhook will be started on
-        https://listen:port/url_path. Also calls :meth:`telegram.Bot.set_webhook` as required.
+        ``https://listen:port/url_path``. Also calls :meth:`telegram.Bot.set_webhook` as required.
 
         .. versionchanged:: 13.4
             :meth:`start_webhook` now *always* calls :meth:`telegram.Bot.set_webhook`, so pass


### PR DESCRIPTION
closes #2974 

runs the job every 2nd month. Ignores a number of URLs where it makes sense IMO. Also fixes a bunch.
Doesn't run on PRs for now. If we want that, we have two options:

- run on all files. After I ignored all the gh pr/issue links, that's actually not too bad performance wise. Would be okay with doing that.
- if we want to run only on changed files, we'd have to somehow map changed files to the corresponding rst files. IMO not worth the trouble.

Example for a failing test at https://github.com/python-telegram-bot/python-telegram-bot/runs/6339916713?check_suite_focus=true

- [ ] remove the `on: push` config from the workflow which is currently just there for demo purposes