### PR TITLE
Cache GH action dependencies

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: '**/requirements*.txt'
       - name: Install dependencies
         run: |
           python -W ignore -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         os: [ubuntu-latest, windows-latest, macos-latest]
+        cache: 'pip'
+        cache-dependency-path: '**/requirements*.txt'
       fail-fast: False
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,6 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         os: [ubuntu-latest, windows-latest, macos-latest]
-        cache: 'pip'
-        cache-dependency-path: '**/requirements*.txt'
       fail-fast: False
     steps:
       - uses: actions/checkout@v3
@@ -27,6 +25,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: '**/requirements*.txt'
       - name: Install dependencies
         run: |
           python -W ignore -m pip install --upgrade pip


### PR DESCRIPTION
Attempts to speed up the test suite by caching GH actions dependencies. About ~1 mins is used every run just to install our dependencies. This should save that.

More info about how the cache is used (and also not used) can be found at https://github.com/actions/setup-python#caching-packages-dependencies

Edit: Confirmed the cache is working correctly by checking both https://github.com/python-telegram-bot/python-telegram-bot/actions/caches & the pytest logs in the workers below.