### PR TITLE
Improve `InvalidToken` Error Message

### DIFF
--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -2852,7 +2852,7 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         connect_timeout: ODVInput[float] = DEFAULT_NONE,
         pool_timeout: ODVInput[float] = DEFAULT_NONE,
         api_kwargs: JSONDict = None,
-    ) -> Optional[UserProfilePhotos]:
+    ) -> UserProfilePhotos:
         """Use this method to get a list of profile pictures for a user.
 
         Args:
@@ -2902,7 +2902,7 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
             api_kwargs=api_kwargs,
         )
 
-        return UserProfilePhotos.de_json(result, self)  # type: ignore[arg-type]
+        return UserProfilePhotos.de_json(result, self)  # type: ignore[return-value, arg-type]
 
     @_log
     async def get_file(

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -374,7 +374,10 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
             return
 
         await asyncio.gather(self._request[0].initialize(), self._request[1].initialize())
-        await self.get_me()
+        try:
+            await self.get_me()
+        except InvalidToken as exc:
+            raise InvalidToken(f"The token {self.token} was rejected by the server.") from exc
         self._initialized = True
 
     async def shutdown(self) -> None:

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -198,7 +198,7 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         private_key_password: bytes = None,
     ):
         if not token:
-            raise InvalidToken("You must pass the token you received from https://t.me/Botfather ")
+            raise InvalidToken("You must pass the token you received from https://t.me/Botfather!")
         self.token = token
 
         self.base_url = base_url + self.token
@@ -374,10 +374,12 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
             return
 
         await asyncio.gather(self._request[0].initialize(), self._request[1].initialize())
+        # Since the bot is to be initialized only once, we can also use it for
+        # verifying the token passed and raising an exception if it's invalid.
         try:
             await self.get_me()
         except InvalidToken as exc:
-            raise InvalidToken(f"The token {self.token} was rejected by the server.") from exc
+            raise InvalidToken(f"The token `{self.token}` was rejected by the server.") from exc
         self._initialized = True
 
     async def shutdown(self) -> None:

--- a/telegram/error.py
+++ b/telegram/error.py
@@ -35,7 +35,7 @@ __all__ = (
     "TimedOut",
 )
 
-from typing import Optional, Tuple, Union
+from typing import Tuple, Union
 
 
 def _lstrip_str(in_s: str, lstr: str) -> str:
@@ -100,14 +100,10 @@ class InvalidToken(TelegramError):
             .. versionadded:: 20.0
     """
 
-    __slots__ = ("_message",)
+    __slots__ = ()
 
     def __init__(self, message: str = None) -> None:
-        self._message = message
-        super().__init__("Invalid token" if self._message is None else self._message)
-
-    def __reduce__(self) -> Tuple[type, Tuple[Optional[str]]]:  # type: ignore[override]
-        return self.__class__, (self._message,)
+        super().__init__("Invalid token" if message is None else message)
 
 
 class NetworkError(TelegramError):

--- a/telegram/request/_baserequest.py
+++ b/telegram/request/_baserequest.py
@@ -320,11 +320,7 @@ class BaseRequest(
             #   2) correct tokens but non-existing method, e.g. api.tg.org/botTOKEN/unkonwnMethod
             # We can basically rule out 2) since we don't let users make requests manually
             # TG returns 401 Unauthorized for correctly formatted tokens that are not valid
-
-            # retrieve token from the url-
-            start = url[url.find("/bot") + 4 :]
-            token = start[: start.find("/")]
-            raise InvalidToken(message + f"\nThe token: {token} was rejected by the server.")
+            raise InvalidToken(message)
         if code == HTTPStatus.BAD_REQUEST:  # 400
             raise BadRequest(message)
         if code == HTTPStatus.CONFLICT:  # 409

--- a/telegram/request/_baserequest.py
+++ b/telegram/request/_baserequest.py
@@ -312,20 +312,24 @@ class BaseRequest(
 
             message += f"\nThe server response contained unknown parameters: {parameters}"
 
-        if code == HTTPStatus.FORBIDDEN:
+        if code == HTTPStatus.FORBIDDEN:  # 403
             raise Forbidden(message)
-        if code in (HTTPStatus.NOT_FOUND, HTTPStatus.UNAUTHORIZED):
+        if code in (HTTPStatus.NOT_FOUND, HTTPStatus.UNAUTHORIZED):  # 404 and 401
             # TG returns 404 Not found for
             #   1) malformed tokens
             #   2) correct tokens but non-existing method, e.g. api.tg.org/botTOKEN/unkonwnMethod
             # We can basically rule out 2) since we don't let users make requests manually
             # TG returns 401 Unauthorized for correctly formatted tokens that are not valid
-            raise InvalidToken(message)
-        if code == HTTPStatus.BAD_REQUEST:
+
+            # retrieve token from the url-
+            start = url[url.find("/bot") + 4 :]
+            token = start[: start.find("/")]
+            raise InvalidToken(message + f"\nThe token: {token} was rejected by the server.")
+        if code == HTTPStatus.BAD_REQUEST:  # 400
             raise BadRequest(message)
-        if code == HTTPStatus.CONFLICT:
+        if code == HTTPStatus.CONFLICT:  # 409
             raise Conflict(message)
-        if code == HTTPStatus.BAD_GATEWAY:
+        if code == HTTPStatus.BAD_GATEWAY:  # 502
             raise NetworkError(description or "Bad Gateway")
         raise NetworkError(f"{message} ({code})")
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -291,30 +291,12 @@ class TestBot:
             assert acd_bot.arbitrary_callback_data == acd
             assert acd_bot.callback_data_cache.maxsize == maxsize
 
-    async def test_invalid_token_ptb_check(self):
-        with pytest.raises(InvalidToken, match="Illegal character") as excinfo:
-            Bot("1234:white space")
-        # checks for correct caret position-
-        assert excinfo.value.message.split("\n")[-1].index("^") == 10
+    async def test_no_token_passed(self):
+        with pytest.raises(InvalidToken, match="You must pass the token"):
+            Bot("")
 
-        with pytest.raises(InvalidToken, match="Illegal character") as excinfo:
-            Bot('1234:extra_quote"')
-        assert excinfo.value.message.split("\n")[-1].index("^") == 16
-
-        with pytest.raises(InvalidToken, match="Missing `:`"):
-            Bot("1234abcde")
-
-        with pytest.raises(InvalidToken, match="All characters left of "):
-            Bot("abcde:fghij_")
-
-        with pytest.raises(InvalidToken, match="Number of digits left of the "):
-            Bot("12:AAc_def")
-
-        Bot("123456789:AAFbcD_-1234")  # no exception raised
-
-    async def test_invalid_token_server_response(self, monkeypatch):
-        monkeypatch.setattr("telegram.Bot._validate_token", lambda x, y: "")
-        with pytest.raises(InvalidToken):
+    async def test_invalid_token_server_response(self):
+        with pytest.raises(InvalidToken, match="The token: 12 was rejected by the server"):
             async with make_bot(token="12") as bot:
                 await bot.get_me()
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -183,22 +183,6 @@ class TestBot:
             assert getattr(inst, attr, "err") != "err", f"got extra slot '{attr}'"
         assert len(mro_slots(inst)) == len(set(mro_slots(inst))), "duplicate slot"
 
-    @pytest.mark.parametrize(
-        "token",
-        argvalues=[
-            "123",
-            "12a:abcd1234",
-            "12:abcd1234",
-            "1234:abcd1234\n",
-            " 1234:abcd1234",
-            " 1234:abcd1234\r",
-            "1234:abcd 1234",
-        ],
-    )
-    async def test_invalid_token(self, token):
-        with pytest.raises(InvalidToken, match="Invalid token"):
-            Bot(token)
-
     async def test_initialize_and_shutdown(self, bot, monkeypatch):
         async def initialize(*args, **kwargs):
             self.test_flag = ["initialize"]

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -296,7 +296,7 @@ class TestBot:
             Bot("")
 
     async def test_invalid_token_server_response(self):
-        with pytest.raises(InvalidToken, match="The token 12 was rejected by the server."):
+        with pytest.raises(InvalidToken, match="The token `12` was rejected by the server."):
             async with make_bot(token="12"):
                 pass
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -296,9 +296,9 @@ class TestBot:
             Bot("")
 
     async def test_invalid_token_server_response(self):
-        with pytest.raises(InvalidToken, match="The token: 12 was rejected by the server"):
-            async with make_bot(token="12") as bot:
-                await bot.get_me()
+        with pytest.raises(InvalidToken, match="The token 12 was rejected by the server."):
+            async with make_bot(token="12"):
+                pass
 
     async def test_unknown_kwargs(self, bot, monkeypatch):
         async def post(url, request_data: RequestData, *args, **kwargs):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -307,7 +307,27 @@ class TestBot:
             assert acd_bot.arbitrary_callback_data == acd
             assert acd_bot.callback_data_cache.maxsize == maxsize
 
-    @flaky(3, 1)
+    async def test_invalid_token_ptb_check(self):
+        with pytest.raises(InvalidToken, match="Illegal character") as excinfo:
+            Bot("1234:white space")
+        # checks for correct caret position-
+        assert excinfo.value.message.split("\n")[-1].index("^") == 10
+
+        with pytest.raises(InvalidToken, match="Illegal character") as excinfo:
+            Bot('1234:extra_quote"')
+        assert excinfo.value.message.split("\n")[-1].index("^") == 16
+
+        with pytest.raises(InvalidToken, match="Missing `:`"):
+            Bot("1234abcde")
+
+        with pytest.raises(InvalidToken, match="All characters left of "):
+            Bot("abcde:fghij_")
+
+        with pytest.raises(InvalidToken, match="Number of digits left of the "):
+            Bot("12:AAc_def")
+
+        Bot("123456789:AAFbcD_-1234")  # no exception raised
+
     async def test_invalid_token_server_response(self, monkeypatch):
         monkeypatch.setattr("telegram.Bot._validate_token", lambda x, y: "")
         with pytest.raises(InvalidToken):

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -240,7 +240,7 @@ class TestRequest:
         )
 
         with pytest.raises(exception_class, match="Test Message"):
-            await httpx_request.post(None, None, None)
+            await httpx_request.post("", None, None)
 
     @pytest.mark.parametrize(
         ["exception", "catch_class", "match"],


### PR DESCRIPTION
Deletes the `Bot._validate_token` step since bot tokens could change in the future. Now whenever an `InvalidToken` exception is raised, the token is printed along with it so the user can see where they went wrong.

----
#### Original proposal:

Improves PTB's verification of bot tokens and also adds a better error message along the way. Suppose your bot token is `123456:AAF5_-y.ert`. So the error message now shows:

```
E telegram.error.InvalidToken: Illegal character found in bot token: 
E 123456:AAF5_-y.ert
E               ^
```
We could also add another check where we assert that the no. of chars after `:` is `34` or `35`. I say `34` since in https://core.telegram.org/bots/#creating-a-new-bot it's 34, but I have only seen it be 35 though. I didn't add this since it might be too strict and could have false positives in the future?
 
### Checklist for PRs

- [ ] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [x] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)
- [ ] Added new classes & modules to the docs and all suitable `__all__` s