### PR TITLE
Feat: Docstring changes + moving limit to constants

### DIFF
--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -775,6 +775,7 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         limitations:
 
         - A message can only be deleted if it was sent less than 48 hours ago.
+        - Service messages about a supergroup, channel, or forum topic creation can't be deleted.
         - A dice message in a private chat can only be deleted if it was sent more than 24
           hours ago.
         - Bots can delete outgoing messages in private chats, groups, and supergroups.
@@ -6171,7 +6172,9 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         Args:
             chat_id (:obj:`int` | :obj:`str`): Unique identifier for the target chat or username
                 of the target channel (in the format ``@channelusername``).
-            title (:obj:`str`): New chat title, 1-255 characters.
+            title (:obj:`str`): New chat title,
+                tg-const:`telegram.constants.ChatLimits.MIN_TITLE_LENGTH`-
+                tg-const:`telegram.constants.ChatLimits.MAX_TITLE_LENGTH` characters.
 
         Keyword Args:
             read_timeout (:obj:`float` | :obj:`None`, optional): Value to pass to

--- a/telegram/_chat.py
+++ b/telegram/_chat.py
@@ -266,7 +266,7 @@ class Chat(TelegramObject):
         "has_restricted_voice_and_video_messages",
         "is_forum",
         "active_usernames",
-        "emoji_status_custom_emoji_id"
+        "emoji_status_custom_emoji_id",
     )
 
     SENDER: ClassVar[str] = constants.ChatType.SENDER

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -39,6 +39,7 @@ __all__ = [
     "ChatAction",
     "ChatID",
     "ChatInviteLinkLimit",
+    "ChatLimit",
     "ChatMemberStatus",
     "ChatType",
     "CustomEmojiStickerLimit",
@@ -903,7 +904,7 @@ class WebhookLimit(IntEnum):
     """:obj:`int`: Maximum length of the secret token."""
 
 
-class ChatLimits(IntEnum):
+class ChatLimit(IntEnum):
     """This enum contains limitations for :paramref:`telegram.Bot.set_chat_title.title`. The
     enum members of this enumeration are instances of :class:`int` and can be treated as such.
 

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -909,6 +909,7 @@ class ChatLimits(IntEnum):
 
     .. versionadded:: 20.0
     """
+
     __slots__ = ()
 
     MIN_TITLE_LENGTH = 1

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -901,3 +901,17 @@ class WebhookLimit(IntEnum):
     """:obj:`int`: Minimum length of the secret token."""
     MAX_SECRET_TOKEN_LENGTH = 256
     """:obj:`int`: Maximum length of the secret token."""
+
+
+class ChatLimits(IntEnum):
+    """This enum contains limitations for :paramref:`telegram.Bot.set_chat_title.title`. The
+    enum members of this enumeration are instances of :class:`int` and can be treated as such.
+
+    .. versionadded:: 20.0
+    """
+    __slots__ = ()
+
+    MIN_TITLE_LENGTH = 1
+    """:obj:`int`: Minimum length of a new chat title."""
+    MAX_TITLE_LENGTH = 128
+    """:obj:`int`: Maximum length of a new chat title."""

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -106,7 +106,7 @@ class TestChat:
             ),
             "is_forum": self.is_forum,
             "active_usernames": self.active_usernames,
-            "emoji_status_custom_emoji_id": self.emoji_status_custom_emoji_id
+            "emoji_status_custom_emoji_id": self.emoji_status_custom_emoji_id,
         }
         chat = Chat.de_json(json_dict, bot)
 


### PR DESCRIPTION
This adds the two docstring changes, I took the opportunity to move the changed limit to constants. At least description can be added to the limit (e.g. in #3336), maybe even more, so I kept the Class name broad.
