### PR TITLE
try updating meta config

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include LICENSE LICENSE.lesser Makefile requirements.txt requirements-opts.txt README_RAW.rst telegram/py.typed
+include LICENSE LICENSE.lesser requirements.txt requirements-opts.txt README_RAW.rst telegram/py.typed

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-license_file = LICENSE.dual
+license_files = LICENSE, LICENSE.dual, LICENSE.lesser
 
 [build_sphinx]
 source-dir = docs/source


### PR DESCRIPTION
setuptools deprected the lincense_file option in favor of a license_files (plural) option. the plural form was introduced in v42.0.0 in 11/2019. the singular form was deprecated in v56.0.0 in 04/2021. setuptools is currently on v65.5.1 (04.11.2022).