### PR TITLE
Add `recursive` parameter to `TO.to_dict()`

### DIFF
--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -8205,7 +8205,7 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
             api_kwargs=api_kwargs,
         )
 
-    def to_dict(self, recursive: bool = True) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:  # skipcq: PYL-W0613
         """See :meth:`telegram.TelegramObject.to_dict`."""
         data: JSONDict = {"id": self.id, "username": self.username, "first_name": self.first_name}
 

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -8205,7 +8205,7 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
             api_kwargs=api_kwargs,
         )
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
         data: JSONDict = {"id": self.id, "username": self.username, "first_name": self.first_name}
 

--- a/telegram/_chatinvitelink.py
+++ b/telegram/_chatinvitelink.py
@@ -151,9 +151,9 @@ class ChatInviteLink(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         data["expire_date"] = to_timestamp(self.expire_date)
 

--- a/telegram/_chatjoinrequest.py
+++ b/telegram/_chatjoinrequest.py
@@ -103,9 +103,9 @@ class ChatJoinRequest(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         data["date"] = to_timestamp(self.date)
 

--- a/telegram/_chatmember.py
+++ b/telegram/_chatmember.py
@@ -123,9 +123,9 @@ class ChatMember(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         if data.get("until_date", False):
             data["until_date"] = to_timestamp(data["until_date"])

--- a/telegram/_chatmemberupdated.py
+++ b/telegram/_chatmemberupdated.py
@@ -122,9 +122,9 @@ class ChatMemberUpdated(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         # Required
         data["date"] = to_timestamp(self.date)

--- a/telegram/_files/inputmedia.py
+++ b/telegram/_files/inputmedia.py
@@ -90,9 +90,9 @@ class InputMedia(TelegramObject):
         self.caption_entities = caption_entities
         self.parse_mode = parse_mode
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         if self.caption_entities:
             data["caption_entities"] = [ce.to_dict() for ce in self.caption_entities]

--- a/telegram/_files/sticker.py
+++ b/telegram/_files/sticker.py
@@ -282,9 +282,9 @@ class StickerSet(TelegramObject):
 
         return super()._de_json(data=data, bot=bot, api_kwargs=api_kwargs)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         data["stickers"] = [s.to_dict() for s in data.get("stickers")]  # type: ignore[union-attr]
 

--- a/telegram/_games/game.py
+++ b/telegram/_games/game.py
@@ -117,9 +117,9 @@ class Game(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         data["photo"] = [p.to_dict() for p in self.photo]
         if self.text_entities:

--- a/telegram/_inline/inlinekeyboardmarkup.py
+++ b/telegram/_inline/inlinekeyboardmarkup.py
@@ -68,9 +68,9 @@ class InlineKeyboardMarkup(TelegramObject):
 
         self._id_attrs = (self.inline_keyboard,)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         data["inline_keyboard"] = []
         for inline_keyboard in self.inline_keyboard:

--- a/telegram/_inline/inlinequeryresult.py
+++ b/telegram/_inline/inlinequeryresult.py
@@ -54,9 +54,9 @@ class InlineQueryResult(TelegramObject):
 
         self._id_attrs = (self.id,)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         # pylint: disable=no-member
         if (

--- a/telegram/_inline/inputinvoicemessagecontent.py
+++ b/telegram/_inline/inputinvoicemessagecontent.py
@@ -228,9 +228,9 @@ class InputInvoiceMessageContent(InputMessageContent):
             )
         )
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         data["prices"] = [price.to_dict() for price in self.prices]
 

--- a/telegram/_inline/inputtextmessagecontent.py
+++ b/telegram/_inline/inputtextmessagecontent.py
@@ -84,9 +84,9 @@ class InputTextMessageContent(InputMessageContent):
 
         self._id_attrs = (self.message_text,)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         if self.entities:
             data["entities"] = [ce.to_dict() for ce in self.entities]

--- a/telegram/_menubutton.py
+++ b/telegram/_menubutton.py
@@ -161,9 +161,9 @@ class MenuButtonWebApp(MenuButton):
 
         return super().de_json(data=data, bot=bot)  # type: ignore[return-value]
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
         data["web_app"] = self.web_app.to_dict()
         return data
 

--- a/telegram/_message.py
+++ b/telegram/_message.py
@@ -718,9 +718,9 @@ class Message(TelegramObject):
 
         return self._effective_attachment  # type: ignore[return-value]
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         # Required
         data["date"] = to_timestamp(self.date)

--- a/telegram/_passport/credentials.py
+++ b/telegram/_passport/credentials.py
@@ -404,9 +404,9 @@ class SecureValue(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         data["files"] = [p.to_dict() for p in self.files]  # type: ignore[union-attr]
         data["translation"] = [p.to_dict() for p in self.translation]  # type: ignore[union-attr]
@@ -450,9 +450,9 @@ class DataCredentials(_CredentialsBase):
     def __init__(self, data_hash: str, secret: str, *, api_kwargs: JSONDict = None):
         super().__init__(hash=data_hash, secret=secret, api_kwargs=api_kwargs)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         del data["file_hash"]
         del data["hash"]
@@ -479,9 +479,9 @@ class FileCredentials(_CredentialsBase):
     def __init__(self, file_hash: str, secret: str, *, api_kwargs: JSONDict = None):
         super().__init__(hash=file_hash, secret=secret, api_kwargs=api_kwargs)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         del data["data_hash"]
         del data["hash"]

--- a/telegram/_passport/encryptedpassportelement.py
+++ b/telegram/_passport/encryptedpassportelement.py
@@ -245,9 +245,9 @@ class EncryptedPassportElement(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         if self.files:
             data["files"] = [p.to_dict() for p in self.files]

--- a/telegram/_passport/passportdata.py
+++ b/telegram/_passport/passportdata.py
@@ -81,9 +81,9 @@ class PassportData(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         data["data"] = [e.to_dict() for e in self.data]
 

--- a/telegram/_payment/shippingoption.py
+++ b/telegram/_payment/shippingoption.py
@@ -65,9 +65,9 @@ class ShippingOption(TelegramObject):
 
         self._id_attrs = (self.id,)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         data["prices"] = [p.to_dict() for p in self.prices]
 

--- a/telegram/_poll.py
+++ b/telegram/_poll.py
@@ -228,9 +228,9 @@ class Poll(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         data["options"] = [x.to_dict() for x in self.options]
         if self.explanation_entities:

--- a/telegram/_replykeyboardmarkup.py
+++ b/telegram/_replykeyboardmarkup.py
@@ -119,9 +119,9 @@ class ReplyKeyboardMarkup(TelegramObject):
 
         self._id_attrs = (self.keyboard,)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         data["keyboard"] = []
         for row in self.keyboard:

--- a/telegram/_telegramobject.py
+++ b/telegram/_telegramobject.py
@@ -170,10 +170,6 @@ class TelegramObject:
         """
         data = {}
 
-        # __dict__ has attrs from superclasses, so no need to loop through them
-        if hasattr(self, "__dict__"):
-            data.update(self.__dict__)  # important when class has no __slots__.
-
         # We want to get all attributes for the class, using self.__slots__ only includes the
         # attributes used by that class itself, and not its superclass(es). Hence, we get its MRO
         # and then get their attributes. The `[:-1]` slice excludes the `object` class

--- a/telegram/_telegramobject.py
+++ b/telegram/_telegramobject.py
@@ -172,17 +172,14 @@ class TelegramObject:
 
         # __dict__ has attrs from superclasses, so no need to loop through them
         if hasattr(self, "__dict__"):
-            org_data = self.__dict__
             data.update(self.__dict__)  # important when class has no __slots__.
-        else:
-            org_data = {}
 
         # We want to get all attributes for the class, using self.__slots__ only includes the
         # attributes used by that class itself, and not its superclass(es). Hence, we get its MRO
         # and then get their attributes. The `[:-1]` slice excludes the `object` class
         all_slots = (s for c in self.__class__.__mro__[:-1] for s in c.__slots__)  # type: ignore
         # chain the class's slots with the user defined subclass __dict__ (class has no slots)
-        for key in chain(org_data, all_slots):
+        for key in chain(self.__dict__, all_slots) if hasattr(self, "__dict__") else all_slots:
             if not include_private and key.startswith("_"):
                 continue
 

--- a/telegram/_telegramobject.py
+++ b/telegram/_telegramobject.py
@@ -178,7 +178,7 @@ class TelegramObject:
         # We want to get all attributes for the class, using self.__slots__ only includes the
         # attributes used by that class itself, and not its superclass(es). Hence, we get its MRO
         # and then get their attributes. The `[:-1]` slice excludes the `object` class
-        all_slots = (slot for cls in self.__class__.__mro__[:-1] for slot in cls.__slots__)
+        all_slots = (s for c in self.__class__.__mro__[:-1] for s in c.__slots__)  # type: ignore
         # chain the class's slots with the user defined subclass __dict__ (class has no slots)
         for key in chain(org_data, all_slots):
             if not include_private and key.startswith("_"):

--- a/telegram/_telegramobject.py
+++ b/telegram/_telegramobject.py
@@ -291,7 +291,7 @@ class TelegramObject:
                 (if found) in the attributes to a dictionary. Else, preserves it as an object
                 itself. Defaults to :obj:`True`.
 
-            .. versionadded:: 20.0
+                .. versionadded:: 20.0
 
         Returns:
             :obj:`dict`

--- a/telegram/_telegramobject.py
+++ b/telegram/_telegramobject.py
@@ -161,8 +161,8 @@ class TelegramObject:
 
         Args:
             include_private (:obj:`bool`): Whether the result should include private variables.
-            recursive (:obj:`bool`): If :obj:`True`, will convert any TelegramObjects (if found) in
-                the attributes to a dictionary. Else, preserves it as an object itself.
+            recursive (:obj:`bool`): If :obj:`True`, will convert any ``TelegramObjects`` (if
+                found) in the attributes to a dictionary. Else, preserves it as an object itself.
             remove_bot (:obj:`bool`): Whether the bot should be included in the result.
 
         Returns:
@@ -170,11 +170,13 @@ class TelegramObject:
         """
         data = {}
 
-        # __dict__ has attrs from superclasses, so no need to recompute/duplicate
+        # __dict__ has attrs from superclasses, so no need to loop through them
         if hasattr(self, "__dict__"):
+            org_data = self.__dict__
             data.update(self.__dict__)  # important when class has no __slots__.
+        else:
+            org_data = {}
 
-        org_data = tuple(data)  # make a copy of the keys to avoid changing length during iteration
         # We want to get all attributes for the class, using self.__slots__ only includes the
         # attributes used by that class itself, and not its superclass(es). Hence, we get its MRO
         # and then get their attributes. The `[:-1]` slice excludes the `object` class

--- a/telegram/_userprofilephotos.py
+++ b/telegram/_userprofilephotos.py
@@ -69,9 +69,9 @@ class UserProfilePhotos(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         data["photos"] = []
         for photo in self.photos:

--- a/telegram/_videochat.py
+++ b/telegram/_videochat.py
@@ -121,9 +121,9 @@ class VideoChatParticipantsInvited(TelegramObject):
         data["users"] = User.de_list(data.get("users", []), bot)
         return super().de_json(data=data, bot=bot)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         if self.users is not None:
             data["users"] = [u.to_dict() for u in self.users]
@@ -176,9 +176,9 @@ class VideoChatScheduled(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         # Required
         data["start_date"] = to_timestamp(self.start_date)

--- a/tests/test_telegramobject.py
+++ b/tests/test_telegramobject.py
@@ -138,6 +138,26 @@ class TestTelegramObject:
         to = TelegramObject(api_kwargs={"foo": "bar"})
         assert to.to_dict() == {"foo": "bar"}
 
+    def test_to_dict_recursion(self):
+        class Recusive(TelegramObject):
+            def __init__(self):
+                super().__init__()
+                self.recursive = "recursive"
+
+        class SubClass(TelegramObject):
+            def __init__(self):
+                super().__init__()
+                self.subclass = Recusive()
+
+        to = SubClass()
+        to_dict_no_recurse = to.to_dict(recursive=False)
+        assert to_dict_no_recurse
+        assert isinstance(to_dict_no_recurse["subclass"], Recusive)
+        to_dict_recuse = to.to_dict(recursive=True)
+        assert to_dict_recuse
+        assert isinstance(to_dict_recuse["subclass"], dict)
+        assert to_dict_recuse["subclass"]["recursive"] == "recursive"
+
     def test_slot_behaviour(self, mro_slots):
         inst = TelegramObject()
         for attr in inst.__slots__:

--- a/tests/test_telegramobject.py
+++ b/tests/test_telegramobject.py
@@ -139,24 +139,26 @@ class TestTelegramObject:
         assert to.to_dict() == {"foo": "bar"}
 
     def test_to_dict_recursion(self):
-        class Recusive(TelegramObject):
+        class Recursive(TelegramObject):
+            __slots__ = ("recursive",)
+
             def __init__(self):
                 super().__init__()
                 self.recursive = "recursive"
 
-        class SubClass(TelegramObject):
+        class SubClass(TelegramObject):  # doesn't have `__slots__`, so has `__dict__` instead.
             def __init__(self):
                 super().__init__()
-                self.subclass = Recusive()
+                self.subclass = Recursive()
 
         to = SubClass()
         to_dict_no_recurse = to.to_dict(recursive=False)
         assert to_dict_no_recurse
-        assert isinstance(to_dict_no_recurse["subclass"], Recusive)
-        to_dict_recuse = to.to_dict(recursive=True)
-        assert to_dict_recuse
-        assert isinstance(to_dict_recuse["subclass"], dict)
-        assert to_dict_recuse["subclass"]["recursive"] == "recursive"
+        assert isinstance(to_dict_no_recurse["subclass"], Recursive)
+        to_dict_recurse = to.to_dict(recursive=True)
+        assert to_dict_recurse
+        assert isinstance(to_dict_recurse["subclass"], dict)
+        assert to_dict_recurse["subclass"]["recursive"] == "recursive"
 
     def test_slot_behaviour(self, mro_slots):
         inst = TelegramObject()

--- a/tests/test_telegramobject.py
+++ b/tests/test_telegramobject.py
@@ -146,7 +146,9 @@ class TestTelegramObject:
                 super().__init__()
                 self.recursive = "recursive"
 
-        class SubClass(TelegramObject):  # doesn't have `__slots__`, so has `__dict__` instead.
+        class SubClass(TelegramObject):
+            """This class doesn't have `__slots__`, so has `__dict__` instead."""
+
             def __init__(self):
                 super().__init__()
                 self.subclass = Recursive()


### PR DESCRIPTION
Closes #3146 

I went with the simple boolean approach instead of specifying a number for the recursion. 
Also based on the TO-overhaul branch since I had to make sure these changes work with that too. (Merge after #3233)

### Checklist for PRs

- [x] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [x] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
