### PR TITLE
Add `api_kwargs` to `log_out`

### DIFF
--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -7422,6 +7422,7 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         write_timeout: ODVInput[float] = DEFAULT_NONE,
         connect_timeout: ODVInput[float] = DEFAULT_NONE,
         pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: JSONDict = None,
     ) -> bool:
         """
         Use this method to log out from the cloud Bot API server before launching the bot locally.
@@ -7443,6 +7444,10 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
             pool_timeout (:obj:`float` | :obj:`None`, optional): Value to pass to
                 :paramref:`telegram.request.BaseRequest.post.pool_timeout`. Defaults to
                 :attr:`~telegram.request.BaseRequest.DEFAULT_NONE`.
+            api_kwargs (:obj:`dict`, optional): Arbitrary keyword arguments to be passed to the
+                Telegram API.
+
+                .. versionadded:: 20.0
 
         Returns:
             :obj:`True`: On success
@@ -7457,6 +7462,7 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
             write_timeout=write_timeout,
             connect_timeout=connect_timeout,
             pool_timeout=pool_timeout,
+            api_kwargs=api_kwargs,
         )
 
     @_log

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -982,6 +982,7 @@ class TestBot:
     @pytest.mark.asyncio
     async def test_answer_web_app_query(self, bot, monkeypatch):
         params = False
+
         # For now just test that our internals pass the correct data
 
         async def make_assertion(url, request_data: RequestData, *args, **kwargs):
@@ -2963,4 +2964,19 @@ class TestBot:
         assert non_coroutine_functions == set(), (
             "The following methods should be defined as coroutine functions: "
             f"{','.join(non_coroutine_functions)} "
+        )
+
+    def test_api_kwargs_present(self):
+        """Check that all bot methods have `api_kwargs` params."""
+        functions_missing_api_kwargs = set()
+        for attr_name, attribute in Bot.__dict__.items():
+            # not islower() skips the camelcase aliases
+            if not callable(attribute) or attr_name.startswith("_") or not attr_name.islower():
+                continue
+            params = inspect.signature(attribute).parameters
+            if "pool_timeout" in params and "api_kwargs" not in params:
+                functions_missing_api_kwargs.add(attr_name)
+        assert functions_missing_api_kwargs == set(), (
+            "The following methods should have a `api_kwargs` parameter: "
+            f"{','.join(functions_missing_api_kwargs)} "
         )

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -415,6 +415,9 @@ class TestBot:
         Finally, there are some tests for Defaults.{parse_mode, quote, allow_sending_without_reply}
         at the appropriate places, as those are the only things we can actually check.
         """
+        if bot_method_name.lower().replace("_", "") == "getupdates":
+            return
+
         try:
             # Check that ExtBot does the right thing
             bot_method = getattr(bot, bot_method_name)


### PR DESCRIPTION
### Checklist for PRs

- [x] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [ ] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)
- [ ] Added new classes & modules to the docs and all suitable `__all__` s