### PR TITLE
Fixed incorrect docstring in `Application.run_webhook`

### DIFF
--- a/telegram/ext/_application.py
+++ b/telegram/ext/_application.py
@@ -677,7 +677,7 @@ class Application(Generic[BT, CCT, UD, CD, BD, JQ], AbstractAsyncContextManager)
         secret_token: str = None,
     ) -> None:
         """Convenience method that takes care of initializing and starting the app,
-        polling updates from Telegram using :meth:`telegram.ext.Updater.start_webhook` and
+        listening for updates from Telegram using :meth:`telegram.ext.Updater.start_webhook` and
         a graceful shutdown of the app on exit.
 
         The app will shut down when :exc:`KeyboardInterrupt` or :exc:`SystemExit` is raised.


### PR DESCRIPTION
It was probably copied from the docstring for `Application.run_polling`, and got me confused. Here's a fix.

Some CI runs fail, but I'm pretty sure it's not due to my changes. Can someone please rerun them?