### PR TITLE
Note on editing with reply markups

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -46,6 +46,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Evan Haberecht <https://github.com/habereet>`_
 - `Evgeny Denisov <https://github.com/eIGato>`_
 - `evgfilim1 <https://github.com/evgfilim1>`_
+- `ExalFabu <https://github.com/ExalFabu>`_
 - `franciscod <https://github.com/franciscod>`_
 - `gamgi <https://github.com/gamgi>`_
 - `Gauthamram Ravichandran <https://github.com/GauthamramRavichandran>`_

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -3374,8 +3374,8 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         """
         Use this method to edit text and game messages.
 
-        Note: 
-            It is currently only possible to edit messages without 
+        Note:
+            It is currently only possible to edit messages without
             :paramref:`reply_markup` or with inline keyboards
 
         Args:
@@ -3470,8 +3470,8 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         """
         Use this method to edit captions of messages.
 
-        Note: 
-            It is currently only possible to edit messages without 
+        Note:
+            Please note, that it is currently only possible to edit messages without
             :paramref:`reply_markup` or with inline keyboards
 
         Args:
@@ -3564,8 +3564,8 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         message is edited, a new file can't be uploaded; use a previously uploaded file via its
         :attr:`~telegram.File.file_id` or specify a URL.
 
-        Note: 
-            It is currently only possible to edit messages without 
+        Note:
+            It is currently only possible to edit messages without
             :paramref:`reply_markup` or with inline keyboards
 
         Args:

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -3376,7 +3376,7 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
 
         Note:
             It is currently only possible to edit messages without
-            :paramref:`reply_markup` or with inline keyboards
+            :attr:`telegram.Message.reply_markup` or with inline keyboards.
 
         Args:
             chat_id (:obj:`int` | :obj:`str`, optional): Required if inline_message_id is not

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -3471,7 +3471,7 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         Use this method to edit captions of messages.
 
         Note:
-            Please note, that it is currently only possible to edit messages without
+            It is currently only possible to edit messages without
             :paramref:`reply_markup` or with inline keyboards
 
         Args:

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -3642,6 +3642,10 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         Use this method to edit only the reply markup of messages sent by the bot or via the bot
         (for inline bots).
 
+        Note:
+            It is currently only possible to edit messages without
+            :attr:`telegram.Message.reply_markup` or with inline keyboards
+
         Args:
             chat_id (:obj:`int` | :obj:`str`, optional): Required if inline_message_id is not
                 specified. Unique identifier for the target chat or username of the target channel

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -3374,6 +3374,10 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         """
         Use this method to edit text and game messages.
 
+        Note: 
+            It is currently only possible to edit messages without 
+            :paramref:`reply_markup` or with inline keyboards
+
         Args:
             chat_id (:obj:`int` | :obj:`str`, optional): Required if inline_message_id is not
                 specified. Unique identifier for the target chat or username of the target channel
@@ -3466,6 +3470,10 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         """
         Use this method to edit captions of messages.
 
+        Note: 
+            It is currently only possible to edit messages without 
+            :paramref:`reply_markup` or with inline keyboards
+
         Args:
             chat_id (:obj:`int` | :obj:`str`, optional): Required if inline_message_id is not
                 specified. Unique identifier for the target chat or username of the target channel
@@ -3555,6 +3563,10 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         to a document for document albums and to a photo or a video otherwise. When an inline
         message is edited, a new file can't be uploaded; use a previously uploaded file via its
         :attr:`~telegram.File.file_id` or specify a URL.
+
+        Note: 
+            It is currently only possible to edit messages without 
+            :paramref:`reply_markup` or with inline keyboards
 
         Args:
             media (:class:`telegram.InputMedia`): An object for a new media content

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -3472,7 +3472,7 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
 
         Note:
             It is currently only possible to edit messages without
-            :paramref:`reply_markup` or with inline keyboards
+            :attr:`telegram.Message.reply_markup` or with inline keyboards
 
         Args:
             chat_id (:obj:`int` | :obj:`str`, optional): Required if inline_message_id is not
@@ -3566,7 +3566,7 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
 
         Note:
             It is currently only possible to edit messages without
-            :paramref:`reply_markup` or with inline keyboards
+            :attr:`telegram.Message.reply_markup` or with inline keyboards
 
         Args:
             media (:class:`telegram.InputMedia`): An object for a new media content


### PR DESCRIPTION
Hi, i would like to help and contribute on #3111 
Following the [official documentation](https://core.telegram.org/bots/api#updating-messages), the methods i updated are: 
- `Bot.edit_message_text`
- `Bot.edit_message_caption`
- `Bot.edit_message_media`

I am not adding the note on the method `Bot.edit_message_reply_markup` since I don't think it makes sense in the first place, I hope I'm not wrong.

Screenshots:
![edit_message_text](https://user-images.githubusercontent.com/53974096/175792167-b3b964e7-06d4-4b66-a41d-4b717bdd9ea2.png)

![edit_message_caption](https://user-images.githubusercontent.com/53974096/175792198-9a82cbda-e7b4-49ba-b128-767114fb1d99.png)

![edit_message_media](https://user-images.githubusercontent.com/53974096/175792208-6dd31af6-417d-48bb-b88b-fd181c18f2fe.png)
