### PR TITLE
Replace `@flaky` with pytest marker

### DIFF
--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -20,7 +20,6 @@ import os
 from pathlib import Path
 
 import pytest
-from flaky import flaky
 
 from telegram import Animation, Bot, InputFile, MessageEntity, PhotoSize, Voice
 from telegram.error import BadRequest, TelegramError
@@ -81,7 +80,7 @@ class TestAnimation:
         assert animation.file_name.startswith("game.gif") == self.file_name.startswith("game.gif")
         assert isinstance(animation.thumb, PhotoSize)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_all_args(self, bot, chat_id, animation_file, animation, thumb_file):
         message = await bot.send_animation(
             chat_id,
@@ -108,7 +107,7 @@ class TestAnimation:
         assert message.animation.thumb.height == self.height
         assert message.has_protected_content
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_animation_custom_filename(self, bot, chat_id, animation_file, monkeypatch):
         async def make_assertion(url, request_data: RequestData, *args, **kwargs):
             return list(request_data.multipart_data.values())[0][0] == "custom_filename"
@@ -118,7 +117,7 @@ class TestAnimation:
         assert await bot.send_animation(chat_id, animation_file, filename="custom_filename")
         monkeypatch.delattr(bot.request, "post")
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_get_and_download(self, bot, animation):
         path = Path("game.gif")
         if path.is_file():
@@ -133,7 +132,7 @@ class TestAnimation:
 
         assert new_filepath.is_file()
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_animation_url_file(self, bot, chat_id, animation):
         message = await bot.send_animation(
             chat_id=chat_id, animation=self.animation_file_url, caption=self.caption
@@ -153,7 +152,7 @@ class TestAnimation:
         ) == animation.file_name.startswith("game.gif")
         assert message.animation.mime_type == animation.mime_type
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_animation_caption_entities(self, bot, chat_id, animation):
         test_string = "Italic Bold Code"
         entities = [
@@ -168,7 +167,7 @@ class TestAnimation:
         assert message.caption == test_string
         assert message.caption_entities == entities
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"parse_mode": "Markdown"}], indirect=True)
     async def test_send_animation_default_parse_mode_1(self, default_bot, chat_id, animation_file):
         test_string = "Italic Bold Code"
@@ -180,7 +179,7 @@ class TestAnimation:
         assert message.caption_markdown == test_markdown_string
         assert message.caption == test_string
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"parse_mode": "Markdown"}], indirect=True)
     async def test_send_animation_default_parse_mode_2(self, default_bot, chat_id, animation_file):
         test_markdown_string = "_Italic_ *Bold* `Code`"
@@ -191,7 +190,7 @@ class TestAnimation:
         assert message.caption == test_markdown_string
         assert message.caption_markdown == escape_markdown(test_markdown_string)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"parse_mode": "Markdown"}], indirect=True)
     async def test_send_animation_default_parse_mode_3(self, default_bot, chat_id, animation_file):
         test_markdown_string = "_Italic_ *Bold* `Code`"
@@ -227,7 +226,7 @@ class TestAnimation:
         finally:
             bot._local_mode = False
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize(
         "default_bot,custom",
         [
@@ -261,7 +260,7 @@ class TestAnimation:
                     chat_id, animation, reply_to_message_id=reply_to_message.message_id
                 )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"protect_content": True}], indirect=True)
     async def test_send_animation_default_protect_content(self, default_bot, chat_id, animation):
         animation_protected = await default_bot.send_animation(chat_id, animation)
@@ -271,7 +270,7 @@ class TestAnimation:
         )
         assert not ani_unprotected.has_protected_content
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_resend(self, bot, chat_id, animation):
         message = await bot.send_animation(chat_id, animation.file_id)
 
@@ -319,14 +318,14 @@ class TestAnimation:
         assert animation_dict["mime_type"] == animation.mime_type
         assert animation_dict["file_size"] == animation.file_size
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_error_send_empty_file(self, bot, chat_id):
         animation_file = open(os.devnull, "rb")
 
         with pytest.raises(TelegramError):
             await bot.send_animation(chat_id=chat_id, animation=animation_file)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_error_send_empty_file_id(self, bot, chat_id):
         with pytest.raises(TelegramError):
             await bot.send_animation(chat_id=chat_id, animation="")

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -20,7 +20,6 @@ import os
 from pathlib import Path
 
 import pytest
-from flaky import flaky
 
 from telegram import Audio, Bot, InputFile, MessageEntity, Voice
 from telegram.error import TelegramError
@@ -89,7 +88,7 @@ class TestAudio:
         assert audio.thumb.width == self.thumb_width
         assert audio.thumb.height == self.thumb_height
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_all_args(self, bot, chat_id, audio_file, thumb_file):
         message = await bot.send_audio(
             chat_id,
@@ -122,7 +121,7 @@ class TestAudio:
         assert message.audio.thumb.height == self.thumb_height
         assert message.has_protected_content
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_audio_custom_filename(self, bot, chat_id, audio_file, monkeypatch):
         async def make_assertion(url, request_data: RequestData, *args, **kwargs):
             return list(request_data.multipart_data.values())[0][0] == "custom_filename"
@@ -131,7 +130,7 @@ class TestAudio:
 
         assert await bot.send_audio(chat_id, audio_file, filename="custom_filename")
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_get_and_download(self, bot, audio):
         path = Path("telegram.mp3")
         if path.is_file():
@@ -148,7 +147,7 @@ class TestAudio:
 
         assert path.is_file()
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_mp3_url_file(self, bot, chat_id, audio):
         message = await bot.send_audio(
             chat_id=chat_id, audio=self.audio_file_url, caption=self.caption
@@ -165,7 +164,7 @@ class TestAudio:
         assert message.audio.mime_type == audio.mime_type
         assert message.audio.file_size == audio.file_size
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_resend(self, bot, chat_id, audio):
         message = await bot.send_audio(chat_id=chat_id, audio=audio.file_id)
 
@@ -179,7 +178,7 @@ class TestAudio:
         message = await bot.send_audio(audio=audio, chat_id=chat_id)
         assert message
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_audio_caption_entities(self, bot, chat_id, audio):
         test_string = "Italic Bold Code"
         entities = [
@@ -194,7 +193,7 @@ class TestAudio:
         assert message.caption == test_string
         assert message.caption_entities == entities
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"parse_mode": "Markdown"}], indirect=True)
     async def test_send_audio_default_parse_mode_1(self, default_bot, chat_id, audio_file):
         test_string = "Italic Bold Code"
@@ -204,7 +203,7 @@ class TestAudio:
         assert message.caption_markdown == test_markdown_string
         assert message.caption == test_string
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"parse_mode": "Markdown"}], indirect=True)
     async def test_send_audio_default_parse_mode_2(self, default_bot, chat_id, audio_file):
         test_markdown_string = "_Italic_ *Bold* `Code`"
@@ -215,7 +214,7 @@ class TestAudio:
         assert message.caption == test_markdown_string
         assert message.caption_markdown == escape_markdown(test_markdown_string)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"parse_mode": "Markdown"}], indirect=True)
     async def test_send_audio_default_parse_mode_3(self, default_bot, chat_id, audio_file):
         test_markdown_string = "_Italic_ *Bold* `Code`"
@@ -226,7 +225,7 @@ class TestAudio:
         assert message.caption == test_markdown_string
         assert message.caption_markdown == escape_markdown(test_markdown_string)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"protect_content": True}], indirect=True)
     async def test_send_audio_default_protect_content(self, default_bot, chat_id, audio):
         protected_audio = await default_bot.send_audio(chat_id, audio)
@@ -295,14 +294,14 @@ class TestAudio:
         assert audio_dict["file_size"] == audio.file_size
         assert audio_dict["file_name"] == audio.file_name
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_error_send_empty_file(self, bot, chat_id):
         audio_file = open(os.devnull, "rb")
 
         with pytest.raises(TelegramError):
             await bot.send_audio(chat_id=chat_id, audio=audio_file)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_error_send_empty_file_id(self, bot, chat_id):
         with pytest.raises(TelegramError):
             await bot.send_audio(chat_id=chat_id, audio="")

--- a/tests/test_basepersistence.py
+++ b/tests/test_basepersistence.py
@@ -27,7 +27,6 @@ from pathlib import Path
 from typing import NamedTuple
 
 import pytest
-from flaky import flaky
 
 from telegram import Bot, Chat, InlineKeyboardButton, InlineKeyboardMarkup, Update, User
 from telegram.ext import (
@@ -573,7 +572,7 @@ class TestBasePersistence:
         with pytest.raises(ValueError, match="when handler is unnamed"):
             papp.add_handler(build_conversation_handler(name=None, persistent=True))
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize(
         "papp",
         [

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -28,7 +28,6 @@ import time
 from collections import defaultdict
 
 import pytest
-from flaky import flaky
 
 from telegram import (
     Bot,
@@ -353,7 +352,7 @@ class TestBot:
             123, "text", api_kwargs={"unknown_kwarg_1": 7, "unknown_kwarg_2": 5}
         )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_get_me_and_properties(self, bot: Bot):
         get_me_bot = await bot.get_me()
 
@@ -406,7 +405,7 @@ class TestBot:
             assert a != d
             assert hash(a) != hash(d)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_to_dict(self, bot):
         to_dict_bot = bot.to_dict()
 
@@ -552,7 +551,7 @@ class TestBot:
                     param.kind == ext_signature.parameters[param_name].kind
                 ), f"Wrong parameter kind for parameter {param_name} of method {name}"
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_forward_message(self, bot, chat_id, message):
         forward_message = await bot.forward_message(
             chat_id, from_chat_id=chat_id, message_id=message.message_id
@@ -582,14 +581,14 @@ class TestBot:
         with pytest.raises(BadRequest, match="can't be forwarded"):
             await forwarded_but_now_protected.forward(chat_id)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_delete_message(self, bot, chat_id):
         message = await bot.send_message(chat_id, text="will be deleted")
         await asyncio.sleep(2)
 
         assert await bot.delete_message(chat_id=chat_id, message_id=message.message_id) is True
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_delete_message_old_message(self, bot, chat_id):
         with pytest.raises(BadRequest):
             # Considering that the first message is old enough
@@ -599,7 +598,7 @@ class TestBot:
     # send_media_group and send_animation are tested in their respective test modules. No need to
     # duplicate here.
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_venue(self, bot, chat_id):
         longitude = -46.788279
         latitude = -23.691288
@@ -654,7 +653,7 @@ class TestBot:
         assert message.venue.foursquare_type is None
         assert message.has_protected_content
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_contact(self, bot, chat_id):
         phone_number = "+11234567890"
         first_name = "Leandro"
@@ -675,7 +674,7 @@ class TestBot:
 
     # TODO: Add bot to group to test polls too
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize(
         "reply_markup",
         [
@@ -751,7 +750,7 @@ class TestBot:
         assert message_quiz.poll.explanation == "Here is a link"
         assert message_quiz.poll.explanation_entities == explanation_entities
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize(
         ["open_period", "close_date"], [(5, None), (None, True)], ids=["open_period", "close_date"]
     )
@@ -785,7 +784,7 @@ class TestBot:
         assert new_message.poll.id == message.poll.id
         assert new_message.poll.is_closed
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_close_date_default_tz(self, tz_bot, super_group_id):
         question = "Is this a test?"
         answers = ["Yes", "No", "Maybe"]
@@ -818,7 +817,7 @@ class TestBot:
         assert new_message.poll.id == msg.poll.id
         assert new_message.poll.is_closed
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_poll_explanation_entities(self, bot, chat_id):
         test_string = "Italic Bold Code"
         entities = [
@@ -839,7 +838,7 @@ class TestBot:
         assert message.poll.explanation == test_string
         assert message.poll.explanation_entities == entities
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"parse_mode": "Markdown"}], indirect=True)
     async def test_send_poll_default_parse_mode(self, default_bot, super_group_id):
         explanation = "Italic Bold Code"
@@ -889,7 +888,7 @@ class TestBot:
         assert message.poll.explanation == explanation_markdown
         assert message.poll.explanation_entities == []
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize(
         "default_bot,custom",
         [
@@ -932,7 +931,7 @@ class TestBot:
                     reply_to_message_id=reply_to_message.message_id,
                 )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"protect_content": True}], indirect=True)
     async def test_send_poll_default_protect_content(self, chat_id, default_bot):
         protected_poll = await default_bot.send_poll(chat_id, "Test", ["1", "2"])
@@ -942,7 +941,7 @@ class TestBot:
         )
         assert not unprotect_poll.has_protected_content
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("emoji", Dice.ALL_EMOJI + [None])
     async def test_send_dice(self, bot, chat_id, emoji):
         message = await bot.send_dice(chat_id, emoji=emoji, protect_content=True)
@@ -954,7 +953,7 @@ class TestBot:
         else:
             assert message.dice.emoji == emoji
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize(
         "default_bot,custom",
         [
@@ -988,7 +987,7 @@ class TestBot:
                     chat_id, reply_to_message_id=reply_to_message.message_id
                 )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"protect_content": True}], indirect=True)
     async def test_send_dice_default_protect_content(self, chat_id, default_bot):
         protected_dice = await default_bot.send_dice(chat_id)
@@ -996,7 +995,7 @@ class TestBot:
         unprotected_dice = await default_bot.send_dice(chat_id, protect_content=False)
         assert not unprotected_dice.has_protected_content
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("chat_action", list(ChatAction))
     async def test_send_chat_action(self, bot, chat_id, chat_action):
         assert await bot.send_chat_action(chat_id, chat_action)
@@ -1377,13 +1376,13 @@ class TestBot:
             1234, results=inline_results_callback, current_offset=6
         )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_get_user_profile_photos(self, bot, chat_id):
         user_profile_photos = await bot.get_user_profile_photos(chat_id)
 
         assert user_profile_photos.photos[0][0].file_size == 5403
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_get_one_user_profile_photo(self, bot, chat_id):
         user_profile_photos = await bot.get_user_profile_photos(chat_id, offset=0, limit=1)
         assert user_profile_photos.photos[0][0].file_size == 5403
@@ -1520,7 +1519,7 @@ class TestBot:
             23, text="answer", show_alert=True, url="no_url", cache_time=1
         )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_edit_message_text(self, bot, message):
         message = await bot.edit_message_text(
             text="new_text",
@@ -1532,7 +1531,7 @@ class TestBot:
 
         assert message.text == "new_text"
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_edit_message_text_entities(self, bot, message):
         test_string = "Italic Bold Code"
         entities = [
@@ -1550,7 +1549,7 @@ class TestBot:
         assert message.text == test_string
         assert message.entities == entities
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"parse_mode": "Markdown"}], indirect=True)
     async def test_edit_message_text_default_parse_mode(self, default_bot, message):
         test_string = "Italic Bold Code"
@@ -1595,7 +1594,7 @@ class TestBot:
     async def test_edit_message_text_inline(self):
         pass
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_edit_message_caption(self, bot, media_message):
         message = await bot.edit_message_caption(
             caption="new_caption",
@@ -1605,7 +1604,7 @@ class TestBot:
 
         assert message.caption == "new_caption"
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_edit_message_caption_entities(self, bot, media_message):
         test_string = "Italic Bold Code"
         entities = [
@@ -1625,7 +1624,7 @@ class TestBot:
 
     # edit_message_media is tested in test_inputmedia
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"parse_mode": "Markdown"}], indirect=True)
     async def test_edit_message_caption_default_parse_mode(self, default_bot, media_message):
         test_string = "Italic Bold Code"
@@ -1662,7 +1661,7 @@ class TestBot:
         assert message.caption == test_markdown_string
         assert message.caption_markdown == escape_markdown(test_markdown_string)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_edit_message_caption_with_parse_mode(self, bot, media_message):
         message = await bot.edit_message_caption(
             caption="new *caption*",
@@ -1677,7 +1676,7 @@ class TestBot:
     async def test_edit_message_caption_inline(self):
         pass
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_edit_reply_markup(self, bot, message):
         new_markup = InlineKeyboardMarkup([[InlineKeyboardButton(text="test", callback_data="1")]])
         message = await bot.edit_message_reply_markup(
@@ -1691,7 +1690,7 @@ class TestBot:
         pass
 
     # TODO: Actually send updates to the test bot so this can be tested properly
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_get_updates(self, bot):
         await bot.delete_webhook()  # make sure there is no webhook set if webhook tests failed
         updates = await bot.get_updates(timeout=1)
@@ -1737,7 +1736,7 @@ class TestBot:
             bot.callback_data_cache.clear_callback_data()
             bot.callback_data_cache.clear_callback_queries()
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("use_ip", [True, False])
     # local file path as file_input is tested below in test_set_webhook_params
     @pytest.mark.parametrize("file_input", ["bytes", "file_handle"])
@@ -1834,7 +1833,7 @@ class TestBot:
             "SoSecretToken",
         )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_leave_chat(self, bot):
         with pytest.raises(BadRequest, match="Chat not found"):
             await bot.leave_chat(-123456)
@@ -1842,7 +1841,7 @@ class TestBot:
         with pytest.raises(NetworkError, match="Chat not found"):
             await bot.leave_chat(-123456)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_get_chat(self, bot, super_group_id):
         chat = await bot.get_chat(super_group_id)
 
@@ -1850,7 +1849,7 @@ class TestBot:
         assert chat.title == f">>> telegram.Bot(test) @{bot.username}"
         assert chat.id == int(super_group_id)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_get_chat_administrators(self, bot, channel_id):
         admins = await bot.get_chat_administrators(channel_id)
         assert isinstance(admins, list)
@@ -1858,13 +1857,13 @@ class TestBot:
         for a in admins:
             assert a.status in ("administrator", "creator")
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_get_chat_member_count(self, bot, channel_id):
         count = await bot.get_chat_member_count(channel_id)
         assert isinstance(count, int)
         assert count > 3
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_get_chat_member(self, bot, channel_id, chat_id):
         chat_member = await bot.get_chat_member(channel_id, chat_id)
 
@@ -1880,7 +1879,7 @@ class TestBot:
     async def test_delete_chat_sticker_set(self):
         pass
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_game(self, bot, chat_id):
         game_short_name = "test_game"
         message = await bot.send_game(chat_id, game_short_name, protect_content=True)
@@ -1895,7 +1894,7 @@ class TestBot:
         assert message.game.photo[0].file_size in [851, 4928, 850]
         assert message.has_protected_content
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize(
         "default_bot,custom",
         [
@@ -1932,7 +1931,7 @@ class TestBot:
                     chat_id, game_short_name, reply_to_message_id=reply_to_message.message_id
                 )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize(
         "default_bot,val",
         [({"protect_content": True}, True), ({"protect_content": False}, None)],
@@ -2084,7 +2083,7 @@ class TestBot:
         monkeypatch.setattr(bot.request, "post", make_assertion)
         assert await bot.answer_pre_checkout_query(1, False, error_message="Not enough fish")
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_restrict_chat_member(self, bot, channel_id, chat_permissions):
         # TODO: Add bot to supergroup so this can be tested properly
         with pytest.raises(BadRequest, match="Method is available only for supergroups"):
@@ -2111,7 +2110,7 @@ class TestBot:
             channel_id, 95205500, chat_permissions, until_date=until_timestamp
         )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_promote_chat_member(self, bot, channel_id, monkeypatch):
         # TODO: Add bot to supergroup so this can be tested properly / give bot perms
         with pytest.raises(BadRequest, match="Not enough rights"):
@@ -2167,14 +2166,14 @@ class TestBot:
             can_manage_video_chats=11,
         )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_export_chat_invite_link(self, bot, channel_id):
         # Each link is unique apparently
         invite_link = await bot.export_chat_invite_link(channel_id)
         assert isinstance(invite_link, str)
         assert invite_link != ""
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_edit_revoke_chat_invite_link_passing_link_objects(self, bot, channel_id):
         invite_link = await bot.create_chat_invite_link(chat_id=channel_id)
         assert invite_link.name is None
@@ -2192,7 +2191,7 @@ class TestBot:
         assert revoked_link.is_revoked is True
         assert revoked_link.name == "some_name"
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("creates_join_request", [True, False])
     @pytest.mark.parametrize("name", [None, "name"])
     async def test_create_chat_invite_link_basics(
@@ -2215,7 +2214,7 @@ class TestBot:
         )
         assert revoked_link.is_revoked
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("datetime", argvalues=[True, False], ids=["datetime", "integer"])
     async def test_advanced_chat_invite_links(self, bot, channel_id, datetime):
         # we are testing this all in one function in order to save api calls
@@ -2270,7 +2269,7 @@ class TestBot:
         assert revoked_invite_link.invite_link == invite_link.invite_link
         assert revoked_invite_link.is_revoked
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_advanced_chat_invite_links_default_tzinfo(self, tz_bot, channel_id):
         # we are testing this all in one function in order to save api calls
         add_seconds = dtm.timedelta(0, 70)
@@ -2319,7 +2318,7 @@ class TestBot:
         assert revoked_invite_link.invite_link == invite_link.invite_link
         assert revoked_invite_link.is_revoked
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_approve_chat_join_request(self, bot, chat_id, channel_id):
         # TODO: Need incoming join request to properly test
         # Since we can't create join requests on the fly, we just tests the call to TG
@@ -2327,7 +2326,7 @@ class TestBot:
         with pytest.raises(BadRequest, match="User_already_participant"):
             await bot.approve_chat_join_request(chat_id=channel_id, user_id=chat_id)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_decline_chat_join_request(self, bot, chat_id, channel_id):
         # TODO: Need incoming join request to properly test
         # Since we can't create join requests on the fly, we just tests the call to TG
@@ -2338,7 +2337,7 @@ class TestBot:
         with pytest.raises(BadRequest, match="User_already_participant|Hide_requester_missing"):
             await bot.decline_chat_join_request(chat_id=channel_id, user_id=chat_id)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_set_chat_photo(self, bot, channel_id):
         async def func():
             assert await bot.set_chat_photo(channel_id, f)
@@ -2370,22 +2369,22 @@ class TestBot:
         finally:
             bot._local_mode = False
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_delete_chat_photo(self, bot, channel_id):
         async def func():
             assert await bot.delete_chat_photo(channel_id)
 
         await expect_bad_request(func, "Chat_not_modified", "Chat photo was not set.")
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_set_chat_title(self, bot, channel_id):
         assert await bot.set_chat_title(channel_id, ">>> telegram.Bot() - Tests")
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_set_chat_description(self, bot, channel_id):
         assert await bot.set_chat_description(channel_id, "Time: " + str(time.time()))
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_pin_and_unpin_message(self, bot, super_group_id):
         message1 = await bot.send_message(super_group_id, text="test_pin_message_1")
         message2 = await bot.send_message(super_group_id, text="test_pin_message_2")
@@ -2481,7 +2480,7 @@ class TestBot:
         with pytest.raises(OkException):
             await bot.send_photo(chat_id, data_file("telegram.jpg").open("rb"))
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_message_entities(self, bot, chat_id):
         test_string = "Italic Bold Code Spoiler"
         entities = [
@@ -2494,7 +2493,7 @@ class TestBot:
         assert message.text == test_string
         assert message.entities == entities
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"parse_mode": "Markdown"}], indirect=True)
     async def test_send_message_default_parse_mode(self, default_bot, chat_id):
         test_string = "Italic Bold Code"
@@ -2512,7 +2511,7 @@ class TestBot:
         assert message.text == test_markdown_string
         assert message.text_markdown == escape_markdown(test_markdown_string)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"protect_content": True}], indirect=True)
     async def test_send_message_default_protect_content(self, default_bot, chat_id):
         to_check = await default_bot.send_message(chat_id, "test")
@@ -2521,7 +2520,7 @@ class TestBot:
         no_protect = await default_bot.send_message(chat_id, "test", protect_content=False)
         assert not no_protect.has_protected_content
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize(
         "default_bot,custom",
         [
@@ -2601,7 +2600,7 @@ class TestBot:
         menu_button = await bot.get_chat_menu_button(chat_id=chat_id)
         assert isinstance(menu_button, MenuButtonDefault)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_set_and_get_my_commands(self, bot):
         commands = [BotCommand("cmd1", "descr1"), ["cmd2", "descr2"]]
         await bot.set_my_commands([])
@@ -2612,7 +2611,7 @@ class TestBot:
             assert bc.command == f"cmd{i+1}"
             assert bc.description == f"descr{i+1}"
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_get_set_delete_my_commands_with_scope(self, bot, super_group_id, chat_id):
         group_cmds = [BotCommand("group_cmd", "visible to this supergroup only")]
         private_cmds = [BotCommand("private_cmd", "visible to this private chat only")]
@@ -2665,7 +2664,7 @@ class TestBot:
 
         assert await bot.close()
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("json_keyboard", [True, False])
     @pytest.mark.parametrize("caption", ["<b>Test</b>", "", None])
     async def test_copy_message(
@@ -2711,7 +2710,7 @@ class TestBot:
             protect_content=True,
         )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_copy_message_without_reply(self, bot, chat_id, media_message):
         keyboard = InlineKeyboardMarkup(
             [[InlineKeyboardButton(text="test", callback_data="test2")]]
@@ -2737,7 +2736,7 @@ class TestBot:
         assert len(message.caption_entities) == 1
         assert message.reply_markup == keyboard
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize(
         "default_bot",
         [

--- a/tests/test_chatphoto.py
+++ b/tests/test_chatphoto.py
@@ -21,7 +21,6 @@ import os
 from pathlib import Path
 
 import pytest
-from flaky import flaky
 
 from telegram import Bot, ChatPhoto, Voice
 from telegram.error import TelegramError
@@ -64,7 +63,7 @@ class TestChatPhoto:
             assert getattr(chat_photo, attr, "err") != "err", f"got extra slot '{attr}'"
         assert len(mro_slots(chat_photo)) == len(set(mro_slots(chat_photo))), "duplicate slot"
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_all_args(
         self, bot, super_group_id, chatphoto_file, chat_photo, thumb_file
     ):
@@ -75,7 +74,7 @@ class TestChatPhoto:
             func, "Type of file mismatch", "Telegram did not accept the file."
         )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_get_and_download(self, bot, chat_photo):
         jpg_file = Path("telegram.jpg")
         if jpg_file.is_file():
@@ -130,14 +129,14 @@ class TestChatPhoto:
         assert chat_photo_dict["small_file_unique_id"] == chat_photo.small_file_unique_id
         assert chat_photo_dict["big_file_unique_id"] == chat_photo.big_file_unique_id
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_error_send_empty_file(self, bot, super_group_id):
         chatphoto_file = open(os.devnull, "rb")
 
         with pytest.raises(TelegramError):
             await bot.set_chat_photo(chat_id=super_group_id, photo=chatphoto_file)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_error_send_empty_file_id(self, bot, super_group_id):
         with pytest.raises(TelegramError):
             await bot.set_chat_photo(chat_id=super_group_id, photo="")

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -19,7 +19,6 @@
 import json
 
 import pytest
-from flaky import flaky
 
 from telegram import constants
 from telegram._utils.enum import IntEnum, StringEnum
@@ -111,7 +110,7 @@ class TestConstants:
 
         assert hash(IntEnumTest.FOO) == hash(1)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_max_message_length(self, bot, chat_id):
         await bot.send_message(chat_id=chat_id, text="a" * constants.MessageLimit.TEXT_LENGTH)
 
@@ -123,7 +122,7 @@ class TestConstants:
                 chat_id=chat_id, text="a" * (constants.MessageLimit.TEXT_LENGTH + 1)
             )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_max_caption_length(self, bot, chat_id):
         good_caption = "a" * constants.MessageLimit.CAPTION_LENGTH
         with data_file("telegram.png").open("rb") as f:

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -18,7 +18,6 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 
 import pytest
-from flaky import flaky
 
 from telegram import Contact, Voice
 from telegram.error import BadRequest
@@ -81,7 +80,7 @@ class TestContact:
         message = await bot.send_contact(contact=contact, chat_id=chat_id)
         assert message
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize(
         "default_bot,custom",
         [
@@ -115,7 +114,7 @@ class TestContact:
                     chat_id, contact=contact, reply_to_message_id=reply_to_message.message_id
                 )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"protect_content": True}], indirect=True)
     async def test_send_contact_default_protect_content(self, chat_id, default_bot, contact):
         protected = await default_bot.send_contact(chat_id, contact=contact)

--- a/tests/test_conversationhandler.py
+++ b/tests/test_conversationhandler.py
@@ -22,7 +22,6 @@ import logging
 from warnings import filterwarnings
 
 import pytest
-from flaky import flaky
 
 from telegram import (
     Bot,
@@ -1379,7 +1378,7 @@ class TestConversationHandler:
 
             await app.stop()
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_conversation_timeout_keeps_extending(self, app, bot, user1):
         handler = ConversationHandler(
             entry_points=self.entry_points,

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -20,7 +20,6 @@ import os
 from pathlib import Path
 
 import pytest
-from flaky import flaky
 
 from telegram import Bot, Document, InputFile, MessageEntity, PhotoSize, Voice
 from telegram.error import BadRequest, TelegramError
@@ -79,7 +78,7 @@ class TestDocument:
         assert document.thumb.width == self.thumb_width
         assert document.thumb.height == self.thumb_height
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_all_args(self, bot, chat_id, document_file, document, thumb_file):
         message = await bot.send_document(
             chat_id,
@@ -106,7 +105,7 @@ class TestDocument:
         assert message.document.thumb.height == self.thumb_height
         assert message.has_protected_content
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_get_and_download(self, bot, document):
         path = Path("telegram.png")
         if path.is_file():
@@ -123,7 +122,7 @@ class TestDocument:
 
         assert path.is_file()
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_url_gif_file(self, bot, chat_id):
         message = await bot.send_document(chat_id, self.document_file_url)
 
@@ -139,7 +138,7 @@ class TestDocument:
         assert document.mime_type == "image/gif"
         assert document.file_size == 3878
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_resend(self, bot, chat_id, document):
         message = await bot.send_document(chat_id=chat_id, document=document.file_id)
 
@@ -166,7 +165,7 @@ class TestDocument:
 
         assert message
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_document_caption_entities(self, bot, chat_id, document):
         test_string = "Italic Bold Code"
         entities = [
@@ -181,7 +180,7 @@ class TestDocument:
         assert message.caption == test_string
         assert message.caption_entities == entities
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"parse_mode": "Markdown"}], indirect=True)
     async def test_send_document_default_parse_mode_1(self, default_bot, chat_id, document):
         test_string = "Italic Bold Code"
@@ -191,7 +190,7 @@ class TestDocument:
         assert message.caption_markdown == test_markdown_string
         assert message.caption == test_string
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"parse_mode": "Markdown"}], indirect=True)
     async def test_send_document_default_parse_mode_2(self, default_bot, chat_id, document):
         test_markdown_string = "_Italic_ *Bold* `Code`"
@@ -202,7 +201,7 @@ class TestDocument:
         assert message.caption == test_markdown_string
         assert message.caption_markdown == escape_markdown(test_markdown_string)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"parse_mode": "Markdown"}], indirect=True)
     async def test_send_document_default_parse_mode_3(self, default_bot, chat_id, document):
         test_markdown_string = "_Italic_ *Bold* `Code`"
@@ -213,7 +212,7 @@ class TestDocument:
         assert message.caption == test_markdown_string
         assert message.caption_markdown == escape_markdown(test_markdown_string)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize(
         "default_bot,custom",
         [
@@ -247,7 +246,7 @@ class TestDocument:
                     chat_id, document, reply_to_message_id=reply_to_message.message_id
                 )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"protect_content": True}], indirect=True)
     async def test_send_document_default_protect_content(self, chat_id, default_bot, document):
         protected = await default_bot.send_document(chat_id, document)
@@ -308,13 +307,13 @@ class TestDocument:
         assert document_dict["mime_type"] == document.mime_type
         assert document_dict["file_size"] == document.file_size
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_error_send_empty_file(self, bot, chat_id):
         with open(os.devnull, "rb") as f:
             with pytest.raises(TelegramError):
                 await bot.send_document(chat_id=chat_id, document=f)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_error_send_empty_file_id(self, bot, chat_id):
         with pytest.raises(TelegramError):
             await bot.send_document(chat_id=chat_id, document="")

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from tempfile import TemporaryFile, mkstemp
 
 import pytest
-from flaky import flaky
 
 from telegram import File, FileCredentials, Voice
 from telegram.error import TelegramError
@@ -123,7 +122,7 @@ class TestFile:
         assert file_dict["file_path"] == file.file_path
         assert file_dict["file_size"] == file.file_size
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_error_get_empty_file_id(self, bot):
         with pytest.raises(TelegramError):
             await bot.get_file(file_id="")

--- a/tests/test_forcereply.py
+++ b/tests/test_forcereply.py
@@ -18,7 +18,6 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 
 import pytest
-from flaky import flaky
 
 from telegram import ForceReply, ReplyKeyboardRemove
 
@@ -41,7 +40,7 @@ class TestForceReply:
             assert getattr(force_reply, attr, "err") != "err", f"got extra slot '{attr}'"
         assert len(mro_slots(force_reply)) == len(set(mro_slots(force_reply))), "duplicate slot"
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_message_with_force_reply(self, bot, chat_id, force_reply):
         message = await bot.send_message(chat_id, "text", reply_markup=force_reply)
 

--- a/tests/test_inlinekeyboardmarkup.py
+++ b/tests/test_inlinekeyboardmarkup.py
@@ -18,7 +18,6 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 
 import pytest
-from flaky import flaky
 
 from telegram import (
     ForceReply,
@@ -48,7 +47,7 @@ class TestInlineKeyboardMarkup:
             assert getattr(inst, attr, "err") != "err", f"got extra slot '{attr}'"
         assert len(mro_slots(inst)) == len(set(mro_slots(inst))), "duplicate slot"
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_message_with_inline_keyboard_markup(
         self, bot, chat_id, inline_keyboard_markup
     ):

--- a/tests/test_inputmedia.py
+++ b/tests/test_inputmedia.py
@@ -19,7 +19,6 @@
 import copy
 
 import pytest
-from flaky import flaky
 
 from telegram import (
     InputFile,
@@ -454,7 +453,7 @@ def media_group_no_caption_only_parse_mode(photo, thumb):  # noqa: F811
 
 
 class TestSendMediaGroup:
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_media_group_photo(self, bot, chat_id, media_group):
         messages = await bot.send_media_group(chat_id, media_group)
         assert isinstance(messages, list)
@@ -494,7 +493,7 @@ class TestSendMediaGroup:
             ("photo 1", None, [MessageEntity(MessageEntity.BOLD, 0, 5)]),
         ],
     )
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_media_group_with_group_caption(
         self,
         bot,
@@ -539,7 +538,7 @@ class TestSendMediaGroup:
         assert all(mes.caption is None for mes in other_messages)
         assert not any(mes.caption_entities for mes in other_messages)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_media_group_all_args(self, bot, raw_bot, chat_id, media_group):
         ext_bot = bot
         for bot in (ext_bot, raw_bot):
@@ -574,7 +573,7 @@ class TestSendMediaGroup:
             )
             assert all(mes.has_protected_content for mes in messages)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_media_group_custom_filename(
         self,
         bot,
@@ -620,7 +619,7 @@ class TestSendMediaGroup:
         with pytest.raises(Exception, match="Test was successful"):
             await bot.send_media_group(chat_id, [input_video, input_video])
 
-    @flaky(3, 1)  # noqa: F811
+    @pytest.mark.flaky(3, 1)  # noqa: F811
     async def test_send_media_group_new_files(
         self,
         bot,
@@ -648,7 +647,7 @@ class TestSendMediaGroup:
         assert all(isinstance(mes, Message) for mes in messages)
         assert all(mes.media_group_id == messages[0].media_group_id for mes in messages)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize(
         "default_bot,custom",
         [
@@ -682,7 +681,7 @@ class TestSendMediaGroup:
                     chat_id, media_group, reply_to_message_id=reply_to_message.message_id
                 )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"protect_content": True}], indirect=True)
     async def test_send_media_group_default_protect_content(
         self, chat_id, media_group, default_bot
@@ -694,7 +693,7 @@ class TestSendMediaGroup:
         )
         assert not all(msg.has_protected_content for msg in unprotected)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"parse_mode": ParseMode.HTML}], indirect=True)
     async def test_send_media_group_default_parse_mode(
         self, chat_id, media_group_no_caption_args, default_bot
@@ -739,7 +738,7 @@ class TestSendMediaGroup:
             assert all(mes.caption is None for mes in other_messages)
             assert not any(mes.caption_entities for mes in other_messages)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_edit_message_media(self, bot, raw_bot, chat_id, media_group):
         ext_bot = bot
         for bot in (ext_bot, raw_bot):
@@ -758,7 +757,7 @@ class TestSendMediaGroup:
             # make sure that the media was not modified
             assert media_group[0].parse_mode == copied_media.parse_mode
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_edit_message_media_new_file(self, bot, chat_id, media_group, thumb_file):
         messages = await bot.send_media_group(chat_id, media_group)
         cid = messages[-1].chat.id
@@ -785,7 +784,7 @@ class TestSendMediaGroup:
         with pytest.raises(Exception, match="Test was successful"):
             await bot.edit_message_media(chat_id=chat_id, message_id=123, media=input_video)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize(
         "default_bot", [{"parse_mode": ParseMode.HTML}], indirect=True, ids=["HTML-Bot"]
     )

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 import pytest
-from flaky import flaky
 
 from telegram import Invoice, LabeledPrice
 from telegram.error import BadRequest
@@ -81,7 +80,7 @@ class TestInvoice:
         assert invoice_dict["currency"] == invoice.currency
         assert invoice_dict["total_amount"] == invoice.total_amount
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_required_args_only(self, bot, chat_id, provider_token):
         message = await bot.send_invoice(
             chat_id=chat_id,
@@ -274,7 +273,7 @@ class TestInvoice:
             start_parameter=self.start_parameter,
         )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize(
         "default_bot,custom",
         [
@@ -327,7 +326,7 @@ class TestInvoice:
                     reply_to_message_id=reply_to_message.message_id,
                 )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"protect_content": True}], indirect=True)
     async def test_send_invoice_default_protect_content(
         self, chat_id, default_bot, provider_token

--- a/tests/test_jobqueue.py
+++ b/tests/test_jobqueue.py
@@ -25,7 +25,6 @@ import platform
 import time
 
 import pytest
-from flaky import flaky
 
 from telegram.ext import ApplicationBuilder, CallbackContext, ContextTypes, Job, JobQueue
 from tests.conftest import env_var_2_bool
@@ -75,7 +74,7 @@ class TestNoJobQueue:
     os.getenv("GITHUB_ACTIONS", False) and platform.system() in ["Windows", "Darwin"],
     reason="On Windows & MacOS precise timings are not accurate.",
 )
-@flaky(10, 1)  # Timings aren't quite perfect
+@pytest.mark.flaky(10, 1)  # Timings aren't quite perfect
 class TestJobQueue:
     result = 0
     job_time = 0

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 import pytest
-from flaky import flaky
 
 from telegram import Location
 from telegram.error import BadRequest
@@ -68,7 +67,7 @@ class TestLocation:
         assert location.heading == self.heading
         assert location.proximity_alert_radius == self.proximity_alert_radius
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.xfail
     async def test_send_live_location(self, bot, chat_id):
         message = await bot.send_location(
@@ -151,7 +150,7 @@ class TestLocation:
         monkeypatch.setattr(bot.request, "post", make_assertion)
         assert await bot.send_location(location=location, chat_id=chat_id)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize(
         "default_bot,custom",
         [
@@ -185,7 +184,7 @@ class TestLocation:
                     chat_id, location=location, reply_to_message_id=reply_to_message.message_id
                 )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"protect_content": True}], indirect=True)
     async def test_send_location_default_protect_content(self, chat_id, default_bot, location):
         protected = await default_bot.send_location(chat_id, location=location)

--- a/tests/test_photo.py
+++ b/tests/test_photo.py
@@ -20,7 +20,6 @@ from io import BytesIO
 from pathlib import Path
 
 import pytest
-from flaky import flaky
 
 from telegram import Bot, InputFile, MessageEntity, PhotoSize, Sticker
 from telegram.error import BadRequest, TelegramError
@@ -100,7 +99,7 @@ class TestPhoto:
         assert thumb.height == 90
         assert thumb.file_size == 1477
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_photo_all_args(self, bot, chat_id, photo_file, thumb, photo):
         message = await bot.send_photo(
             chat_id,
@@ -126,7 +125,7 @@ class TestPhoto:
         assert message.caption == TestPhoto.caption.replace("*", "")
         assert message.has_protected_content
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_photo_custom_filename(self, bot, chat_id, photo_file, monkeypatch):
         async def make_assertion(url, request_data: RequestData, *args, **kwargs):
             return list(request_data.multipart_data.values())[0][0] == "custom_filename"
@@ -135,7 +134,7 @@ class TestPhoto:
 
         assert await bot.send_photo(chat_id, photo_file, filename="custom_filename")
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_photo_parse_mode_markdown(self, bot, chat_id, photo_file, thumb, photo):
         message = await bot.send_photo(
             chat_id, photo_file, caption=self.caption, parse_mode="Markdown"
@@ -155,7 +154,7 @@ class TestPhoto:
         assert message.caption == TestPhoto.caption.replace("*", "")
         assert len(message.caption_entities) == 1
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_photo_parse_mode_html(self, bot, chat_id, photo_file, thumb, photo):
         message = await bot.send_photo(
             chat_id, photo_file, caption=self.caption, parse_mode="HTML"
@@ -175,7 +174,7 @@ class TestPhoto:
         assert message.caption == TestPhoto.caption.replace("<b>", "").replace("</b>", "")
         assert len(message.caption_entities) == 1
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_photo_caption_entities(self, bot, chat_id, photo_file, thumb, photo):
         test_string = "Italic Bold Code"
         entities = [
@@ -190,7 +189,7 @@ class TestPhoto:
         assert message.caption == test_string
         assert message.caption_entities == entities
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"parse_mode": "Markdown"}], indirect=True)
     async def test_send_photo_default_parse_mode_1(
         self, default_bot, chat_id, photo_file, thumb, photo
@@ -202,7 +201,7 @@ class TestPhoto:
         assert message.caption_markdown == test_markdown_string
         assert message.caption == test_string
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"parse_mode": "Markdown"}], indirect=True)
     async def test_send_photo_default_parse_mode_2(
         self, default_bot, chat_id, photo_file, thumb, photo
@@ -215,7 +214,7 @@ class TestPhoto:
         assert message.caption == test_markdown_string
         assert message.caption_markdown == escape_markdown(test_markdown_string)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"parse_mode": "Markdown"}], indirect=True)
     async def test_send_photo_default_parse_mode_3(
         self, default_bot, chat_id, photo_file, thumb, photo
@@ -228,7 +227,7 @@ class TestPhoto:
         assert message.caption == test_markdown_string
         assert message.caption_markdown == escape_markdown(test_markdown_string)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"protect_content": True}], indirect=True)
     async def test_send_photo_default_protect_content(self, chat_id, default_bot, photo):
         protected = await default_bot.send_photo(chat_id, photo)
@@ -258,7 +257,7 @@ class TestPhoto:
         finally:
             bot._local_mode = False
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize(
         "default_bot,custom",
         [
@@ -292,7 +291,7 @@ class TestPhoto:
                     chat_id, photo_file, reply_to_message_id=reply_to_message.message_id
                 )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_get_and_download(self, bot, photo):
         path = Path("telegram.jpg")
         if path.is_file():
@@ -308,7 +307,7 @@ class TestPhoto:
 
         assert path.is_file()
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_url_jpg_file(self, bot, chat_id, thumb, photo):
         message = await bot.send_photo(chat_id, photo=self.photo_file_url)
 
@@ -324,7 +323,7 @@ class TestPhoto:
         assert message.photo[-1].file_id != ""
         assert message.photo[-1].file_unique_id != ""
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_url_png_file(self, bot, chat_id):
         message = await bot.send_photo(
             photo="http://dummyimage.com/600x400/000/fff.png&text=telegram", chat_id=chat_id
@@ -338,7 +337,7 @@ class TestPhoto:
         assert photo.file_id != ""
         assert photo.file_unique_id != ""
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_url_gif_file(self, bot, chat_id):
         message = await bot.send_photo(
             photo="http://dummyimage.com/600x400/000/fff.png&text=telegram", chat_id=chat_id
@@ -352,7 +351,7 @@ class TestPhoto:
         assert photo.file_id != ""
         assert photo.file_unique_id != ""
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_file_unicode_filename(self, bot, chat_id):
         """
         Regression test for https://github.com/python-telegram-bot/python-telegram-bot/issues/1202
@@ -368,7 +367,7 @@ class TestPhoto:
         assert photo.file_id != ""
         assert photo.file_unique_id != ""
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_bytesio_jpg_file(self, bot, chat_id):
         filepath = data_file("telegram_no_standard_header.jpg")
 
@@ -404,7 +403,7 @@ class TestPhoto:
         message = await bot.send_photo(photo=photo, chat_id=chat_id)
         assert message
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_resend(self, bot, chat_id, photo, thumb):
         message = await bot.send_photo(chat_id=chat_id, photo=photo.file_id)
 
@@ -447,12 +446,12 @@ class TestPhoto:
         assert photo_dict["height"] == photo.height
         assert photo_dict["file_size"] == photo.file_size
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_error_send_empty_file(self, bot, chat_id):
         with pytest.raises(TelegramError):
             await bot.send_photo(chat_id=chat_id, photo=open(os.devnull, "rb"))
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_error_send_empty_file_id(self, bot, chat_id):
         with pytest.raises(TelegramError):
             await bot.send_photo(chat_id=chat_id, photo="")

--- a/tests/test_ratelimiter.py
+++ b/tests/test_ratelimiter.py
@@ -30,7 +30,6 @@ from datetime import datetime
 from http import HTTPStatus
 
 import pytest
-from flaky import flaky
 
 from telegram import BotCommand, Chat, Message, User
 from telegram.constants import ParseMode
@@ -149,7 +148,7 @@ class TestBaseRateLimiter:
     os.getenv("GITHUB_ACTIONS", False) and platform.system() == "Darwin",
     reason="The timings are apparently rather inaccurate on MacOS.",
 )
-@flaky(10, 1)  # Timings aren't quite perfect
+@pytest.mark.flaky(10, 1)  # Timings aren't quite perfect
 class TestAIORateLimiter:
     count = 0
     call_times = []

--- a/tests/test_replykeyboardmarkup.py
+++ b/tests/test_replykeyboardmarkup.py
@@ -18,7 +18,6 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 
 import pytest
-from flaky import flaky
 
 from telegram import InlineKeyboardMarkup, KeyboardButton, ReplyKeyboardMarkup
 
@@ -45,7 +44,7 @@ class TestReplyKeyboardMarkup:
             assert getattr(inst, attr, "err") != "err", f"got extra slot '{attr}'"
         assert len(mro_slots(inst)) == len(set(mro_slots(inst))), "duplicate slot"
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_message_with_reply_keyboard_markup(
         self, bot, chat_id, reply_keyboard_markup
     ):
@@ -53,7 +52,7 @@ class TestReplyKeyboardMarkup:
 
         assert message.text == "Text"
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_message_with_data_markup(self, bot, chat_id):
         message = await bot.send_message(
             chat_id, "text 2", reply_markup={"keyboard": [["1", "2"]]}

--- a/tests/test_replykeyboardremove.py
+++ b/tests/test_replykeyboardremove.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 import pytest
-from flaky import flaky
 
 from telegram import ReplyKeyboardRemove
 
@@ -37,7 +36,7 @@ class TestReplyKeyboardRemove:
             assert getattr(inst, attr, "err") != "err", f"got extra slot '{attr}'"
         assert len(mro_slots(inst)) == len(set(mro_slots(inst))), "duplicate slot"
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_message_with_reply_keyboard_remove(
         self, bot, chat_id, reply_keyboard_remove
     ):

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -28,7 +28,6 @@ from typing import Any, Callable, Coroutine, Tuple
 
 import httpx
 import pytest
-from flaky import flaky
 
 from telegram._utils.defaultvalue import DEFAULT_NONE
 from telegram.error import (
@@ -568,7 +567,7 @@ class TestHTTPXRequest:
                     httpx_request.do_request(method="GET", url="URL"),
                 )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_do_request_wait_for_pool(self, monkeypatch, httpx_request):
         """The pool logic is buried rather deeply in httpxcore, so we make actual requests here
         instead of mocking"""

--- a/tests/test_sticker.py
+++ b/tests/test_sticker.py
@@ -21,7 +21,6 @@ import os
 from pathlib import Path
 
 import pytest
-from flaky import flaky
 
 from telegram import Audio, Bot, File, InputFile, MaskPosition, PhotoSize, Sticker, StickerSet
 from telegram.error import BadRequest, TelegramError
@@ -126,7 +125,7 @@ class TestSticker:
         # we need to be a premium TG user to send a premium sticker, so the below is not tested
         # assert sticker.premium_animation == self.premium_animation
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_all_args(self, bot, chat_id, sticker_file, sticker):
         message = await bot.send_sticker(
             chat_id, sticker=sticker_file, disable_notification=False, protect_content=True
@@ -156,7 +155,7 @@ class TestSticker:
         assert message.sticker.thumb.height == sticker.thumb.height
         assert message.sticker.thumb.file_size == sticker.thumb.file_size
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_get_and_download(self, bot, sticker):
         path = Path("telegram.webp")
         if path.is_file():
@@ -173,20 +172,20 @@ class TestSticker:
 
         assert path.is_file()
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_resend(self, bot, chat_id, sticker):
         message = await bot.send_sticker(chat_id=chat_id, sticker=sticker.file_id)
 
         assert message.sticker == sticker
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_on_server_emoji(self, bot, chat_id):
         server_file_id = "CAADAQADHAADyIsGAAFZfq1bphjqlgI"
         message = await bot.send_sticker(chat_id=chat_id, sticker=server_file_id)
         sticker = message.sticker
         assert sticker.emoji == self.emoji
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_from_url(self, bot, chat_id):
         message = await bot.send_sticker(chat_id=chat_id, sticker=self.sticker_file_url)
         sticker = message.sticker
@@ -274,7 +273,7 @@ class TestSticker:
         finally:
             bot._local_mode = False
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize(
         "default_bot,custom",
         [
@@ -308,7 +307,7 @@ class TestSticker:
                     chat_id, sticker, reply_to_message_id=reply_to_message.message_id
                 )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"protect_content": True}], indirect=True)
     async def test_send_sticker_default_protect_content(self, chat_id, sticker, default_bot):
         protected = await default_bot.send_sticker(chat_id, sticker)
@@ -330,12 +329,12 @@ class TestSticker:
         assert sticker_dict["thumb"] == sticker.thumb.to_dict()
         assert sticker_dict["type"] == sticker.type
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_error_send_empty_file(self, bot, chat_id):
         with pytest.raises(TelegramError):
             await bot.send_sticker(chat_id, open(os.devnull, "rb"))
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_error_send_empty_file_id(self, bot, chat_id):
         with pytest.raises(TelegramError):
             await bot.send_sticker(chat_id, "")
@@ -344,7 +343,7 @@ class TestSticker:
         with pytest.raises(TypeError):
             await bot.send_sticker(chat_id)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_premium_animation(self, bot):
         # testing animation sucks a bit since we can't create a premium sticker. What we can do is
         # get a sticker set which includes a premium sticker and check that specific one.
@@ -362,7 +361,7 @@ class TestSticker:
         }
         assert premium_sticker.premium_animation.to_dict() == premium_sticker_dict
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_custom_emoji(self, bot):
         # testing custom emoji stickers is as much of an annoyance as the premium animation, see
         # in test_premium_animation
@@ -553,7 +552,7 @@ class TestStickerSet:
                     )
                     assert v
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_bot_methods_1_png(self, bot, chat_id, sticker_file):
         with data_file("telegram_sticker.png").open("rb") as f:
             # chat_id was hardcoded as 95205500 but it stopped working for some reason
@@ -571,7 +570,7 @@ class TestStickerSet:
             mask_position=MaskPosition(MaskPosition.EYES, -1, 1, 2),
         )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_bot_methods_1_tgs(self, bot, chat_id):
         assert await bot.add_sticker_to_set(
             chat_id,
@@ -580,7 +579,7 @@ class TestStickerSet:
             emojis="😄",
         )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_bot_methods_1_webm(self, bot, chat_id):
         with data_file("telegram_video_sticker.webm").open("rb") as f:
             assert await bot.add_sticker_to_set(
@@ -599,28 +598,28 @@ class TestStickerSet:
         assert sticker_set_dict["thumb"] == sticker_set.thumb.to_dict()
         assert sticker_set_dict["sticker_type"] == sticker_set.sticker_type
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_bot_methods_2_png(self, bot, sticker_set):
         file_id = sticker_set.stickers[0].file_id
         assert await bot.set_sticker_position_in_set(file_id, 1)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_bot_methods_2_tgs(self, bot, animated_sticker_set):
         file_id = animated_sticker_set.stickers[0].file_id
         assert await bot.set_sticker_position_in_set(file_id, 1)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_bot_methods_2_webm(self, bot, video_sticker_set):
         file_id = video_sticker_set.stickers[0].file_id
         assert await bot.set_sticker_position_in_set(file_id, 1)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_bot_methods_3_png(self, bot, chat_id, sticker_set_thumb_file):
         assert await bot.set_sticker_set_thumb(
             f"test_by_{bot.username}", chat_id, sticker_set_thumb_file
         )
 
-    @flaky(10, 1)
+    @pytest.mark.flaky(10, 1)
     async def test_bot_methods_3_tgs(
         self, bot, chat_id, animated_sticker_file, animated_sticker_set
     ):
@@ -639,19 +638,19 @@ class TestStickerSet:
     def test_bot_methods_3_webm(self, bot, chat_id, video_sticker_file, video_sticker_set):
         pass
 
-    @flaky(10, 1)
+    @pytest.mark.flaky(10, 1)
     async def test_bot_methods_4_png(self, bot, sticker_set):
         await asyncio.sleep(1)
         file_id = sticker_set.stickers[-1].file_id
         assert await bot.delete_sticker_from_set(file_id)
 
-    @flaky(10, 1)
+    @pytest.mark.flaky(10, 1)
     async def test_bot_methods_4_tgs(self, bot, animated_sticker_set):
         await asyncio.sleep(1)
         file_id = animated_sticker_set.stickers[-1].file_id
         assert await bot.delete_sticker_from_set(file_id)
 
-    @flaky(10, 1)
+    @pytest.mark.flaky(10, 1)
     async def test_bot_methods_4_webm(self, bot, video_sticker_set):
         await asyncio.sleep(1)
         file_id = video_sticker_set.stickers[-1].file_id

--- a/tests/test_venue.py
+++ b/tests/test_venue.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 import pytest
-from flaky import flaky
 
 from telegram import Location, Venue
 from telegram.error import BadRequest
@@ -90,7 +89,7 @@ class TestVenue:
         message = await bot.send_venue(chat_id, venue=venue)
         assert message
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize(
         "default_bot,custom",
         [
@@ -124,7 +123,7 @@ class TestVenue:
                     chat_id, venue=venue, reply_to_message_id=reply_to_message.message_id
                 )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"protect_content": True}], indirect=True)
     async def test_send_venue_default_protect_content(self, default_bot, chat_id, venue):
         protected = await default_bot.send_venue(chat_id, venue=venue)

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -20,7 +20,6 @@ import os
 from pathlib import Path
 
 import pytest
-from flaky import flaky
 
 from telegram import Bot, InputFile, MessageEntity, PhotoSize, Video, Voice
 from telegram.error import BadRequest, TelegramError
@@ -92,7 +91,7 @@ class TestVideo:
         assert video.file_size == self.file_size
         assert video.mime_type == self.mime_type
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_all_args(self, bot, chat_id, video_file, video, thumb_file):
         message = await bot.send_video(
             chat_id,
@@ -127,7 +126,7 @@ class TestVideo:
         assert message.video.file_name == self.file_name
         assert message.has_protected_content
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_video_custom_filename(self, bot, chat_id, video_file, monkeypatch):
         async def make_assertion(url, request_data: RequestData, *args, **kwargs):
             return list(request_data.multipart_data.values())[0][0] == "custom_filename"
@@ -136,7 +135,7 @@ class TestVideo:
 
         assert await bot.send_video(chat_id, video_file, filename="custom_filename")
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_get_and_download(self, bot, video):
         path = Path("telegram.mp4")
         if path.is_file():
@@ -153,7 +152,7 @@ class TestVideo:
 
         assert path.is_file()
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_mp4_file_url(self, bot, chat_id, video):
         message = await bot.send_video(chat_id, self.video_file_url, caption=self.caption)
 
@@ -178,7 +177,7 @@ class TestVideo:
 
         assert message.caption == self.caption
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_video_caption_entities(self, bot, chat_id, video):
         test_string = "Italic Bold Code"
         entities = [
@@ -193,7 +192,7 @@ class TestVideo:
         assert message.caption == test_string
         assert message.caption_entities == entities
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_resend(self, bot, chat_id, video):
         message = await bot.send_video(chat_id, video.file_id)
 
@@ -207,7 +206,7 @@ class TestVideo:
         message = await bot.send_video(chat_id, video=video)
         assert message
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"parse_mode": "Markdown"}], indirect=True)
     async def test_send_video_default_parse_mode_1(self, default_bot, chat_id, video):
         test_string = "Italic Bold Code"
@@ -217,7 +216,7 @@ class TestVideo:
         assert message.caption_markdown == test_markdown_string
         assert message.caption == test_string
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"parse_mode": "Markdown"}], indirect=True)
     async def test_send_video_default_parse_mode_2(self, default_bot, chat_id, video):
         test_markdown_string = "_Italic_ *Bold* `Code`"
@@ -228,7 +227,7 @@ class TestVideo:
         assert message.caption == test_markdown_string
         assert message.caption_markdown == escape_markdown(test_markdown_string)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"parse_mode": "Markdown"}], indirect=True)
     async def test_send_video_default_parse_mode_3(self, default_bot, chat_id, video):
         test_markdown_string = "_Italic_ *Bold* `Code`"
@@ -239,7 +238,7 @@ class TestVideo:
         assert message.caption == test_markdown_string
         assert message.caption_markdown == escape_markdown(test_markdown_string)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"protect_content": True}], indirect=True)
     async def test_send_video_default_protect_content(self, chat_id, default_bot, video):
         protected = await default_bot.send_video(chat_id, video)
@@ -271,7 +270,7 @@ class TestVideo:
         finally:
             bot._local_mode = False
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize(
         "default_bot,custom",
         [
@@ -341,12 +340,12 @@ class TestVideo:
         assert video_dict["file_size"] == video.file_size
         assert video_dict["file_name"] == video.file_name
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_error_send_empty_file(self, bot, chat_id):
         with pytest.raises(TelegramError):
             await bot.send_video(chat_id, open(os.devnull, "rb"))
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_error_send_empty_file_id(self, bot, chat_id):
         with pytest.raises(TelegramError):
             await bot.send_video(chat_id, "")

--- a/tests/test_videonote.py
+++ b/tests/test_videonote.py
@@ -20,7 +20,6 @@ import os
 from pathlib import Path
 
 import pytest
-from flaky import flaky
 
 from telegram import Bot, InputFile, PhotoSize, VideoNote, Voice
 from telegram.error import BadRequest, TelegramError
@@ -83,7 +82,7 @@ class TestVideoNote:
         assert video_note.duration == self.duration
         assert video_note.file_size == self.file_size
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_all_args(self, bot, chat_id, video_note_file, video_note, thumb_file):
         message = await bot.send_video_note(
             chat_id,
@@ -109,7 +108,7 @@ class TestVideoNote:
         assert message.video_note.thumb.height == self.thumb_height
         assert message.has_protected_content
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_video_note_custom_filename(
         self, bot, chat_id, video_note_file, monkeypatch
     ):
@@ -120,7 +119,7 @@ class TestVideoNote:
 
         assert await bot.send_video_note(chat_id, video_note_file, filename="custom_filename")
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_get_and_download(self, bot, video_note):
         path = Path("telegram2.mp4")
         if path.is_file():
@@ -137,7 +136,7 @@ class TestVideoNote:
 
         assert path.is_file()
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_resend(self, bot, chat_id, video_note):
         message = await bot.send_video_note(chat_id, video_note.file_id)
 
@@ -204,7 +203,7 @@ class TestVideoNote:
         finally:
             bot._local_mode = False
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize(
         "default_bot,custom",
         [
@@ -238,7 +237,7 @@ class TestVideoNote:
                     chat_id, video_note, reply_to_message_id=reply_to_message.message_id
                 )
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"protect_content": True}], indirect=True)
     async def test_send_video_note_default_protect_content(self, chat_id, default_bot, video_note):
         protected = await default_bot.send_video_note(chat_id, video_note)
@@ -246,12 +245,12 @@ class TestVideoNote:
         unprotected = await default_bot.send_video_note(chat_id, video_note, protect_content=False)
         assert not unprotected.has_protected_content
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_error_send_empty_file(self, bot, chat_id):
         with pytest.raises(TelegramError):
             await bot.send_video_note(chat_id, open(os.devnull, "rb"))
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_error_send_empty_file_id(self, bot, chat_id):
         with pytest.raises(TelegramError):
             await bot.send_video_note(chat_id, "")

--- a/tests/test_voice.py
+++ b/tests/test_voice.py
@@ -20,7 +20,6 @@ import os
 from pathlib import Path
 
 import pytest
-from flaky import flaky
 
 from telegram import Audio, Bot, InputFile, MessageEntity, Voice
 from telegram.error import BadRequest, TelegramError
@@ -76,7 +75,7 @@ class TestVoice:
         assert voice.mime_type == self.mime_type
         assert voice.file_size == self.file_size
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_all_args(self, bot, chat_id, voice_file, voice):
         message = await bot.send_voice(
             chat_id,
@@ -99,7 +98,7 @@ class TestVoice:
         assert message.caption == self.caption.replace("*", "")
         assert message.has_protected_content
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_voice_custom_filename(self, bot, chat_id, voice_file, monkeypatch):
         async def make_assertion(url, request_data: RequestData, *args, **kwargs):
             return list(request_data.multipart_data.values())[0][0] == "custom_filename"
@@ -108,7 +107,7 @@ class TestVoice:
 
         assert await bot.send_voice(chat_id, voice_file, filename="custom_filename")
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_get_and_download(self, bot, voice):
         path = Path("telegram.ogg")
         if path.is_file():
@@ -125,7 +124,7 @@ class TestVoice:
 
         assert path.is_file()
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_ogg_url_file(self, bot, chat_id, voice):
         message = await bot.sendVoice(chat_id, self.voice_file_url, duration=self.duration)
 
@@ -138,7 +137,7 @@ class TestVoice:
         assert message.voice.mime_type == voice.mime_type
         assert message.voice.file_size == voice.file_size
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_resend(self, bot, chat_id, voice):
         message = await bot.sendVoice(chat_id, voice.file_id)
 
@@ -152,7 +151,7 @@ class TestVoice:
         message = await bot.send_voice(chat_id, voice=voice)
         assert message
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_send_voice_caption_entities(self, bot, chat_id, voice_file):
         test_string = "Italic Bold Code"
         entities = [
@@ -167,7 +166,7 @@ class TestVoice:
         assert message.caption == test_string
         assert message.caption_entities == entities
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"parse_mode": "Markdown"}], indirect=True)
     async def test_send_voice_default_parse_mode_1(self, default_bot, chat_id, voice):
         test_string = "Italic Bold Code"
@@ -177,7 +176,7 @@ class TestVoice:
         assert message.caption_markdown == test_markdown_string
         assert message.caption == test_string
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"parse_mode": "Markdown"}], indirect=True)
     async def test_send_voice_default_parse_mode_2(self, default_bot, chat_id, voice):
         test_markdown_string = "_Italic_ *Bold* `Code`"
@@ -188,7 +187,7 @@ class TestVoice:
         assert message.caption == test_markdown_string
         assert message.caption_markdown == escape_markdown(test_markdown_string)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"parse_mode": "Markdown"}], indirect=True)
     async def test_send_voice_default_parse_mode_3(self, default_bot, chat_id, voice):
         test_markdown_string = "_Italic_ *Bold* `Code`"
@@ -199,7 +198,7 @@ class TestVoice:
         assert message.caption == test_markdown_string
         assert message.caption_markdown == escape_markdown(test_markdown_string)
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize("default_bot", [{"protect_content": True}], indirect=True)
     async def test_send_voice_default_protect_content(self, chat_id, default_bot, voice):
         protected = await default_bot.send_voice(chat_id, voice)
@@ -229,7 +228,7 @@ class TestVoice:
         finally:
             bot._local_mode = False
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     @pytest.mark.parametrize(
         "default_bot,custom",
         [
@@ -290,12 +289,12 @@ class TestVoice:
         assert voice_dict["mime_type"] == voice.mime_type
         assert voice_dict["file_size"] == voice.file_size
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_error_send_empty_file(self, bot, chat_id):
         with pytest.raises(TelegramError):
             await bot.sendVoice(chat_id, open(os.devnull, "rb"))
 
-    @flaky(3, 1)
+    @pytest.mark.flaky(3, 1)
     async def test_error_send_empty_file_id(self, bot, chat_id):
         with pytest.raises(TelegramError):
             await bot.sendVoice(chat_id, "")


### PR DESCRIPTION
Simply use the pytest marker instead of the flaky decorator. Same behaviour. Just saving an import statement.. 