### PR TITLE
Propose to add unit test example for echobot example

### DIFF
--- a/tests/examples/test_echobot.py
+++ b/tests/examples/test_echobot.py
@@ -1,0 +1,42 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from examples.echobot import echo, help_command, start
+from telegram import ForceReply, Message, Update, User
+from telegram.ext import ContextTypes
+
+
+class TestEchoBot:
+    MENTION_HTML = "mention_html"
+    TEXT = "text"
+
+    def setup_method(self) -> None:
+        self.user = MagicMock(spec=User)
+        self.user.mention_html.return_value = self.MENTION_HTML
+
+        self.message = MagicMock(spec=Message)
+        self.message.text = self.TEXT
+
+        self.update = MagicMock(spec=Update)
+        self.update.effective_user = self.user
+        self.update.message = self.message
+
+        self.context = MagicMock(spec=ContextTypes.DEFAULT_TYPE)
+
+    @pytest.mark.asyncio
+    async def test_start(self) -> None:
+        await start(self.update, self.context)
+        self.update.message.reply_html.assert_called_once_with(
+            f"Hi {self.MENTION_HTML}!", reply_markup=ForceReply(selective=True)
+        )
+
+    @pytest.mark.asyncio
+    async def test_help_command(self) -> None:
+        await help_command(self.update, self.context)
+        self.update.message.reply_text.assert_called_once_with("Help!")
+
+    @pytest.mark.asyncio
+    async def test_echo(self) -> None:
+        await echo(self.update, self.context)
+        self.update.message.reply_text.assert_called_once_with(self.TEXT)


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool! Please have a look at the below checklist. It's here to help both you and the maintainers to remember some aspects. Make sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
-->

### Checklist for PRs

- [ ] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [ ] Created new or adapted existing unit tests
- [ ] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)
- [ ] Added new classes & modules to the docs and all suitable `__all__` s

Recently, I've achieved full test coverage in my project with `python-telegram-bot`. So I figured to share my approach of testing back to the community and to discuss with you all 🙂 

I noticed the unit tests [section](https://github.com/python-telegram-bot/python-telegram-bot/wiki/Writing-Tests#unit-tests) of the Wiki mentioned an unmaintained unit testing framework. I would argue the approach there is closer to being an integration test than a unit test. In my humble opinion, a unit test would simply be testing a method/API by providing some inputs and checking for the expecting outputs. This is also the approach I've taken in my project.

This PR proposes a unit test example for the echobot [example](https://github.com/python-telegram-bot/python-telegram-bot/blob/master/examples/echobot.py) to test for the callbacks. Basically, it mocks out `Update` and `CallbackContext` which are the expected arguments for the callbacks. We then pass the arguments to the callback and assert for the expected behaviour. Other than being able to unit test the code, another benefit is that this approach doesn't rely on another testing library/framework and all we need is `unittest` and `pytest`.

We should also be able to test out if the handlers have been added to the `Application` with a similar approach, but might require a little bit of refactoring of the example code so maybe will have to discuss on whether it's worth unit testing that bit.

Happy to discuss if this unit test example is appropriate. And I can also add more testing examples for the other example code if you think they're relevant.

PS, I'm not sure if you want this example test to be part of the `tests` folder or the `examples` folder.