### PR TITLE
Add chat_id(s) and username(s) parameters to ChatJoinRequestHandler 

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -70,6 +70,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Loo Zheng Yuan <https://github.com/loozhengyuan>`_
 - `LRezende <https://github.com/lrezende>`_
 - `macrojames <https://github.com/macrojames>`_
+- `miles <https://github.com/miles170>`_
 - `Matheus Lemos <https://github.com/mlemosf>`_
 - `Michael Elovskikh <https://github.com/wronglink>`_
 - `Mischa Krüger <https://github.com/Makman2>`_

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -70,9 +70,9 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Loo Zheng Yuan <https://github.com/loozhengyuan>`_
 - `LRezende <https://github.com/lrezende>`_
 - `macrojames <https://github.com/macrojames>`_
-- `miles <https://github.com/miles170>`_
 - `Matheus Lemos <https://github.com/mlemosf>`_
 - `Michael Elovskikh <https://github.com/wronglink>`_
+- `miles <https://github.com/miles170>`_
 - `Mischa Krüger <https://github.com/Makman2>`_
 - `naveenvhegde <https://github.com/naveenvhegde>`_
 - `neurrone <https://github.com/neurrone>`_

--- a/telegram/ext/_chatjoinrequesthandler.py
+++ b/telegram/ext/_chatjoinrequesthandler.py
@@ -60,7 +60,6 @@ class ChatJoinRequestHandler(BaseHandler[Update, CCT]):
             .. versionadded:: 20.0
         username (:obj:`str` | Collection[:obj:`str`], optional): Filters requests to allow only
             those which are asking to join the specified username(s).
-            Leading ``'@'`` in username will be discarded.
 
             .. versionadded:: 20.0
         block (:obj:`bool`, optional): Determines whether the return value of the callback should

--- a/telegram/ext/_chatjoinrequesthandler.py
+++ b/telegram/ext/_chatjoinrequesthandler.py
@@ -45,11 +45,11 @@ class ChatJoinRequestHandler(BaseHandler[Update, CCT]):
             The return value of the callback is usually ignored except for the special case of
             :class:`telegram.ext.ConversationHandler`.
         chat_id (:obj:`int` | Collection[:obj:`int`], optional): Filters requests to allow only
-            those which are from specified chat ID(s).
+            those which are asking to join the specified chat ID(s).
 
             .. versionadded:: 20.0
         username (:obj:`str` | Collection[:obj:`str`], optional): Filters requests to allow only
-            those which are from specified username(s).
+            those which are asking to join the specified username(s).
 
             .. versionadded:: 20.0
         block (:obj:`bool`, optional): Determines whether the return value of the callback should

--- a/telegram/ext/_chatjoinrequesthandler.py
+++ b/telegram/ext/_chatjoinrequesthandler.py
@@ -44,12 +44,12 @@ class ChatJoinRequestHandler(BaseHandler[Update, CCT]):
 
             The return value of the callback is usually ignored except for the special case of
             :class:`telegram.ext.ConversationHandler`.
-        chat_id (SCT[:obj:`int`], optional): Filters requests to allow only
-            those which are from a specified chat ID.
+        chat_id (:obj:`int` | Collection[:obj:`int`], optional): Filters requests to allow only
+            those which are from specified chat ID(s).
 
             .. versionadded:: 20.0
-        username (SCT[:obj:`str`], optional): Filters requests to allow only
-            those which are from a specified username.
+        username (:obj:`str` | Collection[:obj:`str`], optional): Filters requests to allow only
+            those which are from specified username(s).
 
             .. versionadded:: 20.0
         block (:obj:`bool`, optional): Determines whether the return value of the callback should
@@ -58,14 +58,6 @@ class ChatJoinRequestHandler(BaseHandler[Update, CCT]):
 
     Attributes:
         callback (:term:`coroutine function`): The callback function for this handler.
-        _chat_ids (:frozenset(:obj:`int`), optional):
-            Which chat ID(s) to allow through.
-
-            .. versionadded:: 20.0
-        _usernames (:frozenset(:obj:`str`), optional):
-            Which username(s) to allow through.
-
-            .. versionadded:: 20.0
         block (:obj:`bool`): Determines whether the callback will run in a blocking way..
 
     """

--- a/telegram/ext/_chatjoinrequesthandler.py
+++ b/telegram/ext/_chatjoinrequesthandler.py
@@ -32,8 +32,10 @@ class ChatJoinRequestHandler(BaseHandler[Update, CCT]):
     :attr:`telegram.Update.chat_join_request`.
 
     Note:
-        If either the :paramref:`username` or the :paramref:`chat_id` corresponds to one
-        in the appropriate, the request will be passed to this handler.
+        If neither of :paramref:`username` and the :paramref:`chat_id` are passed, this handler
+        accepts *any* join request. Otherwise, this handler accepts all requests to join chats
+        for which the chat ID is listed in :paramref:`chat_id` or the username is listed in
+        :paramref:`username`, or both.
 
         .. versionadded:: 20.0
 

--- a/telegram/ext/_chatjoinrequesthandler.py
+++ b/telegram/ext/_chatjoinrequesthandler.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains the ChatJoinRequestHandler class."""
 
-from typing import Optional
+from typing import FrozenSet, Optional
 
 from telegram import Update
 from telegram._utils.defaultvalue import DEFAULT_TRUE
@@ -89,7 +89,7 @@ class ChatJoinRequestHandler(BaseHandler[Update, CCT]):
         self._usernames = self._parse_username(username)
 
     @staticmethod
-    def _parse_chat_id(chat_id: Optional[SCT[int]]) -> frozenset[int]:
+    def _parse_chat_id(chat_id: Optional[SCT[int]]) -> FrozenSet[int]:
         if chat_id is None:
             return frozenset()
         if isinstance(chat_id, int):
@@ -97,7 +97,7 @@ class ChatJoinRequestHandler(BaseHandler[Update, CCT]):
         return frozenset(chat_id)
 
     @staticmethod
-    def _parse_username(username: Optional[SCT[str]]) -> frozenset[str]:
+    def _parse_username(username: Optional[SCT[str]]) -> FrozenSet[str]:
         if username is None:
             return frozenset()
         if isinstance(username, str):

--- a/telegram/ext/_chatjoinrequesthandler.py
+++ b/telegram/ext/_chatjoinrequesthandler.py
@@ -31,6 +31,12 @@ class ChatJoinRequestHandler(BaseHandler[Update, CCT]):
     """BaseHandler class to handle Telegram updates that contain
     :attr:`telegram.Update.chat_join_request`.
 
+    Note:
+        If either the :paramref:`username` or the :paramref:`chat_id` corresponds to one
+        in the appropriate, the request will be passed to this handler.
+
+        .. versionadded:: 20.0
+
     Warning:
         When setting :paramref:`block` to :obj:`False`, you cannot rely on adding custom
         attributes to :class:`telegram.ext.CallbackContext`. See its docs for more info.
@@ -109,11 +115,11 @@ class ChatJoinRequestHandler(BaseHandler[Update, CCT]):
 
         """
         if isinstance(update, Update) and update.chat_join_request:
-            chat = update.chat_join_request.chat
-            if self._chat_ids and chat.id not in self._chat_ids:
-                return False
-            from_user = update.chat_join_request.from_user
-            if self._usernames and from_user.username not in self._usernames:
-                return False
-            return True
+            if not self._chat_ids and not self._usernames:
+                return True
+            if update.chat_join_request.chat.id in self._chat_ids:
+                return True
+            if update.chat_join_request.from_user.username in self._usernames:
+                return True
+            return False
         return False

--- a/tests/test_chatjoinrequesthandler.py
+++ b/tests/test_chatjoinrequesthandler.py
@@ -149,6 +149,9 @@ class TestChatJoinRequestHandler:
         handler = ChatJoinRequestHandler(self.callback, username=["user_b"])
         assert not handler.check_update(chat_join_request_update)
 
+        chat_join_request_update.chat_join_request.from_user.username = None
+        assert not handler.check_update(chat_join_request_update)
+
     def test_other_update_types(self, false_update):
         handler = ChatJoinRequestHandler(self.callback)
         assert not handler.check_update(false_update)

--- a/tests/test_chatjoinrequesthandler.py
+++ b/tests/test_chatjoinrequesthandler.py
@@ -78,7 +78,7 @@ def time():
 def chat_join_request(time, bot):
     return ChatJoinRequest(
         chat=Chat(1, Chat.SUPERGROUP),
-        from_user=User(2, "first_name", False),
+        from_user=User(2, "first_name", False, username="user_a"),
         date=time,
         bio="bio",
         invite_link=ChatInviteLink(
@@ -126,6 +126,28 @@ class TestChatJoinRequestHandler:
                 ChatJoinRequest,
             )
         )
+
+    def test_with_chat_id(self, chat_join_request_update):
+        handler = ChatJoinRequestHandler(self.callback, chat_id=1)
+        assert handler.check_update(chat_join_request_update)
+        handler = ChatJoinRequestHandler(self.callback, chat_id=[1])
+        assert handler.check_update(chat_join_request_update)
+
+        handler = ChatJoinRequestHandler(self.callback, chat_id=2)
+        assert not handler.check_update(chat_join_request_update)
+        handler = ChatJoinRequestHandler(self.callback, chat_id=[2])
+        assert not handler.check_update(chat_join_request_update)
+
+    def test_with_username(self, chat_join_request_update):
+        handler = ChatJoinRequestHandler(self.callback, username="user_a")
+        assert handler.check_update(chat_join_request_update)
+        handler = ChatJoinRequestHandler(self.callback, username=["user_a"])
+        assert handler.check_update(chat_join_request_update)
+
+        handler = ChatJoinRequestHandler(self.callback, username="user_b")
+        assert not handler.check_update(chat_join_request_update)
+        handler = ChatJoinRequestHandler(self.callback, username=["user_b"])
+        assert not handler.check_update(chat_join_request_update)
 
     def test_other_update_types(self, false_update):
         handler = ChatJoinRequestHandler(self.callback)

--- a/tests/test_chatjoinrequesthandler.py
+++ b/tests/test_chatjoinrequesthandler.py
@@ -141,12 +141,20 @@ class TestChatJoinRequestHandler:
     def test_with_username(self, chat_join_request_update):
         handler = ChatJoinRequestHandler(self.callback, username="user_a")
         assert handler.check_update(chat_join_request_update)
+        handler = ChatJoinRequestHandler(self.callback, username="@user_a")
+        assert handler.check_update(chat_join_request_update)
         handler = ChatJoinRequestHandler(self.callback, username=["user_a"])
+        assert handler.check_update(chat_join_request_update)
+        handler = ChatJoinRequestHandler(self.callback, username=["@user_a"])
         assert handler.check_update(chat_join_request_update)
 
         handler = ChatJoinRequestHandler(self.callback, username="user_b")
         assert not handler.check_update(chat_join_request_update)
+        handler = ChatJoinRequestHandler(self.callback, username="@user_b")
+        assert not handler.check_update(chat_join_request_update)
         handler = ChatJoinRequestHandler(self.callback, username=["user_b"])
+        assert not handler.check_update(chat_join_request_update)
+        handler = ChatJoinRequestHandler(self.callback, username=["@user_b"])
         assert not handler.check_update(chat_join_request_update)
 
         chat_join_request_update.chat_join_request.from_user.username = None

--- a/tests/test_chatjoinrequesthandler.py
+++ b/tests/test_chatjoinrequesthandler.py
@@ -132,6 +132,8 @@ class TestChatJoinRequestHandler:
         assert handler.check_update(chat_join_request_update)
         handler = ChatJoinRequestHandler(self.callback, chat_id=[1])
         assert handler.check_update(chat_join_request_update)
+        handler = ChatJoinRequestHandler(self.callback, chat_id=2, username="@user_a")
+        assert handler.check_update(chat_join_request_update)
 
         handler = ChatJoinRequestHandler(self.callback, chat_id=2)
         assert not handler.check_update(chat_join_request_update)
@@ -146,6 +148,8 @@ class TestChatJoinRequestHandler:
         handler = ChatJoinRequestHandler(self.callback, username=["user_a"])
         assert handler.check_update(chat_join_request_update)
         handler = ChatJoinRequestHandler(self.callback, username=["@user_a"])
+        assert handler.check_update(chat_join_request_update)
+        handler = ChatJoinRequestHandler(self.callback, chat_id=1, username="@user_b")
         assert handler.check_update(chat_join_request_update)
 
         handler = ChatJoinRequestHandler(self.callback, username="user_b")


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool! Please have a look at the below checklist. It's here to help both you and the maintainers to remember some aspects. Make sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
-->

`chat_id` and `username` parameters should allow filtering requests to allow only those from a specified chat ID or username.

Closes #3215.

### Checklist for PRs

- [x] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [x] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- [x] Added myself alphabetically to `AUTHORS.rst` (optional)
- [ ] Added new classes & modules to the docs and all suitable `__all__` s
