### PR TITLE
Aligned JobQueue.run_daily `days` parameter with cron weekdays notation (#3038)

### DIFF
--- a/tests/test_jobqueue.py
+++ b/tests/test_jobqueue.py
@@ -303,7 +303,11 @@ class TestJobQueue:
         scheduled_time = job_queue.jobs()[0].next_t.timestamp()
         assert scheduled_time == pytest.approx(expected_time)
 
-    async def test_run_daily(self, job_queue):
+    async def test_run_daily(self, job_queue, recwarn):
+        expected_warning = (
+            "Prior to v20.0 the `days` parameter was aligned to that of cron's weekday scheme we "
+            "recommend double checking if the passed value is correct."
+        )
         delta, now = 1, dtm.datetime.now(pytz.utc)
         time_of_day = (now + dtm.timedelta(seconds=delta)).time()
         expected_reschedule_time = (now + dtm.timedelta(seconds=delta, days=1)).timestamp()
@@ -313,6 +317,27 @@ class TestJobQueue:
         assert self.result == 1
         scheduled_time = job_queue.jobs()[0].next_t.timestamp()
         assert scheduled_time == pytest.approx(expected_reschedule_time)
+        assert len(recwarn) == 1
+        assert str(recwarn[0].message) == expected_warning
+
+    async def test_run_daily_days_of_week(self, job_queue, recwarn):
+        expected_warning = (
+            "Prior to v20.0 the `days` parameter was aligned to that of cron's weekday scheme we "
+            "recommend double checking if the passed value is correct."
+        )
+        delta, now = 1, dtm.datetime.now(pytz.utc)
+        time_of_day = (now + dtm.timedelta(seconds=delta)).time()
+        # offset in days until next monday
+        offset = 7 - now.weekday()
+        expected_reschedule_time = (now + dtm.timedelta(seconds=delta, days=offset)).timestamp()
+        monday_only = [1]
+
+        job_queue.run_daily(self.job_run_once, time_of_day, monday_only)
+        await asyncio.sleep(delta + 0.1)
+        scheduled_time = job_queue.jobs()[0].next_t.timestamp()
+        assert scheduled_time == pytest.approx(expected_reschedule_time)
+        assert len(recwarn) == 1
+        assert str(recwarn[0].message) == expected_warning
 
     async def test_run_monthly(self, job_queue, timezone):
         delta, now = 1, dtm.datetime.now(timezone)


### PR DESCRIPTION
Changes included in the PR:
- Updated docstring of `JobQueue.run_daily` that the `days` parameter range 0-6 is now sunday-saturday.
- Added a warning message to double check if the parameter is still correct.
- Added a test case to check if the new number scheme is correctly scheduled.
- Updated test cases where the warning should be visible on call.

### Checklist for PRs

- [x] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests