### PR TITLE
unify args and attributes docstrings in Chat class.

### DIFF
--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -8205,7 +8205,7 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
             api_kwargs=api_kwargs,
         )
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:  # skipcq: PYL-W0613
         """See :meth:`telegram.TelegramObject.to_dict`."""
         data: JSONDict = {"id": self.id, "username": self.username, "first_name": self.first_name}
 

--- a/telegram/_chat.py
+++ b/telegram/_chat.py
@@ -145,21 +145,28 @@ class Chat(TelegramObject):
 
             .. versionadded:: 20.0
     Attributes:
-        id (:obj:`int`): Unique identifier for this chat.
-        type (:obj:`str`): Type of chat.
+        id (:obj:`int`): Unique identifier for this chat. This number may be greater than 32 bits
+            and some programming languages may have difficulty/silent defects in interpreting it.
+            But it is smaller than 52 bits, so a signed 64-bit integer or double-precision float
+            type are safe for storing this identifier.
+        type (:obj:`str`): Type of chat, can be either :attr:`PRIVATE`, :attr:`GROUP`,
+            :attr:`SUPERGROUP` or :attr:`CHANNEL`.
         title (:obj:`str`): Optional. Title, for supergroups, channels and group chats.
-        username (:obj:`str`): Optional. Username.
+        username (:obj:`str`): Optional. Username, for private chats, supergroups and channels if
+            available.
         first_name (:obj:`str`): Optional. First name of the other party in a private chat.
         last_name (:obj:`str`): Optional. Last name of the other party in a private chat.
-        photo (:class:`telegram.ChatPhoto`): Optional. Chat photo.
+        photo (:class:`telegram.ChatPhoto`): Optional. Chat photo. 
+            Returned only in :meth:`telegram.Bot.get_chat`.
         bio (:obj:`str`): Optional. Bio of the other party in a private chat. Returned only in
             :meth:`telegram.Bot.get_chat`.
         has_private_forwards (:obj:`bool`): Optional. :obj:`True`, if privacy settings of the other
             party in the private chat allows to use ``tg://user?id=<user_id>`` links only in chats
-            with the user.
+            with the user. Returned only in :meth:`telegram.Bot.get_chat`.
 
             .. versionadded:: 13.9
         description (:obj:`str`): Optional. Description, for groups, supergroups and channel chats.
+            Returned only in :meth:`telegram.Bot.get_chat`.
         invite_link (:obj:`str`): Optional. Primary invite link, for groups, supergroups and
             channel. Returned only in :meth:`telegram.Bot.get_chat`.
         pinned_message (:class:`telegram.Message`): Optional. The most recent pinned message
@@ -175,12 +182,13 @@ class Chat(TelegramObject):
 
             .. versionadded:: 13.4
         has_protected_content (:obj:`bool`): Optional. :obj:`True`, if messages from the chat can't
-            be forwarded to other chats.
+            be forwarded to other chats. Returned only in :meth:`telegram.Bot.get_chat`.
 
             .. versionadded:: 13.9
-        sticker_set_name (:obj:`str`): Optional. For supergroups, name of Group sticker set.
+        sticker_set_name (:obj:`str`): Optional. For supergroups, name of Group sticker set. 
+            Returned only in :meth:`telegram.Bot.get_chat`.
         can_set_sticker_set (:obj:`bool`): Optional. :obj:`True`, if the bot can change group the
-            sticker set.
+            sticker set. Returned only in :meth:`telegram.Bot.get_chat`.
         linked_chat_id (:obj:`int`): Optional. Unique identifier for the linked chat, i.e. the
             discussion group identifier for a channel and vice versa; for supergroups and channel
             chats. Returned only in :meth:`telegram.Bot.get_chat`.

--- a/telegram/_chatinvitelink.py
+++ b/telegram/_chatinvitelink.py
@@ -151,9 +151,9 @@ class ChatInviteLink(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         data["expire_date"] = to_timestamp(self.expire_date)
 

--- a/telegram/_chatjoinrequest.py
+++ b/telegram/_chatjoinrequest.py
@@ -103,9 +103,9 @@ class ChatJoinRequest(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         data["date"] = to_timestamp(self.date)
 

--- a/telegram/_chatmember.py
+++ b/telegram/_chatmember.py
@@ -123,9 +123,9 @@ class ChatMember(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         if data.get("until_date", False):
             data["until_date"] = to_timestamp(data["until_date"])

--- a/telegram/_chatmemberupdated.py
+++ b/telegram/_chatmemberupdated.py
@@ -122,9 +122,9 @@ class ChatMemberUpdated(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         # Required
         data["date"] = to_timestamp(self.date)

--- a/telegram/_files/inputmedia.py
+++ b/telegram/_files/inputmedia.py
@@ -90,9 +90,9 @@ class InputMedia(TelegramObject):
         self.caption_entities = caption_entities
         self.parse_mode = parse_mode
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         if self.caption_entities:
             data["caption_entities"] = [ce.to_dict() for ce in self.caption_entities]

--- a/telegram/_files/sticker.py
+++ b/telegram/_files/sticker.py
@@ -282,9 +282,9 @@ class StickerSet(TelegramObject):
 
         return super()._de_json(data=data, bot=bot, api_kwargs=api_kwargs)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         data["stickers"] = [s.to_dict() for s in data.get("stickers")]  # type: ignore[union-attr]
 

--- a/telegram/_games/game.py
+++ b/telegram/_games/game.py
@@ -117,9 +117,9 @@ class Game(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         data["photo"] = [p.to_dict() for p in self.photo]
         if self.text_entities:

--- a/telegram/_inline/inlinekeyboardmarkup.py
+++ b/telegram/_inline/inlinekeyboardmarkup.py
@@ -68,9 +68,9 @@ class InlineKeyboardMarkup(TelegramObject):
 
         self._id_attrs = (self.inline_keyboard,)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         data["inline_keyboard"] = []
         for inline_keyboard in self.inline_keyboard:

--- a/telegram/_inline/inlinequeryresult.py
+++ b/telegram/_inline/inlinequeryresult.py
@@ -54,9 +54,9 @@ class InlineQueryResult(TelegramObject):
 
         self._id_attrs = (self.id,)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         # pylint: disable=no-member
         if (

--- a/telegram/_inline/inputinvoicemessagecontent.py
+++ b/telegram/_inline/inputinvoicemessagecontent.py
@@ -228,9 +228,9 @@ class InputInvoiceMessageContent(InputMessageContent):
             )
         )
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         data["prices"] = [price.to_dict() for price in self.prices]
 

--- a/telegram/_inline/inputtextmessagecontent.py
+++ b/telegram/_inline/inputtextmessagecontent.py
@@ -84,9 +84,9 @@ class InputTextMessageContent(InputMessageContent):
 
         self._id_attrs = (self.message_text,)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         if self.entities:
             data["entities"] = [ce.to_dict() for ce in self.entities]

--- a/telegram/_menubutton.py
+++ b/telegram/_menubutton.py
@@ -161,9 +161,9 @@ class MenuButtonWebApp(MenuButton):
 
         return super().de_json(data=data, bot=bot)  # type: ignore[return-value]
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
         data["web_app"] = self.web_app.to_dict()
         return data
 

--- a/telegram/_message.py
+++ b/telegram/_message.py
@@ -660,10 +660,11 @@ class Message(TelegramObject):
     def effective_attachment(
         self,
     ) -> Union[
+        Animation,
+        Audio,
         Contact,
         Dice,
         Document,
-        Animation,
         Game,
         Invoice,
         Location,

--- a/telegram/_message.py
+++ b/telegram/_message.py
@@ -719,9 +719,9 @@ class Message(TelegramObject):
 
         return self._effective_attachment  # type: ignore[return-value]
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         # Required
         data["date"] = to_timestamp(self.date)

--- a/telegram/_passport/credentials.py
+++ b/telegram/_passport/credentials.py
@@ -404,9 +404,9 @@ class SecureValue(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         data["files"] = [p.to_dict() for p in self.files]  # type: ignore[union-attr]
         data["translation"] = [p.to_dict() for p in self.translation]  # type: ignore[union-attr]
@@ -450,9 +450,9 @@ class DataCredentials(_CredentialsBase):
     def __init__(self, data_hash: str, secret: str, *, api_kwargs: JSONDict = None):
         super().__init__(hash=data_hash, secret=secret, api_kwargs=api_kwargs)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         del data["file_hash"]
         del data["hash"]
@@ -479,9 +479,9 @@ class FileCredentials(_CredentialsBase):
     def __init__(self, file_hash: str, secret: str, *, api_kwargs: JSONDict = None):
         super().__init__(hash=file_hash, secret=secret, api_kwargs=api_kwargs)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         del data["data_hash"]
         del data["hash"]

--- a/telegram/_passport/encryptedpassportelement.py
+++ b/telegram/_passport/encryptedpassportelement.py
@@ -245,9 +245,9 @@ class EncryptedPassportElement(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         if self.files:
             data["files"] = [p.to_dict() for p in self.files]

--- a/telegram/_passport/passportdata.py
+++ b/telegram/_passport/passportdata.py
@@ -81,9 +81,9 @@ class PassportData(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         data["data"] = [e.to_dict() for e in self.data]
 

--- a/telegram/_payment/shippingoption.py
+++ b/telegram/_payment/shippingoption.py
@@ -65,9 +65,9 @@ class ShippingOption(TelegramObject):
 
         self._id_attrs = (self.id,)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         data["prices"] = [p.to_dict() for p in self.prices]
 

--- a/telegram/_poll.py
+++ b/telegram/_poll.py
@@ -228,9 +228,9 @@ class Poll(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         data["options"] = [x.to_dict() for x in self.options]
         if self.explanation_entities:

--- a/telegram/_replykeyboardmarkup.py
+++ b/telegram/_replykeyboardmarkup.py
@@ -119,9 +119,9 @@ class ReplyKeyboardMarkup(TelegramObject):
 
         self._id_attrs = (self.keyboard,)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         data["keyboard"] = []
         for row in self.keyboard:

--- a/telegram/_telegramobject.py
+++ b/telegram/_telegramobject.py
@@ -20,6 +20,7 @@
 import inspect
 import json
 from copy import deepcopy
+from itertools import chain
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Type, TypeVar, Union
 
 from telegram._utils.types import JSONDict
@@ -160,8 +161,8 @@ class TelegramObject:
 
         Args:
             include_private (:obj:`bool`): Whether the result should include private variables.
-            recursive (:obj:`bool`): If :obj:`True`, will convert any TelegramObjects (if found) in
-                the attributes to a dictionary. Else, preserves it as an object itself.
+            recursive (:obj:`bool`): If :obj:`True`, will convert any ``TelegramObjects`` (if
+                found) in the attributes to a dictionary. Else, preserves it as an object itself.
             remove_bot (:obj:`bool`): Whether the bot should be included in the result.
 
         Returns:
@@ -169,28 +170,23 @@ class TelegramObject:
         """
         data = {}
 
-        if not recursive:
-            try:
-                # __dict__ has attrs from superclasses, so no need to put in the for loop below
-                data.update(self.__dict__)
-            except AttributeError:
-                pass
         # We want to get all attributes for the class, using self.__slots__ only includes the
         # attributes used by that class itself, and not its superclass(es). Hence, we get its MRO
         # and then get their attributes. The `[:-1]` slice excludes the `object` class
-        for cls in self.__class__.__mro__[:-1]:
-            for key in cls.__slots__:  # type: ignore[attr-defined]
-                if not include_private and key.startswith("_"):
-                    continue
+        all_slots = (s for c in self.__class__.__mro__[:-1] for s in c.__slots__)  # type: ignore
+        # chain the class's slots with the user defined subclass __dict__ (class has no slots)
+        for key in chain(self.__dict__, all_slots) if hasattr(self, "__dict__") else all_slots:
+            if not include_private and key.startswith("_"):
+                continue
 
-                value = getattr(self, key, None)
-                if value is not None:
-                    if recursive and hasattr(value, "to_dict"):
-                        data[key] = value.to_dict()  # pylint: disable=no-member
-                    else:
-                        data[key] = value
-                elif not recursive:
+            value = getattr(self, key, None)
+            if value is not None:
+                if recursive and hasattr(value, "to_dict"):
+                    data[key] = value.to_dict(recursive=True)  # pylint: disable=no-member
+                else:
                     data[key] = value
+            elif not recursive:
+                data[key] = value
 
         if recursive and data.get("from_user"):
             data["from"] = data.pop("from_user", None)
@@ -279,16 +275,23 @@ class TelegramObject:
         """
         return json.dumps(self.to_dict())
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """Gives representation of object as :obj:`dict`.
 
         .. versionchanged:: 20.0
             Now includes all entries of :attr:`api_kwargs`.
 
+        Args:
+            recursive (:obj:`bool`, optional): If :obj:`True`, will convert any TelegramObjects
+                (if found) in the attributes to a dictionary. Else, preserves it as an object
+                itself. Defaults to :obj:`True`.
+
+                .. versionadded:: 20.0
+
         Returns:
             :obj:`dict`
         """
-        out = self._get_attrs(recursive=True)
+        out = self._get_attrs(recursive=recursive)
         out.update(out.pop("api_kwargs", {}))  # type: ignore[call-overload]
         return out
 

--- a/telegram/_userprofilephotos.py
+++ b/telegram/_userprofilephotos.py
@@ -69,9 +69,9 @@ class UserProfilePhotos(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         data["photos"] = []
         for photo in self.photos:

--- a/telegram/_videochat.py
+++ b/telegram/_videochat.py
@@ -121,9 +121,9 @@ class VideoChatParticipantsInvited(TelegramObject):
         data["users"] = User.de_list(data.get("users", []), bot)
         return super().de_json(data=data, bot=bot)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         if self.users is not None:
             data["users"] = [u.to_dict() for u in self.users]
@@ -176,9 +176,9 @@ class VideoChatScheduled(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    def to_dict(self) -> JSONDict:
+    def to_dict(self, recursive: bool = True) -> JSONDict:
         """See :meth:`telegram.TelegramObject.to_dict`."""
-        data = super().to_dict()
+        data = super().to_dict(recursive=recursive)
 
         # Required
         data["start_date"] = to_timestamp(self.start_date)

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -66,6 +66,7 @@ __all__ = [
     "UpdateType",
 ]
 
+import sys
 from typing import List, NamedTuple
 
 from telegram._utils.enum import IntEnum, StringEnum
@@ -334,6 +335,13 @@ class FileSizeLimit(IntEnum):
     """:obj:`int`: Bots can download files of up to 20MB in size."""
     FILESIZE_UPLOAD = int(50e6)  # (50MB)
     """:obj:`int`: Bots can upload non-photo files of up to 50MB in size."""
+    FILESIZE_UPLOAD_LOCAL_MODE = int(2e9)  # (2000MB)
+    """:obj:`int`: Bots can upload non-photo files of up to 2000MB in size when using a local bot
+       API server.
+    """
+    FILESIZE_DOWNLOAD_LOCAL_MODE = sys.maxsize
+    """:obj:`int`: Bots can download files without a size limit when using a local bot API server.
+    """
     PHOTOSIZE_UPLOAD = int(10e6)  # (10MB)
     """:obj:`int`: Bots can upload photo files of up to 10MB in size."""
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -49,6 +49,7 @@ class TestConstants:
                 not key.startswith("_")
                 # exclude imported stuff
                 and getattr(member, "__module__", "telegram.constants") == "telegram.constants"
+                and key != "sys"
             )
         }
         actual = set(constants.__all__)

--- a/tests/test_telegramobject.py
+++ b/tests/test_telegramobject.py
@@ -138,6 +138,30 @@ class TestTelegramObject:
         to = TelegramObject(api_kwargs={"foo": "bar"})
         assert to.to_dict() == {"foo": "bar"}
 
+    def test_to_dict_recursion(self):
+        class Recursive(TelegramObject):
+            __slots__ = ("recursive",)
+
+            def __init__(self):
+                super().__init__()
+                self.recursive = "recursive"
+
+        class SubClass(TelegramObject):
+            """This class doesn't have `__slots__`, so has `__dict__` instead."""
+
+            def __init__(self):
+                super().__init__()
+                self.subclass = Recursive()
+
+        to = SubClass()
+        to_dict_no_recurse = to.to_dict(recursive=False)
+        assert to_dict_no_recurse
+        assert isinstance(to_dict_no_recurse["subclass"], Recursive)
+        to_dict_recurse = to.to_dict(recursive=True)
+        assert to_dict_recurse
+        assert isinstance(to_dict_recurse["subclass"], dict)
+        assert to_dict_recurse["subclass"]["recursive"] == "recursive"
+
     def test_slot_behaviour(self, mro_slots):
         inst = TelegramObject()
         for attr in inst.__slots__:


### PR DESCRIPTION
Refer to https://github.com/python-telegram-bot/python-telegram-bot/issues/3109, Chat class arguments docstrings and attributes docstrings are unified.

### Checklist for PRs

- [ ] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [ ] Created new or adapted existing unit tests
- [ ] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)
- [ ] Added new classes & modules to the docs and all suitable `__all__` s