### PR TITLE
Downgrade `sphinx` to 5.3.0 to fix docs search

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -185,7 +185,7 @@ doc strings don't have a separate documentation site they generate, instead, the
 
 User facing documentation
 -------------------------
-We use `sphinx`_ to generate static HTML docs. Note that this requires Poython 3.8+. To build the docs, first make sure you have the required dependencies:
+We use `sphinx`_ to generate static HTML docs. To build them, first make sure you have the required dependencies:
 
 .. code-block:: bash
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,7 @@ on:
       - master
       - doc-fixes
   push:
-    branches: 
+    branches:
       - master
       - doc-fixes
 
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.9]
         os: [ubuntu-latest]
       fail-fast: False
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,7 @@ on:
       - master
       - doc-fixes
   push:
-    branches:
+    branches: 
       - master
       - doc-fixes
 
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.7]
         os: [ubuntu-latest]
       fail-fast: False
     steps:

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,4 +1,4 @@
-sphinx==6.0.0
+sphinx==5.3.0
 sphinx-pypi-upload
 furo==2022.12.7
 git+https://github.com/harshil21/furo-sphinx-search@be5cfa221a01f6e259bb2bb1f76d6ede7ffc1f11#egg=furo-sphinx-search


### PR DESCRIPTION
The docs search stopped working when we upgraded to sphinx 6.0.0, so let's downgrade back to 5.3.0 for now.

Reverts https://github.com/python-telegram-bot/python-telegram-bot/pull/3450.

Doc build up at: https://docs.python-telegram-bot.org/en/doc-downgrade-sphinx/ you can check as well

