### PR TITLE
Override `Bot.__deepcopy__`

### DIFF
--- a/docs/source/telegram.bot.rst
+++ b/docs/source/telegram.bot.rst
@@ -4,3 +4,4 @@ telegram.Bot
 .. autoclass:: telegram.Bot
     :members:
     :show-inheritance:
+    :special-members: __reduce__, __deepcopy__

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -141,7 +141,7 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         * Bots should not be serialized since if you for e.g. change the bots token, then your
           serialized instance will not reflect that change. Trying to pickle a bot instance will
           raise :exc:`pickle.PicklingError`. Trying to deepcopy a bot instance will raise
-          :exce:`TypeError`.
+          :exc:`TypeError`.
 
     Examples:
         :any:`Raw API Bot <examples.rawapibot>`
@@ -167,7 +167,7 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
           :class:`telegram.ext.Defaults`, please use the subclass :class:`telegram.ext.ExtBot`
           instead.
         * Attempting to pickle a bot instance will now raise :exc:`pickle.PicklingError`.
-        * Attempting to deepcopy a bot instance will now raise :exce:`TypeError`.
+        * Attempting to deepcopy a bot instance will now raise :exc:`TypeError`.
         * The following are now keyword-only arguments in Bot methods:
           ``location``, ``filename``, ``venue``, ``contact``,
           ``{read, write, connect, pool}_timeout``, ``api_kwargs``. Use a named argument for those,

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -299,8 +299,22 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         return self._private_key
 
     def __reduce__(self) -> NoReturn:
-        """Called by pickle.dumps(). Serializing bots is unadvisable, so we forbid pickling."""
+        """Customizes how :func:`copy.deepcopy` processes objects of this type. Bots can not
+        be pickled and this method will always raise an exception.
+
+        Raises:
+            :exc:`pickle.PicklingError`
+        """
         raise pickle.PicklingError("Bot objects cannot be pickled!")
+
+    def __deepcopy__(self, memodict: dict) -> NoReturn:
+        """Customizes how :func:`copy.deepcopy` processes objects of this type. Bots can not
+        be deepcopied and this method will always raise an exception.
+
+        Raises:
+            :exc:`TypeError`
+        """
+        raise TypeError("Bot objects cannot be deepcopied!")
 
     # TODO: After https://youtrack.jetbrains.com/issue/PY-50952 is fixed, we can revisit this and
     # consider adding Paramspec from typing_extensions to properly fix this. Currently a workaround

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -140,7 +140,8 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
           passing files.
         * Bots should not be serialized since if you for e.g. change the bots token, then your
           serialized instance will not reflect that change. Trying to pickle a bot instance will
-          raise :exc:`pickle.PicklingError`.
+          raise :exc:`pickle.PicklingError`. Trying to deepcopy a bot instance will raise
+          :exce:`TypeError`.
 
     Examples:
         :any:`Raw API Bot <examples.rawapibot>`
@@ -166,6 +167,7 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
           :class:`telegram.ext.Defaults`, please use the subclass :class:`telegram.ext.ExtBot`
           instead.
         * Attempting to pickle a bot instance will now raise :exc:`pickle.PicklingError`.
+        * Attempting to deepcopy a bot instance will now raise :exce:`TypeError`.
         * The following are now keyword-only arguments in Bot methods:
           ``location``, ``filename``, ``venue``, ``contact``,
           ``{read, write, connect, pool}_timeout``, ``api_kwargs``. Use a named argument for those,
@@ -302,6 +304,8 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
         """Customizes how :func:`copy.deepcopy` processes objects of this type. Bots can not
         be pickled and this method will always raise an exception.
 
+        .. versionadded:: 20.0
+
         Raises:
             :exc:`pickle.PicklingError`
         """
@@ -310,6 +314,8 @@ class Bot(TelegramObject, AbstractAsyncContextManager):
     def __deepcopy__(self, memodict: dict) -> NoReturn:
         """Customizes how :func:`copy.deepcopy` processes objects of this type. Bots can not
         be deepcopied and this method will always raise an exception.
+
+        .. versionadded:: 20.0
 
         Raises:
             :exc:`TypeError`

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -426,6 +426,10 @@ class TestBot:
         with pytest.raises(pickle.PicklingError, match="Bot objects cannot be pickled"):
             pickle.dumps(bot)
 
+    def test_bot_deepcopy_error(self, bot):
+        with pytest.raises(TypeError, match="Bot objects cannot be deepcopied"):
+            copy.deepcopy(bot)
+
     @bot_methods(ext_bot=False)
     async def test_defaults_handling(
         self, bot_class, bot_method_name, bot_method, bot, raw_bot, monkeypatch


### PR DESCRIPTION
Closes #3445. Also documents `__reduce__` and `__deepcopy__` in the style we used for `TelegramObject`

### Checklist for PRs

- [x] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [x] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- ~[ ] Added myself alphabetically to `AUTHORS.rst` (optional)~
- ~[ ] Added new classes & modules to the docs and all suitable `__all__` s~
