### PR TITLE
Read only `CallbackDataCache`

### DIFF
--- a/docs/source/telegram.ext.extbot.rst
+++ b/docs/source/telegram.ext.extbot.rst
@@ -3,4 +3,4 @@ telegram.ext.ExtBot
 
 .. autoclass:: telegram.ext.ExtBot
     :show-inheritance:
-    :members: insert_callback_data, defaults, rate_limiter, initialize, shutdown
+    :members: insert_callback_data, defaults, rate_limiter, initialize, shutdown, callback_data_cache

--- a/telegram/_callbackquery.py
+++ b/telegram/_callbackquery.py
@@ -57,7 +57,7 @@ class CallbackQuery(TelegramObject):
           until you call :attr:`answer`. It is, therefore, necessary to react
           by calling :attr:`telegram.Bot.answer_callback_query` even if no notification to the user
           is needed (e.g., without specifying any of the optional parameters).
-        * If you're using :attr:`telegram.ext.ExtBot.arbitrary_callback_data`, :attr:`data` may be
+        * If you're using :attr:`telegram.ext.ExtBot.callback_data_cache`, :attr:`data` may be
           an instance
           of :class:`telegram.ext.InvalidCallbackData`. This will be the case, if the data
           associated with the button triggering the :class:`telegram.CallbackQuery` was already

--- a/telegram/ext/_application.py
+++ b/telegram/ext/_application.py
@@ -54,7 +54,6 @@ from telegram._utils.types import DVInput, ODVInput
 from telegram._utils.warnings import warn
 from telegram.error import TelegramError
 from telegram.ext._basepersistence import BasePersistence
-from telegram.ext._callbackdatacache import CallbackDataCache
 from telegram.ext._contexttypes import ContextTypes
 from telegram.ext._extbot import ExtBot
 from telegram.ext._handler import BaseHandler
@@ -440,10 +439,8 @@ class Application(Generic[BT, CCT, UD, CD, BD, JQ], AbstractAsyncContextManager)
                     raise ValueError("callback_data must be a tuple of length 2")
                 # Mypy doesn't know that persistence.set_bot (see above) already checks that
                 # self.bot is an instance of ExtBot if callback_data should be stored ...
-                self.bot.callback_data_cache = CallbackDataCache(  # type: ignore[attr-defined]
-                    self.bot,  # type: ignore[arg-type]
-                    self.bot.callback_data_cache.maxsize,  # type: ignore[attr-defined]
-                    persistent_data=persistent_data,
+                self.bot.callback_data_cache.load_persistence_data(  # type: ignore[attr-defined]
+                    persistent_data
                 )
 
     @staticmethod

--- a/telegram/ext/_basepersistence.py
+++ b/telegram/ext/_basepersistence.py
@@ -174,10 +174,16 @@ class BasePersistence(Generic[UD, CD, BD], ABC):
 
         Raises:
             :exc:`TypeError`: If :attr:`PersistenceInput.callback_data` is :obj:`True` and the
-                :paramref:`bot` is not an instance of :class:`telegram.ext.ExtBot`.
+                :paramref:`bot` is not an instance of :class:`telegram.ext.ExtBot` or
+                :attr:`~telegram.ext.ExtBot.callback_data_cache` is :obj:`None`.
         """
-        if self.store_data.callback_data and not isinstance(bot, ExtBot):
-            raise TypeError("callback_data can only be stored when using telegram.ext.ExtBot.")
+        if self.store_data.callback_data and (
+            not isinstance(bot, ExtBot) or bot.callback_data_cache is None
+        ):
+            raise TypeError(
+                "callback_data can only be stored when using telegram.ext.ExtBot with arbitrary "
+                "callback_data enabled. "
+            )
 
         self.bot = bot
 

--- a/telegram/ext/_callbackcontext.py
+++ b/telegram/ext/_callbackcontext.py
@@ -235,7 +235,7 @@ class CallbackContext(Generic[BT, UD, CD, BD]):
                 callback data.
         """
         if isinstance(self.bot, ExtBot):
-            if not self.bot.arbitrary_callback_data:
+            if self.bot.callback_data_cache is None:
                 raise RuntimeError(
                     "This telegram.ext.ExtBot instance does not use arbitrary callback data."
                 )

--- a/telegram/ext/_callbackdatacache.py
+++ b/telegram/ext/_callbackdatacache.py
@@ -141,6 +141,28 @@ class CallbackDataCache:
                     keyboard_uuid=uuid, access_time=access_time, button_data=data
                 )
 
+    def load_persistence_data(self, persistent_data: CDCData) -> None:
+        """Loads data into the cache.
+
+        Warning:
+            This method is not intended to be called by users directly.
+
+        .. versionadded:: 20.0
+
+        Args:
+            persistent_data (Tuple[List[Tuple[:obj:`str`, :obj:`float`, \
+            Dict[:obj:`str`, :class:`object`]]], Dict[:obj:`str`, :obj:`str`]], optional): \
+            Data to load, as returned by \
+            :meth:`telegram.ext.BasePersistence.get_callback_data`.
+        """
+        keyboard_data, callback_queries = persistent_data
+        for key, value in callback_queries.items():
+            self._callback_queries[key] = value
+        for uuid, access_time, data in keyboard_data:
+            self._keyboard_data[uuid] = _KeyboardData(
+                keyboard_uuid=uuid, access_time=access_time, button_data=data
+            )
+
     @property
     def persistence_data(self) -> CDCData:
         """Tuple[List[Tuple[:obj:`str`, :obj:`float`, Dict[:obj:`str`, :class:`object`]]],

--- a/telegram/ext/_callbackdatacache.py
+++ b/telegram/ext/_callbackdatacache.py
@@ -113,11 +113,10 @@ class CallbackDataCache:
 
     Attributes:
         bot (:class:`telegram.ext.ExtBot`): The bot this cache is for.
-        maxsize (:obj:`int`): maximum size of the cache.
 
     """
 
-    __slots__ = ("bot", "maxsize", "_keyboard_data", "_callback_queries", "logger")
+    __slots__ = ("bot", "_maxsize", "_keyboard_data", "_callback_queries", "logger")
 
     def __init__(
         self,
@@ -128,7 +127,7 @@ class CallbackDataCache:
         self.logger = logging.getLogger(__name__)
 
         self.bot = bot
-        self.maxsize = maxsize
+        self._maxsize = maxsize
         self._keyboard_data: MutableMapping[str, _KeyboardData] = LRUCache(maxsize=maxsize)
         self._callback_queries: MutableMapping[str, str] = LRUCache(maxsize=maxsize)
 
@@ -162,6 +161,15 @@ class CallbackDataCache:
             self._keyboard_data[uuid] = _KeyboardData(
                 keyboard_uuid=uuid, access_time=access_time, button_data=data
             )
+
+    @property
+    def maxsize(self) -> int:
+        """:obj:`int`: The maximum size of the cache.
+
+        .. versionchanged:: 20.0
+           This property is now read-only.
+        """
+        return self._maxsize
 
     @property
     def persistence_data(self) -> CDCData:

--- a/telegram/ext/_callbackdatacache.py
+++ b/telegram/ext/_callbackdatacache.py
@@ -132,13 +132,7 @@ class CallbackDataCache:
         self._callback_queries: MutableMapping[str, str] = LRUCache(maxsize=maxsize)
 
         if persistent_data:
-            keyboard_data, callback_queries = persistent_data
-            for key, value in callback_queries.items():
-                self._callback_queries[key] = value
-            for uuid, access_time, data in keyboard_data:
-                self._keyboard_data[uuid] = _KeyboardData(
-                    keyboard_uuid=uuid, access_time=access_time, button_data=data
-                )
+            self.load_persistence_data(persistent_data)
 
     def load_persistence_data(self, persistent_data: CDCData) -> None:
         """Loads data into the cache.

--- a/telegram/ext/_extbot.py
+++ b/telegram/ext/_extbot.py
@@ -124,6 +124,10 @@ class ExtBot(Bot, Generic[RLARGS]):
 
     .. versionadded:: 13.6
 
+    .. versionchanged:: 20.0
+        Removed the attribute ``arbitrary_callback_data``. You can instead use
+        ``bot.callback_data_cache.max_size`` to access the size of the cache.
+
     Args:
         defaults (:class:`telegram.ext.Defaults`, optional): An object containing default values to
             be used if not set explicitly in the bot methods.
@@ -137,16 +141,9 @@ class ExtBot(Bot, Generic[RLARGS]):
 
             .. versionadded:: 20.0
 
-    Attributes:
-        arbitrary_callback_data (:obj:`bool` | :obj:`int`): Whether this bot instance
-            allows to use arbitrary objects as callback data for
-            :class:`telegram.InlineKeyboardButton`.
-        callback_data_cache (:class:`telegram.ext.CallbackDataCache`): The cache for objects passed
-            as callback data for :class:`telegram.InlineKeyboardButton`.
-
     """
 
-    __slots__ = ("arbitrary_callback_data", "callback_data_cache", "_defaults", "_rate_limiter")
+    __slots__ = ("_callback_data_cache", "_defaults", "_rate_limiter")
 
     # using object() would be a tiny bit safer, but a string plays better with the typing setup
     __RL_KEY = uuid4().hex
@@ -210,15 +207,30 @@ class ExtBot(Bot, Generic[RLARGS]):
         )
         self._defaults = defaults
         self._rate_limiter = rate_limiter
+        self._callback_data_cache: Optional[CallbackDataCache] = None
 
         # set up callback_data
+        if arbitrary_callback_data is False:
+            return
+
         if not isinstance(arbitrary_callback_data, bool):
             maxsize = cast(int, arbitrary_callback_data)
-            self.arbitrary_callback_data = True
         else:
             maxsize = 1024
-            self.arbitrary_callback_data = arbitrary_callback_data
-        self.callback_data_cache: CallbackDataCache = CallbackDataCache(bot=self, maxsize=maxsize)
+
+        self._callback_data_cache = CallbackDataCache(bot=self, maxsize=maxsize)
+
+    @property
+    def callback_data_cache(self) -> Optional[CallbackDataCache]:
+        """:class:`telegram.ext.CallbackDataCache`: Optional. The cache for
+        objects passed as callback data for :class:`telegram.InlineKeyboardButton`.
+
+        .. versionchange:: 20.0
+           * This property is now read-only.
+           * This property is now optional and can be :obj:`None` if
+             :attr:`arbitrary_callback_data` is set to :obj:`False`.
+        """
+        return self._callback_data_cache
 
     async def initialize(self) -> None:
         """See :meth:`telegram.Bot.initialize`. Also initializes the
@@ -366,7 +378,7 @@ class ExtBot(Bot, Generic[RLARGS]):
     def _replace_keyboard(self, reply_markup: Optional[ReplyMarkup]) -> Optional[ReplyMarkup]:
         # If the reply_markup is an inline keyboard and we allow arbitrary callback data, let the
         # CallbackDataCache build a new keyboard with the data replaced. Otherwise return the input
-        if isinstance(reply_markup, InlineKeyboardMarkup) and self.arbitrary_callback_data:
+        if isinstance(reply_markup, InlineKeyboardMarkup) and self.callback_data_cache is not None:
             return self.callback_data_cache.process_keyboard(reply_markup)
 
         return reply_markup
@@ -405,7 +417,7 @@ class ExtBot(Bot, Generic[RLARGS]):
             self._insert_callback_data(update.effective_message)
 
     def _insert_callback_data(self, obj: HandledTypes) -> HandledTypes:
-        if not self.arbitrary_callback_data:
+        if self.callback_data_cache is None:
             return obj
 
         if isinstance(obj, CallbackQuery):
@@ -514,7 +526,7 @@ class ExtBot(Bot, Generic[RLARGS]):
         )
 
         # Process arbitrary callback
-        if not self.arbitrary_callback_data:
+        if self.callback_data_cache is None:
             return effective_results, next_offset
         results = []
         for result in effective_results:

--- a/telegram/ext/_extbot.py
+++ b/telegram/ext/_extbot.py
@@ -126,7 +126,8 @@ class ExtBot(Bot, Generic[RLARGS]):
 
     .. versionchanged:: 20.0
         Removed the attribute ``arbitrary_callback_data``. You can instead use
-        ``bot.callback_data_cache.max_size`` to access the size of the cache.
+        :attr:`bot.callback_data_cache.maxsize <telegram.ext.CallbackDataCache.maxsize>` to
+        access the size of the cache.
 
     Args:
         defaults (:class:`telegram.ext.Defaults`, optional): An object containing default values to

--- a/telegram/ext/_extbot.py
+++ b/telegram/ext/_extbot.py
@@ -225,10 +225,10 @@ class ExtBot(Bot, Generic[RLARGS]):
         """:class:`telegram.ext.CallbackDataCache`: Optional. The cache for
         objects passed as callback data for :class:`telegram.InlineKeyboardButton`.
 
-        .. versionchange:: 20.0
+        .. versionchanged:: 20.0
            * This property is now read-only.
            * This property is now optional and can be :obj:`None` if
-             :attr:`arbitrary_callback_data` is set to :obj:`False`.
+             :paramref:`~telegram.ext.ExtBot.arbitrary_callback_data` is set to :obj:`False`.
         """
         return self._callback_data_cache
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,6 +159,13 @@ async def bot(bot_info):
 
 
 @pytest.fixture(scope="session")
+async def cdc_bot(bot_info):
+    """Makes an ExtBot instance with the given bot_info that uses arbitrary callback_data"""
+    async with make_bot(bot_info, arbitrary_callback_data=True) as _bot:
+        yield _bot
+
+
+@pytest.fixture(scope="session")
 async def raw_bot(bot_info):
     """Makes an regular Bot instance with the given bot_info"""
     async with DictBot(

--- a/tests/test_applicationbuilder.py
+++ b/tests/test_applicationbuilder.py
@@ -81,7 +81,7 @@ class TestApplicationBuilder:
         assert "api.telegram.org" in app.bot.base_file_url
         assert bot.token in app.bot.base_file_url
         assert app.bot.private_key is None
-        assert app.bot.arbitrary_callback_data is False
+        assert app.bot.callback_data_cache is None
         assert app.bot.defaults is None
         assert app.bot.rate_limiter is None
         assert app.bot.local_mode is False
@@ -346,6 +346,7 @@ class TestApplicationBuilder:
             .concurrent_updates(concurrent_updates)
             .post_init(post_init)
             .post_shutdown(post_shutdown)
+            .arbitrary_callback_data(True)
         ).build()
         assert app.job_queue is job_queue
         assert app.job_queue.application is app

--- a/tests/test_applicationbuilder.py
+++ b/tests/test_applicationbuilder.py
@@ -26,6 +26,7 @@ from telegram.ext import (
     AIORateLimiter,
     Application,
     ApplicationBuilder,
+    CallbackDataCache,
     ContextTypes,
     Defaults,
     ExtBot,
@@ -359,6 +360,7 @@ class TestApplicationBuilder:
         assert app.concurrent_updates == concurrent_updates
         assert app.post_init is post_init
         assert app.post_shutdown is post_shutdown
+        assert isinstance(app.bot.callback_data_cache, CallbackDataCache)
 
         updater = Updater(bot=bot, update_queue=update_queue)
         app = ApplicationBuilder().updater(updater).build()

--- a/tests/test_basepersistence.py
+++ b/tests/test_basepersistence.py
@@ -38,6 +38,7 @@ from telegram.ext import (
     BasePersistence,
     CallbackContext,
     ConversationHandler,
+    ExtBot,
     MessageHandler,
     PersistenceInput,
     filters,
@@ -389,6 +390,9 @@ class TestBasePersistence:
     def test_set_bot_error(self, papp):
         with pytest.raises(TypeError, match="when using telegram.ext.ExtBot"):
             papp.persistence.set_bot(Bot(papp.bot.token))
+
+        with pytest.raises(TypeError, match="when using telegram.ext.ExtBot"):
+            papp.persistence.set_bot(ExtBot(papp.bot.token))
 
     def test_construction_with_bad_persistence(self, caplog, bot):
         class MyPersistence:
@@ -1024,7 +1028,13 @@ class TestBasePersistence:
             test_flag.append(str(context.error) == "PersistenceError")
             raise Exception("ErrorHandlingError")
 
-        app = ApplicationBuilder().token(bot.token).persistence(ErrorPersistence()).build()
+        app = (
+            ApplicationBuilder()
+            .token(bot.token)
+            .arbitrary_callback_data(True)
+            .persistence(ErrorPersistence())
+            .build()
+        )
 
         async with app:
             app.add_error_handler(error)

--- a/tests/test_callbackdatacache.py
+++ b/tests/test_callbackdatacache.py
@@ -74,6 +74,7 @@ class TestCallbackDataCache:
         assert cdc.bot is bot
 
     def test_init_and_access__persistent_data(self, bot):
+        """This als test CDC.load_persistent_data."""
         keyboard_data = _KeyboardData("123", 456, {"button": 678})
         persistent_data = ([keyboard_data.to_tuple()], {"id": "123"})
         cdc = CallbackDataCache(bot, persistent_data=persistent_data)

--- a/tests/test_callbackdatacache.py
+++ b/tests/test_callbackdatacache.py
@@ -74,7 +74,7 @@ class TestCallbackDataCache:
         assert cdc.bot is bot
 
     def test_init_and_access__persistent_data(self, bot):
-        """This als test CDC.load_persistent_data."""
+        """This also tests CDC.load_persistent_data."""
         keyboard_data = _KeyboardData("123", 456, {"button": 678})
         persistent_data = ([keyboard_data.to_tuple()], {"id": "123"})
         cdc = CallbackDataCache(bot, persistent_data=persistent_data)

--- a/tests/test_dictpersistence.py
+++ b/tests/test_dictpersistence.py
@@ -24,11 +24,10 @@ from telegram.ext import DictPersistence
 
 
 @pytest.fixture(autouse=True)
-def reset_callback_data_cache(bot):
+def reset_callback_data_cache(cdc_bot):
     yield
-    bot.callback_data_cache.clear_callback_data()
-    bot.callback_data_cache.clear_callback_queries()
-    bot.arbitrary_callback_data = False
+    cdc_bot.callback_data_cache.clear_callback_data()
+    cdc_bot.callback_data_cache.clear_callback_queries()
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -693,11 +693,11 @@ class TestUpdater:
 
     @pytest.mark.parametrize("invalid_data", [True, False], ids=("invalid data", "valid data"))
     async def test_webhook_arbitrary_callback_data(
-        self, monkeypatch, updater, invalid_data, chat_id
+        self, monkeypatch, cdc_bot, invalid_data, chat_id
     ):
         """Here we only test one simple setup. telegram.ext.ExtBot.insert_callback_data is tested
         extensively in test_bot.py in conjunction with get_updates."""
-        updater.bot.arbitrary_callback_data = True
+        updater = Updater(bot=cdc_bot, update_queue=asyncio.Queue())
 
         async def return_true(*args, **kwargs):
             return True
@@ -743,7 +743,6 @@ class TestUpdater:
 
                 await updater.stop()
         finally:
-            updater.bot.arbitrary_callback_data = False
             updater.bot.callback_data_cache.clear_callback_data()
             updater.bot.callback_data_cache.clear_callback_queries()
 


### PR DESCRIPTION
Makes `ExtBot.callback_data_cache` readonly and optional. In particular, the CDC is now only instantiated if requested. This is a preparation for making the corresponding 3rd party dependency optional.
Also removes `ExtBot.arbitrary_callback_data`.

### Checklist for PRs

- [u] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [x] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- [ ] ~Added myself alphabetically to `AUTHORS.rst` (optional)~
- [ ] ~Added new classes & modules to the docs and all suitable `__all__` s~

