### PR TITLE
Don't throw error in `BP.set_bot` if `store_cdc=True` but `bot.cdc is None`

### DIFF
--- a/telegram/ext/_application.py
+++ b/telegram/ext/_application.py
@@ -451,13 +451,16 @@ class Application(Generic[BT, CCT, UD, CD, BD, JQ], AbstractAsyncContextManager)
                 raise ValueError(
                     f"bot_data must be of type {self.context_types.bot_data.__name__}"
                 )
-        if self.persistence.store_data.callback_data:
+
+        # Mypy doesn't know that persistence.set_bot (see above) already checks that
+        # self.bot is an instance of ExtBot if callback_data should be stored ...
+        if self.persistence.store_data.callback_data and (
+            self.bot.callback_data_cache is not None  # type: ignore[attr-defined]
+        ):
             persistent_data = await self.persistence.get_callback_data()
             if persistent_data is not None:
                 if not isinstance(persistent_data, tuple) or len(persistent_data) != 2:
                     raise ValueError("callback_data must be a tuple of length 2")
-                # Mypy doesn't know that persistence.set_bot (see above) already checks that
-                # self.bot is an instance of ExtBot if callback_data should be stored ...
                 self.bot.callback_data_cache.load_persistence_data(  # type: ignore[attr-defined]
                     persistent_data
                 )
@@ -1348,9 +1351,11 @@ class Application(Generic[BT, CCT, UD, CD, BD, JQ], AbstractAsyncContextManager)
 
         coroutines: Set[Coroutine] = set()
 
-        if self.persistence.store_data.callback_data:
-            # Mypy doesn't know that persistence.set_bot (see above) already checks that
-            # self.bot is an instance of ExtBot if callback_data should be stored ...
+        # Mypy doesn't know that persistence.set_bot (see above) already checks that
+        # self.bot is an instance of ExtBot if callback_data should be stored ...
+        if self.persistence.store_data.callback_data and (
+            self.bot.callback_data_cache is not None  # type: ignore[attr-defined]
+        ):
             coroutines.add(
                 self.persistence.update_callback_data(
                     deepcopy(

--- a/telegram/ext/_basepersistence.py
+++ b/telegram/ext/_basepersistence.py
@@ -181,13 +181,8 @@ class BasePersistence(Generic[UD, CD, BD], ABC):
                 :paramref:`bot` is not an instance of :class:`telegram.ext.ExtBot` or
                 :attr:`~telegram.ext.ExtBot.callback_data_cache` is :obj:`None`.
         """
-        if self.store_data.callback_data and (
-            not isinstance(bot, ExtBot) or bot.callback_data_cache is None
-        ):
-            raise TypeError(
-                "callback_data can only be stored when using telegram.ext.ExtBot with arbitrary "
-                "callback_data enabled. "
-            )
+        if self.store_data.callback_data and (not isinstance(bot, ExtBot)):
+            raise TypeError("callback_data can only be stored when using telegram.ext.ExtBot.")
 
         self.bot = bot
 

--- a/telegram/ext/_basepersistence.py
+++ b/telegram/ext/_basepersistence.py
@@ -178,8 +178,7 @@ class BasePersistence(Generic[UD, CD, BD], ABC):
 
         Raises:
             :exc:`TypeError`: If :attr:`PersistenceInput.callback_data` is :obj:`True` and the
-                :paramref:`bot` is not an instance of :class:`telegram.ext.ExtBot` or
-                :attr:`~telegram.ext.ExtBot.callback_data_cache` is :obj:`None`.
+                :paramref:`bot` is not an instance of :class:`telegram.ext.ExtBot`.
         """
         if self.store_data.callback_data and (not isinstance(bot, ExtBot)):
             raise TypeError("callback_data can only be stored when using telegram.ext.ExtBot.")

--- a/tests/test_basepersistence.py
+++ b/tests/test_basepersistence.py
@@ -37,6 +37,7 @@ from telegram.ext import (
     BasePersistence,
     CallbackContext,
     ConversationHandler,
+    ExtBot,
     MessageHandler,
     PersistenceInput,
     filters,
@@ -388,6 +389,12 @@ class TestBasePersistence:
     def test_set_bot_error(self, papp):
         with pytest.raises(TypeError, match="when using telegram.ext.ExtBot"):
             papp.persistence.set_bot(Bot(papp.bot.token))
+
+        # just making sure that setting an ExtBoxt without callback_data_cache doesn't raise an
+        # error even though store_callback_data is True
+        bot = ExtBot(papp.bot.token)
+        assert bot.callback_data_cache is None
+        assert papp.persistence.set_bot(bot) is None
 
     def test_construction_with_bad_persistence(self, caplog, bot):
         class MyPersistence:

--- a/tests/test_basepersistence.py
+++ b/tests/test_basepersistence.py
@@ -37,7 +37,6 @@ from telegram.ext import (
     BasePersistence,
     CallbackContext,
     ConversationHandler,
-    ExtBot,
     MessageHandler,
     PersistenceInput,
     filters,
@@ -389,9 +388,6 @@ class TestBasePersistence:
     def test_set_bot_error(self, papp):
         with pytest.raises(TypeError, match="when using telegram.ext.ExtBot"):
             papp.persistence.set_bot(Bot(papp.bot.token))
-
-        with pytest.raises(TypeError, match="when using telegram.ext.ExtBot"):
-            papp.persistence.set_bot(ExtBot(papp.bot.token))
 
     def test_construction_with_bad_persistence(self, caplog, bot):
         class MyPersistence:


### PR DESCRIPTION
Changes some behavior introduced in #3266 .

Issue was reported at https://t.me/pythontelegrambotgroup/639987.

This change allows `ExtBot.callback_data_cache` to be `None` even if `store_arbitrary_callback_data is True`. Reasoning:

* We want to keep the default of `store_arbitrary_callback_data` such that integrating persistence is as easy as possible
* using arbitrary callback_data must stay opt-in

So instead of reasing an error, this PR changes the behavior such that `Application.update_persistence` just doesn't call `update_callback_data` if `bot.cdc is None`.

### Checklist for PRs

- ~[ ] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)~
- [x] Created new or adapted existing unit tests
- [x] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- ~[ ] Added myself alphabetically to `AUTHORS.rst` (optional)~
- ~[ ] Added new classes & modules to the docs and all suitable `__all__` s~

