### PR TITLE
Make `Bot.delete_my_commands` a coroutine function

### DIFF
--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -7345,7 +7345,7 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         return result  # type: ignore[return-value]
 
     @_log
-    def delete_my_commands(
+    async def delete_my_commands(
         self,
         scope: BotCommandScope = None,
         language_code: str = None,
@@ -7402,7 +7402,7 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         if language_code:
             data["language_code"] = language_code
 
-        result = self._post(
+        result = await self._post(
             "deleteMyCommands",
             data,
             read_timeout=read_timeout,

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2944,3 +2944,23 @@ class TestBot:
             if not camel_case_function:
                 not_available_camelcase_functions.append(function_name)
         assert not_available_camelcase_functions == []
+
+    def test_coroutine_functions(self):
+        """Check that all bot methods are defined as async def  ..."""
+        non_coroutine_functions = set()
+        for attr_name, attribute in Bot.__dict__.items():
+            # not islower() skips the camelcase aliases
+            if not callable(attribute) or attr_name.startswith("_") or not attr_name.islower():
+                continue
+            # unfortunately `inspect.iscoroutinefunction` doesn't do the trick directly,
+            # as the @_log decorator interferes
+            source = "".join(inspect.getsourcelines(attribute)[0])
+            if (
+                "pool_timeout: ODVInput[float]" in source
+                and f"async def {attr_name}" not in source
+            ):
+                non_coroutine_functions.add(attr_name)
+        assert non_coroutine_functions == set(), (
+            "The following methods should be defined as coroutine functions: "
+            f"{','.join(non_coroutine_functions)} "
+        )


### PR DESCRIPTION
Funnily enough, this didn't show in the tests so far, since the function currently returns a coroutine such that `await delete_my_commands(…)` still works …

### Checklist for PRs

- [ ] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [ ] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)
- [ ] Added new classes & modules to the docs and all suitable `__all__` s

