### PR TITLE
Fix english typo in conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,7 +160,7 @@ async def bot(bot_info):
 
 @pytest.fixture(scope="session")
 async def raw_bot(bot_info):
-    """Makes an regular Bot instance with the given bot_info"""
+    """Makes a regular Bot instance with the given bot_info"""
     async with DictBot(
         bot_info["token"],
         private_key=PRIVATE_KEY,


### PR DESCRIPTION
Refer to #3109, small typo fix found during fixtures check.

### Checklist for PRs

- [ ] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [ ] Created new or adapted existing unit tests
- [ ] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)
- [ ] Added new classes & modules to the docs and all suitable `__all__` s