### PR TITLE
feat(`Bot`): add shortcut to pass caption to media group

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -34,6 +34,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `daimajia <https://github.com/daimajia>`_
 - `Daniel Reed <https://github.com/nmlorg>`_
 - `D David Livingston <https://github.com/daviddl9>`_
+- `Dmitry Kolomatskiy <https://github.com/lemontree210>`_
 - `DonalDuck004 <https://github.com/DonalDuck004>`_
 - `Eana Hufwe <https://github.com/blueset>`_
 - `Ehsan Online <https://github.com/ehsanonline>`_

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -2078,7 +2078,6 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         ):
             raise ValueError("You can only supply either group caption or media with captions.")
 
-        changed_media = None
         if caption:
             # Apply group caption to the first media item.
             # This will lead to the group being shown with this caption.
@@ -2089,12 +2088,12 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
             item_to_get_caption.caption_entities = caption_entities
 
             # copy the list (just the references) to avoid mutating the original list
-            changed_media = media[:]
-            changed_media[0] = item_to_get_caption
+            media = media.copy()
+            media[0] = item_to_get_caption
 
         data: JSONDict = {
             "chat_id": chat_id,
-            "media": changed_media if caption else media,
+            "media": media,
             "disable_notification": disable_notification,
             "allow_sending_without_reply": allow_sending_without_reply,
             "protect_content": protect_content,

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -2076,18 +2076,20 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
             raise ValueError("You can only supply either group caption or media with captions.")
 
         if caption:
-            # Apply group caption to the first media item.
+            # Create copies of objects in media and apply group caption to the first item.
             # This will lead to the group being shown with this caption.
-            # Copy first item to avoid mutation of original object
-            item_to_get_caption = copy.copy(media[0])
+
+            # Only copying of first item should be enough, but the behaviour of Defaults is such
+            # that a bot with a default parse mode will automatically set `parse_mode` for
+            # each item to default parse mode of the bot.
+            # This will throw ValueError at subsequent calls with same media items.
+            media = [copy.copy(item) for item in media]
+
+            item_to_get_caption = media[0]
             item_to_get_caption.caption = caption
             if parse_mode is not DEFAULT_NONE:
                 item_to_get_caption.parse_mode = parse_mode
             item_to_get_caption.caption_entities = caption_entities
-
-            # copy the list (just the references) to avoid mutating the original list
-            media = media.copy()
-            media[0] = item_to_get_caption
 
         data: JSONDict = {
             "chat_id": chat_id,

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -1999,20 +1999,18 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         connect_timeout: ODVInput[float] = DEFAULT_NONE,
         pool_timeout: ODVInput[float] = DEFAULT_NONE,
         api_kwargs: JSONDict = None,
-        group_caption: Optional[str] = None,
-        # Notes on group_caption_parse_mode:
-        # 1. To be fully consistent with media items it would be called
-        # `group_parse_mode`, but that is ambiguous.
-        # 2. Typing ODVInput[str] = DEFAULT_NONE will make tests for shortcuts fail
+        caption: Optional[str] = None,
+        # Note on parse_mode:
+        # Typing ODVInput[str] = DEFAULT_NONE will make tests for shortcuts fail
         # (check_defaults_handling) despite it being used for parse mode for individual captions.
-        group_caption_parse_mode: Optional[str] = None,
-        group_caption_entities: Union[List["MessageEntity"], Tuple["MessageEntity", ...]] = None,
+        parse_mode: Optional[str] = None,
+        caption_entities: Union[List["MessageEntity"], Tuple["MessageEntity", ...]] = None,
     ) -> List[Message]:
         """Use this method to send a group of photos or videos as an album.
 
         Note:
-            If you supply a :paramref:`group_caption` (along with either
-            :paramref:`group_caption_parse_mode` or :paramref:`group_caption_entities`),
+            If you supply a :paramref:`caption` (along with either
+            :paramref:`parse_mode` or :paramref:`caption_entities`),
             then items in :paramref:`media` must have no captions, and vice verca.
 
         .. seealso:: :attr:`telegram.Message.reply_media_group`,
@@ -2051,18 +2049,18 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
                 :attr:`~telegram.request.BaseRequest.DEFAULT_NONE`.
             api_kwargs (:obj:`dict`, optional): Arbitrary keyword arguments to be passed to the
                 Telegram API.
-            group_caption (:obj:`str`, optional): Caption that will be added to the
+            caption (:obj:`str`, optional): Caption that will be added to the
                 first element of :paramref:`media`, so that it will be used as caption for the
                 whole media group.
                 Defaults to :obj:`None`.
-            group_caption_parse_mode (:obj:`str` | :obj:`None`, optional):
-                Parse mode for :paramref:`group_caption`.
+            parse_mode (:obj:`str` | :obj:`None`, optional):
+                Parse mode for :paramref:`caption`.
                 See the constants in :class:`telegram.constants.ParseMode` for the
                 available modes.
                 Defaults to :obj:`None`.
-            group_caption_entities (List[:class:`telegram.MessageEntity`], optional):
-                List of special entities for :paramref:`group_caption`,
-                which can be specified instead of :paramref:`group_caption_parse_mode`.
+            caption_entities (List[:class:`telegram.MessageEntity`], optional):
+                List of special entities for :paramref:`caption`,
+                which can be specified instead of :paramref:`parse_mode`.
                 Defaults to :obj:`None`.
 
         Returns:
@@ -2071,7 +2069,7 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         Raises:
             :class:`telegram.error.TelegramError`
         """
-        if group_caption and any(
+        if caption and any(
             [
                 any(item.caption for item in media),
                 any(item.caption_entities for item in media),
@@ -2081,14 +2079,14 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
             raise ValueError("You can only supply either group caption or media with captions.")
 
         changed_media = None
-        if group_caption:
+        if caption:
             # Apply group caption to the first media item.
             # This will lead to the group being shown with this caption.
             # Copy first item to avoid mutation of original object
             item_to_get_caption = copy.copy(media[0])
-            item_to_get_caption.caption = group_caption
-            item_to_get_caption.parse_mode = group_caption_parse_mode
-            item_to_get_caption.caption_entities = group_caption_entities
+            item_to_get_caption.caption = caption
+            item_to_get_caption.parse_mode = parse_mode
+            item_to_get_caption.caption_entities = caption_entities
 
             # copy the list (just the references) to avoid mutating the original list
             changed_media = media[:]
@@ -2096,7 +2094,7 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
 
         data: JSONDict = {
             "chat_id": chat_id,
-            "media": changed_media if group_caption else media,
+            "media": changed_media if caption else media,
             "disable_notification": disable_notification,
             "allow_sending_without_reply": allow_sending_without_reply,
             "protect_content": protect_content,

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -2054,12 +2054,16 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
             group_caption (:obj:`str`, optional): Caption that will be added to the
                 first element of :paramref:`media`, so that it will be used as caption for the
                 whole media group.
-                Defaults to :attr:`~telegram.request.BaseRequest.DEFAULT_NONE`.
+                Defaults to :obj:`None`.
             group_caption_parse_mode (:obj:`str` | :obj:`None`, optional):
                 Parse mode for :paramref:`group_caption`.
-                Defaults to :attr:`~telegram.request.BaseRequest.DEFAULT_NONE`.
+                See the constants in :class:`telegram.constants.ParseMode` for the
+                available modes.
+                Defaults to :obj:`None`.
             group_caption_entities (List[:class:`telegram.MessageEntity`], optional):
-                List of special entities for :paramref:`group_caption`.
+                List of special entities for :paramref:`group_caption`,
+                which can be specified instead of :paramref:`group_caption_parse_mode`.
+                Defaults to :obj:`None`.
 
         Returns:
             List[:class:`telegram.Message`]: An array of the sent Messages.

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -2051,14 +2051,15 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
                 :attr:`~telegram.request.BaseRequest.DEFAULT_NONE`.
             api_kwargs (:obj:`dict`, optional): Arbitrary keyword arguments to be passed to the
                 Telegram API.
-            group_caption (:obj:`str`, optional): Text of the caption
-                that will be shown for the whole media group.
+            group_caption (:obj:`str`, optional): Caption that will be added to the
+                first element of :paramref:`media`, so that it will be used as caption for the
+                whole media group.
                 Defaults to :attr:`~telegram.request.BaseRequest.DEFAULT_NONE`.
             group_caption_parse_mode (:obj:`str` | :obj:`None`, optional):
-                Parse mode of the caption that will be shown for the whole media group.
+                Parse mode for :paramref:`group_caption`.
                 Defaults to :attr:`~telegram.request.BaseRequest.DEFAULT_NONE`.
             group_caption_entities (List[:class:`telegram.MessageEntity`], optional):
-                List of special entities that appear in the group caption.
+                List of special entities for :paramref:`group_caption`.
 
         Returns:
             List[:class:`telegram.Message`]: An array of the sent Messages.

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -2073,7 +2073,8 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
             [
                 any(item.caption for item in media),
                 any(item.caption_entities for item in media),
-                any(item.parse_mode for item in media),
+                # if parse_mode was set explicitly, even to None, error must be raised
+                any(item.parse_mode is not DEFAULT_NONE for item in media),
             ]
         ):
             raise ValueError("You can only supply either group caption or media with captions.")

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -2012,7 +2012,7 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
 
         Note:
             If you supply a :paramref:`group_caption` (along with either
-            :paramref:`group_parse_mode` or :paramref:`group_caption_entities`),
+            :paramref:`group_caption_parse_mode` or :paramref:`group_caption_entities`),
             then items in :paramref:`media` must have no captions, and vice verca.
 
         .. seealso:: :attr:`telegram.Message.reply_media_group`,
@@ -2066,8 +2066,14 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         Raises:
             :class:`telegram.error.TelegramError`
         """
-        if group_caption and any(item.caption for item in media):
-            raise ValueError("You can only supply either group caption or images with captions.")
+        if group_caption and any(
+            [
+                any(item.caption for item in media),
+                any(item.caption_entities for item in media),
+                any(item.parse_mode is DEFAULT_NONE for item in media),
+            ]
+        ):
+            raise ValueError("You can only supply either group caption or media with captions.")
 
         # First object could be mutated if group caption has to be applied to it,
         # so it's best to copy media to avoid side effects.

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -2073,7 +2073,7 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
             [
                 any(item.caption for item in media),
                 any(item.caption_entities for item in media),
-                any(item.parse_mode is DEFAULT_NONE for item in media),
+                any(item.parse_mode for item in media),
             ]
         ):
             raise ValueError("You can only supply either group caption or media with captions.")

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -2000,10 +2000,7 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         pool_timeout: ODVInput[float] = DEFAULT_NONE,
         api_kwargs: JSONDict = None,
         caption: Optional[str] = None,
-        # Note on parse_mode:
-        # Typing ODVInput[str] = DEFAULT_NONE will make tests for shortcuts fail
-        # (check_defaults_handling) despite it being used for parse mode for individual captions.
-        parse_mode: Optional[str] = None,
+        parse_mode: ODVInput[str] = DEFAULT_NONE,
         caption_entities: Union[List["MessageEntity"], Tuple["MessageEntity", ...]] = None,
     ) -> List[Message]:
         """Use this method to send a group of photos or videos as an album.
@@ -2057,7 +2054,6 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
                 Parse mode for :paramref:`caption`.
                 See the constants in :class:`telegram.constants.ParseMode` for the
                 available modes.
-                Defaults to :obj:`None`.
             caption_entities (List[:class:`telegram.MessageEntity`], optional):
                 List of special entities for :paramref:`caption`,
                 which can be specified instead of :paramref:`parse_mode`.
@@ -2085,7 +2081,8 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
             # Copy first item to avoid mutation of original object
             item_to_get_caption = copy.copy(media[0])
             item_to_get_caption.caption = caption
-            item_to_get_caption.parse_mode = parse_mode
+            if parse_mode is not DEFAULT_NONE:
+                item_to_get_caption.parse_mode = parse_mode
             item_to_get_caption.caption_entities = caption_entities
 
             # copy the list (just the references) to avoid mutating the original list

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -2082,20 +2082,17 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
             raise ValueError("You can only supply either group caption or media with captions.")
 
         if caption:
-            # Create copies of objects in media and apply group caption to the first item.
+            # Copy first item (to avoid mutation of original object), apply group caption to it.
             # This will lead to the group being shown with this caption.
-
-            # Only copying of first item should be enough, but the behaviour of Defaults is such
-            # that a bot with a default parse mode will automatically set `parse_mode` for
-            # each item to default parse mode of the bot.
-            # This will throw ValueError at subsequent calls with same media items.
-            media = [copy.copy(item) for item in media]
-
-            item_to_get_caption = media[0]
+            item_to_get_caption = copy.copy(media[0])
             item_to_get_caption.caption = caption
             if parse_mode is not DEFAULT_NONE:
                 item_to_get_caption.parse_mode = parse_mode
             item_to_get_caption.caption_entities = caption_entities
+
+            # copy the list (just the references) to avoid mutating the original list
+            media = media[:]
+            media[0] = item_to_get_caption
 
         data: JSONDict = {
             "chat_id": chat_id,

--- a/telegram/_chat.py
+++ b/telegram/_chat.py
@@ -1130,7 +1130,7 @@ class Chat(TelegramObject):
         pool_timeout: ODVInput[float] = DEFAULT_NONE,
         api_kwargs: JSONDict = None,
         caption: Optional[str] = None,
-        parse_mode: Optional[str] = None,
+        parse_mode: ODVInput[str] = DEFAULT_NONE,
         caption_entities: Union[List["MessageEntity"], Tuple["MessageEntity", ...]] = None,
     ) -> List["Message"]:
         """Shortcut for::

--- a/telegram/_chat.py
+++ b/telegram/_chat.py
@@ -1129,9 +1129,9 @@ class Chat(TelegramObject):
         connect_timeout: ODVInput[float] = DEFAULT_NONE,
         pool_timeout: ODVInput[float] = DEFAULT_NONE,
         api_kwargs: JSONDict = None,
-        group_caption: Optional[str] = None,
-        group_caption_parse_mode: Optional[str] = None,
-        group_caption_entities: Union[List["MessageEntity"], Tuple["MessageEntity", ...]] = None,
+        caption: Optional[str] = None,
+        parse_mode: Optional[str] = None,
+        caption_entities: Union[List["MessageEntity"], Tuple["MessageEntity", ...]] = None,
     ) -> List["Message"]:
         """Shortcut for::
 
@@ -1155,9 +1155,9 @@ class Chat(TelegramObject):
             api_kwargs=api_kwargs,
             allow_sending_without_reply=allow_sending_without_reply,
             protect_content=protect_content,
-            group_caption=group_caption,
-            group_caption_parse_mode=group_caption_parse_mode,
-            group_caption_entities=group_caption_entities,
+            caption=caption,
+            parse_mode=parse_mode,
+            caption_entities=caption_entities,
         )
 
     async def send_chat_action(

--- a/telegram/_chat.py
+++ b/telegram/_chat.py
@@ -1129,6 +1129,9 @@ class Chat(TelegramObject):
         connect_timeout: ODVInput[float] = DEFAULT_NONE,
         pool_timeout: ODVInput[float] = DEFAULT_NONE,
         api_kwargs: JSONDict = None,
+        group_caption: Optional[str] = None,
+        group_caption_parse_mode: Optional[str] = None,
+        group_caption_entities: Union[List["MessageEntity"], Tuple["MessageEntity", ...]] = None,
     ) -> List["Message"]:
         """Shortcut for::
 
@@ -1152,6 +1155,9 @@ class Chat(TelegramObject):
             api_kwargs=api_kwargs,
             allow_sending_without_reply=allow_sending_without_reply,
             protect_content=protect_content,
+            group_caption=group_caption,
+            group_caption_parse_mode=group_caption_parse_mode,
+            group_caption_entities=group_caption_entities,
         )
 
     async def send_chat_action(

--- a/telegram/_message.py
+++ b/telegram/_message.py
@@ -1011,7 +1011,7 @@ class Message(TelegramObject):
         pool_timeout: ODVInput[float] = DEFAULT_NONE,
         api_kwargs: JSONDict = None,
         caption: Optional[str] = None,
-        parse_mode: Optional[str] = None,
+        parse_mode: ODVInput[str] = DEFAULT_NONE,
         caption_entities: Union[List["MessageEntity"], Tuple["MessageEntity", ...]] = None,
     ) -> List["Message"]:
         """Shortcut for::

--- a/telegram/_message.py
+++ b/telegram/_message.py
@@ -1010,6 +1010,9 @@ class Message(TelegramObject):
         connect_timeout: ODVInput[float] = DEFAULT_NONE,
         pool_timeout: ODVInput[float] = DEFAULT_NONE,
         api_kwargs: JSONDict = None,
+        group_caption: Optional[str] = None,
+        group_caption_parse_mode: Optional[str] = None,
+        group_caption_entities: Union[List["MessageEntity"], Tuple["MessageEntity", ...]] = None,
     ) -> List["Message"]:
         """Shortcut for::
 
@@ -1042,6 +1045,9 @@ class Message(TelegramObject):
             api_kwargs=api_kwargs,
             allow_sending_without_reply=allow_sending_without_reply,
             protect_content=protect_content,
+            group_caption=group_caption,
+            group_caption_parse_mode=group_caption_parse_mode,
+            group_caption_entities=group_caption_entities,
         )
 
     async def reply_photo(

--- a/telegram/_message.py
+++ b/telegram/_message.py
@@ -1010,9 +1010,9 @@ class Message(TelegramObject):
         connect_timeout: ODVInput[float] = DEFAULT_NONE,
         pool_timeout: ODVInput[float] = DEFAULT_NONE,
         api_kwargs: JSONDict = None,
-        group_caption: Optional[str] = None,
-        group_caption_parse_mode: Optional[str] = None,
-        group_caption_entities: Union[List["MessageEntity"], Tuple["MessageEntity", ...]] = None,
+        caption: Optional[str] = None,
+        parse_mode: Optional[str] = None,
+        caption_entities: Union[List["MessageEntity"], Tuple["MessageEntity", ...]] = None,
     ) -> List["Message"]:
         """Shortcut for::
 
@@ -1045,9 +1045,9 @@ class Message(TelegramObject):
             api_kwargs=api_kwargs,
             allow_sending_without_reply=allow_sending_without_reply,
             protect_content=protect_content,
-            group_caption=group_caption,
-            group_caption_parse_mode=group_caption_parse_mode,
-            group_caption_entities=group_caption_entities,
+            caption=caption,
+            parse_mode=parse_mode,
+            caption_entities=caption_entities,
         )
 
     async def reply_photo(

--- a/telegram/_user.py
+++ b/telegram/_user.py
@@ -474,9 +474,9 @@ class User(TelegramObject):
         connect_timeout: ODVInput[float] = DEFAULT_NONE,
         pool_timeout: ODVInput[float] = DEFAULT_NONE,
         api_kwargs: JSONDict = None,
-        group_caption: Optional[str] = None,
-        group_caption_parse_mode: Optional[str] = None,
-        group_caption_entities: Union[List["MessageEntity"], Tuple["MessageEntity", ...]] = None,
+        caption: Optional[str] = None,
+        parse_mode: Optional[str] = None,
+        caption_entities: Union[List["MessageEntity"], Tuple["MessageEntity", ...]] = None,
     ) -> List["Message"]:
         """Shortcut for::
 
@@ -500,9 +500,9 @@ class User(TelegramObject):
             api_kwargs=api_kwargs,
             allow_sending_without_reply=allow_sending_without_reply,
             protect_content=protect_content,
-            group_caption=group_caption,
-            group_caption_parse_mode=group_caption_parse_mode,
-            group_caption_entities=group_caption_entities,
+            caption=caption,
+            parse_mode=parse_mode,
+            caption_entities=caption_entities,
         )
 
     async def send_audio(

--- a/telegram/_user.py
+++ b/telegram/_user.py
@@ -474,6 +474,9 @@ class User(TelegramObject):
         connect_timeout: ODVInput[float] = DEFAULT_NONE,
         pool_timeout: ODVInput[float] = DEFAULT_NONE,
         api_kwargs: JSONDict = None,
+        group_caption: Optional[str] = None,
+        group_caption_parse_mode: Optional[str] = None,
+        group_caption_entities: Union[List["MessageEntity"], Tuple["MessageEntity", ...]] = None,
     ) -> List["Message"]:
         """Shortcut for::
 
@@ -497,6 +500,9 @@ class User(TelegramObject):
             api_kwargs=api_kwargs,
             allow_sending_without_reply=allow_sending_without_reply,
             protect_content=protect_content,
+            group_caption=group_caption,
+            group_caption_parse_mode=group_caption_parse_mode,
+            group_caption_entities=group_caption_entities,
         )
 
     async def send_audio(

--- a/telegram/_user.py
+++ b/telegram/_user.py
@@ -475,7 +475,7 @@ class User(TelegramObject):
         pool_timeout: ODVInput[float] = DEFAULT_NONE,
         api_kwargs: JSONDict = None,
         caption: Optional[str] = None,
-        parse_mode: Optional[str] = None,
+        parse_mode: ODVInput[str] = DEFAULT_NONE,
         caption_entities: Union[List["MessageEntity"], Tuple["MessageEntity", ...]] = None,
     ) -> List["Message"]:
         """Shortcut for::

--- a/telegram/ext/_extbot.py
+++ b/telegram/ext/_extbot.py
@@ -2242,9 +2242,9 @@ class ExtBot(Bot, Generic[RLARGS]):
         pool_timeout: ODVInput[float] = DEFAULT_NONE,
         api_kwargs: JSONDict = None,
         rate_limit_args: RLARGS = None,
-        group_caption: Optional[str] = None,
-        group_caption_parse_mode: Optional[str] = None,
-        group_caption_entities: Union[List["MessageEntity"], Tuple["MessageEntity", ...]] = None,
+        caption: Optional[str] = None,
+        parse_mode: Optional[str] = None,
+        caption_entities: Union[List["MessageEntity"], Tuple["MessageEntity", ...]] = None,
     ) -> List[Message]:
         return await super().send_media_group(
             chat_id=chat_id,
@@ -2258,9 +2258,9 @@ class ExtBot(Bot, Generic[RLARGS]):
             connect_timeout=connect_timeout,
             pool_timeout=pool_timeout,
             api_kwargs=self._merge_api_rl_kwargs(api_kwargs, rate_limit_args),
-            group_caption=group_caption,
-            group_caption_parse_mode=group_caption_parse_mode,
-            group_caption_entities=group_caption_entities,
+            caption=caption,
+            parse_mode=parse_mode,
+            caption_entities=caption_entities,
         )
 
     async def send_message(

--- a/telegram/ext/_extbot.py
+++ b/telegram/ext/_extbot.py
@@ -2242,7 +2242,21 @@ class ExtBot(Bot, Generic[RLARGS]):
         pool_timeout: ODVInput[float] = DEFAULT_NONE,
         api_kwargs: JSONDict = None,
         rate_limit_args: RLARGS = None,
+        group_caption: Optional[str] = None,
+        group_caption_parse_mode: Optional[str] = None,
+        group_caption_entities: Union[List["MessageEntity"], Tuple["MessageEntity", ...]] = None,
     ) -> List[Message]:
+        """Shortcut for::
+
+             await bot.send_media_group(update.effective_chat.id, *args, **kwargs)
+
+        For the documentation of the arguments, please see :meth:`telegram.Bot.send_media_group`.
+
+        Returns:
+            List[:class:`telegram.Message`]: On success, instance representing the message posted.
+
+        """
+
         return await super().send_media_group(
             chat_id=chat_id,
             media=media,
@@ -2255,6 +2269,9 @@ class ExtBot(Bot, Generic[RLARGS]):
             connect_timeout=connect_timeout,
             pool_timeout=pool_timeout,
             api_kwargs=self._merge_api_rl_kwargs(api_kwargs, rate_limit_args),
+            group_caption=group_caption,
+            group_caption_parse_mode=group_caption_parse_mode,
+            group_caption_entities=group_caption_entities,
         )
 
     async def send_message(

--- a/telegram/ext/_extbot.py
+++ b/telegram/ext/_extbot.py
@@ -2243,7 +2243,7 @@ class ExtBot(Bot, Generic[RLARGS]):
         api_kwargs: JSONDict = None,
         rate_limit_args: RLARGS = None,
         caption: Optional[str] = None,
-        parse_mode: Optional[str] = None,
+        parse_mode: ODVInput[str] = DEFAULT_NONE,
         caption_entities: Union[List["MessageEntity"], Tuple["MessageEntity", ...]] = None,
     ) -> List[Message]:
         return await super().send_media_group(

--- a/telegram/ext/_extbot.py
+++ b/telegram/ext/_extbot.py
@@ -2246,16 +2246,6 @@ class ExtBot(Bot, Generic[RLARGS]):
         group_caption_parse_mode: Optional[str] = None,
         group_caption_entities: Union[List["MessageEntity"], Tuple["MessageEntity", ...]] = None,
     ) -> List[Message]:
-        """Shortcut for::
-
-             await bot.send_media_group(update.effective_chat.id, *args, **kwargs)
-
-        For the documentation of the arguments, please see :meth:`telegram.Bot.send_media_group`.
-
-        Returns:
-            List[:class:`telegram.Message`]: On success, instance representing the message posted.
-
-        """
         return await super().send_media_group(
             chat_id=chat_id,
             media=media,

--- a/telegram/ext/_extbot.py
+++ b/telegram/ext/_extbot.py
@@ -2256,7 +2256,6 @@ class ExtBot(Bot, Generic[RLARGS]):
             List[:class:`telegram.Message`]: On success, instance representing the message posted.
 
         """
-
         return await super().send_media_group(
             chat_id=chat_id,
             media=media,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -699,6 +699,10 @@ async def check_defaults_handling(
         if isinstance(value.default, DefaultValue) and not kwarg.endswith("_timeout")
     ]
 
+    if method.__name__.endswith("_media_group"):
+        # the parse_mode is applied to the first media item, and we test this elsewhere
+        kwargs_need_default.remove("parse_mode")
+
     defaults_no_custom_defaults = Defaults()
     kwargs = {kwarg: "custom_default" for kwarg in inspect.signature(Defaults).parameters.keys()}
     kwargs["tzinfo"] = pytz.timezone("America/New_York")
@@ -712,7 +716,7 @@ async def check_defaults_handling(
         data = request_data.parameters
 
         # Check regular arguments that need defaults
-        for arg in (dkw for dkw in kwargs_need_default if dkw not in ("timeout", "parse_mode")):
+        for arg in kwargs_need_default:
             # 'None' should not be passed along to Telegram
             if df_value in [None, DEFAULT_NONE]:
                 if arg in data:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -712,7 +712,7 @@ async def check_defaults_handling(
         data = request_data.parameters
 
         # Check regular arguments that need defaults
-        for arg in (dkw for dkw in kwargs_need_default if dkw != "timeout"):
+        for arg in (dkw for dkw in kwargs_need_default if dkw not in ("timeout", "parse_mode")):
             # 'None' should not be passed along to Telegram
             if df_value in [None, DEFAULT_NONE]:
                 if arg in data:

--- a/tests/test_inputmedia.py
+++ b/tests/test_inputmedia.py
@@ -470,6 +470,9 @@ class TestSendMediaGroup:
         parse_mode,
         caption_entities,
     ):
+        # prepare a copy to check later on if calling the method has caused side effects
+        copied_media_group = media_group.copy()
+
         # clear media_group of all_captions
         for item in media_group:
             item.caption = None
@@ -483,6 +486,13 @@ class TestSendMediaGroup:
             parse_mode=parse_mode,
             caption_entities=caption_entities,
         )
+
+        # Check that the method had no side effects:
+        # original group was not changed and 1st item still points to the same object
+        # (1st item must be copied within the method before adding the caption)
+        assert media_group == copied_media_group
+        assert media_group[0] is copied_media_group[0]
+
         assert isinstance(messages, list)
         assert len(messages) == 3
         assert all(isinstance(mes, Message) for mes in messages)

--- a/tests/test_inputmedia.py
+++ b/tests/test_inputmedia.py
@@ -449,10 +449,10 @@ class TestSendMediaGroup:
         with pytest.raises(
             ValueError, match="You can only supply either group caption or media with captions."
         ):
-            await bot.send_media_group(chat_id, media_group, group_caption="foo")
+            await bot.send_media_group(chat_id, media_group, caption="foo")
 
     @pytest.mark.parametrize(
-        "group_caption, group_caption_parse_mode, group_caption_entities",
+        "caption, parse_mode, caption_entities",
         [
             # same combinations of caption options as in media_group fixture
             ("*photo* 1", "Markdown", None),
@@ -466,9 +466,9 @@ class TestSendMediaGroup:
         bot,
         chat_id,
         media_group,
-        group_caption,
-        group_caption_parse_mode,
-        group_caption_entities,
+        caption,
+        parse_mode,
+        caption_entities,
     ):
         # clear media_group of all_captions
         for item in media_group:
@@ -479,9 +479,9 @@ class TestSendMediaGroup:
         messages = await bot.send_media_group(
             chat_id,
             media_group,
-            group_caption=group_caption,
-            group_caption_parse_mode=group_caption_parse_mode,
-            group_caption_entities=group_caption_entities,
+            caption=caption,
+            parse_mode=parse_mode,
+            caption_entities=caption_entities,
         )
         assert isinstance(messages, list)
         assert len(messages) == 3

--- a/tests/test_inputmedia.py
+++ b/tests/test_inputmedia.py
@@ -497,14 +497,16 @@ class TestSendMediaGroup:
         parse_mode,
         caption_entities,
     ):
+        from telegram._utils.defaultvalue import DEFAULT_NONE
+
         # prepare a copy to check later on if calling the method has caused side effects
         copied_media_group = media_group.copy()
 
         # clear media_group of all_captions
         for item in media_group:
             item.caption = None
-            item.parse_mode = None
             item.caption_entities = None
+            item.parse_mode = DEFAULT_NONE  # parse_mode must not be explicitly set to anything
 
         messages = await bot.send_media_group(
             chat_id,

--- a/tests/test_inputmedia.py
+++ b/tests/test_inputmedia.py
@@ -431,6 +431,11 @@ def media_group(photo, thumb):  # noqa: F811
 
 
 @pytest.fixture(scope="function")  # noqa: F811
+def media_group_no_caption_args(photo, thumb):  # noqa: F811
+    return [InputMediaPhoto(photo), InputMediaPhoto(thumb), InputMediaPhoto(photo)]
+
+
+@pytest.fixture(scope="function")  # noqa: F811
 def media_group_no_caption_only_caption_entities(photo, thumb):  # noqa: F811
     return [
         InputMediaPhoto(photo, caption_entities=[MessageEntity(MessageEntity.BOLD, 0, 5)]),
@@ -492,25 +497,17 @@ class TestSendMediaGroup:
         self,
         bot,
         chat_id,
-        media_group,
+        media_group_no_caption_args,
         caption,
         parse_mode,
         caption_entities,
     ):
-        from telegram._utils.defaultvalue import DEFAULT_NONE
-
         # prepare a copy to check later on if calling the method has caused side effects
-        copied_media_group = media_group.copy()
-
-        # clear media_group of all_captions
-        for item in media_group:
-            item.caption = None
-            item.caption_entities = None
-            item.parse_mode = DEFAULT_NONE  # parse_mode must not be explicitly set to anything
+        copied_media_group = media_group_no_caption_args.copy()
 
         messages = await bot.send_media_group(
             chat_id,
-            media_group,
+            media_group_no_caption_args,
             caption=caption,
             parse_mode=parse_mode,
             caption_entities=caption_entities,
@@ -519,8 +516,8 @@ class TestSendMediaGroup:
         # Check that the method had no side effects:
         # original group was not changed and 1st item still points to the same object
         # (1st item must be copied within the method before adding the caption)
-        assert media_group == copied_media_group
-        assert media_group[0] is copied_media_group[0]
+        assert media_group_no_caption_args == copied_media_group
+        assert media_group_no_caption_args[0] is copied_media_group[0]
 
         assert isinstance(messages, list)
         assert len(messages) == 3

--- a/tests/test_inputmedia.py
+++ b/tests/test_inputmedia.py
@@ -676,6 +676,51 @@ class TestSendMediaGroup:
         assert not all(msg.has_protected_content for msg in unprotected)
 
     @flaky(3, 1)
+    @pytest.mark.parametrize("default_bot", [{"parse_mode": ParseMode.HTML}], indirect=True)
+    async def test_send_media_group_default_parse_mode(
+        self, chat_id, media_group_no_caption_args, default_bot
+    ):
+        messages = await default_bot.send_media_group(
+            chat_id, media_group_no_caption_args, caption="*photo* 1"
+        )
+
+        first_message, other_messages = messages[0], messages[1:]
+        assert all(mes.media_group_id == first_message.media_group_id for mes in messages)
+
+        # Make sure first message got the caption, which will lead
+        # to Telegram displaying its caption as group caption
+        assert first_message.caption == "photo 1"
+        assert first_message.caption_entities == [MessageEntity(MessageEntity.BOLD, 0, 5)]
+
+        # Check that other messages have no captions
+        assert all(mes.caption is None for mes in other_messages)
+        assert not any(mes.caption_entities for mes in other_messages)
+
+    @flaky(3, 1)
+    @pytest.mark.parametrize("default_bot", [{"parse_mode": ParseMode.HTML}], indirect=True)
+    async def test_send_media_group_default_parse_mode_overridden(
+        self, chat_id, media_group_no_caption_args, default_bot
+    ):
+        messages = await default_bot.send_media_group(
+            chat_id,
+            media_group_no_caption_args,
+            caption="*photo* 1",
+            parse_mode=ParseMode.MARKDOWN_V2,
+        )
+
+        first_message, other_messages = messages[0], messages[1:]
+        assert all(mes.media_group_id == first_message.media_group_id for mes in messages)
+
+        # Make sure first message got the caption, which will lead
+        # to Telegram displaying its caption as group caption
+        assert first_message.caption == "photo 1"
+        assert first_message.caption_entities == [MessageEntity(MessageEntity.BOLD, 0, 5)]
+
+        # Check that other messages have no captions
+        assert all(mes.caption is None for mes in other_messages)
+        assert not any(mes.caption_entities for mes in other_messages)
+
+    @flaky(3, 1)
     async def test_edit_message_media(self, bot, chat_id, media_group):
         messages = await bot.send_media_group(chat_id, media_group)
         cid = messages[-1].chat.id

--- a/tests/test_inputmedia.py
+++ b/tests/test_inputmedia.py
@@ -681,7 +681,7 @@ class TestSendMediaGroup:
         self, chat_id, media_group_no_caption_args, default_bot
     ):
         messages = await default_bot.send_media_group(
-            chat_id, media_group_no_caption_args, caption="*photo* 1"
+            chat_id, media_group_no_caption_args, caption="<b>photo</b> 1"
         )
 
         first_message, other_messages = messages[0], messages[1:]

--- a/tests/test_inputmedia.py
+++ b/tests/test_inputmedia.py
@@ -430,6 +430,22 @@ def media_group(photo, thumb):  # noqa: F811
     ]
 
 
+@pytest.fixture(scope="function")  # noqa: F811
+def media_group_no_caption_only_caption_entities(photo, thumb):  # noqa: F811
+    return [
+        InputMediaPhoto(photo, caption_entities=[MessageEntity(MessageEntity.BOLD, 0, 5)]),
+        InputMediaPhoto(photo, caption_entities=[MessageEntity(MessageEntity.BOLD, 0, 5)]),
+    ]
+
+
+@pytest.fixture(scope="function")  # noqa: F811
+def media_group_no_caption_only_parse_mode(photo, thumb):  # noqa: F811
+    return [
+        InputMediaPhoto(photo, parse_mode="Markdown"),
+        InputMediaPhoto(thumb, parse_mode="HTML"),
+    ]
+
+
 class TestSendMediaGroup:
     @flaky(3, 1)
     async def test_send_media_group_photo(self, bot, chat_id, media_group):
@@ -444,12 +460,23 @@ class TestSendMediaGroup:
         )
 
     async def test_send_media_group_throws_error_with_group_caption_and_individual_captions(
-        self, bot, chat_id, media_group
+        self,
+        bot,
+        chat_id,
+        media_group,
+        media_group_no_caption_only_caption_entities,
+        media_group_no_caption_only_parse_mode,
     ):
-        with pytest.raises(
-            ValueError, match="You can only supply either group caption or media with captions."
+        for group in (
+            media_group,
+            media_group_no_caption_only_caption_entities,
+            media_group_no_caption_only_parse_mode,
         ):
-            await bot.send_media_group(chat_id, media_group, caption="foo")
+            with pytest.raises(
+                ValueError,
+                match="You can only supply either group caption or media with captions.",
+            ):
+                await bot.send_media_group(chat_id, group, caption="foo")
 
     @pytest.mark.parametrize(
         "caption, parse_mode, caption_entities",

--- a/tests/test_inputmedia.py
+++ b/tests/test_inputmedia.py
@@ -471,7 +471,6 @@ class TestSendMediaGroup:
         group_caption_entities,
     ):
         # clear media_group of all_captions
-
         for item in media_group:
             item.caption = None
             item.parse_mode = None
@@ -487,13 +486,20 @@ class TestSendMediaGroup:
         assert isinstance(messages, list)
         assert len(messages) == 3
         assert all(isinstance(mes, Message) for mes in messages)
-        assert all(mes.media_group_id == messages[0].media_group_id for mes in messages)
+
+        first_message, other_messages = messages[0], messages[1:]
+        assert all(mes.media_group_id == first_message.media_group_id for mes in messages)
 
         # Make sure first message got the caption, which will lead
         # to Telegram displaying its caption as group caption
-        first_message = messages[0]
         assert first_message.caption
         assert first_message.caption_entities == [MessageEntity(MessageEntity.BOLD, 0, 5)]
+
+        # Check that other messages have no captions
+        assert all(mes.caption is None for mes in other_messages)
+        assert not any(mes.caption_entities for mes in other_messages)
+        # .parse_mode must be completely absent
+        assert not any(getattr(mes, "parse_mode", None) for mes in other_messages)
 
     @flaky(3, 1)
     async def test_send_media_group_all_args(self, bot, chat_id, media_group):

--- a/tests/test_inputmedia.py
+++ b/tests/test_inputmedia.py
@@ -447,7 +447,7 @@ class TestSendMediaGroup:
         self, bot, chat_id, media_group
     ):
         with pytest.raises(
-            ValueError, match="You can only supply either group caption or images with captions."
+            ValueError, match="You can only supply either group caption or media with captions."
         ):
             await bot.send_media_group(chat_id, media_group, group_caption="foo")
 

--- a/tests/test_inputmedia.py
+++ b/tests/test_inputmedia.py
@@ -443,7 +443,6 @@ class TestSendMediaGroup:
             mes.caption_entities == [MessageEntity(MessageEntity.BOLD, 0, 5)] for mes in messages
         )
 
-    @flaky(3, 1)
     async def test_send_media_group_throws_error_with_group_caption_and_individual_captions(
         self, bot, chat_id, media_group
     ):

--- a/tests/test_inputmedia.py
+++ b/tests/test_inputmedia.py
@@ -498,8 +498,6 @@ class TestSendMediaGroup:
         # Check that other messages have no captions
         assert all(mes.caption is None for mes in other_messages)
         assert not any(mes.caption_entities for mes in other_messages)
-        # .parse_mode must be completely absent
-        assert not any(getattr(mes, "parse_mode", None) for mes in other_messages)
 
     @flaky(3, 1)
     async def test_send_media_group_all_args(self, bot, chat_id, media_group):

--- a/tests/test_official.py
+++ b/tests/test_official.py
@@ -120,7 +120,7 @@ def check_method(h4):
         ignored |= {"current_offset"}  # Added for ease of use
     elif name == "sendMediaGroup":
         # Added for ease of use
-        ignored |= {"group_caption", "group_caption_parse_mode", "group_caption_entities"}
+        ignored |= {"caption", "parse_mode", "caption_entities"}
 
     assert (sig.parameters.keys() ^ checked) - ignored == set()
 

--- a/tests/test_official.py
+++ b/tests/test_official.py
@@ -118,6 +118,9 @@ def check_method(h4):
         ignored |= {"venue"}  # Added for ease of use
     elif name == "answerInlineQuery":
         ignored |= {"current_offset"}  # Added for ease of use
+    elif name == "sendMediaGroup":
+        # Added for ease of use
+        ignored |= {"group_caption", "group_caption_parse_mode", "group_caption_entities"}
 
     assert (sig.parameters.keys() ^ checked) - ignored == set()
 


### PR DESCRIPTION
closes #3185

Adds 3 keyword-only arguments to pass caption to entire media group.

All tests pass (locally) including `test_official.py`.

All pre-commit hooks passed except for `pylint` that found errors in code that I hadn't changed (cyclic import in `telegram/ext/_chatjoinrequesthandler.py`).

I'm not sure if I have to: 
- [ ] Add`.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes) (_I changed doctrings themselves, just not sure about these `version...` notes_)
- [ ] Add more tests, e.g. for shortcuts (`Chat`, `User`, `Message`)