### PR TITLE
Add backslash character to be escaped in escape_markdown()

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -89,6 +89,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Poolitzer <https://github.com/Poolitzer>`_
 - `Pranjalya Tiwari <https://github.com/Pranjalya>`_
 - `Rahiel Kasim <https://github.com/rahiel>`_
+- `rikkaneko <https://github.com/rikkaneko>`_
 - `Riko Naka <https://github.com/rikonaka>`_
 - `Rizlas <https://github.com/rizlas>`_
 - `Sahil Sharma <https://github.com/sahilsharma811>`_

--- a/telegram/helpers.py
+++ b/telegram/helpers.py
@@ -63,7 +63,7 @@ def escape_markdown(text: str, version: int = 1, entity_type: str = None) -> str
         elif entity_type == "text_link":
             escape_chars = r"\)"
         else:
-            escape_chars = r"\_*[]()~`>#+-=|{}.!"
+            escape_chars = r"\_*[]()~`>#+-=|{}.!\\"
     else:
         raise ValueError("Markdown version must be either 1 or 2!")
 


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool! Please have a look at the below checklist. It's here to help both you and the maintainers to remember some aspects. Make sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
-->

### Checklist for PRs

- [ ] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [ ] Created new or adapted existing unit tests
- [ ] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- [x] Added myself alphabetically to `AUTHORS.rst` (optional)
- [ ] Added new classes & modules to the docs and all suitable `__all__` s

#### This PR just add the backslash character `\` to the `escape_chars` in `telegram/helpers.py`. This is my first PR too :)  

I found that Telegram will return error if the message text contain the backslash character `\`, in **Markdown V2** mode.  
`escape_markdown()` does not handle this special symbol.  Backslash character `\` **does not need** to be escaped in V1.
For example, this sample Markdown V2 link `*\\\*` would become `\*\\\\*` after `escape_markdown()`.  However, Telegram will reply with error since the `\` is incorrectly escaped. The correct result should be `\*\\\\\\\*` with escaped `\`.  