### PR TITLE
Drop explicit type conversions in `__init__` s

### DIFF
--- a/telegram/_botcommandscope.py
+++ b/telegram/_botcommandscope.py
@@ -260,5 +260,5 @@ class BotCommandScopeChatMember(BotCommandScope):
         self.chat_id = (
             chat_id if isinstance(chat_id, str) and chat_id.startswith("@") else int(chat_id)
         )
-        self.user_id = int(user_id)
+        self.user_id = user_id
         self._id_attrs = (self.type, self.chat_id, self.user_id)

--- a/telegram/_chat.py
+++ b/telegram/_chat.py
@@ -235,7 +235,7 @@ class Chat(TelegramObject):
         **_kwargs: Any,
     ):
         # Required
-        self.id = int(id)  # pylint: disable=invalid-name
+        self.id = id  # pylint: disable=invalid-name
         self.type = enum.get_member(constants.ChatType, type, type)
         # Optionals
         self.title = title

--- a/telegram/_chatinvitelink.py
+++ b/telegram/_chatinvitelink.py
@@ -124,7 +124,7 @@ class ChatInviteLink(TelegramObject):
 
         # Optionals
         self.expire_date = expire_date
-        self.member_limit = int(member_limit) if member_limit is not None else None
+        self.member_limit = member_limit
         self.name = name
         self.pending_join_request_count = (
             int(pending_join_request_count) if pending_join_request_count is not None else None

--- a/telegram/_files/animation.py
+++ b/telegram/_files/animation.py
@@ -88,8 +88,8 @@ class Animation(_BaseThumbedMedium):
             bot=bot,
         )
         # Required
-        self.width = int(width)
-        self.height = int(height)
+        self.width = width
+        self.height = height
         self.duration = duration
         # Optional
         self.mime_type = mime_type

--- a/telegram/_files/location.py
+++ b/telegram/_files/location.py
@@ -76,13 +76,13 @@ class Location(TelegramObject):
         **_kwargs: Any,
     ):
         # Required
-        self.longitude = float(longitude)
-        self.latitude = float(latitude)
+        self.longitude = longitude
+        self.latitude = latitude
 
         # Optionals
-        self.horizontal_accuracy = float(horizontal_accuracy) if horizontal_accuracy else None
-        self.live_period = int(live_period) if live_period else None
-        self.heading = int(heading) if heading else None
+        self.horizontal_accuracy = horizontal_accuracy
+        self.live_period = live_period
+        self.heading = heading
         self.proximity_alert_radius = (
             int(proximity_alert_radius) if proximity_alert_radius else None
         )

--- a/telegram/_files/photosize.py
+++ b/telegram/_files/photosize.py
@@ -72,5 +72,5 @@ class PhotoSize(_BaseMedium):
             file_id=file_id, file_unique_id=file_unique_id, file_size=file_size, bot=bot
         )
         # Required
-        self.width = int(width)
-        self.height = int(height)
+        self.width = width
+        self.height = height

--- a/telegram/_files/sticker.py
+++ b/telegram/_files/sticker.py
@@ -120,8 +120,8 @@ class Sticker(_BaseThumbedMedium):
             bot=bot,
         )
         # Required
-        self.width = int(width)
-        self.height = int(height)
+        self.width = width
+        self.height = height
         self.is_animated = is_animated
         self.is_video = is_video
         # Optional

--- a/telegram/_files/video.py
+++ b/telegram/_files/video.py
@@ -89,8 +89,8 @@ class Video(_BaseThumbedMedium):
             bot=bot,
         )
         # Required
-        self.width = int(width)
-        self.height = int(height)
+        self.width = width
+        self.height = height
         self.duration = duration
         # Optional
         self.mime_type = mime_type

--- a/telegram/_files/videonote.py
+++ b/telegram/_files/videonote.py
@@ -81,5 +81,5 @@ class VideoNote(_BaseThumbedMedium):
             bot=bot,
         )
         # Required
-        self.length = int(length)
+        self.length = length
         self.duration = duration

--- a/telegram/_files/voice.py
+++ b/telegram/_files/voice.py
@@ -75,6 +75,6 @@ class Voice(_BaseMedium):
             bot=bot,
         )
         # Required
-        self.duration = int(duration)
+        self.duration = duration
         # Optional
         self.mime_type = mime_type

--- a/telegram/_inline/inlinequeryresultlocation.py
+++ b/telegram/_inline/inlinequeryresultlocation.py
@@ -116,8 +116,8 @@ class InlineQueryResultLocation(InlineQueryResult):
     ):
         # Required
         super().__init__(InlineQueryResultType.LOCATION, id)
-        self.latitude = float(latitude)
-        self.longitude = float(longitude)
+        self.latitude = latitude
+        self.longitude = longitude
         self.title = title
 
         # Optionals
@@ -127,8 +127,8 @@ class InlineQueryResultLocation(InlineQueryResult):
         self.thumb_url = thumb_url
         self.thumb_width = thumb_width
         self.thumb_height = thumb_height
-        self.horizontal_accuracy = float(horizontal_accuracy) if horizontal_accuracy else None
-        self.heading = int(heading) if heading else None
+        self.horizontal_accuracy = horizontal_accuracy
+        self.heading = heading
         self.proximity_alert_radius = (
             int(proximity_alert_radius) if proximity_alert_radius else None
         )

--- a/telegram/_inline/inlinequeryresultphoto.py
+++ b/telegram/_inline/inlinequeryresultphoto.py
@@ -123,8 +123,8 @@ class InlineQueryResultPhoto(InlineQueryResult):
         self.thumb_url = thumb_url
 
         # Optionals
-        self.photo_width = int(photo_width) if photo_width is not None else None
-        self.photo_height = int(photo_height) if photo_height is not None else None
+        self.photo_width = photo_width
+        self.photo_height = photo_height
         self.title = title
         self.description = description
         self.caption = caption

--- a/telegram/_inline/inputinvoicemessagecontent.py
+++ b/telegram/_inline/inputinvoicemessagecontent.py
@@ -179,15 +179,15 @@ class InputInvoiceMessageContent(InputMessageContent):
         self.currency = currency
         self.prices = prices
         # Optionals
-        self.max_tip_amount = int(max_tip_amount) if max_tip_amount else None
+        self.max_tip_amount = max_tip_amount
         self.suggested_tip_amounts = (
             [int(sta) for sta in suggested_tip_amounts] if suggested_tip_amounts else None
         )
         self.provider_data = provider_data
         self.photo_url = photo_url
-        self.photo_size = int(photo_size) if photo_size else None
-        self.photo_width = int(photo_width) if photo_width else None
-        self.photo_height = int(photo_height) if photo_height else None
+        self.photo_size = photo_size
+        self.photo_width = photo_width
+        self.photo_height = photo_height
         self.need_name = need_name
         self.need_phone_number = need_phone_number
         self.need_email = need_email

--- a/telegram/_inline/inputinvoicemessagecontent.py
+++ b/telegram/_inline/inputinvoicemessagecontent.py
@@ -180,9 +180,7 @@ class InputInvoiceMessageContent(InputMessageContent):
         self.prices = prices
         # Optionals
         self.max_tip_amount = max_tip_amount
-        self.suggested_tip_amounts = (
-            [int(sta) for sta in suggested_tip_amounts] if suggested_tip_amounts else None
-        )
+        self.suggested_tip_amounts = suggested_tip_amounts
         self.provider_data = provider_data
         self.photo_url = photo_url
         self.photo_size = photo_size

--- a/telegram/_inline/inputlocationmessagecontent.py
+++ b/telegram/_inline/inputlocationmessagecontent.py
@@ -79,9 +79,9 @@ class InputLocationMessageContent(InputMessageContent):
         self.longitude = longitude
 
         # Optionals
-        self.live_period = int(live_period) if live_period else None
-        self.horizontal_accuracy = float(horizontal_accuracy) if horizontal_accuracy else None
-        self.heading = int(heading) if heading else None
+        self.live_period = live_period
+        self.horizontal_accuracy = horizontal_accuracy
+        self.heading = heading
         self.proximity_alert_radius = (
             int(proximity_alert_radius) if proximity_alert_radius else None
         )

--- a/telegram/_message.py
+++ b/telegram/_message.py
@@ -499,7 +499,7 @@ class Message(TelegramObject):
         **_kwargs: Any,
     ):
         # Required
-        self.message_id = int(message_id)
+        self.message_id = message_id
         # Optionals
         self.from_user = from_user
         self.sender_chat = sender_chat

--- a/telegram/_messageautodeletetimerchanged.py
+++ b/telegram/_messageautodeletetimerchanged.py
@@ -51,6 +51,6 @@ class MessageAutoDeleteTimerChanged(TelegramObject):
         message_auto_delete_time: int,
         **_kwargs: Any,
     ):
-        self.message_auto_delete_time = int(message_auto_delete_time)
+        self.message_auto_delete_time = message_auto_delete_time
 
         self._id_attrs = (self.message_auto_delete_time,)

--- a/telegram/_messageid.py
+++ b/telegram/_messageid.py
@@ -35,6 +35,6 @@ class MessageId(TelegramObject):
     __slots__ = ("message_id",)
 
     def __init__(self, message_id: int, **_kwargs: Any):
-        self.message_id = int(message_id)
+        self.message_id = message_id
 
         self._id_attrs = (self.message_id,)

--- a/telegram/_update.py
+++ b/telegram/_update.py
@@ -239,7 +239,7 @@ class Update(TelegramObject):
         **_kwargs: Any,
     ):
         # Required
-        self.update_id = int(update_id)
+        self.update_id = update_id
         # Optionals
         self.message = message
         self.edited_message = edited_message

--- a/telegram/_user.py
+++ b/telegram/_user.py
@@ -128,7 +128,7 @@ class User(TelegramObject):
         **_kwargs: Any,
     ):
         # Required
-        self.id = int(id)  # pylint: disable=invalid-name
+        self.id = id  # pylint: disable=invalid-name
         self.first_name = first_name
         self.is_bot = is_bot
         # Optionals

--- a/telegram/_userprofilephotos.py
+++ b/telegram/_userprofilephotos.py
@@ -49,7 +49,7 @@ class UserProfilePhotos(TelegramObject):
 
     def __init__(self, total_count: int, photos: List[List[PhotoSize]], **_kwargs: Any):
         # Required
-        self.total_count = int(total_count)
+        self.total_count = total_count
         self.photos = photos
 
         self._id_attrs = (self.total_count, self.photos)

--- a/telegram/_videochat.py
+++ b/telegram/_videochat.py
@@ -71,7 +71,7 @@ class VideoChatEnded(TelegramObject):
     __slots__ = ("duration",)
 
     def __init__(self, duration: int, **_kwargs: object) -> None:
-        self.duration = int(duration) if duration is not None else None
+        self.duration = duration
         self._id_attrs = (self.duration,)
 
 

--- a/telegram/error.py
+++ b/telegram/error.py
@@ -144,13 +144,16 @@ class ChatMigrated(TelegramError):
     Args:
         new_chat_id (:obj:`int`): The new chat id of the group.
 
+    Attributes:
+        new_chat_id (:obj:`int`): The new chat id of the group.
+
     """
 
     __slots__ = ("new_chat_id",)
 
     def __init__(self, new_chat_id: int):
         super().__init__(f"Group migrated to supergroup. New chat id: {new_chat_id}")
-        self.new_chat_id = int(new_chat_id)
+        self.new_chat_id = new_chat_id
 
     def __reduce__(self) -> Tuple[type, Tuple[int]]:  # type: ignore[override]
         return self.__class__, (self.new_chat_id,)
@@ -160,7 +163,13 @@ class RetryAfter(TelegramError):
     """
     Raised when flood limits where exceeded.
 
+    .. versionchanged:: 20.0
+       :attr:`retry_after` is now an integer to comply with the Bot API.
+
     Args:
+        retry_after (:obj:`int`): Time in seconds, after which the bot can retry the request.
+
+    Attributes:
         retry_after (:obj:`int`): Time in seconds, after which the bot can retry the request.
 
     """
@@ -168,8 +177,8 @@ class RetryAfter(TelegramError):
     __slots__ = ("retry_after",)
 
     def __init__(self, retry_after: int):
-        super().__init__(f"Flood control exceeded. Retry in {float(retry_after)} seconds")
-        self.retry_after = float(retry_after)
+        super().__init__(f"Flood control exceeded. Retry in {retry_after} seconds")
+        self.retry_after = retry_after
 
     def __reduce__(self) -> Tuple[type, Tuple[float]]:  # type: ignore[override]
         return self.__class__, (self.retry_after,)

--- a/tests/test_chatinvitelink.py
+++ b/tests/test_chatinvitelink.py
@@ -85,7 +85,7 @@ class TestChatInviteLink:
             "is_primary": self.primary,
             "is_revoked": self.revoked,
             "expire_date": to_timestamp(self.expire_date),
-            "member_limit": str(self.member_limit),
+            "member_limit": self.member_limit,
             "name": self.name,
             "pending_join_request_count": str(self.pending_join_request_count),
         }

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -94,7 +94,7 @@ class TestErrors:
             assert e.new_chat_id == 1234
 
     def test_retry_after(self):
-        with pytest.raises(RetryAfter, match="Flood control exceeded. Retry in 12.0 seconds"):
+        with pytest.raises(RetryAfter, match="Flood control exceeded. Retry in 12 seconds"):
             raise RetryAfter(12)
 
     def test_conflict(self):
@@ -186,8 +186,8 @@ class TestErrors:
         assert str(e) == "This is a message"
 
         e = RetryAfter(42)
-        assert repr(e) == "RetryAfter('Flood control exceeded. Retry in 42.0 seconds')"
-        assert str(e) == "Flood control exceeded. Retry in 42.0 seconds"
+        assert repr(e) == "RetryAfter('Flood control exceeded. Retry in 42 seconds')"
+        assert str(e) == "Flood control exceeded. Retry in 42 seconds"
 
         e = BadRequest("This is a message")
         assert repr(e) == "BadRequest('This is a message')"

--- a/tests/test_inputinvoicemessagecontent.py
+++ b/tests/test_inputinvoicemessagecontent.py
@@ -56,12 +56,12 @@ class TestInputInvoiceMessageContent:
     currency = "PTBCoin"
     prices = [LabeledPrice("label1", 42), LabeledPrice("label2", 314)]
     max_tip_amount = 420
-    suggested_tip_amounts = ["314", "256"]
+    suggested_tip_amounts = [314, 256]
     provider_data = "provider data"
     photo_url = "photo_url"
-    photo_size = "314"
-    photo_width = "420"
-    photo_height = "256"
+    photo_size = 314
+    photo_width = 420
+    photo_height = 256
     need_name = True
     need_phone_number = True
     need_email = True

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -140,7 +140,7 @@ class TestRequest:
             await httpx_request.post(None, None, None)
 
     async def test_chat_migrated(self, monkeypatch, httpx_request: HTTPXRequest):
-        server_response = b'{"ok": "False", "parameters": {"migrate_to_chat_id": "123"}}'
+        server_response = b'{"ok": "False", "parameters": {"migrate_to_chat_id": 123}}'
 
         monkeypatch.setattr(
             httpx_request,
@@ -154,7 +154,7 @@ class TestRequest:
         assert exc_info.value.new_chat_id == 123
 
     async def test_retry_after(self, monkeypatch, httpx_request: HTTPXRequest):
-        server_response = b'{"ok": "False", "parameters": {"retry_after": "42"}}'
+        server_response = b'{"ok": "False", "parameters": {"retry_after": 42}}'
 
         monkeypatch.setattr(
             httpx_request,
@@ -162,10 +162,10 @@ class TestRequest:
             mocker_factory(response=server_response, return_code=HTTPStatus.BAD_REQUEST),
         )
 
-        with pytest.raises(RetryAfter, match="Retry in 42.0") as exc_info:
+        with pytest.raises(RetryAfter, match="Retry in 42") as exc_info:
             await httpx_request.post(None, None, None)
 
-        assert exc_info.value.retry_after == 42.0
+        assert exc_info.value.retry_after == 42
 
     async def test_unknown_request_params(self, monkeypatch, httpx_request: HTTPXRequest):
         server_response = b'{"ok": "False", "parameters": {"unknown": "42"}}'


### PR DESCRIPTION
Addresses the second part of and closes #2901.

I double checked: [numbers](https://json-schema.org/understanding-json-schema/reference/numeric.html) and [strings](https://json-schema.org/understanding-json-schema/reference/string.html) are indeed different things in json, so this won't be a problem. My concerns in https://github.com/python-telegram-bot/python-telegram-bot/issues/2901#issuecomment-1085061334 probably came from my subconscious recalling that [keys can only be strings](https://json-schema.org/understanding-json-schema/reference/object.html) in json, which is why `json.dumps({1: '1'}) == '{"1": 1}'` and `json.loads('{"1": 1}') == {"1": 1}`.

This also makes `RetryAfter.retry_after` an integer b/c that's what TG documents (this is a tiny breaking change) and adds some missing docs to the error module.

### Checklist for PRs

- [x] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [ ] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)
- [ ] Added new classes & modules to the docs and all suitable `__all__` s
