### PR TITLE
Fix a bug with non-blocking entry points

### DIFF
--- a/telegram/ext/_conversationhandler.py
+++ b/telegram/ext/_conversationhandler.py
@@ -708,8 +708,13 @@ class ConversationHandler(BaseHandler[Update, CCT]):
             # check if future is finished or not
             if state.done():
                 res = state.resolve()
-                self._update_state(res, key)
-                state = self._conversations.get(key)
+                if res is None:
+                    # Special case if the error was raised in a non-blocking entry-point
+                    self._conversations.pop(key, None)
+                    state = None
+                else:
+                    self._update_state(res, key)
+                    state = self._conversations.get(key)
 
             # if not then handle WAITING state instead
             else:

--- a/telegram/ext/_conversationhandler.py
+++ b/telegram/ext/_conversationhandler.py
@@ -107,7 +107,6 @@ class PendingState:
             _logger.exception(
                 "Task function raised exception. Falling back to old state %s",
                 self.old_state,
-                exc_info=exc,
             )
             return self.old_state
 
@@ -717,7 +716,6 @@ class ConversationHandler(BaseHandler[Update, CCT]):
                     self._conversations.pop(key, None)
                     state = None
                 else:
-                    print("resolved stat", res)
                     self._update_state(res, key)
                     state = self._conversations.get(key)
 

--- a/telegram/ext/_conversationhandler.py
+++ b/telegram/ext/_conversationhandler.py
@@ -711,8 +711,15 @@ class ConversationHandler(BaseHandler[Update, CCT]):
 
             # check if future is finished or not
             if state.done():
-                state = state.resolve()
-                self._update_state(state, key)
+                res = state.resolve()
+                # Special case if an error was raised in a non-blocking entry-point
+                if state.old_state is None and state.task.exception():
+                    self._conversations.pop(key, None)
+                    state = None
+                else:
+                    print("resolved stat", res)
+                    self._update_state(res, key)
+                    state = self._conversations.get(key)
 
             # if not then handle WAITING state instead
             else:

--- a/tests/test_conversationhandler.py
+++ b/tests/test_conversationhandler.py
@@ -1101,7 +1101,7 @@ class TestConversationHandler:
                     caplog.records[0].message
                     == "Task function raised exception. Falling back to old state 1"
                 )
-                assert caplog.records[0].exc_info[1] is error
+                assert caplog.records[0].exc_info[1] is None
             else:
                 assert len(caplog.records) == 0
 
@@ -1145,7 +1145,7 @@ class TestConversationHandler:
                 caplog.records[0].message
                 == "Task function raised exception. Falling back to old state None"
             )
-            assert caplog.records[0].exc_info[1] is error
+            assert caplog.records[0].exc_info[1] is None
 
     async def test_conversation_timeout(self, app, bot, user1):
         handler = ConversationHandler(

--- a/tests/test_conversationhandler.py
+++ b/tests/test_conversationhandler.py
@@ -1099,6 +1099,48 @@ class TestConversationHandler:
             )
             assert caplog.records[0].exc_info[1] is error
 
+    async def test_non_blocking_entry_point_exception(self, app, bot, user1, caplog):
+        """Here we make sure that when a non-blocking entry point raises an
+        exception, the state isn't changed.
+        """
+        error = Exception("task exception")
+
+        async def raise_error(*a, **kw):
+            raise error
+
+        handler = ConversationHandler(
+            entry_points=[CommandHandler("start", raise_error, block=False)],
+            states={},
+            fallbacks=self.fallbacks,
+        )
+        app.add_handler(handler)
+
+        message = Message(
+            0,
+            None,
+            self.group,
+            from_user=user1,
+            text="/start",
+            entities=[
+                MessageEntity(type=MessageEntity.BOT_COMMAND, offset=0, length=len("/start"))
+            ],
+            bot=bot,
+        )
+        # start the conversation
+        async with app:
+            await app.process_update(Update(update_id=0, message=message))
+            await asyncio.sleep(0.1)
+            caplog.clear()
+            with caplog.at_level(logging.ERROR):
+                # This also makes sure that we're still in the same state
+                assert handler.check_update(Update(0, message=message))
+            assert len(caplog.records) == 1
+            assert (
+                caplog.records[0].message
+                == "Task function raised exception. Falling back to old state None"
+            )
+            assert caplog.records[0].exc_info[1] is error
+
     async def test_conversation_timeout(self, app, bot, user1):
         handler = ConversationHandler(
             entry_points=self.entry_points,


### PR DESCRIPTION
See https://t.me/pythontelegrambotgroup/595029?thread=595002 for discussion. The problem is that `_update_state` doesn't do anything if the new state is `None` (because `return None` means "stay in the current state") so that `_conversations.get(key)` returns the `PendingState`.

### Checklist for PRs

- [ ] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [ ] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)
- [ ] Added new classes & modules to the docs and all suitable `__all__` s
