### PR TITLE
Add 2 new constants related to local Bot API server

### DIFF
--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -340,7 +340,8 @@ class FileSizeLimit(IntEnum):
        API server.
     """
     FILESIZE_DOWNLOAD_LOCAL = sys.maxsize
-    """obj:`int`: Bots can download files without a size limit when using a local bot API server"""
+    """:obj:`int`: Bots can download files without a size limit when using a local bot API server.
+    """
     PHOTOSIZE_UPLOAD = int(10e6)  # (10MB)
     """:obj:`int`: Bots can upload photo files of up to 10MB in size."""
 

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -335,11 +335,11 @@ class FileSizeLimit(IntEnum):
     """:obj:`int`: Bots can download files of up to 20MB in size."""
     FILESIZE_UPLOAD = int(50e6)  # (50MB)
     """:obj:`int`: Bots can upload non-photo files of up to 50MB in size."""
-    FILESIZE_UPLOAD_LOCAL = int(2e9)  # (2000MB)
+    FILESIZE_UPLOAD_LOCAL_MODE = int(2e9)  # (2000MB)
     """:obj:`int`: Bots can upload non-photo files of up to 2000MB in size when using a local bot
        API server.
     """
-    FILESIZE_DOWNLOAD_LOCAL = sys.maxsize
+    FILESIZE_DOWNLOAD_LOCAL_MODE = sys.maxsize
     """:obj:`int`: Bots can download files without a size limit when using a local bot API server.
     """
     PHOTOSIZE_UPLOAD = int(10e6)  # (10MB)

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -66,6 +66,7 @@ __all__ = [
     "UpdateType",
 ]
 
+import sys
 from typing import List, NamedTuple
 
 from telegram._utils.enum import IntEnum, StringEnum
@@ -334,6 +335,12 @@ class FileSizeLimit(IntEnum):
     """:obj:`int`: Bots can download files of up to 20MB in size."""
     FILESIZE_UPLOAD = int(50e6)  # (50MB)
     """:obj:`int`: Bots can upload non-photo files of up to 50MB in size."""
+    FILESIZE_UPLOAD_LOCAL = int(2e9)  # (2000MB)
+    """:obj:`int`: Bots can upload non-photo files of up to 2000MB in size when using a local bot
+       API server.
+    """
+    FILESIZE_DOWNLOAD_LOCAL = sys.maxsize
+    """obj:`int`: Bots can download files without a size limit when using a local bot API server"""
     PHOTOSIZE_UPLOAD = int(10e6)  # (10MB)
     """:obj:`int`: Bots can upload photo files of up to 10MB in size."""
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -49,6 +49,7 @@ class TestConstants:
                 not key.startswith("_")
                 # exclude imported stuff
                 and getattr(member, "__module__", "telegram.constants") == "telegram.constants"
+                and key != "sys"
             )
         }
         actual = set(constants.__all__)


### PR DESCRIPTION
Adds 2 new constants to `FileSizeLimit` if you're running in local mode.

Didn't go with `math.inf` for `FILESIZE_DOWNLOAD_LOCAL` since that's a float which can't be converted to `int.` So went with `sys.maxsize`

### Checklist for PRs

- [x] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [x] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- [ ] Added new classes & modules to the docs and all suitable `__all__` s

