### PR TITLE
Test python 3.11 & Change Enum Behaviour 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,13 @@ jobs:
         experimental: [false]
         include:
           - python-version: 3.11.0-rc.1
-            os: [ubuntu-latest, windows-latest, macos-latest]
+            os: ubuntu-latest
+            experimental: true
+          - python-version: 3.11.0-rc.1
+            os: windows-latest
+            experimental: true
+          - python-version: 3.11.0-rc.1
+            os: macos-latest
             experimental: true
       fail-fast: False
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,11 +19,11 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [ubuntu-latest, windows-latest, macos-latest]
-        experimental: [false]
+        experimental: false
         include:
           - python-version: 3.11.0-rc.1
             os: [ubuntu-latest, windows-latest, macos-latest]
-            experimental: [true]
+            experimental: true
       fail-fast: False
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11.0-beta.4']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11.0-beta.5']
         os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: False
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
   push:
-    branches: 
+    branches:
       - master
   schedule:
     # Run monday and friday morning at 03:07 - odd time to spread load on GitHub Actions
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11.0-beta.4']
         os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: False
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [ubuntu-latest, windows-latest, macos-latest]
-        experimental: false
+        experimental: [false]
         include:
           - python-version: 3.11.0-rc.1
             os: [ubuntu-latest, windows-latest, macos-latest]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,16 @@ jobs:
   pytest:
     name: pytest
     runs-on: ${{matrix.os}}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11.0-beta.5']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [ubuntu-latest, windows-latest, macos-latest]
+        experimental: [false]
+        include:
+          - python-version: 3.11.0-rc.1
+            os: [ubuntu-latest, windows-latest, macos-latest]
+            experimental: [true]
       fail-fast: False
     steps:
       - uses: actions/checkout@v3

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -478,6 +478,10 @@ def autodoc_process_bases(app, name, obj, option, bases: list):
             bases.insert(0, ":class:`str`")
             continue
 
+        if "IntEnum" in base:
+            bases[idx] = ":class:`enum.IntEnum`"
+            continue
+
         # Drop generics (at least for now)
         if base.endswith("]"):
             base = base.split("[", maxsplit=1)[0]

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ def get_setup_kwargs(raw=False):
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
         ],
         python_requires=">=3.7",
     )

--- a/telegram/_utils/enum.py
+++ b/telegram/_utils/enum.py
@@ -23,21 +23,21 @@ Warning:
     user. Changes to this module are not considered breaking changes and may not be documented in
     the changelog.
 """
-import enum
+import enum as _enum
 import sys
 from typing import Type, TypeVar, Union
 
 _A = TypeVar("_A")
 _B = TypeVar("_B")
-_Enum = TypeVar("_Enum", bound=enum.Enum)
+_Enum = TypeVar("_Enum", bound=_enum.Enum)
 
 
-def get_member(_enum: Type[_Enum], value: _A, default: _B) -> Union[_Enum, _A, _B]:
-    """Tries to call ``enum(value)`` to convert the value into an enumeration member.
+def get_member(enum_cls: Type[_Enum], value: _A, default: _B) -> Union[_Enum, _A, _B]:
+    """Tries to call ``enum_cls(value)`` to convert the value into an enumeration member.
     If that fails, the ``default`` is returned.
     """
     try:
-        return _enum(value)
+        return enum_cls(value)
     except ValueError:
         return default
 
@@ -45,7 +45,7 @@ def get_member(_enum: Type[_Enum], value: _A, default: _B) -> Union[_Enum, _A, _
 # Python 3.11 and above has a different output for mixin classes for IntEnum, StrEnum and IntFlag
 # see https://docs.python.org/3.11/library/enum.html#notes. We want e.g. str(StrEnumTest.FOO) to
 # return "foo" instead of "StrEnumTest.FOO", which is not the case < py3.11
-class StringEnum(str, enum.Enum):
+class StringEnum(str, _enum.Enum):
     """Helper class for string enums where ``str(member)`` prints the value, but ``repr(member)``
     gives ``EnumName.MEMBER_NAME``.
     """
@@ -60,7 +60,7 @@ class StringEnum(str, enum.Enum):
 
 
 # Apply the __repr__ modification and __str__ fix to IntEnum
-class IntEnum(enum.IntEnum):
+class IntEnum(_enum.IntEnum):
     """Helper class for int enums where ``str(member)`` prints the value, but ``repr(member)``
     gives ``EnumName.MEMBER_NAME``.
     """

--- a/telegram/_utils/enum.py
+++ b/telegram/_utils/enum.py
@@ -23,24 +23,21 @@ Warning:
     user. Changes to this module are not considered breaking changes and may not be documented in
     the changelog.
 """
+import enum
 import sys
-from enum import Enum, IntEnum
 from typing import Type, TypeVar, Union
-
-if sys.version_info >= (3, 11):
-    from enum import StrEnum
 
 _A = TypeVar("_A")
 _B = TypeVar("_B")
-_Enum = TypeVar("_Enum", bound=Enum)
+_Enum = TypeVar("_Enum", bound=enum.Enum)
 
 
-def get_member(enum: Type[_Enum], value: _A, default: _B) -> Union[_Enum, _A, _B]:
+def get_member(_enum: Type[_Enum], value: _A, default: _B) -> Union[_Enum, _A, _B]:
     """Tries to call ``enum(value)`` to convert the value into an enumeration member.
     If that fails, the ``default`` is returned.
     """
     try:
-        return enum(value)
+        return _enum(value)
     except ValueError:
         return default
 
@@ -48,38 +45,24 @@ def get_member(enum: Type[_Enum], value: _A, default: _B) -> Union[_Enum, _A, _B
 # Python 3.11 and above has a different output for mixin classes for IntEnum, StrEnum and IntFlag
 # see https://docs.python.org/3.11/library/enum.html#notes. We want e.g. str(StrEnumTest.FOO) to
 # return "foo" instead of "StrEnumTest.FOO", which is not the case < py3.11
-if sys.version_info < (3, 11):
+class StringEnum(str, enum.Enum):
+    """Helper class for string enums where ``str(member)`` prints the value, but ``repr(member)``
+    gives ``EnumName.MEMBER_NAME``.
+    """
 
-    class StringEnum(str, Enum):
-        """Helper class for string enums where the value is not important to be displayed on
-        stringification.
-        """
+    __slots__ = ()
 
-        __slots__ = ()
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}.{self.name}>"
 
-        def __repr__(self) -> str:
-            return f"<{self.__class__.__name__}.{self.name}>"
-
-        def __str__(self) -> str:
-            return str.__str__(self)
-
-else:
-
-    class StringEnum(StrEnum):
-        """Helper class for string enums where the value is not important to be displayed on
-        stringification.
-        """
-
-        __slots__ = ()
-
-        def __repr__(self) -> str:
-            return f"<{self.__class__.__name__}.{self.name}>"
+    def __str__(self) -> str:
+        return str.__str__(self)
 
 
 # Apply the __repr__ modification and __str__ fix to IntEnum
-class IntEnum(IntEnum):  # type: ignore[no-redef]  # pylint: disable=function-redefined
-    """Helper class for int enums where the value is not important to be displayed on
-    stringification.
+class IntEnum(enum.IntEnum):
+    """Helper class for int enums where ``str(member)`` prints the value, but ``repr(member)``
+    gives ``EnumName.MEMBER_NAME``.
     """
 
     __slots__ = ()

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -61,10 +61,9 @@ __all__ = [
     "UpdateType",
 ]
 
-from enum import IntEnum
 from typing import List, NamedTuple
 
-from telegram._utils.enum import StringEnum
+from telegram._utils.enum import IntEnum, StringEnum
 
 
 class _BotAPIVersion(NamedTuple):

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -27,7 +27,6 @@ those classes.
 .. versionchanged:: 20.0
 
     * Most of the constants in this module are grouped into enums.
-    * ``str(<Enum>)`` now returns the value of the enum instead of the name of the enum.
 """
 
 __all__ = [

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -25,7 +25,9 @@ enums. If they are related to a specific class, then they are also available as 
 those classes.
 
 .. versionchanged:: 20.0
-    Since v20.0, most of the constants in this module are grouped into enums.
+
+    * Most of the constants in this module are grouped into enums.
+    * ``str(<Enum>)`` now returns the value of the enum instead of the name of the enum.
 """
 
 __all__ = [

--- a/tests/bots.py
+++ b/tests/bots.py
@@ -58,7 +58,7 @@ def get(name, fallback):
     if GITHUB_ACTION is not None and BOTS is not None and JOB_INDEX is not None:
         try:
             return BOTS[JOB_INDEX][name]
-        except KeyError:
+        except (KeyError, IndexError):
             pass
 
     # Otherwise go with the fallback

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 import json
+import sys
 from enum import IntEnum
 
 import pytest
@@ -62,8 +63,24 @@ class TestConstants:
         assert json.dumps(IntEnumTest.FOO) == json.dumps(1)
 
     def test_string_representation(self):
+        # test repr
         assert repr(StrEnumTest.FOO) == "<StrEnumTest.FOO>"
+
+        # test __format__
+        assert f"{StrEnumTest.FOO} this {StrEnumTest.BAR}" == "foo this bar"
+        assert f"{StrEnumTest.FOO} this {StrEnumTest.BAR}" == "foo this bar"
+        assert f"{StrEnumTest.FOO:*^10}" == "***foo****"
+
+        # test __str__
         assert str(StrEnumTest.FOO) == "StrEnumTest.FOO"
+
+    def test_int_representation(self):
+        assert repr(IntEnumTest.FOO) == "<IntEnumTest.FOO: 1>"
+        if sys.version_info < (3, 11):
+            assert str(IntEnumTest.FOO) == "IntEnumTest.FOO"
+        else:
+            assert str(IntEnumTest.FOO) == "1"
+        assert f"{IntEnumTest.FOO}" == "1"
 
     def test_string_inheritance(self):
         assert isinstance(StrEnumTest.FOO, str)

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -17,14 +17,12 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 import json
-import sys
-from enum import IntEnum
 
 import pytest
 from flaky import flaky
 
 from telegram import constants
-from telegram._utils.enum import StringEnum
+from telegram._utils.enum import IntEnum, StringEnum
 from telegram.error import BadRequest
 from tests.conftest import data_file
 
@@ -63,24 +61,24 @@ class TestConstants:
         assert json.dumps(IntEnumTest.FOO) == json.dumps(1)
 
     def test_string_representation(self):
-        # test repr
+        # test __repr__
         assert repr(StrEnumTest.FOO) == "<StrEnumTest.FOO>"
 
         # test __format__
         assert f"{StrEnumTest.FOO} this {StrEnumTest.BAR}" == "foo this bar"
-        assert f"{StrEnumTest.FOO} this {StrEnumTest.BAR}" == "foo this bar"
         assert f"{StrEnumTest.FOO:*^10}" == "***foo****"
 
         # test __str__
-        assert str(StrEnumTest.FOO) == "StrEnumTest.FOO"
+        assert str(StrEnumTest.FOO) == "foo"
 
     def test_int_representation(self):
-        assert repr(IntEnumTest.FOO) == "<IntEnumTest.FOO: 1>"
-        if sys.version_info < (3, 11):
-            assert str(IntEnumTest.FOO) == "IntEnumTest.FOO"
-        else:
-            assert str(IntEnumTest.FOO) == "1"
-        assert f"{IntEnumTest.FOO}" == "1"
+        # test __repr__
+        assert repr(IntEnumTest.FOO) == "<IntEnumTest.FOO>"
+        # test __format__
+        assert f"{IntEnumTest.FOO}/0 is undefined!" == "1/0 is undefined!"
+        assert f"{IntEnumTest.FOO:*^10}" == "****1*****"
+        # test __str__
+        assert str(IntEnumTest.FOO) == "1"
 
     def test_string_inheritance(self):
         assert isinstance(StrEnumTest.FOO, str)


### PR DESCRIPTION
Tests if py 3.11 works with the lib or not (the Python team really wants everyone to test it out). Not to be merged atm.

Also changes:
- Made str(StringEnum) & str(IntEnum) return consistent across python versions
- Also modify IntEnum's `__repr__` to match `StringEnum`'s
