### PR TITLE
Point to correct "edit on github" link

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,6 +1,6 @@
-sphinx==5.1.1
+sphinx==5.2.3
 sphinx-pypi-upload
-furo==2022.9.15
+furo==2022.9.29
 git+https://github.com/harshil21/furo-sphinx-search@be5cfa221a01f6e259bb2bb1f76d6ede7ffc1f11#egg=furo-sphinx-search
 sphinx-paramlinks==0.5.4
 sphinxcontrib-mermaid==0.7.1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -129,6 +129,7 @@ html_theme_options = {
         "admonition-title-font-size": "0.95rem",
         "admonition-font-size": "0.92rem",
     },
+    "source_edit_link": "https://github.com/python-telegram-bot/python-telegram-bot/blob/master/{filename}",
     "announcement": "PTB has undergone significant changes in v20. Please read the documentation "
     "carefully and also check out the transition guide in the "
     '<a href="https://github.com/python-telegram-bot/python-telegram-bot/wiki/'


### PR DESCRIPTION
Uses the new furo `source_edit_link` to fix the edit button link at the top of every page