### PR TITLE
Empty lists

### DIFF
--- a/telegram/_games/game.py
+++ b/telegram/_games/game.py
@@ -63,8 +63,9 @@ class Game(TelegramObject):
             game message. Can be automatically edited to include current high scores for the game
             when the bot calls :meth:`telegram.Bot.set_game_score`, or manually edited
             using :meth:`telegram.Bot.edit_message_text`.
-        text_entities (List[:class:`telegram.MessageEntity`]): Optional. Special entities that
+        text_entities (List[:class:`telegram.MessageEntity`]):  Special entities that
             appear in text, such as usernames, URLs, bot commands, etc.
+            This list is empty if the message does not contain text entities.
         animation (:class:`telegram.Animation`): Optional. Animation that will be displayed in the
             game message in chats. Upload via `BotFather <https://t.me/BotFather>`_.
 
@@ -182,7 +183,7 @@ class Game(TelegramObject):
 
         return {
             entity: self.parse_text_entity(entity)
-            for entity in (self.text_entities or [])
+            for entity in self.text_entities
             if entity.type in types
         }
 

--- a/telegram/_games/game.py
+++ b/telegram/_games/game.py
@@ -63,7 +63,7 @@ class Game(TelegramObject):
             game message. Can be automatically edited to include current high scores for the game
             when the bot calls :meth:`telegram.Bot.set_game_score`, or manually edited
             using :meth:`telegram.Bot.edit_message_text`.
-        text_entities (List[:class:`telegram.MessageEntity`]):  Special entities that
+        text_entities (List[:class:`telegram.MessageEntity`]): Special entities that
             appear in text, such as usernames, URLs, bot commands, etc.
             This list is empty if the message does not contain text entities.
         animation (:class:`telegram.Animation`): Optional. Animation that will be displayed in the

--- a/telegram/_message.py
+++ b/telegram/_message.py
@@ -141,7 +141,7 @@ class Message(TelegramObject):
         entities (List[:class:`telegram.MessageEntity`], optional): For text messages, special
             entities like usernames, URLs, bot commands, etc. that appear in the text. See
             :attr:`parse_entity` and :attr:`parse_entities` methods for how to use properly.
-        caption_entities (List[:class:`telegram.MessageEntity`]): Optional. For Messages with a
+        caption_entities (List[:class:`telegram.MessageEntity`], optional): For messages with a
             Caption. Special entities like usernames, URLs, bot commands, etc. that appear in the
             caption. See :attr:`Message.parse_caption_entity` and :attr:`parse_caption_entities`
             methods for how to use properly.
@@ -280,27 +280,29 @@ class Message(TelegramObject):
         media_group_id (:obj:`str`): Optional. The unique identifier of a media message group this
             message belongs to.
         text (:obj:`str`): Optional. The actual UTF-8 text of the message.
-        entities (List[:class:`telegram.MessageEntity`]): Optional. Special entities like
+        entities (List[:class:`telegram.MessageEntity`]): Special entities like
             usernames, URLs, bot commands, etc. that appear in the text. See
             :attr:`Message.parse_entity` and :attr:`parse_entities` methods for how to use
-            properly.
-        caption_entities (List[:class:`telegram.MessageEntity`]): Optional. Special entities like
+            properly. This list is empty if the message does not contain entities.
+        caption_entities (List[:class:`telegram.MessageEntity`]): Special entities like
             usernames, URLs, bot commands, etc. that appear in the caption. See
             :attr:`Message.parse_caption_entity` and :attr:`parse_caption_entities` methods for how
-            to use properly.
+            to use properly. This list is empty if the message does not contain caption entities.
         audio (:class:`telegram.Audio`): Optional. Information about the file.
         document (:class:`telegram.Document`): Optional. Information about the file.
         animation (:class:`telegram.Animation`) Optional. Information about the file.
             For backward compatibility, when this field is set, the document field will also be
             set.
         game (:class:`telegram.Game`): Optional. Information about the game.
-        photo (List[:class:`telegram.PhotoSize`]): Optional. Available sizes of the photo.
+        photo (List[:class:`telegram.PhotoSize`]): Available sizes of the photo.
+            This list is empty if the message does not contain a photo.
         sticker (:class:`telegram.Sticker`): Optional. Information about the sticker.
         video (:class:`telegram.Video`): Optional. Information about the video.
         voice (:class:`telegram.Voice`): Optional. Information about the file.
         video_note (:class:`telegram.VideoNote`): Optional. Information about the video message.
-        new_chat_members (List[:class:`telegram.User`]): Optional. Information about new members to
-            the chat. (the bot itself may be one of these members).
+        new_chat_members (List[:class:`telegram.User`]): Information about new members to
+            the chat. The bot itself may be one of these members.
+            This list is empty if the message does not contain new chat members.
         caption (:obj:`str`): Optional. Caption for the document, photo or video,
             0-:tg-const:`telegram.constants.MessageLimit.CAPTION_LENGTH`
             characters.
@@ -310,8 +312,8 @@ class Message(TelegramObject):
         left_chat_member (:class:`telegram.User`): Optional. Information about the user that left
             the group. (this member may be the bot itself).
         new_chat_title (:obj:`str`): Optional. A chat title was changed to this value.
-        new_chat_photo (List[:class:`telegram.PhotoSize`]): Optional. A chat photo was changed to
-            this value.
+        new_chat_photo (List[:class:`telegram.PhotoSize`]): A chat photo was changed to
+            this value. This list is empty if the message does not contain a new chat photo.
         delete_chat_photo (:obj:`bool`): Optional. The chat photo was deleted.
         group_chat_created (:obj:`bool`): Optional. The group has been created.
         supergroup_chat_created (:obj:`bool`): Optional. The supergroup has been created.
@@ -2724,9 +2726,7 @@ class Message(TelegramObject):
             types = MessageEntity.ALL_TYPES
 
         return {
-            entity: self.parse_entity(entity)
-            for entity in (self.entities or [])
-            if entity.type in types
+            entity: self.parse_entity(entity) for entity in self.entities if entity.type in types
         }
 
     def parse_caption_entities(self, types: List[str] = None) -> Dict[MessageEntity, str]:
@@ -2757,7 +2757,7 @@ class Message(TelegramObject):
 
         return {
             entity: self.parse_caption_entity(entity)
-            for entity in (self.caption_entities or [])
+            for entity in self.caption_entities
             if entity.type in types
         }
 

--- a/telegram/_poll.py
+++ b/telegram/_poll.py
@@ -144,8 +144,12 @@ class Poll(TelegramObject):
         correct_option_id (:obj:`int`): Optional. Identifier of the correct answer option.
         explanation (:obj:`str`): Optional. Text that is shown when a user chooses an incorrect
             answer or taps on the lamp icon in a quiz-style poll.
-        explanation_entities (List[:class:`telegram.MessageEntity`]): Optional. Special entities
+        explanation_entities (List[:class:`telegram.MessageEntity`]): Special entities
             like usernames, URLs, bot commands, etc. that appear in the :attr:`explanation`.
+            This list is empty if the message does not contain explanation entities.
+
+            .. versionchanged:: 20.0
+               This attribute is now always a (possibly empty) list and never :obj:`None`.
         open_period (:obj:`int`): Optional. Amount of time in seconds the poll will be active
             after creation.
         close_date (:obj:`datetime.datetime`): Optional. Point in time when the poll will be
@@ -196,7 +200,7 @@ class Poll(TelegramObject):
         self.allows_multiple_answers = allows_multiple_answers
         self.correct_option_id = correct_option_id
         self.explanation = explanation
-        self.explanation_entities = explanation_entities
+        self.explanation_entities = explanation_entities or []
         self.open_period = open_period
         self.close_date = close_date
 
@@ -283,7 +287,7 @@ class Poll(TelegramObject):
 
         return {
             entity: self.parse_explanation_entity(entity)
-            for entity in (self.explanation_entities or [])
+            for entity in self.explanation_entities
             if entity.type in types
         }
 


### PR DESCRIPTION
Addresses https://github.com/python-telegram-bot/python-telegram-bot/pull/2741#issuecomment-1001740609 and the respective item of #2633.

I also made some smaller code changes, hence this is a standalone PR instead of being included in the doc fixes pr.
In addition to updating the docs of `Message`, I also made corresponding changes to `Poll` and `Game`. Note that there are also classes like `InlineQueryResult*` which have a `caption_entities` attribute. However, those classes are used as input for API methods and having those attributes always be list would make problems - we'd have to somehow decide when to pass an empty list to TG and when to skip the parameter. So I left them as is.

### Checklist for PRs

- [x] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [ ] Created new or adapted existing unit tests
- [ ] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)
- [ ] Added new classes & modules to the docs and all suitable `__all__` s
