### PR TITLE
Drop `Job.__lt__`

### DIFF
--- a/telegram/ext/_jobqueue.py
+++ b/telegram/ext/_jobqueue.py
@@ -804,9 +804,6 @@ class Job:
                 f"Neither 'telegram.ext.Job' nor 'apscheduler.job.Job' has attribute '{item}'"
             ) from exc
 
-    def __lt__(self, other: object) -> bool:
-        return False
-
     def __eq__(self, other: object) -> bool:
         if isinstance(other, self.__class__):
             return self.id == other.id

--- a/tests/test_jobqueue.py
+++ b/tests/test_jobqueue.py
@@ -491,10 +491,6 @@ class TestJobQueue:
         assert hash(job) != hash(job_2)
         assert hash(job) == hash(job_3)
 
-        assert not job < job
-        assert not job < job_2
-        assert not job < job_3
-
     async def test_process_error_context(self, job_queue, app):
         app.add_error_handler(self.error_handler_context)
 


### PR DESCRIPTION
as discussed in the dev chat

Was removed since its use case is unknown, is misleading since you may think it compared something, when it actually did not. Was also undocumented, hence non-breaking

### Checklist for PRs

- ~[ ] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)~
- [x] Created new or adapted existing unit tests
- ~[ ] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)~
- ~[ ] Added myself alphabetically to `AUTHORS.rst` (optional)~
- ~[ ] Added new classes & modules to the docs and all suitable `__all__` s~

