### PR TITLE
Fix dependency warning typo

### DIFF
--- a/telegram/ext/_application.py
+++ b/telegram/ext/_application.py
@@ -351,7 +351,7 @@ class Application(Generic[BT, CCT, UD, CD, BD, JQ], AbstractAsyncContextManager)
         if self._job_queue is None:
             warn(
                 "No `JobQueue` set up. To use `JobQueue`, you must install PTB via "
-                "`pip install python-telegram-bot[job_queue]`.",
+                "`pip install python-telegram-bot[job-queue]`.",
                 stacklevel=2,
             )
         return self._job_queue

--- a/telegram/ext/_callbackcontext.py
+++ b/telegram/ext/_callbackcontext.py
@@ -386,7 +386,7 @@ class CallbackContext(Generic[BT, UD, CD, BD]):
         if self._application._job_queue is None:  # pylint: disable=protected-access
             warn(
                 "No `JobQueue` set up. To use `JobQueue`, you must install PTB via "
-                "`pip install python-telegram-bot[job_queue]`.",
+                "`pip install python-telegram-bot[job-queue]`.",
                 stacklevel=2,
             )
         return self._application._job_queue  # pylint: disable=protected-access

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -204,7 +204,7 @@ class TestApplication:
     def test_job_queue(self, bot, app, recwarn):
         expected_warning = (
             "No `JobQueue` set up. To use `JobQueue`, you must install PTB via "
-            "`pip install python-telegram-bot[job_queue]`."
+            "`pip install python-telegram-bot[job-queue]`."
         )
         assert app.job_queue is app._job_queue
         application = ApplicationBuilder().token(bot.token).job_queue(None).build()

--- a/tests/test_callbackcontext.py
+++ b/tests/test_callbackcontext.py
@@ -61,7 +61,7 @@ class TestCallbackContext:
     def test_job_queue(self, bot, app, recwarn):
         expected_warning = (
             "No `JobQueue` set up. To use `JobQueue`, you must install PTB via "
-            "`pip install python-telegram-bot[job_queue]`."
+            "`pip install python-telegram-bot[job-queue]`."
         )
 
         callback_context = CallbackContext(app)


### PR DESCRIPTION
Fixes a typo in the warning message for the optional dependency during installation, which was introduced in pull request #3391. Originally reported [here](https://t.me/pythontelegrambotgroup/648878).