### PR TITLE
Renamed job.context to job.data

### DIFF
--- a/examples/timerbot.py
+++ b/examples/timerbot.py
@@ -43,7 +43,7 @@ async def start(update: Update, context: CallbackContext.DEFAULT_TYPE) -> None:
 async def alarm(context: CallbackContext.DEFAULT_TYPE) -> None:
     """Send the alarm message."""
     job = context.job
-    await context.bot.send_message(job.chat_id, text=f"Beep! {job.context} seconds are over!")
+    await context.bot.send_message(job.chat_id, text=f"Beep! {job.data} seconds are over!")
 
 
 def remove_job_if_exists(name: str, context: CallbackContext.DEFAULT_TYPE) -> bool:
@@ -67,7 +67,7 @@ async def set_timer(update: Update, context: CallbackContext.DEFAULT_TYPE) -> No
             return
 
         job_removed = remove_job_if_exists(str(chat_id), context)
-        context.job_queue.run_once(alarm, due, chat_id=chat_id, name=str(chat_id), context=due)
+        context.job_queue.run_once(alarm, due, chat_id=chat_id, name=str(chat_id), data=due)
 
         text = "Timer successfully set!"
         if job_removed:

--- a/telegram/ext/_conversationhandler.py
+++ b/telegram/ext/_conversationhandler.py
@@ -64,7 +64,7 @@ _logger = logging.getLogger(__name__)
 @dataclass
 class _ConversationTimeoutContext(Generic[CCT]):
     """Used as a datastore for conversation timeouts. Passed in the
-    :paramref:`JobQueue.run_once.context` parameter. See :meth:`_trigger_timeout`.
+    :paramref:`JobQueue.run_once.data` parameter. See :meth:`_trigger_timeout`.
     """
 
     __slots__ = ("conversation_key", "update", "application", "callback_context")
@@ -666,9 +666,7 @@ class ConversationHandler(Handler[Update, CCT]):
             self.timeout_jobs[conversation_key] = j_queue.run_once(
                 self._trigger_timeout,
                 self.conversation_timeout,  # type: ignore[arg-type]
-                context=_ConversationTimeoutContext(
-                    conversation_key, update, application, context
-                ),
+                data=_ConversationTimeoutContext(conversation_key, update, application, context),
             )
         except Exception as exc:
             _logger.exception("Failed to schedule timeout.", exc_info=exc)

--- a/telegram/ext/_jobqueue.py
+++ b/telegram/ext/_jobqueue.py
@@ -121,7 +121,7 @@ class JobQueue:
         self,
         callback: JobCallback,
         when: Union[float, datetime.timedelta, datetime.datetime, datetime.time],
-        context: object = None,
+        data: object = None,
         name: str = None,
         chat_id: int = None,
         user_id: int = None,
@@ -163,8 +163,8 @@ class JobQueue:
                 be available in the callback.
 
                 .. versionadded:: 20.0
-            context (:obj:`object`, optional): Additional data needed for the callback function.
-                Can be accessed through :attr:`Job.context` in the callback. Defaults to
+            data (:obj:`object`, optional): Additional data needed for the callback function.
+                Can be accessed through :attr:`Job.data` in the callback. Defaults to
                 :obj:`None`.
             name (:obj:`str`, optional): The name of the new job. Defaults to
                 :external:attr:`callback.__name__ <definition.__name__>`.
@@ -180,7 +180,7 @@ class JobQueue:
             job_kwargs = {}
 
         name = name or callback.__name__
-        job = Job(callback=callback, context=context, name=name, chat_id=chat_id, user_id=user_id)
+        job = Job(callback=callback, data=data, name=name, chat_id=chat_id, user_id=user_id)
         date_time = self._parse_time_input(when, shift_day=True)
 
         j = self.scheduler.add_job(
@@ -202,7 +202,7 @@ class JobQueue:
         interval: Union[float, datetime.timedelta],
         first: Union[float, datetime.timedelta, datetime.datetime, datetime.time] = None,
         last: Union[float, datetime.timedelta, datetime.datetime, datetime.time] = None,
-        context: object = None,
+        data: object = None,
         name: str = None,
         chat_id: int = None,
         user_id: int = None,
@@ -254,8 +254,8 @@ class JobQueue:
                 assumed.
 
                 Defaults to :obj:`None`.
-            context (:obj:`object`, optional): Additional data needed for the callback function.
-                Can be accessed through :attr:`Job.context` in the callback. Defaults to
+            data (:obj:`object`, optional): Additional data needed for the callback function.
+                Can be accessed through :attr:`Job.data` in the callback. Defaults to
                 :obj:`None`.
             name (:obj:`str`, optional): The name of the new job. Defaults to
                 :external:attr:`callback.__name__ <definition.__name__>`.
@@ -282,7 +282,7 @@ class JobQueue:
             job_kwargs = {}
 
         name = name or callback.__name__
-        job = Job(callback=callback, context=context, name=name, chat_id=chat_id, user_id=user_id)
+        job = Job(callback=callback, data=data, name=name, chat_id=chat_id, user_id=user_id)
 
         dt_first = self._parse_time_input(first)
         dt_last = self._parse_time_input(last)
@@ -312,7 +312,7 @@ class JobQueue:
         callback: JobCallback,
         when: datetime.time,
         day: int,
-        context: object = None,
+        data: object = None,
         name: str = None,
         chat_id: int = None,
         user_id: int = None,
@@ -336,8 +336,8 @@ class JobQueue:
                 be within the range of 1 and 31, inclusive. If a month has fewer days than this
                 number, the job will not run in this month. Passing -1 leads to the job running on
                 the last day of the month.
-            context (:obj:`object`, optional): Additional data needed for the callback function.
-                Can be accessed through :attr:`Job.context` in the callback. Defaults to
+            data (:obj:`object`, optional): Additional data needed for the callback function.
+                Can be accessed through :attr:`Job.data` in the callback. Defaults to
                 :obj:`None`.
             name (:obj:`str`, optional): The name of the new job. Defaults to
                 :external:attr:`callback.__name__ <definition.__name__>`.
@@ -364,7 +364,7 @@ class JobQueue:
             job_kwargs = {}
 
         name = name or callback.__name__
-        job = Job(callback=callback, context=context, name=name, chat_id=chat_id, user_id=user_id)
+        job = Job(callback=callback, data=data, name=name, chat_id=chat_id, user_id=user_id)
 
         j = self.scheduler.add_job(
             job.run,
@@ -386,7 +386,7 @@ class JobQueue:
         callback: JobCallback,
         time: datetime.time,
         days: Tuple[int, ...] = tuple(range(7)),
-        context: object = None,
+        data: object = None,
         name: str = None,
         chat_id: int = None,
         user_id: int = None,
@@ -411,8 +411,8 @@ class JobQueue:
                 be used.
             days (Tuple[:obj:`int`], optional): Defines on which days of the week the job should
                 run (where ``0-6`` correspond to monday - sunday). Defaults to ``EVERY_DAY``
-            context (:obj:`object`, optional): Additional data needed for the callback function.
-                Can be accessed through :attr:`Job.context` in the callback. Defaults to
+            data (:obj:`object`, optional): Additional data needed for the callback function.
+                Can be accessed through :attr:`Job.data` in the callback. Defaults to
                 :obj:`None`.
             name (:obj:`str`, optional): The name of the new job. Defaults to
                 :external:attr:`callback.__name__ <definition.__name__>`.
@@ -439,7 +439,7 @@ class JobQueue:
             job_kwargs = {}
 
         name = name or callback.__name__
-        job = Job(callback=callback, context=context, name=name, chat_id=chat_id, user_id=user_id)
+        job = Job(callback=callback, data=data, name=name, chat_id=chat_id, user_id=user_id)
 
         j = self.scheduler.add_job(
             job.run,
@@ -461,7 +461,7 @@ class JobQueue:
         self,
         callback: JobCallback,
         job_kwargs: JSONDict,
-        context: object = None,
+        data: object = None,
         name: str = None,
         chat_id: int = None,
         user_id: int = None,
@@ -476,8 +476,8 @@ class JobQueue:
 
             job_kwargs (:obj:`dict`): Arbitrary keyword arguments. Used as arguments for
                 :meth:`apscheduler.schedulers.base.BaseScheduler.add_job`.
-            context (:obj:`object`, optional): Additional data needed for the callback function.
-                Can be accessed through :attr:`Job.context` in the callback. Defaults to
+            data (:obj:`object`, optional): Additional data needed for the callback function.
+                Can be accessed through :attr:`Job.data` in the callback. Defaults to
                 :obj:`None`.
             name (:obj:`str`, optional): The name of the new job. Defaults to
                 :external:attr:`callback.__name__ <definition.__name__>`.
@@ -499,7 +499,7 @@ class JobQueue:
 
         """
         name = name or callback.__name__
-        job = Job(callback=callback, context=context, name=name, chat_id=chat_id, user_id=user_id)
+        job = Job(callback=callback, data=data, name=name, chat_id=chat_id, user_id=user_id)
 
         j = self.scheduler.add_job(job.run, args=(self.application,), name=name, **job_kwargs)
 
@@ -565,6 +565,7 @@ class Job:
 
     .. versionchanged:: 20.0
         Removed argument and attribute ``job_queue``.
+        Renamed ``job.context`` to ``job.data``.
 
     Args:
         callback (:term:`coroutine function`): The callback function that should be executed by the
@@ -572,8 +573,8 @@ class Job:
 
                 async def callback(context: CallbackContext)
 
-        context (:obj:`object`, optional): Additional data needed for the callback function. Can be
-            accessed through :attr:`Job.context` in the callback. Defaults to :obj:`None`.
+        data (:obj:`object`, optional): Additional data needed for the callback function. Can be
+            accessed through :attr:`Job.data` in the callback. Defaults to :obj:`None`.
         name (:obj:`str`, optional): The name of the new job. Defaults to
             :external:obj:`callback.__name__ <definition.__name__>`.
         job (:class:`apscheduler.job.Job`, optional): The APS Job this job is a wrapper for.
@@ -587,7 +588,7 @@ class Job:
     Attributes:
         callback (:term:`coroutine function`): The callback function that should be executed by the
             new job.
-        context (:obj:`object`): Optional. Additional data needed for the callback function.
+        data (:obj:`object`): Optional. Additional data needed for the callback function.
         name (:obj:`str`): Optional. The name of the new job.
         job (:class:`apscheduler.job.Job`): Optional. The APS Job this job is a wrapper for.
         chat_id (:obj:`int`): Optional. Chat id of the chat that this job is associated with.
@@ -600,7 +601,7 @@ class Job:
 
     __slots__ = (
         "callback",
-        "context",
+        "data",
         "name",
         "_removed",
         "_enabled",
@@ -612,7 +613,7 @@ class Job:
     def __init__(
         self,
         callback: JobCallback,
-        context: object = None,
+        data: object = None,
         name: str = None,
         job: APSJob = None,
         chat_id: int = None,
@@ -620,7 +621,7 @@ class Job:
     ):
 
         self.callback = callback
-        self.context = context
+        self.data = data
         self.name = name or callback.__name__
         self.chat_id = chat_id
         self.user_id = user_id

--- a/tests/test_jobqueue.py
+++ b/tests/test_jobqueue.py
@@ -65,7 +65,7 @@ class TestJobQueue:
             isinstance(context, CallbackContext)
             and isinstance(context.job, Job)
             and isinstance(context.update_queue, asyncio.Queue)
-            and context.job.context is None
+            and context.job.data is None
             and context.chat_data is None
             and context.user_data is None
             and isinstance(context.bot_data, dict)
@@ -79,8 +79,8 @@ class TestJobQueue:
         self.result += 1
         context.job.schedule_removal()
 
-    async def job_run_once_with_context(self, context):
-        self.result += context.job.context
+    async def job_run_once_with_data(self, context):
+        self.result += context.job.data
 
     async def job_datetime_tests(self, context):
         self.job_time = time.time()
@@ -121,8 +121,8 @@ class TestJobQueue:
         await asyncio.sleep(0.1)
         assert self.result == 1
 
-    async def test_job_with_context(self, job_queue):
-        job_queue.run_once(self.job_run_once_with_context, 0.1, context=5)
+    async def test_job_with_data(self, job_queue):
+        job_queue.run_once(self.job_run_once_with_data, 0.1, data=5)
         await asyncio.sleep(0.2)
         assert self.result == 5
 


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool! Please have a look at the below checklist. It's here to help both you and the maintainers to remember some aspects. Make sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
-->
Hi, this is my first time contribution to the lib. Do let me know if I did something wrong or missed out something:D
closes #3015 
### Checklist for PRs

- [ ] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [ ] Created new or adapted existing unit tests
- [ ] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)
- [ ] Added new classes & modules to the docs and all suitable `__all__` s


### If the PR contains API changes (otherwise, you can delete this passage)

* New classes:
    - [ ] Added `self._id_attrs` and corresponding documentation
    - [ ] `__init__` accepts `**_kwargs`
    
* Added new shortcuts:
    - [ ] In `Chat` & `User` for all methods that accept `chat/user_id`
    - [ ] In `Message` for all methods that accept `chat_id` and `message_id`
    - [ ] For new `Message` shortcuts: Added `quote` argument if methods accepts `reply_to_message_id`
    - [ ] In `CallbackQuery` for all methods that accept either `chat_id` and `message_id` or `inline_message_id`
    
* If relevant:

    - [ ] Added new constants at `telegram.constants` and shortcuts to them as class variables
    - [ ] Link new and existing constants in docstrings instead of hard coded number and strings
    - [ ] Add new message types to `Message.effective_attachment`
    - [ ] Added new handlers for new update types
      - [ ] Add the handlers to the warning loop in the `ConversationHandler`
    - [ ] Added new filters for new message (sub)types
    - [ ] Added or updated documentation for the changed class(es) and/or method(s)
    - [ ] Added or updated `bot_methods.rst`
    - [ ] Updated the Bot API version number in all places: `README.rst` and `README_RAW.rst` (including the badge), as well as `telegram.constants.BOT_API_VERSION`
    - [ ] Added logic for arbitrary callback data in `tg.ext.Bot` for new methods that either accept a `reply_markup` in some form or have a return type that is/contains `telegram.Message`
