### PR TITLE
Try improving CC type hinting

### DIFF
--- a/telegram/ext/_callbackcontext.py
+++ b/telegram/ext/_callbackcontext.py
@@ -39,7 +39,7 @@ from telegram.ext._utils.types import BD, BT, CD, UD  # pylint: disable=unused-i
 if TYPE_CHECKING:
     from asyncio import Queue
 
-    from telegram.ext import Application, Job, JobQueue
+    from telegram.ext import Application, Job, JobQueue  # noqa: F401
     from telegram.ext._utils.types import CCT, JQ
 
 _STORING_DATA_WIKI = (
@@ -48,7 +48,7 @@ _STORING_DATA_WIKI = (
 )
 
 
-class CallbackContext(Generic[BT, UD, CD, BD]):
+class CallbackContext(Generic[BT, UD, CD, BD, JQ]):
     """
     This is a context object passed to the callback called by :class:`telegram.ext.Handler`
     or by the :class:`telegram.ext.Application` in an error handler added by
@@ -105,9 +105,7 @@ class CallbackContext(Generic[BT, UD, CD, BD]):
     """
 
     if TYPE_CHECKING:
-        DEFAULT_TYPE = CallbackContext[  # type: ignore[misc]  # noqa: F821
-            ExtBot, Dict, Dict, Dict
-        ]
+        DEFAULT_TYPE = CallbackContext[ExtBot, Dict, Dict, Dict, "JobQueue"]  # noqa: F821
     else:
         # Somewhat silly workaround so that accessing the attribute
         # doesn't only work while type checking
@@ -312,7 +310,7 @@ class CallbackContext(Generic[BT, UD, CD, BD]):
         Returns:
             :class:`telegram.ext.CallbackContext`
         """
-        self = cls(application)  # type: ignore[arg-type]
+        self = cls(application)
 
         if update is not None and isinstance(update, Update):
             chat = update.effective_chat
@@ -350,7 +348,7 @@ class CallbackContext(Generic[BT, UD, CD, BD]):
         Returns:
             :class:`telegram.ext.CallbackContext`
         """
-        self = cls(application)  # type: ignore[arg-type]
+        self = cls(application)
         self.job = job
 
         if job.chat_id:
@@ -380,7 +378,7 @@ class CallbackContext(Generic[BT, UD, CD, BD]):
         return self._application.bot
 
     @property
-    def job_queue(self) -> Optional["JobQueue"]:
+    def job_queue(self) -> JQ:
         """
         :class:`telegram.ext.JobQueue`: The :class:`JobQueue` used by the
             :class:`telegram.ext.Application`.

--- a/telegram/ext/_callbackcontext.py
+++ b/telegram/ext/_callbackcontext.py
@@ -38,9 +38,10 @@ from telegram.ext._utils.types import BD, BT, CD, UD
 
 if TYPE_CHECKING:
     from asyncio import Queue
+    from typing import Any
 
     from telegram.ext import Application, Job, JobQueue  # noqa: F401
-    from telegram.ext._utils.types import CCT, JQ
+    from telegram.ext._utils.types import CCT
 
 _STORING_DATA_WIKI = (
     "https://github.com/python-telegram-bot/python-telegram-bot"
@@ -48,7 +49,7 @@ _STORING_DATA_WIKI = (
 )
 
 
-class CallbackContext(Generic[BT, UD, CD, BD, JQ]):
+class CallbackContext(Generic[BT, UD, CD, BD]):
     """
     This is a context object passed to the callback called by :class:`telegram.ext.Handler`
     or by the :class:`telegram.ext.Application` in an error handler added by
@@ -118,7 +119,7 @@ class CallbackContext(Generic[BT, UD, CD, BD, JQ]):
         "__dict__",
     )
 
-    def __init__(self: "CCT", application: "Application[BT, CCT, UD, CD, BD, JQ]"):
+    def __init__(self: "CCT", application: "Application[BT, CCT, UD, CD, BD, Any]"):
         self._application = application
         self._chat_id_and_data: Optional[Tuple[int, CD]] = None
         self._user_id_and_data: Optional[Tuple[int, UD]] = None
@@ -129,7 +130,7 @@ class CallbackContext(Generic[BT, UD, CD, BD, JQ]):
         self.coroutine: Optional[Coroutine] = None
 
     @property
-    def application(self) -> "Application[BT, CCT, UD, CD, BD, JQ]":
+    def application(self) -> "Application[BT, CCT, UD, CD, BD, Any]":
         """:class:`telegram.ext.Application`: The application associated with this context."""
         return self._application
 
@@ -242,7 +243,7 @@ class CallbackContext(Generic[BT, UD, CD, BD, JQ]):
         cls: Type["CCT"],
         update: object,
         error: Exception,
-        application: "Application[BT, CCT, UD, CD, BD, JQ]",
+        application: "Application[BT, CCT, UD, CD, BD, Any]",
         job: "Job" = None,
         coroutine: Coroutine = None,
     ) -> "CCT":
@@ -278,7 +279,7 @@ class CallbackContext(Generic[BT, UD, CD, BD, JQ]):
     def from_update(
         cls: Type["CCT"],
         update: object,
-        application: "Application[BT, CCT, UD, CD, BD, JQ]",
+        application: "Application[Any, CCT, Any, Any, Any, Any]",
     ) -> "CCT":
         """
         Constructs an instance of :class:`telegram.ext.CallbackContext` to be passed to the
@@ -294,7 +295,7 @@ class CallbackContext(Generic[BT, UD, CD, BD, JQ]):
         Returns:
             :class:`telegram.ext.CallbackContext`
         """
-        self = cls(application)
+        self = cls(application)  # type: ignore
 
         if update is not None and isinstance(update, Update):
             chat = update.effective_chat
@@ -316,7 +317,7 @@ class CallbackContext(Generic[BT, UD, CD, BD, JQ]):
     def from_job(
         cls: Type["CCT"],
         job: "Job",
-        application: "Application[BT, CCT, UD, CD, BD, JQ]",
+        application: "Application[Any, CCT, Any, Any, Any, Any]",
     ) -> "CCT":
         """
         Constructs an instance of :class:`telegram.ext.CallbackContext` to be passed to a
@@ -332,7 +333,7 @@ class CallbackContext(Generic[BT, UD, CD, BD, JQ]):
         Returns:
             :class:`telegram.ext.CallbackContext`
         """
-        self = cls(application)
+        self = cls(application)  # type: ignore
         self.job = job
 
         if job.chat_id:
@@ -362,7 +363,7 @@ class CallbackContext(Generic[BT, UD, CD, BD, JQ]):
         return self._application.bot
 
     @property
-    def job_queue(self) -> JQ:
+    def job_queue(self) -> Optional["JobQueue"]:
         """
         :class:`telegram.ext.JobQueue`: The :class:`JobQueue` used by the
             :class:`telegram.ext.Application`.

--- a/telegram/ext/_contexttypes.py
+++ b/telegram/ext/_contexttypes.py
@@ -53,7 +53,7 @@ class ContextTypes(Generic[CCT, UD, CD, BD]):
 
     """
 
-    DEFAULT_TYPE = CallbackContext["ExtBot", Dict, Dict, Dict]  # type: ignore[misc]
+    DEFAULT_TYPE = CallbackContext["ExtBot", Dict, Dict, Dict]
     """Shortcut for the type annotation for the `context` argument that's correct for the
     default settings, i.e. if :class:`telegram.ext.ContextTypes` is not used.
 

--- a/telegram/ext/_contexttypes.py
+++ b/telegram/ext/_contexttypes.py
@@ -54,7 +54,7 @@ class ContextTypes(Generic[CCT, UD, CD, BD]):
 
     """
 
-    DEFAULT_TYPE = CallbackContext["ExtBot", dict, dict, dict]  # type: ignore[misc]
+    DEFAULT_TYPE = CallbackContext["ExtBot", dict, dict, dict]
     """Shortcut for the type annotation for the ``context`` argument that's correct for the
     default settings, i.e. if :class:`telegram.ext.ContextTypes` is not used.
 


### PR DESCRIPTION
Effectively just uses a bit of `Any` to get a best effort result.

What we'd like to do is to infer the type of `CC.job_queue` from the `Application`. However, this is problematic, as the app has a type for the used (sub)class of `CallbackContext` itself. in particular, when speciyinf a subclass with `ContextTypes`, we'd like to somehow say `CallbackContext[ExtBot, dict, dict, dict, TypeVar('JQ')]` + `App[…, JobQueue]` = `CC[…, JobQueue]`. Similar things happen on `CC.__init__/from_*`.
I don't see how this can be achieved with the current status of the `typing` module, as neither

```python
CCT = TypeVar('CCT', bound=CallbackContext)
def foo(arg: CCT[BT, UD, CD, BD, JQ]):
    pass
``` 

nor something like

```python
def foo(arg: CCT) -> CCT.JQ:
   pass
```
are currently supported.

Hence, `CallbackContext.job_queue` stays annotated as `Optional[JobQueue]`.

@harshil21 if you can test if pyright works with this as well, that would be nice. We can then maybe merge into #3017 and then merge both together into master.

Example snippet of what I've tested with mypy:


```python
from telegram.ext import ApplicationBuilder, ContextTypes, CallbackContext, ExtBot


class CustomContext(CallbackContext[ExtBot, int, dict, dict]):
    pass


context_types = ContextTypes(user_data=int, context=CustomContext)
app = (
    ApplicationBuilder()
    .token("123456048:AAGpuiaeuiaeuiaeuiaev76jqr45aA")
    .context_types(context_types)
    .job_queue(None)
    .build()
)
reveal_type(app)
reveal_type(app.context_types)
context = CallbackContext(application=app)
reveal_type(context)
reveal_type(context.job_queue)


reveal_type(CallbackContext.from_update(1, app))
reveal_type(CustomContext.from_update(1, app))

```

