### PR TITLE
update: added deep link maximum character constant

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -28,6 +28,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Avanatiker <https://github.com/Avanatiker>`_
 - `Balduro <https://github.com/Balduro>`_
 - `Bibo-Joshi <https://github.com/Bibo-Joshi>`_
+- `Biruk Alamirew <https://github.com/BAcode-X>`_
 - `bimmlerd <https://github.com/bimmlerd>`_
 - `cyc8 <https://github.com/cyc8>`_ 
 - `d-qoi <https://github.com/d-qoi>`_

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -654,6 +654,8 @@ class MessageLimit(IntEnum):
     """:obj:`int`: Maximum number of characters for a text message."""
     CAPTION_LENGTH = 1024
     """:obj:`int`: Maximum number of characters for a message caption."""
+    DEEP_LINK_LENGTH = 64
+    """:obj:`int`: Maximum number of characters for a deep link."""
     # constants above this line are tested
     MESSAGE_ENTITIES = 100
     """:obj:`int`: Maximum number of entities that can be displayed in a message. Further entities

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -654,9 +654,9 @@ class MessageLimit(IntEnum):
     """:obj:`int`: Maximum number of characters for a text message."""
     CAPTION_LENGTH = 1024
     """:obj:`int`: Maximum number of characters for a message caption."""
+    # constants above this line are tested
     DEEP_LINK_LENGTH = 64
     """:obj:`int`: Maximum number of characters for a deep link."""
-    # constants above this line are tested
     MESSAGE_ENTITIES = 100
     """:obj:`int`: Maximum number of entities that can be displayed in a message. Further entities
     will simply be ignored by Telegram.


### PR DESCRIPTION
Based on [Telegram API doc](https://core.telegram.org/bots/features#deep-linking), the parameter can only be up to 64 characters long.

### Checklist
    - [ ] Added new constants at `telegram.constants`