### PR TITLE
Drop support for `ujson`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,7 +137,6 @@ Optional Dependencies
 PTB can be installed with optional dependencies:
 
 * ``pip install python-telegram-bot[passport]`` installs the `cryptography>=3.0 <https://cryptography.io>`_ library. Use this, if you want to use Telegram Passport related functionality.
-* ``pip install python-telegram-bot[json]`` installs the `ujson>=4.0.0 <https://pypi.org/project/ujson/>`_ library. It will then be used for JSON de- & encoding, which can bring speed up compared to the standard `json <https://docs.python.org/3/library/json.html>`_ library.
 * ``pip install python-telegram-bot[socks]`` installs ``httpx[socks]``. Use this, if you want to work behind a Socks5 server.
 
 Quick Start

--- a/README_RAW.rst
+++ b/README_RAW.rst
@@ -135,7 +135,6 @@ Optional Dependencies
 ``python-telegram-bot-raw`` can be installed with optional dependencies:
 
 * ``pip install python-telegram-bot[passport]`` installs the `cryptography <https://cryptography.io>`_ library. Use this, if you want to use Telegram Passport related functionality.
-* ``pip install python-telegram-bot[json]`` installs the `ujson <https://pypi.org/project/ujson/>`_ library. It will then be used for JSON de- & encoding, which can bring speed up compared to the standard `json <https://docs.python.org/3/library/json.html>`_ library.
 * ``pip install python-telegram-bot[socks]`` installs the `PySocks <https://pypi.org/project/PySocks/>`_ library. Use this, if you want to work behind a Socks5 server.
 
 Quick Start

--- a/setup.py
+++ b/setup.py
@@ -71,9 +71,6 @@ def get_setup_kwargs(raw=False):
         install_requires=requirements,
         extras_require={
             "socks": "httpx[socks]",
-            # json and cryptography are very stable, so we use a reasonably new version as
-            # lower bound and have no upper bound
-            "json": "ujson>=4.0.0",
             # 3.4-3.4.3 contained some cyclical import bugs
             "passport": "cryptography!=3.4,!=3.4.1,!=3.4.2,!=3.4.3,>=3.0",
         },

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -42,10 +42,6 @@ from typing import (
     no_type_check,
 )
 
-try:
-    import ujson as json
-except ImportError:
-    import json  # type: ignore[no-redef]  # noqa: F723
 
 try:
     from cryptography.hazmat.backends import default_backend
@@ -4571,10 +4567,7 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         if start_parameter is not None:
             data["start_parameter"] = start_parameter
         if provider_data is not None:
-            if isinstance(provider_data, str):
-                data["provider_data"] = provider_data
-            else:
-                data["provider_data"] = json.dumps(provider_data)
+            data["provider_data"] = provider_data
         if photo_url is not None:
             data["photo_url"] = photo_url
         if photo_size is not None:

--- a/telegram/_passport/credentials.py
+++ b/telegram/_passport/credentials.py
@@ -17,11 +17,7 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 # pylint: disable=missing-module-docstring,  redefined-builtin
-try:
-    import ujson as json
-except ImportError:
-    import json  # type: ignore[no-redef]
-
+import json
 from base64 import b64decode
 from typing import TYPE_CHECKING, Any, List, Optional, no_type_check
 

--- a/telegram/_telegramobject.py
+++ b/telegram/_telegramobject.py
@@ -17,12 +17,9 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """Base class for Telegram Objects."""
+import json
 from copy import deepcopy
 
-try:
-    import ujson as json
-except ImportError:
-    import json  # type: ignore[no-redef]
 
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Type, TypeVar, Union
 

--- a/telegram/ext/_dictpersistence.py
+++ b/telegram/ext/_dictpersistence.py
@@ -17,18 +17,13 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains the DictPersistence class."""
-
+import json
 from copy import deepcopy
 from typing import Dict, Optional, cast
 
 from telegram._utils.types import JSONDict
 from telegram.ext import BasePersistence, PersistenceInput
 from telegram.ext._utils.types import CDCData, ConversationDict, ConversationKey
-
-try:
-    import ujson as json
-except ImportError:
-    import json  # type: ignore[no-redef]
 
 
 class DictPersistence(BasePersistence):

--- a/telegram/ext/_utils/webhookhandler.py
+++ b/telegram/ext/_utils/webhookhandler.py
@@ -18,6 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 # pylint: disable=missing-module-docstring
 import asyncio
+import json
 import logging
 from http import HTTPStatus
 from ssl import SSLContext
@@ -32,11 +33,6 @@ from telegram.ext._extbot import ExtBot
 
 if TYPE_CHECKING:
     from telegram import Bot
-
-try:
-    import ujson as json
-except ImportError:
-    import json  # type: ignore[no-redef]
 
 
 class WebhookServer:

--- a/telegram/request/_baserequest.py
+++ b/telegram/request/_baserequest.py
@@ -19,15 +19,12 @@
 """This module contains an abstract class to make POST and GET requests."""
 import abc
 import asyncio
+import json
 from contextlib import AbstractAsyncContextManager
 from http import HTTPStatus
 from types import TracebackType
 from typing import ClassVar, Optional, Tuple, Type, TypeVar, Union
 
-try:
-    import ujson as json
-except ImportError:
-    import json  # type: ignore[no-redef]
 
 from telegram._utils.defaultvalue import DEFAULT_NONE as _DEFAULT_NONE
 from telegram._utils.types import JSONDict, ODVInput

--- a/telegram/request/_requestdata.py
+++ b/telegram/request/_requestdata.py
@@ -17,16 +17,12 @@
 #  You should have received a copy of the GNU Lesser Public License
 #  along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains a class that holds the parameters of a request to the Bot API."""
+import json
 from typing import Any, Dict, List, Union
 from urllib.parse import urlencode
 
 from telegram._utils.types import UploadFileDict
 from telegram.request._requestparameter import RequestParameter
-
-try:
-    import ujson as json
-except ImportError:
-    import json  # type: ignore[no-redef]  # noqa: F723
 
 
 class RequestData:

--- a/telegram/request/_requestparameter.py
+++ b/telegram/request/_requestparameter.py
@@ -17,6 +17,7 @@
 #  You should have received a copy of the GNU Lesser Public License
 #  along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains a class that describes a single parameter of a request to the Bot API."""
+import json
 from dataclasses import dataclass
 from datetime import datetime
 from typing import List, Optional, Tuple
@@ -27,11 +28,6 @@ from telegram._telegramobject import TelegramObject
 from telegram._utils.datetime import to_timestamp
 from telegram._utils.enum import StringEnum
 from telegram._utils.types import UploadFileDict
-
-try:
-    import ujson as json
-except ImportError:
-    import json  # type: ignore[no-redef]  # noqa: F723
 
 
 @dataclass(repr=False, eq=False, order=False, frozen=True)

--- a/tests/test_dictpersistence.py
+++ b/tests/test_dictpersistence.py
@@ -16,12 +16,9 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-import pytest
+import json
 
-try:
-    import ujson as json
-except ImportError:
-    import json
+import pytest
 
 from telegram.ext import DictPersistence
 

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -195,11 +195,7 @@ class TestInvoice:
 
     async def test_send_object_as_provider_data(self, monkeypatch, bot, chat_id, provider_token):
         async def make_assertion(url, request_data: RequestData, *args, **kwargs):
-            # depends on whether we're using ujson
-            return request_data.json_parameters["provider_data"] in [
-                '{"test_data": 123456789}',
-                '{"test_data":123456789}',
-            ]
+            return request_data.json_parameters["provider_data"] == '{"test_data": 123456789}'
 
         monkeypatch.setattr(bot.request, "post", make_assertion)
 

--- a/tests/test_requestdata.py
+++ b/tests/test_requestdata.py
@@ -16,12 +16,9 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
+import json
 from urllib.parse import quote
 
-try:
-    import ujson as json
-except ImportError:
-    import json
 
 from typing import Any, Dict
 

--- a/tests/test_telegramobject.py
+++ b/tests/test_telegramobject.py
@@ -17,16 +17,11 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 import datetime
-import json as json_lib
 import pickle
 from copy import deepcopy
 
 import pytest
 
-try:
-    import ujson
-except ImportError:
-    ujson = None
 
 from telegram import Chat, Message, PhotoSize, TelegramObject, User
 
@@ -38,9 +33,7 @@ class TestTelegramObject:
             self.normal = normal
             self._bot = b
 
-    def test_to_json_native(self, monkeypatch):
-        if ujson:
-            monkeypatch.setattr("ujson.dumps", json_lib.dumps)
+    def test_to_json(self, monkeypatch):
         # to_json simply takes whatever comes from to_dict, therefore we only need to test it once
         telegram_object = TelegramObject()
 
@@ -60,28 +53,6 @@ class TestTelegramObject:
         monkeypatch.setattr("telegram.TelegramObject.to_dict", lambda _: d)
         with pytest.raises(TypeError):
             telegram_object.to_json()
-
-    @pytest.mark.skipif(not ujson, reason="ujson not installed")
-    def test_to_json_ujson(self, monkeypatch):
-        # to_json simply takes whatever comes from to_dict, therefore we only need to test it once
-        telegram_object = TelegramObject()
-
-        # Test that it works with a dict with str keys as well as dicts as lists as values
-        d = {"str": "str", "str2": ["str", "str"], "str3": {"str": "str"}}
-        monkeypatch.setattr("telegram.TelegramObject.to_dict", lambda _: d)
-        json = telegram_object.to_json()
-        # Order isn't guarantied and ujon discards whitespace
-        assert '"str":"str"' in json
-        assert '"str2":["str","str"]' in json
-        assert '"str3":{"str":"str"}' in json
-
-        # Test that ujson allows tuples
-        # NOTE: This could be seen as a bug (since it's differnt from the normal "json",
-        # but we test it anyways
-        d = {("str", "str"): "str"}
-
-        monkeypatch.setattr("telegram.TelegramObject.to_dict", lambda _: d)
-        telegram_object.to_json()
 
     def test_to_dict_private_attribute(self):
         class TelegramObjectSubclass(TelegramObject):


### PR DESCRIPTION
Let me try to wrap up what lead us here:

* Noam suggested to switch from `ujson` to `orjson` as optional 3rd party json library, because the latter has serveral benefits
* orjson turned out to not play well with httpx out of the box, because `orjson.dumps` returns bytes instead of a string
* investigating the different possibilities lead us to the conclusion that it may be better (in terms of maintenance and code design) if PTB did not offer a built-in support for a 3rd party json library

Hence, this PR removes support for `ujson`.
We don't really know how many users are actually using the `ujson` feature currently and we also don't have any benchmarks on how `ujson` actually affects the performance. _If_ users do request the option to use a custom json library, there are a few things that we can do and that we need to consider. I'm writing them down below in some detail for future reference.

* Where is `ujson` currently used, i.e. where could users want to use a 3rd party library instead?
  1. `DictPersisence`: This is no problem. `BasePersistence` is already an ABC, so any user can go ahead and implement a custom version of `DictPersistence` with a 3rd party json library
  2. a small part in the passport-decryption logic. This is a problem, but IMHO a neglectible one b/c passports are basically dead anyways
  3. `WebhookHandler`: No problem. Users can implement a custom webhook solution that uses a 3rd party json lib
  4. `TelegramObject.to_json`: No problem. This method is not actually used anywhere.
  5. Networking backend. This is the actually interesting point. Let's get into that
* Networking backend: JSON DE-coding: This is currently not possible to customize. If needed, we can easily fix that by making `BaseRequest._parse_json_payload` a public method. Then custom implementations can override it to use a 3rd party json lib.
* Networking backend: JSON EN-coding: This is already mostly doable already: in `do_request` just do something like `{name: my_json_lib.dumps(value) for name, value in request_data.parameters.items()}`. However, the big performance advantage of some json libraries comes from the fact that they can readily json-dump a larger variety of objects, i.e. not only lists, dicts, strings & numbers but also e.g. `datetime` and `dataclass` objects. So a user might want to skip the `TelegramObject.to_dict()` step. To support this, we could consider to add a propert `RequestData.raw_parameters` (or similar naming) through which we expose exactly those values.