### PR TITLE
Pin tornado to v6.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
           - --rcfile=setup.cfg
         additional_dependencies:
           - certifi
-          - tornado>=6.1
+          - tornado==6.1
           - APScheduler==3.6.3
           - cachetools==4.2.2
           - . # this basically does `pip install -e .`
@@ -39,7 +39,7 @@ repos:
         files: ^telegram/.*\.py$
         additional_dependencies:
           - certifi
-          - tornado>=6.1
+          - tornado==6.1
           - APScheduler==3.6.3
           - cachetools==4.2.2
           - . # this basically does `pip install -e .`
@@ -51,7 +51,7 @@ repos:
           - --follow-imports=silent
         additional_dependencies:
           - certifi
-          - tornado>=6.1
+          - tornado==6.1
           - APScheduler==3.6.3
           - cachetools==4.2.2
           - . # this basically does `pip install -e .`

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # pre-commit hooks for pylint & mypy
 certifi
 # only telegram.ext: # Keep this line here; used in setup(-raw).py
-tornado>=6.1
+tornado==6.1
 APScheduler==3.6.3
 pytz>=2018.6
 cachetools==4.2.2


### PR DESCRIPTION
v6.2 [deprecated some things](https://www.tornadoweb.org/en/stable/releases/v6.2.0.html) leading to failing tests on v13 (see #3140)

Since v13.x is in API-compatibility mode only, pinning tornado to the previously minimal required version should be enough IMO.