### PR TITLE
Drop `telegram(.ext).` prefixes

### DIFF
--- a/docs/source/telegram.animation.rst
+++ b/docs/source/telegram.animation.rst
@@ -1,5 +1,5 @@
 Animation
-==================
+=========
 
 .. Also lists methods of _BaseThumbedMedium, but not the ones of TelegramObject
 

--- a/docs/source/telegram.animation.rst
+++ b/docs/source/telegram.animation.rst
@@ -1,4 +1,4 @@
-telegram.Animation
+Animation
 ==================
 
 .. Also lists methods of _BaseThumbedMedium, but not the ones of TelegramObject

--- a/docs/source/telegram.audio.rst
+++ b/docs/source/telegram.audio.rst
@@ -1,4 +1,4 @@
-telegram.Audio
+Audio
 ==============
 
 .. Also lists methods of _BaseThumbedMedium, but not the ones of TelegramObject

--- a/docs/source/telegram.audio.rst
+++ b/docs/source/telegram.audio.rst
@@ -1,5 +1,5 @@
 Audio
-==============
+=====
 
 .. Also lists methods of _BaseThumbedMedium, but not the ones of TelegramObject
 

--- a/docs/source/telegram.bot.rst
+++ b/docs/source/telegram.bot.rst
@@ -1,5 +1,5 @@
-telegram.Bot
-============
+Bot
+===
 
 .. autoclass:: telegram.Bot
     :members:

--- a/docs/source/telegram.botcommand.rst
+++ b/docs/source/telegram.botcommand.rst
@@ -1,5 +1,5 @@
 BotCommand
-===================
+==========
 
 .. autoclass:: telegram.BotCommand
     :members:

--- a/docs/source/telegram.botcommand.rst
+++ b/docs/source/telegram.botcommand.rst
@@ -1,4 +1,4 @@
-telegram.BotCommand
+BotCommand
 ===================
 
 .. autoclass:: telegram.BotCommand

--- a/docs/source/telegram.botcommandscope.rst
+++ b/docs/source/telegram.botcommandscope.rst
@@ -1,5 +1,5 @@
 BotCommandScope
-========================
+===============
 
 .. autoclass:: telegram.BotCommandScope
     :members:

--- a/docs/source/telegram.botcommandscope.rst
+++ b/docs/source/telegram.botcommandscope.rst
@@ -1,4 +1,4 @@
-telegram.BotCommandScope
+BotCommandScope
 ========================
 
 .. autoclass:: telegram.BotCommandScope

--- a/docs/source/telegram.botcommandscopeallchatadministrators.rst
+++ b/docs/source/telegram.botcommandscopeallchatadministrators.rst
@@ -1,5 +1,5 @@
 BotCommandScopeAllChatAdministrators
-=============================================
+====================================
 
 .. autoclass:: telegram.BotCommandScopeAllChatAdministrators
     :members:

--- a/docs/source/telegram.botcommandscopeallchatadministrators.rst
+++ b/docs/source/telegram.botcommandscopeallchatadministrators.rst
@@ -1,4 +1,4 @@
-telegram.BotCommandScopeAllChatAdministrators
+BotCommandScopeAllChatAdministrators
 =============================================
 
 .. autoclass:: telegram.BotCommandScopeAllChatAdministrators

--- a/docs/source/telegram.botcommandscopeallgroupchats.rst
+++ b/docs/source/telegram.botcommandscopeallgroupchats.rst
@@ -1,4 +1,4 @@
-telegram.BotCommandScopeAllGroupChats
+BotCommandScopeAllGroupChats
 =======================================
 
 .. autoclass:: telegram.BotCommandScopeAllGroupChats

--- a/docs/source/telegram.botcommandscopeallgroupchats.rst
+++ b/docs/source/telegram.botcommandscopeallgroupchats.rst
@@ -1,5 +1,5 @@
 BotCommandScopeAllGroupChats
-=======================================
+============================
 
 .. autoclass:: telegram.BotCommandScopeAllGroupChats
     :members:

--- a/docs/source/telegram.botcommandscopeallprivatechats.rst
+++ b/docs/source/telegram.botcommandscopeallprivatechats.rst
@@ -1,5 +1,5 @@
 BotCommandScopeAllPrivateChats
-=======================================
+==============================
 
 .. autoclass:: telegram.BotCommandScopeAllPrivateChats
     :members:

--- a/docs/source/telegram.botcommandscopeallprivatechats.rst
+++ b/docs/source/telegram.botcommandscopeallprivatechats.rst
@@ -1,4 +1,4 @@
-telegram.BotCommandScopeAllPrivateChats
+BotCommandScopeAllPrivateChats
 =======================================
 
 .. autoclass:: telegram.BotCommandScopeAllPrivateChats

--- a/docs/source/telegram.botcommandscopechat.rst
+++ b/docs/source/telegram.botcommandscopechat.rst
@@ -1,5 +1,5 @@
 BotCommandScopeChat
-============================
+===================
 
 .. autoclass:: telegram.BotCommandScopeChat
     :members:

--- a/docs/source/telegram.botcommandscopechat.rst
+++ b/docs/source/telegram.botcommandscopechat.rst
@@ -1,4 +1,4 @@
-telegram.BotCommandScopeChat
+BotCommandScopeChat
 ============================
 
 .. autoclass:: telegram.BotCommandScopeChat

--- a/docs/source/telegram.botcommandscopechatadministrators.rst
+++ b/docs/source/telegram.botcommandscopechatadministrators.rst
@@ -1,5 +1,5 @@
 BotCommandScopeChatAdministrators
-==========================================
+=================================
 
 .. autoclass:: telegram.BotCommandScopeChatAdministrators
     :members:

--- a/docs/source/telegram.botcommandscopechatadministrators.rst
+++ b/docs/source/telegram.botcommandscopechatadministrators.rst
@@ -1,4 +1,4 @@
-telegram.BotCommandScopeChatAdministrators
+BotCommandScopeChatAdministrators
 ==========================================
 
 .. autoclass:: telegram.BotCommandScopeChatAdministrators

--- a/docs/source/telegram.botcommandscopechatmember.rst
+++ b/docs/source/telegram.botcommandscopechatmember.rst
@@ -1,5 +1,5 @@
 BotCommandScopeChatMember
-==================================
+=========================
 
 .. autoclass:: telegram.BotCommandScopeChatMember
     :members:

--- a/docs/source/telegram.botcommandscopechatmember.rst
+++ b/docs/source/telegram.botcommandscopechatmember.rst
@@ -1,4 +1,4 @@
-telegram.BotCommandScopeChatMember
+BotCommandScopeChatMember
 ==================================
 
 .. autoclass:: telegram.BotCommandScopeChatMember

--- a/docs/source/telegram.botcommandscopedefault.rst
+++ b/docs/source/telegram.botcommandscopedefault.rst
@@ -1,4 +1,4 @@
-telegram.BotCommandScopeDefault
+BotCommandScopeDefault
 ===============================
 
 .. autoclass:: telegram.BotCommandScopeDefault

--- a/docs/source/telegram.botcommandscopedefault.rst
+++ b/docs/source/telegram.botcommandscopedefault.rst
@@ -1,5 +1,5 @@
 BotCommandScopeDefault
-===============================
+======================
 
 .. autoclass:: telegram.BotCommandScopeDefault
     :members:

--- a/docs/source/telegram.callbackgame.rst
+++ b/docs/source/telegram.callbackgame.rst
@@ -1,5 +1,5 @@
 Callbackgame
-=====================
+============
 
 .. autoclass:: telegram.CallbackGame
     :members:

--- a/docs/source/telegram.callbackgame.rst
+++ b/docs/source/telegram.callbackgame.rst
@@ -1,4 +1,4 @@
-telegram.Callbackgame
+Callbackgame
 =====================
 
 .. autoclass:: telegram.CallbackGame

--- a/docs/source/telegram.callbackquery.rst
+++ b/docs/source/telegram.callbackquery.rst
@@ -1,4 +1,4 @@
-telegram.CallbackQuery
+CallbackQuery
 ======================
 
 .. autoclass:: telegram.CallbackQuery

--- a/docs/source/telegram.callbackquery.rst
+++ b/docs/source/telegram.callbackquery.rst
@@ -1,5 +1,5 @@
 CallbackQuery
-======================
+=============
 
 .. autoclass:: telegram.CallbackQuery
     :members:

--- a/docs/source/telegram.chat.rst
+++ b/docs/source/telegram.chat.rst
@@ -1,4 +1,4 @@
-telegram.Chat
+Chat
 =============
 
 .. autoclass:: telegram.Chat

--- a/docs/source/telegram.chat.rst
+++ b/docs/source/telegram.chat.rst
@@ -1,5 +1,5 @@
 Chat
-=============
+====
 
 .. autoclass:: telegram.Chat
     :members:

--- a/docs/source/telegram.chatadministratorrights.rst
+++ b/docs/source/telegram.chatadministratorrights.rst
@@ -1,5 +1,5 @@
 ChatAdministratorRights
-================================
+=======================
 
 .. versionadded:: 20.0
 

--- a/docs/source/telegram.chatadministratorrights.rst
+++ b/docs/source/telegram.chatadministratorrights.rst
@@ -1,4 +1,4 @@
-telegram.ChatAdministratorRights
+ChatAdministratorRights
 ================================
 
 .. versionadded:: 20.0

--- a/docs/source/telegram.chatinvitelink.rst
+++ b/docs/source/telegram.chatinvitelink.rst
@@ -1,4 +1,4 @@
-telegram.ChatInviteLink
+ChatInviteLink
 =======================
 
 .. autoclass:: telegram.ChatInviteLink

--- a/docs/source/telegram.chatinvitelink.rst
+++ b/docs/source/telegram.chatinvitelink.rst
@@ -1,5 +1,5 @@
 ChatInviteLink
-=======================
+==============
 
 .. autoclass:: telegram.ChatInviteLink
     :members:

--- a/docs/source/telegram.chatjoinrequest.rst
+++ b/docs/source/telegram.chatjoinrequest.rst
@@ -1,5 +1,5 @@
 ChatJoinRequest
-========================
+===============
 
 .. autoclass:: telegram.ChatJoinRequest
     :members:

--- a/docs/source/telegram.chatjoinrequest.rst
+++ b/docs/source/telegram.chatjoinrequest.rst
@@ -1,4 +1,4 @@
-telegram.ChatJoinRequest
+ChatJoinRequest
 ========================
 
 .. autoclass:: telegram.ChatJoinRequest

--- a/docs/source/telegram.chatlocation.rst
+++ b/docs/source/telegram.chatlocation.rst
@@ -1,5 +1,5 @@
 ChatLocation
-=====================
+============
 
 .. autoclass:: telegram.ChatLocation
     :members:

--- a/docs/source/telegram.chatlocation.rst
+++ b/docs/source/telegram.chatlocation.rst
@@ -1,4 +1,4 @@
-telegram.ChatLocation
+ChatLocation
 =====================
 
 .. autoclass:: telegram.ChatLocation

--- a/docs/source/telegram.chatmember.rst
+++ b/docs/source/telegram.chatmember.rst
@@ -1,4 +1,4 @@
-telegram.ChatMember
+ChatMember
 ===================
 
 .. autoclass:: telegram.ChatMember

--- a/docs/source/telegram.chatmember.rst
+++ b/docs/source/telegram.chatmember.rst
@@ -1,5 +1,5 @@
 ChatMember
-===================
+==========
 
 .. autoclass:: telegram.ChatMember
     :members:

--- a/docs/source/telegram.chatmemberadministrator.rst
+++ b/docs/source/telegram.chatmemberadministrator.rst
@@ -1,5 +1,5 @@
 ChatMemberAdministrator
-================================
+=======================
 
 .. autoclass:: telegram.ChatMemberAdministrator
     :members:

--- a/docs/source/telegram.chatmemberadministrator.rst
+++ b/docs/source/telegram.chatmemberadministrator.rst
@@ -1,4 +1,4 @@
-telegram.ChatMemberAdministrator
+ChatMemberAdministrator
 ================================
 
 .. autoclass:: telegram.ChatMemberAdministrator

--- a/docs/source/telegram.chatmemberbanned.rst
+++ b/docs/source/telegram.chatmemberbanned.rst
@@ -1,4 +1,4 @@
-telegram.ChatMemberBanned
+ChatMemberBanned
 =========================
 
 .. autoclass:: telegram.ChatMemberBanned

--- a/docs/source/telegram.chatmemberbanned.rst
+++ b/docs/source/telegram.chatmemberbanned.rst
@@ -1,5 +1,5 @@
 ChatMemberBanned
-=========================
+================
 
 .. autoclass:: telegram.ChatMemberBanned
     :members:

--- a/docs/source/telegram.chatmemberleft.rst
+++ b/docs/source/telegram.chatmemberleft.rst
@@ -1,5 +1,5 @@
 ChatMemberLeft
-=======================
+==============
 
 .. autoclass:: telegram.ChatMemberLeft
     :members:

--- a/docs/source/telegram.chatmemberleft.rst
+++ b/docs/source/telegram.chatmemberleft.rst
@@ -1,4 +1,4 @@
-telegram.ChatMemberLeft
+ChatMemberLeft
 =======================
 
 .. autoclass:: telegram.ChatMemberLeft

--- a/docs/source/telegram.chatmembermember.rst
+++ b/docs/source/telegram.chatmembermember.rst
@@ -1,5 +1,5 @@
 ChatMemberMember
-=========================
+================
 
 .. autoclass:: telegram.ChatMemberMember
     :members:

--- a/docs/source/telegram.chatmembermember.rst
+++ b/docs/source/telegram.chatmembermember.rst
@@ -1,4 +1,4 @@
-telegram.ChatMemberMember
+ChatMemberMember
 =========================
 
 .. autoclass:: telegram.ChatMemberMember

--- a/docs/source/telegram.chatmemberowner.rst
+++ b/docs/source/telegram.chatmemberowner.rst
@@ -1,5 +1,5 @@
 ChatMemberOwner
-========================
+===============
 
 .. autoclass:: telegram.ChatMemberOwner
     :members:

--- a/docs/source/telegram.chatmemberowner.rst
+++ b/docs/source/telegram.chatmemberowner.rst
@@ -1,4 +1,4 @@
-telegram.ChatMemberOwner
+ChatMemberOwner
 ========================
 
 .. autoclass:: telegram.ChatMemberOwner

--- a/docs/source/telegram.chatmemberrestricted.rst
+++ b/docs/source/telegram.chatmemberrestricted.rst
@@ -1,5 +1,5 @@
 ChatMemberRestricted
-=============================
+====================
 
 .. autoclass:: telegram.ChatMemberRestricted
     :members:

--- a/docs/source/telegram.chatmemberrestricted.rst
+++ b/docs/source/telegram.chatmemberrestricted.rst
@@ -1,4 +1,4 @@
-telegram.ChatMemberRestricted
+ChatMemberRestricted
 =============================
 
 .. autoclass:: telegram.ChatMemberRestricted

--- a/docs/source/telegram.chatmemberupdated.rst
+++ b/docs/source/telegram.chatmemberupdated.rst
@@ -1,4 +1,4 @@
-telegram.ChatMemberUpdated
+ChatMemberUpdated
 ==========================
 
 .. autoclass:: telegram.ChatMemberUpdated

--- a/docs/source/telegram.chatmemberupdated.rst
+++ b/docs/source/telegram.chatmemberupdated.rst
@@ -1,5 +1,5 @@
 ChatMemberUpdated
-==========================
+=================
 
 .. autoclass:: telegram.ChatMemberUpdated
     :members:

--- a/docs/source/telegram.chatpermissions.rst
+++ b/docs/source/telegram.chatpermissions.rst
@@ -1,5 +1,5 @@
 ChatPermissions
-========================
+===============
 
 .. autoclass:: telegram.ChatPermissions
     :members:

--- a/docs/source/telegram.chatpermissions.rst
+++ b/docs/source/telegram.chatpermissions.rst
@@ -1,4 +1,4 @@
-telegram.ChatPermissions
+ChatPermissions
 ========================
 
 .. autoclass:: telegram.ChatPermissions

--- a/docs/source/telegram.chatphoto.rst
+++ b/docs/source/telegram.chatphoto.rst
@@ -1,5 +1,5 @@
 ChatPhoto
-==================
+=========
 
 .. autoclass:: telegram.ChatPhoto
     :members:

--- a/docs/source/telegram.chatphoto.rst
+++ b/docs/source/telegram.chatphoto.rst
@@ -1,4 +1,4 @@
-telegram.ChatPhoto
+ChatPhoto
 ==================
 
 .. autoclass:: telegram.ChatPhoto

--- a/docs/source/telegram.choseninlineresult.rst
+++ b/docs/source/telegram.choseninlineresult.rst
@@ -1,5 +1,5 @@
 ChosenInlineResult
-===========================
+==================
 
 .. autoclass:: telegram.ChosenInlineResult
     :members:

--- a/docs/source/telegram.choseninlineresult.rst
+++ b/docs/source/telegram.choseninlineresult.rst
@@ -1,4 +1,4 @@
-telegram.ChosenInlineResult
+ChosenInlineResult
 ===========================
 
 .. autoclass:: telegram.ChosenInlineResult

--- a/docs/source/telegram.contact.rst
+++ b/docs/source/telegram.contact.rst
@@ -1,5 +1,5 @@
 Contact
-================
+=======
 
 .. autoclass:: telegram.Contact
     :members:

--- a/docs/source/telegram.contact.rst
+++ b/docs/source/telegram.contact.rst
@@ -1,4 +1,4 @@
-telegram.Contact
+Contact
 ================
 
 .. autoclass:: telegram.Contact

--- a/docs/source/telegram.credentials.rst
+++ b/docs/source/telegram.credentials.rst
@@ -1,5 +1,5 @@
 Credentials
-====================
+===========
 
 .. autoclass:: telegram.Credentials
     :members:

--- a/docs/source/telegram.credentials.rst
+++ b/docs/source/telegram.credentials.rst
@@ -1,4 +1,4 @@
-telegram.Credentials
+Credentials
 ====================
 
 .. autoclass:: telegram.Credentials

--- a/docs/source/telegram.datacredentials.rst
+++ b/docs/source/telegram.datacredentials.rst
@@ -1,4 +1,4 @@
-telegram.DataCredentials
+DataCredentials
 ========================
 
 .. autoclass:: telegram.DataCredentials

--- a/docs/source/telegram.datacredentials.rst
+++ b/docs/source/telegram.datacredentials.rst
@@ -1,5 +1,5 @@
 DataCredentials
-========================
+===============
 
 .. autoclass:: telegram.DataCredentials
     :members:

--- a/docs/source/telegram.dice.rst
+++ b/docs/source/telegram.dice.rst
@@ -1,4 +1,4 @@
-telegram.Dice
+Dice
 =============
 
 .. autoclass:: telegram.Dice

--- a/docs/source/telegram.dice.rst
+++ b/docs/source/telegram.dice.rst
@@ -1,5 +1,5 @@
 Dice
-=============
+====
 
 .. autoclass:: telegram.Dice
     :members:

--- a/docs/source/telegram.document.rst
+++ b/docs/source/telegram.document.rst
@@ -1,4 +1,4 @@
-telegram.Document
+Document
 =================
 .. Also lists methods of _BaseThumbedMedium, but not the ones of TelegramObject
 

--- a/docs/source/telegram.document.rst
+++ b/docs/source/telegram.document.rst
@@ -1,5 +1,5 @@
 Document
-=================
+========
 .. Also lists methods of _BaseThumbedMedium, but not the ones of TelegramObject
 
 .. autoclass:: telegram.Document

--- a/docs/source/telegram.encryptedcredentials.rst
+++ b/docs/source/telegram.encryptedcredentials.rst
@@ -1,4 +1,4 @@
-telegram.EncryptedCredentials
+EncryptedCredentials
 =============================
 
 .. autoclass:: telegram.EncryptedCredentials

--- a/docs/source/telegram.encryptedcredentials.rst
+++ b/docs/source/telegram.encryptedcredentials.rst
@@ -1,5 +1,5 @@
 EncryptedCredentials
-=============================
+====================
 
 .. autoclass:: telegram.EncryptedCredentials
     :members:

--- a/docs/source/telegram.encryptedpassportelement.rst
+++ b/docs/source/telegram.encryptedpassportelement.rst
@@ -1,5 +1,5 @@
 EncryptedPassportElement
-=================================
+========================
 
 .. autoclass:: telegram.EncryptedPassportElement
     :members:

--- a/docs/source/telegram.encryptedpassportelement.rst
+++ b/docs/source/telegram.encryptedpassportelement.rst
@@ -1,4 +1,4 @@
-telegram.EncryptedPassportElement
+EncryptedPassportElement
 =================================
 
 .. autoclass:: telegram.EncryptedPassportElement

--- a/docs/source/telegram.ext.aioratelimiter.rst
+++ b/docs/source/telegram.ext.aioratelimiter.rst
@@ -1,5 +1,5 @@
 AIORateLimiter
-============================
+==============
 
 .. autoclass:: telegram.ext.AIORateLimiter
     :members:

--- a/docs/source/telegram.ext.aioratelimiter.rst
+++ b/docs/source/telegram.ext.aioratelimiter.rst
@@ -1,4 +1,4 @@
-telegram.ext.AIORateLimiter
+AIORateLimiter
 ============================
 
 .. autoclass:: telegram.ext.AIORateLimiter

--- a/docs/source/telegram.ext.application.rst
+++ b/docs/source/telegram.ext.application.rst
@@ -1,5 +1,5 @@
 Application
-========================
+===========
 
 .. autoclass:: telegram.ext.Application
     :members:

--- a/docs/source/telegram.ext.application.rst
+++ b/docs/source/telegram.ext.application.rst
@@ -1,4 +1,4 @@
-telegram.ext.Application
+Application
 ========================
 
 .. autoclass:: telegram.ext.Application

--- a/docs/source/telegram.ext.applicationbuilder.rst
+++ b/docs/source/telegram.ext.applicationbuilder.rst
@@ -1,4 +1,4 @@
-telegram.ext.ApplicationBuilder
+ApplicationBuilder
 ===============================
 
 .. autoclass:: telegram.ext.ApplicationBuilder

--- a/docs/source/telegram.ext.applicationbuilder.rst
+++ b/docs/source/telegram.ext.applicationbuilder.rst
@@ -1,5 +1,5 @@
 ApplicationBuilder
-===============================
+==================
 
 .. autoclass:: telegram.ext.ApplicationBuilder
     :members:

--- a/docs/source/telegram.ext.applicationhandlerstop.rst
+++ b/docs/source/telegram.ext.applicationhandlerstop.rst
@@ -1,4 +1,4 @@
-telegram.ext.ApplicationHandlerStop
+ApplicationHandlerStop
 ===================================
 
 .. autoclass:: telegram.ext.ApplicationHandlerStop

--- a/docs/source/telegram.ext.applicationhandlerstop.rst
+++ b/docs/source/telegram.ext.applicationhandlerstop.rst
@@ -1,5 +1,5 @@
 ApplicationHandlerStop
-===================================
+======================
 
 .. autoclass:: telegram.ext.ApplicationHandlerStop
     :members:

--- a/docs/source/telegram.ext.basehandler.rst
+++ b/docs/source/telegram.ext.basehandler.rst
@@ -1,5 +1,5 @@
 BaseHandler
-========================
+===========
 
 .. autoclass:: telegram.ext.BaseHandler
     :members:

--- a/docs/source/telegram.ext.basehandler.rst
+++ b/docs/source/telegram.ext.basehandler.rst
@@ -1,4 +1,4 @@
-telegram.ext.BaseHandler
+BaseHandler
 ========================
 
 .. autoclass:: telegram.ext.BaseHandler

--- a/docs/source/telegram.ext.basepersistence.rst
+++ b/docs/source/telegram.ext.basepersistence.rst
@@ -1,5 +1,5 @@
 BasePersistence
-============================
+===============
 
 .. autoclass:: telegram.ext.BasePersistence
     :members:

--- a/docs/source/telegram.ext.basepersistence.rst
+++ b/docs/source/telegram.ext.basepersistence.rst
@@ -1,4 +1,4 @@
-telegram.ext.BasePersistence
+BasePersistence
 ============================
 
 .. autoclass:: telegram.ext.BasePersistence

--- a/docs/source/telegram.ext.baseratelimiter.rst
+++ b/docs/source/telegram.ext.baseratelimiter.rst
@@ -1,5 +1,5 @@
 BaseRateLimiter
-============================
+===============
 
 .. autoclass:: telegram.ext.BaseRateLimiter
     :members:

--- a/docs/source/telegram.ext.baseratelimiter.rst
+++ b/docs/source/telegram.ext.baseratelimiter.rst
@@ -1,4 +1,4 @@
-telegram.ext.BaseRateLimiter
+BaseRateLimiter
 ============================
 
 .. autoclass:: telegram.ext.BaseRateLimiter

--- a/docs/source/telegram.ext.callbackcontext.rst
+++ b/docs/source/telegram.ext.callbackcontext.rst
@@ -1,4 +1,4 @@
-telegram.ext.CallbackContext
+CallbackContext
 ============================
 
 .. autoclass:: telegram.ext.CallbackContext

--- a/docs/source/telegram.ext.callbackcontext.rst
+++ b/docs/source/telegram.ext.callbackcontext.rst
@@ -1,5 +1,5 @@
 CallbackContext
-============================
+===============
 
 .. autoclass:: telegram.ext.CallbackContext
     :members:

--- a/docs/source/telegram.ext.callbackdatacache.rst
+++ b/docs/source/telegram.ext.callbackdatacache.rst
@@ -1,5 +1,5 @@
 CallbackDataCache
-==============================
+=================
 
 .. autoclass:: telegram.ext.CallbackDataCache
     :members:

--- a/docs/source/telegram.ext.callbackdatacache.rst
+++ b/docs/source/telegram.ext.callbackdatacache.rst
@@ -1,4 +1,4 @@
-telegram.ext.CallbackDataCache
+CallbackDataCache
 ==============================
 
 .. autoclass:: telegram.ext.CallbackDataCache

--- a/docs/source/telegram.ext.callbackqueryhandler.rst
+++ b/docs/source/telegram.ext.callbackqueryhandler.rst
@@ -1,4 +1,4 @@
-telegram.ext.CallbackQueryHandler
+CallbackQueryHandler
 =================================
 
 .. autoclass:: telegram.ext.CallbackQueryHandler

--- a/docs/source/telegram.ext.callbackqueryhandler.rst
+++ b/docs/source/telegram.ext.callbackqueryhandler.rst
@@ -1,5 +1,5 @@
 CallbackQueryHandler
-=================================
+====================
 
 .. autoclass:: telegram.ext.CallbackQueryHandler
     :members:

--- a/docs/source/telegram.ext.chatjoinrequesthandler.rst
+++ b/docs/source/telegram.ext.chatjoinrequesthandler.rst
@@ -1,4 +1,4 @@
-telegram.ext.ChatJoinRequestHandler
+ChatJoinRequestHandler
 ===================================
 
 .. autoclass:: telegram.ext.ChatJoinRequestHandler

--- a/docs/source/telegram.ext.chatjoinrequesthandler.rst
+++ b/docs/source/telegram.ext.chatjoinrequesthandler.rst
@@ -1,5 +1,5 @@
 ChatJoinRequestHandler
-===================================
+======================
 
 .. autoclass:: telegram.ext.ChatJoinRequestHandler
     :members:

--- a/docs/source/telegram.ext.chatmemberhandler.rst
+++ b/docs/source/telegram.ext.chatmemberhandler.rst
@@ -1,5 +1,5 @@
 ChatMemberHandler
-==============================
+=================
 
 .. autoclass:: telegram.ext.ChatMemberHandler
     :members:

--- a/docs/source/telegram.ext.chatmemberhandler.rst
+++ b/docs/source/telegram.ext.chatmemberhandler.rst
@@ -1,4 +1,4 @@
-telegram.ext.ChatMemberHandler
+ChatMemberHandler
 ==============================
 
 .. autoclass:: telegram.ext.ChatMemberHandler

--- a/docs/source/telegram.ext.choseninlineresulthandler.rst
+++ b/docs/source/telegram.ext.choseninlineresulthandler.rst
@@ -1,4 +1,4 @@
-telegram.ext.ChosenInlineResultHandler
+ChosenInlineResultHandler
 ======================================
 
 .. autoclass:: telegram.ext.ChosenInlineResultHandler

--- a/docs/source/telegram.ext.choseninlineresulthandler.rst
+++ b/docs/source/telegram.ext.choseninlineresulthandler.rst
@@ -1,5 +1,5 @@
 ChosenInlineResultHandler
-======================================
+=========================
 
 .. autoclass:: telegram.ext.ChosenInlineResultHandler
     :members:

--- a/docs/source/telegram.ext.commandhandler.rst
+++ b/docs/source/telegram.ext.commandhandler.rst
@@ -1,5 +1,5 @@
 CommandHandler
-===========================
+==============
 
 .. autoclass:: telegram.ext.CommandHandler
     :members:

--- a/docs/source/telegram.ext.commandhandler.rst
+++ b/docs/source/telegram.ext.commandhandler.rst
@@ -1,4 +1,4 @@
-telegram.ext.CommandHandler
+CommandHandler
 ===========================
 
 .. autoclass:: telegram.ext.CommandHandler

--- a/docs/source/telegram.ext.contexttypes.rst
+++ b/docs/source/telegram.ext.contexttypes.rst
@@ -1,5 +1,5 @@
 ContextTypes
-=========================
+============
 
 .. autoclass:: telegram.ext.ContextTypes
     :members:

--- a/docs/source/telegram.ext.contexttypes.rst
+++ b/docs/source/telegram.ext.contexttypes.rst
@@ -1,4 +1,4 @@
-telegram.ext.ContextTypes
+ContextTypes
 =========================
 
 .. autoclass:: telegram.ext.ContextTypes

--- a/docs/source/telegram.ext.conversationhandler.rst
+++ b/docs/source/telegram.ext.conversationhandler.rst
@@ -1,4 +1,4 @@
-telegram.ext.ConversationHandler
+ConversationHandler
 ================================
 
 .. autoclass:: telegram.ext.ConversationHandler

--- a/docs/source/telegram.ext.conversationhandler.rst
+++ b/docs/source/telegram.ext.conversationhandler.rst
@@ -1,5 +1,5 @@
 ConversationHandler
-================================
+===================
 
 .. autoclass:: telegram.ext.ConversationHandler
     :members:

--- a/docs/source/telegram.ext.defaults.rst
+++ b/docs/source/telegram.ext.defaults.rst
@@ -1,5 +1,5 @@
 Defaults
-=====================
+========
 
 .. autoclass:: telegram.ext.Defaults
     :members:

--- a/docs/source/telegram.ext.defaults.rst
+++ b/docs/source/telegram.ext.defaults.rst
@@ -1,4 +1,4 @@
-telegram.ext.Defaults
+Defaults
 =====================
 
 .. autoclass:: telegram.ext.Defaults

--- a/docs/source/telegram.ext.dictpersistence.rst
+++ b/docs/source/telegram.ext.dictpersistence.rst
@@ -1,5 +1,5 @@
 DictPersistence
-============================
+===============
 
 .. autoclass:: telegram.ext.DictPersistence
     :members:

--- a/docs/source/telegram.ext.dictpersistence.rst
+++ b/docs/source/telegram.ext.dictpersistence.rst
@@ -1,4 +1,4 @@
-telegram.ext.DictPersistence
+DictPersistence
 ============================
 
 .. autoclass:: telegram.ext.DictPersistence

--- a/docs/source/telegram.ext.extbot.rst
+++ b/docs/source/telegram.ext.extbot.rst
@@ -1,5 +1,5 @@
 ExtBot
-===================
+======
 
 .. autoclass:: telegram.ext.ExtBot
     :show-inheritance:

--- a/docs/source/telegram.ext.extbot.rst
+++ b/docs/source/telegram.ext.extbot.rst
@@ -1,4 +1,4 @@
-telegram.ext.ExtBot
+ExtBot
 ===================
 
 .. autoclass:: telegram.ext.ExtBot

--- a/docs/source/telegram.ext.filters.rst
+++ b/docs/source/telegram.ext.filters.rst
@@ -1,5 +1,5 @@
-telegram.ext.filters Module
-===========================
+filters Module
+==============
 
 .. :bysource: since e.g filters.CHAT is much above filters.Chat() in the docs when it shouldn't.
    The classes in `filters.py` are sorted alphabetically such that :bysource: still is readable

--- a/docs/source/telegram.ext.inlinequeryhandler.rst
+++ b/docs/source/telegram.ext.inlinequeryhandler.rst
@@ -1,4 +1,4 @@
-telegram.ext.InlineQueryHandler
+InlineQueryHandler
 ===============================
 
 .. autoclass:: telegram.ext.InlineQueryHandler

--- a/docs/source/telegram.ext.inlinequeryhandler.rst
+++ b/docs/source/telegram.ext.inlinequeryhandler.rst
@@ -1,5 +1,5 @@
 InlineQueryHandler
-===============================
+==================
 
 .. autoclass:: telegram.ext.InlineQueryHandler
     :members:

--- a/docs/source/telegram.ext.invalidcallbackdata.rst
+++ b/docs/source/telegram.ext.invalidcallbackdata.rst
@@ -1,5 +1,5 @@
 InvalidCallbackData
-================================
+===================
 
 .. autoclass:: telegram.ext.InvalidCallbackData
     :members:

--- a/docs/source/telegram.ext.invalidcallbackdata.rst
+++ b/docs/source/telegram.ext.invalidcallbackdata.rst
@@ -1,4 +1,4 @@
-telegram.ext.InvalidCallbackData
+InvalidCallbackData
 ================================
 
 .. autoclass:: telegram.ext.InvalidCallbackData

--- a/docs/source/telegram.ext.job.rst
+++ b/docs/source/telegram.ext.job.rst
@@ -1,5 +1,5 @@
 Job
-=====================
+===
 
 .. autoclass:: telegram.ext.Job
     :members:

--- a/docs/source/telegram.ext.job.rst
+++ b/docs/source/telegram.ext.job.rst
@@ -1,4 +1,4 @@
-telegram.ext.Job
+Job
 =====================
 
 .. autoclass:: telegram.ext.Job

--- a/docs/source/telegram.ext.jobqueue.rst
+++ b/docs/source/telegram.ext.jobqueue.rst
@@ -1,4 +1,4 @@
-telegram.ext.JobQueue
+JobQueue
 =====================
 
 .. autoclass:: telegram.ext.JobQueue

--- a/docs/source/telegram.ext.jobqueue.rst
+++ b/docs/source/telegram.ext.jobqueue.rst
@@ -1,5 +1,5 @@
 JobQueue
-=====================
+========
 
 .. autoclass:: telegram.ext.JobQueue
     :members:

--- a/docs/source/telegram.ext.messagehandler.rst
+++ b/docs/source/telegram.ext.messagehandler.rst
@@ -1,4 +1,4 @@
-telegram.ext.MessageHandler
+MessageHandler
 ===========================
 
 .. autoclass:: telegram.ext.MessageHandler

--- a/docs/source/telegram.ext.messagehandler.rst
+++ b/docs/source/telegram.ext.messagehandler.rst
@@ -1,5 +1,5 @@
 MessageHandler
-===========================
+==============
 
 .. autoclass:: telegram.ext.MessageHandler
     :members:

--- a/docs/source/telegram.ext.persistenceinput.rst
+++ b/docs/source/telegram.ext.persistenceinput.rst
@@ -1,4 +1,4 @@
-telegram.ext.PersistenceInput
+PersistenceInput
 =============================
 
 .. autoclass:: telegram.ext.PersistenceInput

--- a/docs/source/telegram.ext.persistenceinput.rst
+++ b/docs/source/telegram.ext.persistenceinput.rst
@@ -1,5 +1,5 @@
 PersistenceInput
-=============================
+================
 
 .. autoclass:: telegram.ext.PersistenceInput
     :show-inheritance:

--- a/docs/source/telegram.ext.picklepersistence.rst
+++ b/docs/source/telegram.ext.picklepersistence.rst
@@ -1,4 +1,4 @@
-telegram.ext.PicklePersistence
+PicklePersistence
 ==============================
 
 .. autoclass:: telegram.ext.PicklePersistence

--- a/docs/source/telegram.ext.picklepersistence.rst
+++ b/docs/source/telegram.ext.picklepersistence.rst
@@ -1,5 +1,5 @@
 PicklePersistence
-==============================
+=================
 
 .. autoclass:: telegram.ext.PicklePersistence
     :members:

--- a/docs/source/telegram.ext.pollanswerhandler.rst
+++ b/docs/source/telegram.ext.pollanswerhandler.rst
@@ -1,5 +1,5 @@
 PollAnswerHandler
-==============================
+=================
 
 .. autoclass:: telegram.ext.PollAnswerHandler
     :members:

--- a/docs/source/telegram.ext.pollanswerhandler.rst
+++ b/docs/source/telegram.ext.pollanswerhandler.rst
@@ -1,4 +1,4 @@
-telegram.ext.PollAnswerHandler
+PollAnswerHandler
 ==============================
 
 .. autoclass:: telegram.ext.PollAnswerHandler

--- a/docs/source/telegram.ext.pollhandler.rst
+++ b/docs/source/telegram.ext.pollhandler.rst
@@ -1,4 +1,4 @@
-telegram.ext.PollHandler
+PollHandler
 ========================
 
 .. autoclass:: telegram.ext.PollHandler

--- a/docs/source/telegram.ext.pollhandler.rst
+++ b/docs/source/telegram.ext.pollhandler.rst
@@ -1,5 +1,5 @@
 PollHandler
-========================
+===========
 
 .. autoclass:: telegram.ext.PollHandler
     :members:

--- a/docs/source/telegram.ext.precheckoutqueryhandler.rst
+++ b/docs/source/telegram.ext.precheckoutqueryhandler.rst
@@ -1,5 +1,5 @@
 PreCheckoutQueryHandler
-====================================
+=======================
 
 .. autoclass:: telegram.ext.PreCheckoutQueryHandler
     :members:

--- a/docs/source/telegram.ext.precheckoutqueryhandler.rst
+++ b/docs/source/telegram.ext.precheckoutqueryhandler.rst
@@ -1,4 +1,4 @@
-telegram.ext.PreCheckoutQueryHandler
+PreCheckoutQueryHandler
 ====================================
 
 .. autoclass:: telegram.ext.PreCheckoutQueryHandler

--- a/docs/source/telegram.ext.prefixhandler.rst
+++ b/docs/source/telegram.ext.prefixhandler.rst
@@ -1,5 +1,5 @@
 PrefixHandler
-===========================
+=============
 
 .. autoclass:: telegram.ext.PrefixHandler
     :members:

--- a/docs/source/telegram.ext.prefixhandler.rst
+++ b/docs/source/telegram.ext.prefixhandler.rst
@@ -1,4 +1,4 @@
-telegram.ext.PrefixHandler
+PrefixHandler
 ===========================
 
 .. autoclass:: telegram.ext.PrefixHandler

--- a/docs/source/telegram.ext.shippingqueryhandler.rst
+++ b/docs/source/telegram.ext.shippingqueryhandler.rst
@@ -1,5 +1,5 @@
 ShippingQueryHandler
-=================================
+====================
 
 .. autoclass:: telegram.ext.ShippingQueryHandler
     :members:

--- a/docs/source/telegram.ext.shippingqueryhandler.rst
+++ b/docs/source/telegram.ext.shippingqueryhandler.rst
@@ -1,4 +1,4 @@
-telegram.ext.ShippingQueryHandler
+ShippingQueryHandler
 =================================
 
 .. autoclass:: telegram.ext.ShippingQueryHandler

--- a/docs/source/telegram.ext.stringcommandhandler.rst
+++ b/docs/source/telegram.ext.stringcommandhandler.rst
@@ -1,4 +1,4 @@
-telegram.ext.StringCommandHandler
+StringCommandHandler
 =================================
 
 .. autoclass:: telegram.ext.StringCommandHandler

--- a/docs/source/telegram.ext.stringcommandhandler.rst
+++ b/docs/source/telegram.ext.stringcommandhandler.rst
@@ -1,5 +1,5 @@
 StringCommandHandler
-=================================
+====================
 
 .. autoclass:: telegram.ext.StringCommandHandler
     :members:

--- a/docs/source/telegram.ext.stringregexhandler.rst
+++ b/docs/source/telegram.ext.stringregexhandler.rst
@@ -1,5 +1,5 @@
 StringRegexHandler
-===============================
+==================
 
 .. autoclass:: telegram.ext.StringRegexHandler
     :members:

--- a/docs/source/telegram.ext.stringregexhandler.rst
+++ b/docs/source/telegram.ext.stringregexhandler.rst
@@ -1,4 +1,4 @@
-telegram.ext.StringRegexHandler
+StringRegexHandler
 ===============================
 
 .. autoclass:: telegram.ext.StringRegexHandler

--- a/docs/source/telegram.ext.typehandler.rst
+++ b/docs/source/telegram.ext.typehandler.rst
@@ -1,4 +1,4 @@
-telegram.ext.TypeHandler
+TypeHandler
 ========================
 
 .. autoclass:: telegram.ext.TypeHandler

--- a/docs/source/telegram.ext.typehandler.rst
+++ b/docs/source/telegram.ext.typehandler.rst
@@ -1,5 +1,5 @@
 TypeHandler
-========================
+===========
 
 .. autoclass:: telegram.ext.TypeHandler
     :members:

--- a/docs/source/telegram.ext.updater.rst
+++ b/docs/source/telegram.ext.updater.rst
@@ -1,4 +1,4 @@
-telegram.ext.Updater
+Updater
 ====================
 
 .. autoclass:: telegram.ext.Updater

--- a/docs/source/telegram.ext.updater.rst
+++ b/docs/source/telegram.ext.updater.rst
@@ -1,5 +1,5 @@
 Updater
-====================
+=======
 
 .. autoclass:: telegram.ext.Updater
     :members:

--- a/docs/source/telegram.file.rst
+++ b/docs/source/telegram.file.rst
@@ -1,4 +1,4 @@
-telegram.File
+File
 =============
 
 .. autoclass:: telegram.File

--- a/docs/source/telegram.file.rst
+++ b/docs/source/telegram.file.rst
@@ -1,5 +1,5 @@
 File
-=============
+====
 
 .. autoclass:: telegram.File
     :members:

--- a/docs/source/telegram.filecredentials.rst
+++ b/docs/source/telegram.filecredentials.rst
@@ -1,5 +1,5 @@
 FileCredentials
-========================
+===============
 
 .. autoclass:: telegram.FileCredentials
     :members:

--- a/docs/source/telegram.filecredentials.rst
+++ b/docs/source/telegram.filecredentials.rst
@@ -1,4 +1,4 @@
-telegram.FileCredentials
+FileCredentials
 ========================
 
 .. autoclass:: telegram.FileCredentials

--- a/docs/source/telegram.forcereply.rst
+++ b/docs/source/telegram.forcereply.rst
@@ -1,5 +1,5 @@
 ForceReply
-===================
+==========
 
 .. autoclass:: telegram.ForceReply
     :members:

--- a/docs/source/telegram.forcereply.rst
+++ b/docs/source/telegram.forcereply.rst
@@ -1,4 +1,4 @@
-telegram.ForceReply
+ForceReply
 ===================
 
 .. autoclass:: telegram.ForceReply

--- a/docs/source/telegram.forumtopic.rst
+++ b/docs/source/telegram.forumtopic.rst
@@ -1,4 +1,4 @@
-telegram.ForumTopic
+ForumTopic
 ===================
 
 .. autoclass:: telegram.ForumTopic

--- a/docs/source/telegram.forumtopic.rst
+++ b/docs/source/telegram.forumtopic.rst
@@ -1,5 +1,5 @@
 ForumTopic
-===================
+==========
 
 .. autoclass:: telegram.ForumTopic
     :members:

--- a/docs/source/telegram.forumtopicclosed.rst
+++ b/docs/source/telegram.forumtopicclosed.rst
@@ -1,4 +1,4 @@
-telegram.ForumTopicClosed
+ForumTopicClosed
 =========================
 
 .. autoclass:: telegram.ForumTopicClosed

--- a/docs/source/telegram.forumtopicclosed.rst
+++ b/docs/source/telegram.forumtopicclosed.rst
@@ -1,5 +1,5 @@
 ForumTopicClosed
-=========================
+================
 
 .. autoclass:: telegram.ForumTopicClosed
     :members:

--- a/docs/source/telegram.forumtopiccreated.rst
+++ b/docs/source/telegram.forumtopiccreated.rst
@@ -1,5 +1,5 @@
 ForumTopicCreated
-==========================
+=================
 
 .. autoclass:: telegram.ForumTopicCreated
     :members:

--- a/docs/source/telegram.forumtopiccreated.rst
+++ b/docs/source/telegram.forumtopiccreated.rst
@@ -1,4 +1,4 @@
-telegram.ForumTopicCreated
+ForumTopicCreated
 ==========================
 
 .. autoclass:: telegram.ForumTopicCreated

--- a/docs/source/telegram.forumtopicedited.rst
+++ b/docs/source/telegram.forumtopicedited.rst
@@ -1,5 +1,5 @@
 ForumTopicEdited
-=========================
+================
 
 .. autoclass:: telegram.ForumTopicEdited
     :members:

--- a/docs/source/telegram.forumtopicedited.rst
+++ b/docs/source/telegram.forumtopicedited.rst
@@ -1,4 +1,4 @@
-telegram.ForumTopicEdited
+ForumTopicEdited
 =========================
 
 .. autoclass:: telegram.ForumTopicEdited

--- a/docs/source/telegram.forumtopicreopened.rst
+++ b/docs/source/telegram.forumtopicreopened.rst
@@ -1,4 +1,4 @@
-telegram.ForumTopicReopened
+ForumTopicReopened
 ===========================
 
 .. autoclass:: telegram.ForumTopicReopened

--- a/docs/source/telegram.forumtopicreopened.rst
+++ b/docs/source/telegram.forumtopicreopened.rst
@@ -1,5 +1,5 @@
 ForumTopicReopened
-===========================
+==================
 
 .. autoclass:: telegram.ForumTopicReopened
     :members:

--- a/docs/source/telegram.game.rst
+++ b/docs/source/telegram.game.rst
@@ -1,5 +1,5 @@
 Game
-=============
+====
 
 .. autoclass:: telegram.Game
     :members:

--- a/docs/source/telegram.game.rst
+++ b/docs/source/telegram.game.rst
@@ -1,4 +1,4 @@
-telegram.Game
+Game
 =============
 
 .. autoclass:: telegram.Game

--- a/docs/source/telegram.gamehighscore.rst
+++ b/docs/source/telegram.gamehighscore.rst
@@ -1,4 +1,4 @@
-telegram.GameHighScore
+GameHighScore
 ======================
 
 .. autoclass:: telegram.GameHighScore

--- a/docs/source/telegram.gamehighscore.rst
+++ b/docs/source/telegram.gamehighscore.rst
@@ -1,5 +1,5 @@
 GameHighScore
-======================
+=============
 
 .. autoclass:: telegram.GameHighScore
     :members:

--- a/docs/source/telegram.generalforumtopichidden.rst
+++ b/docs/source/telegram.generalforumtopichidden.rst
@@ -1,4 +1,4 @@
-telegram.GeneralForumTopicHidden
+GeneralForumTopicHidden
 ================================
 
 .. autoclass:: telegram.GeneralForumTopicHidden

--- a/docs/source/telegram.generalforumtopichidden.rst
+++ b/docs/source/telegram.generalforumtopichidden.rst
@@ -1,5 +1,5 @@
 GeneralForumTopicHidden
-================================
+=======================
 
 .. autoclass:: telegram.GeneralForumTopicHidden
     :members:

--- a/docs/source/telegram.generalforumtopicunhidden.rst
+++ b/docs/source/telegram.generalforumtopicunhidden.rst
@@ -1,4 +1,4 @@
-telegram.GeneralForumTopicUnhidden
+GeneralForumTopicUnhidden
 ==================================
 
 .. autoclass:: telegram.GeneralForumTopicUnhidden

--- a/docs/source/telegram.generalforumtopicunhidden.rst
+++ b/docs/source/telegram.generalforumtopicunhidden.rst
@@ -1,5 +1,5 @@
 GeneralForumTopicUnhidden
-==================================
+=========================
 
 .. autoclass:: telegram.GeneralForumTopicUnhidden
     :members:

--- a/docs/source/telegram.iddocumentdata.rst
+++ b/docs/source/telegram.iddocumentdata.rst
@@ -1,4 +1,4 @@
-telegram.IdDocumentData
+IdDocumentData
 =======================
 
 .. autoclass:: telegram.IdDocumentData

--- a/docs/source/telegram.iddocumentdata.rst
+++ b/docs/source/telegram.iddocumentdata.rst
@@ -1,5 +1,5 @@
 IdDocumentData
-=======================
+==============
 
 .. autoclass:: telegram.IdDocumentData
     :members:

--- a/docs/source/telegram.inlinekeyboardbutton.rst
+++ b/docs/source/telegram.inlinekeyboardbutton.rst
@@ -1,5 +1,5 @@
 InlineKeyboardButton
-=============================
+====================
 
 .. autoclass:: telegram.InlineKeyboardButton
     :members:

--- a/docs/source/telegram.inlinekeyboardbutton.rst
+++ b/docs/source/telegram.inlinekeyboardbutton.rst
@@ -1,4 +1,4 @@
-telegram.InlineKeyboardButton
+InlineKeyboardButton
 =============================
 
 .. autoclass:: telegram.InlineKeyboardButton

--- a/docs/source/telegram.inlinekeyboardmarkup.rst
+++ b/docs/source/telegram.inlinekeyboardmarkup.rst
@@ -1,5 +1,5 @@
 InlineKeyboardMarkup
-=============================
+====================
 
 .. autoclass:: telegram.InlineKeyboardMarkup
     :members:

--- a/docs/source/telegram.inlinekeyboardmarkup.rst
+++ b/docs/source/telegram.inlinekeyboardmarkup.rst
@@ -1,4 +1,4 @@
-telegram.InlineKeyboardMarkup
+InlineKeyboardMarkup
 =============================
 
 .. autoclass:: telegram.InlineKeyboardMarkup

--- a/docs/source/telegram.inlinequery.rst
+++ b/docs/source/telegram.inlinequery.rst
@@ -1,4 +1,4 @@
-telegram.InlineQuery
+InlineQuery
 ====================
 
 .. autoclass:: telegram.InlineQuery

--- a/docs/source/telegram.inlinequery.rst
+++ b/docs/source/telegram.inlinequery.rst
@@ -1,5 +1,5 @@
 InlineQuery
-====================
+===========
 
 .. autoclass:: telegram.InlineQuery
     :members:

--- a/docs/source/telegram.inlinequeryresult.rst
+++ b/docs/source/telegram.inlinequeryresult.rst
@@ -1,4 +1,4 @@
-telegram.InlineQueryResult
+InlineQueryResult
 ==========================
 
 .. autoclass:: telegram.InlineQueryResult

--- a/docs/source/telegram.inlinequeryresult.rst
+++ b/docs/source/telegram.inlinequeryresult.rst
@@ -1,5 +1,5 @@
 InlineQueryResult
-==========================
+=================
 
 .. autoclass:: telegram.InlineQueryResult
     :members:

--- a/docs/source/telegram.inlinequeryresultarticle.rst
+++ b/docs/source/telegram.inlinequeryresultarticle.rst
@@ -1,4 +1,4 @@
-telegram.InlineQueryResultArticle
+InlineQueryResultArticle
 =================================
 
 .. autoclass:: telegram.InlineQueryResultArticle

--- a/docs/source/telegram.inlinequeryresultarticle.rst
+++ b/docs/source/telegram.inlinequeryresultarticle.rst
@@ -1,5 +1,5 @@
 InlineQueryResultArticle
-=================================
+========================
 
 .. autoclass:: telegram.InlineQueryResultArticle
     :members:

--- a/docs/source/telegram.inlinequeryresultaudio.rst
+++ b/docs/source/telegram.inlinequeryresultaudio.rst
@@ -1,5 +1,5 @@
 InlineQueryResultAudio
-===============================
+======================
 
 .. autoclass:: telegram.InlineQueryResultAudio
     :members:

--- a/docs/source/telegram.inlinequeryresultaudio.rst
+++ b/docs/source/telegram.inlinequeryresultaudio.rst
@@ -1,4 +1,4 @@
-telegram.InlineQueryResultAudio
+InlineQueryResultAudio
 ===============================
 
 .. autoclass:: telegram.InlineQueryResultAudio

--- a/docs/source/telegram.inlinequeryresultcachedaudio.rst
+++ b/docs/source/telegram.inlinequeryresultcachedaudio.rst
@@ -1,4 +1,4 @@
-telegram.InlineQueryResultCachedAudio
+InlineQueryResultCachedAudio
 =====================================
 
 .. autoclass:: telegram.InlineQueryResultCachedAudio

--- a/docs/source/telegram.inlinequeryresultcachedaudio.rst
+++ b/docs/source/telegram.inlinequeryresultcachedaudio.rst
@@ -1,5 +1,5 @@
 InlineQueryResultCachedAudio
-=====================================
+============================
 
 .. autoclass:: telegram.InlineQueryResultCachedAudio
     :members:

--- a/docs/source/telegram.inlinequeryresultcacheddocument.rst
+++ b/docs/source/telegram.inlinequeryresultcacheddocument.rst
@@ -1,4 +1,4 @@
-telegram.InlineQueryResultCachedDocument
+InlineQueryResultCachedDocument
 ========================================
 
 .. autoclass:: telegram.InlineQueryResultCachedDocument

--- a/docs/source/telegram.inlinequeryresultcacheddocument.rst
+++ b/docs/source/telegram.inlinequeryresultcacheddocument.rst
@@ -1,5 +1,5 @@
 InlineQueryResultCachedDocument
-========================================
+===============================
 
 .. autoclass:: telegram.InlineQueryResultCachedDocument
     :members:

--- a/docs/source/telegram.inlinequeryresultcachedgif.rst
+++ b/docs/source/telegram.inlinequeryresultcachedgif.rst
@@ -1,4 +1,4 @@
-telegram.InlineQueryResultCachedGif
+InlineQueryResultCachedGif
 ===================================
 
 .. autoclass:: telegram.InlineQueryResultCachedGif

--- a/docs/source/telegram.inlinequeryresultcachedgif.rst
+++ b/docs/source/telegram.inlinequeryresultcachedgif.rst
@@ -1,5 +1,5 @@
 InlineQueryResultCachedGif
-===================================
+==========================
 
 .. autoclass:: telegram.InlineQueryResultCachedGif
     :members:

--- a/docs/source/telegram.inlinequeryresultcachedmpeg4gif.rst
+++ b/docs/source/telegram.inlinequeryresultcachedmpeg4gif.rst
@@ -1,5 +1,5 @@
 InlineQueryResultCachedMpeg4Gif
-========================================
+===============================
 
 .. autoclass:: telegram.InlineQueryResultCachedMpeg4Gif
     :members:

--- a/docs/source/telegram.inlinequeryresultcachedmpeg4gif.rst
+++ b/docs/source/telegram.inlinequeryresultcachedmpeg4gif.rst
@@ -1,4 +1,4 @@
-telegram.InlineQueryResultCachedMpeg4Gif
+InlineQueryResultCachedMpeg4Gif
 ========================================
 
 .. autoclass:: telegram.InlineQueryResultCachedMpeg4Gif

--- a/docs/source/telegram.inlinequeryresultcachedphoto.rst
+++ b/docs/source/telegram.inlinequeryresultcachedphoto.rst
@@ -1,5 +1,5 @@
 InlineQueryResultCachedPhoto
-=====================================
+============================
 
 .. autoclass:: telegram.InlineQueryResultCachedPhoto
     :members:

--- a/docs/source/telegram.inlinequeryresultcachedphoto.rst
+++ b/docs/source/telegram.inlinequeryresultcachedphoto.rst
@@ -1,4 +1,4 @@
-telegram.InlineQueryResultCachedPhoto
+InlineQueryResultCachedPhoto
 =====================================
 
 .. autoclass:: telegram.InlineQueryResultCachedPhoto

--- a/docs/source/telegram.inlinequeryresultcachedsticker.rst
+++ b/docs/source/telegram.inlinequeryresultcachedsticker.rst
@@ -1,5 +1,5 @@
 InlineQueryResultCachedSticker
-=======================================
+==============================
 
 .. autoclass:: telegram.InlineQueryResultCachedSticker
     :members:

--- a/docs/source/telegram.inlinequeryresultcachedsticker.rst
+++ b/docs/source/telegram.inlinequeryresultcachedsticker.rst
@@ -1,4 +1,4 @@
-telegram.InlineQueryResultCachedSticker
+InlineQueryResultCachedSticker
 =======================================
 
 .. autoclass:: telegram.InlineQueryResultCachedSticker

--- a/docs/source/telegram.inlinequeryresultcachedvideo.rst
+++ b/docs/source/telegram.inlinequeryresultcachedvideo.rst
@@ -1,4 +1,4 @@
-telegram.InlineQueryResultCachedVideo
+InlineQueryResultCachedVideo
 =====================================
 
 .. autoclass:: telegram.InlineQueryResultCachedVideo

--- a/docs/source/telegram.inlinequeryresultcachedvideo.rst
+++ b/docs/source/telegram.inlinequeryresultcachedvideo.rst
@@ -1,5 +1,5 @@
 InlineQueryResultCachedVideo
-=====================================
+============================
 
 .. autoclass:: telegram.InlineQueryResultCachedVideo
     :members:

--- a/docs/source/telegram.inlinequeryresultcachedvoice.rst
+++ b/docs/source/telegram.inlinequeryresultcachedvoice.rst
@@ -1,4 +1,4 @@
-telegram.InlineQueryResultCachedVoice
+InlineQueryResultCachedVoice
 =====================================
 
 .. autoclass:: telegram.InlineQueryResultCachedVoice

--- a/docs/source/telegram.inlinequeryresultcachedvoice.rst
+++ b/docs/source/telegram.inlinequeryresultcachedvoice.rst
@@ -1,5 +1,5 @@
 InlineQueryResultCachedVoice
-=====================================
+============================
 
 .. autoclass:: telegram.InlineQueryResultCachedVoice
     :members:

--- a/docs/source/telegram.inlinequeryresultcontact.rst
+++ b/docs/source/telegram.inlinequeryresultcontact.rst
@@ -1,5 +1,5 @@
 InlineQueryResultContact
-=================================
+========================
 
 .. autoclass:: telegram.InlineQueryResultContact
     :members:

--- a/docs/source/telegram.inlinequeryresultcontact.rst
+++ b/docs/source/telegram.inlinequeryresultcontact.rst
@@ -1,4 +1,4 @@
-telegram.InlineQueryResultContact
+InlineQueryResultContact
 =================================
 
 .. autoclass:: telegram.InlineQueryResultContact

--- a/docs/source/telegram.inlinequeryresultdocument.rst
+++ b/docs/source/telegram.inlinequeryresultdocument.rst
@@ -1,5 +1,5 @@
 InlineQueryResultDocument
-==================================
+=========================
 
 .. autoclass:: telegram.InlineQueryResultDocument
     :members:

--- a/docs/source/telegram.inlinequeryresultdocument.rst
+++ b/docs/source/telegram.inlinequeryresultdocument.rst
@@ -1,4 +1,4 @@
-telegram.InlineQueryResultDocument
+InlineQueryResultDocument
 ==================================
 
 .. autoclass:: telegram.InlineQueryResultDocument

--- a/docs/source/telegram.inlinequeryresultgame.rst
+++ b/docs/source/telegram.inlinequeryresultgame.rst
@@ -1,5 +1,5 @@
 InlineQueryResultGame
-==============================
+=====================
 
 .. autoclass:: telegram.InlineQueryResultGame
     :members:

--- a/docs/source/telegram.inlinequeryresultgame.rst
+++ b/docs/source/telegram.inlinequeryresultgame.rst
@@ -1,4 +1,4 @@
-telegram.InlineQueryResultGame
+InlineQueryResultGame
 ==============================
 
 .. autoclass:: telegram.InlineQueryResultGame

--- a/docs/source/telegram.inlinequeryresultgif.rst
+++ b/docs/source/telegram.inlinequeryresultgif.rst
@@ -1,5 +1,5 @@
 InlineQueryResultGif
-=============================
+====================
 
 .. autoclass:: telegram.InlineQueryResultGif
     :members:

--- a/docs/source/telegram.inlinequeryresultgif.rst
+++ b/docs/source/telegram.inlinequeryresultgif.rst
@@ -1,4 +1,4 @@
-telegram.InlineQueryResultGif
+InlineQueryResultGif
 =============================
 
 .. autoclass:: telegram.InlineQueryResultGif

--- a/docs/source/telegram.inlinequeryresultlocation.rst
+++ b/docs/source/telegram.inlinequeryresultlocation.rst
@@ -1,5 +1,5 @@
 InlineQueryResultLocation
-==================================
+=========================
 
 .. autoclass:: telegram.InlineQueryResultLocation
     :members:

--- a/docs/source/telegram.inlinequeryresultlocation.rst
+++ b/docs/source/telegram.inlinequeryresultlocation.rst
@@ -1,4 +1,4 @@
-telegram.InlineQueryResultLocation
+InlineQueryResultLocation
 ==================================
 
 .. autoclass:: telegram.InlineQueryResultLocation

--- a/docs/source/telegram.inlinequeryresultmpeg4gif.rst
+++ b/docs/source/telegram.inlinequeryresultmpeg4gif.rst
@@ -1,5 +1,5 @@
 InlineQueryResultMpeg4Gif
-==================================
+=========================
 
 .. autoclass:: telegram.InlineQueryResultMpeg4Gif
     :members:

--- a/docs/source/telegram.inlinequeryresultmpeg4gif.rst
+++ b/docs/source/telegram.inlinequeryresultmpeg4gif.rst
@@ -1,4 +1,4 @@
-telegram.InlineQueryResultMpeg4Gif
+InlineQueryResultMpeg4Gif
 ==================================
 
 .. autoclass:: telegram.InlineQueryResultMpeg4Gif

--- a/docs/source/telegram.inlinequeryresultphoto.rst
+++ b/docs/source/telegram.inlinequeryresultphoto.rst
@@ -1,5 +1,5 @@
 InlineQueryResultPhoto
-===============================
+======================
 
 .. autoclass:: telegram.InlineQueryResultPhoto
     :members:

--- a/docs/source/telegram.inlinequeryresultphoto.rst
+++ b/docs/source/telegram.inlinequeryresultphoto.rst
@@ -1,4 +1,4 @@
-telegram.InlineQueryResultPhoto
+InlineQueryResultPhoto
 ===============================
 
 .. autoclass:: telegram.InlineQueryResultPhoto

--- a/docs/source/telegram.inlinequeryresultvenue.rst
+++ b/docs/source/telegram.inlinequeryresultvenue.rst
@@ -1,4 +1,4 @@
-telegram.InlineQueryResultVenue
+InlineQueryResultVenue
 ===============================
 
 .. autoclass:: telegram.InlineQueryResultVenue

--- a/docs/source/telegram.inlinequeryresultvenue.rst
+++ b/docs/source/telegram.inlinequeryresultvenue.rst
@@ -1,5 +1,5 @@
 InlineQueryResultVenue
-===============================
+======================
 
 .. autoclass:: telegram.InlineQueryResultVenue
     :members:

--- a/docs/source/telegram.inlinequeryresultvideo.rst
+++ b/docs/source/telegram.inlinequeryresultvideo.rst
@@ -1,4 +1,4 @@
-telegram.InlineQueryResultVideo
+InlineQueryResultVideo
 ===============================
 
 .. autoclass:: telegram.InlineQueryResultVideo

--- a/docs/source/telegram.inlinequeryresultvideo.rst
+++ b/docs/source/telegram.inlinequeryresultvideo.rst
@@ -1,5 +1,5 @@
 InlineQueryResultVideo
-===============================
+======================
 
 .. autoclass:: telegram.InlineQueryResultVideo
     :members:

--- a/docs/source/telegram.inlinequeryresultvoice.rst
+++ b/docs/source/telegram.inlinequeryresultvoice.rst
@@ -1,5 +1,5 @@
 InlineQueryResultVoice
-===============================
+======================
 
 .. autoclass:: telegram.InlineQueryResultVoice
     :members:

--- a/docs/source/telegram.inlinequeryresultvoice.rst
+++ b/docs/source/telegram.inlinequeryresultvoice.rst
@@ -1,4 +1,4 @@
-telegram.InlineQueryResultVoice
+InlineQueryResultVoice
 ===============================
 
 .. autoclass:: telegram.InlineQueryResultVoice

--- a/docs/source/telegram.inputcontactmessagecontent.rst
+++ b/docs/source/telegram.inputcontactmessagecontent.rst
@@ -1,5 +1,5 @@
 InputContactMessageContent
-===================================
+==========================
 
 .. autoclass:: telegram.InputContactMessageContent
     :members:

--- a/docs/source/telegram.inputcontactmessagecontent.rst
+++ b/docs/source/telegram.inputcontactmessagecontent.rst
@@ -1,4 +1,4 @@
-telegram.InputContactMessageContent
+InputContactMessageContent
 ===================================
 
 .. autoclass:: telegram.InputContactMessageContent

--- a/docs/source/telegram.inputfile.rst
+++ b/docs/source/telegram.inputfile.rst
@@ -1,5 +1,5 @@
 InputFile
-==================
+=========
 
 .. autoclass:: telegram.InputFile
     :members:

--- a/docs/source/telegram.inputfile.rst
+++ b/docs/source/telegram.inputfile.rst
@@ -1,4 +1,4 @@
-telegram.InputFile
+InputFile
 ==================
 
 .. autoclass:: telegram.InputFile

--- a/docs/source/telegram.inputinvoicemessagecontent.rst
+++ b/docs/source/telegram.inputinvoicemessagecontent.rst
@@ -1,5 +1,5 @@
 InputInvoiceMessageContent
-===================================
+==========================
 
 .. autoclass:: telegram.InputInvoiceMessageContent
     :members:

--- a/docs/source/telegram.inputinvoicemessagecontent.rst
+++ b/docs/source/telegram.inputinvoicemessagecontent.rst
@@ -1,4 +1,4 @@
-telegram.InputInvoiceMessageContent
+InputInvoiceMessageContent
 ===================================
 
 .. autoclass:: telegram.InputInvoiceMessageContent

--- a/docs/source/telegram.inputlocationmessagecontent.rst
+++ b/docs/source/telegram.inputlocationmessagecontent.rst
@@ -1,5 +1,5 @@
 InputLocationMessageContent
-====================================
+===========================
 
 .. autoclass:: telegram.InputLocationMessageContent
     :members:

--- a/docs/source/telegram.inputlocationmessagecontent.rst
+++ b/docs/source/telegram.inputlocationmessagecontent.rst
@@ -1,4 +1,4 @@
-telegram.InputLocationMessageContent
+InputLocationMessageContent
 ====================================
 
 .. autoclass:: telegram.InputLocationMessageContent

--- a/docs/source/telegram.inputmedia.rst
+++ b/docs/source/telegram.inputmedia.rst
@@ -1,5 +1,5 @@
 InputMedia
-===================
+==========
 
 .. autoclass:: telegram.InputMedia
     :members:

--- a/docs/source/telegram.inputmedia.rst
+++ b/docs/source/telegram.inputmedia.rst
@@ -1,4 +1,4 @@
-telegram.InputMedia
+InputMedia
 ===================
 
 .. autoclass:: telegram.InputMedia

--- a/docs/source/telegram.inputmediaanimation.rst
+++ b/docs/source/telegram.inputmediaanimation.rst
@@ -1,4 +1,4 @@
-telegram.InputMediaAnimation
+InputMediaAnimation
 ============================
 
 .. autoclass:: telegram.InputMediaAnimation

--- a/docs/source/telegram.inputmediaanimation.rst
+++ b/docs/source/telegram.inputmediaanimation.rst
@@ -1,5 +1,5 @@
 InputMediaAnimation
-============================
+===================
 
 .. autoclass:: telegram.InputMediaAnimation
     :members:

--- a/docs/source/telegram.inputmediaaudio.rst
+++ b/docs/source/telegram.inputmediaaudio.rst
@@ -1,4 +1,4 @@
-telegram.InputMediaAudio
+InputMediaAudio
 ========================
 
 .. autoclass:: telegram.InputMediaAudio

--- a/docs/source/telegram.inputmediaaudio.rst
+++ b/docs/source/telegram.inputmediaaudio.rst
@@ -1,5 +1,5 @@
 InputMediaAudio
-========================
+===============
 
 .. autoclass:: telegram.InputMediaAudio
     :members:

--- a/docs/source/telegram.inputmediadocument.rst
+++ b/docs/source/telegram.inputmediadocument.rst
@@ -1,5 +1,5 @@
 InputMediaDocument
-===========================
+==================
 
 .. autoclass:: telegram.InputMediaDocument
     :members:

--- a/docs/source/telegram.inputmediadocument.rst
+++ b/docs/source/telegram.inputmediadocument.rst
@@ -1,4 +1,4 @@
-telegram.InputMediaDocument
+InputMediaDocument
 ===========================
 
 .. autoclass:: telegram.InputMediaDocument

--- a/docs/source/telegram.inputmediaphoto.rst
+++ b/docs/source/telegram.inputmediaphoto.rst
@@ -1,4 +1,4 @@
-telegram.InputMediaPhoto
+InputMediaPhoto
 ========================
 
 .. autoclass:: telegram.InputMediaPhoto

--- a/docs/source/telegram.inputmediaphoto.rst
+++ b/docs/source/telegram.inputmediaphoto.rst
@@ -1,5 +1,5 @@
 InputMediaPhoto
-========================
+===============
 
 .. autoclass:: telegram.InputMediaPhoto
     :members:

--- a/docs/source/telegram.inputmediavideo.rst
+++ b/docs/source/telegram.inputmediavideo.rst
@@ -1,4 +1,4 @@
-telegram.InputMediaVideo
+InputMediaVideo
 ========================
 
 .. autoclass:: telegram.InputMediaVideo

--- a/docs/source/telegram.inputmediavideo.rst
+++ b/docs/source/telegram.inputmediavideo.rst
@@ -1,5 +1,5 @@
 InputMediaVideo
-========================
+===============
 
 .. autoclass:: telegram.InputMediaVideo
     :members:

--- a/docs/source/telegram.inputmessagecontent.rst
+++ b/docs/source/telegram.inputmessagecontent.rst
@@ -1,5 +1,5 @@
 InputMessageContent
-============================
+===================
 
 .. autoclass:: telegram.InputMessageContent
     :members:

--- a/docs/source/telegram.inputmessagecontent.rst
+++ b/docs/source/telegram.inputmessagecontent.rst
@@ -1,4 +1,4 @@
-telegram.InputMessageContent
+InputMessageContent
 ============================
 
 .. autoclass:: telegram.InputMessageContent

--- a/docs/source/telegram.inputtextmessagecontent.rst
+++ b/docs/source/telegram.inputtextmessagecontent.rst
@@ -1,5 +1,5 @@
 InputTextMessageContent
-================================
+=======================
 
 .. autoclass:: telegram.InputTextMessageContent
     :members:

--- a/docs/source/telegram.inputtextmessagecontent.rst
+++ b/docs/source/telegram.inputtextmessagecontent.rst
@@ -1,4 +1,4 @@
-telegram.InputTextMessageContent
+InputTextMessageContent
 ================================
 
 .. autoclass:: telegram.InputTextMessageContent

--- a/docs/source/telegram.inputvenuemessagecontent.rst
+++ b/docs/source/telegram.inputvenuemessagecontent.rst
@@ -1,5 +1,5 @@
 InputVenueMessageContent
-=================================
+========================
 
 .. autoclass:: telegram.InputVenueMessageContent
     :members:

--- a/docs/source/telegram.inputvenuemessagecontent.rst
+++ b/docs/source/telegram.inputvenuemessagecontent.rst
@@ -1,4 +1,4 @@
-telegram.InputVenueMessageContent
+InputVenueMessageContent
 =================================
 
 .. autoclass:: telegram.InputVenueMessageContent

--- a/docs/source/telegram.invoice.rst
+++ b/docs/source/telegram.invoice.rst
@@ -1,4 +1,4 @@
-telegram.Invoice
+Invoice
 ================
 
 .. autoclass:: telegram.Invoice

--- a/docs/source/telegram.invoice.rst
+++ b/docs/source/telegram.invoice.rst
@@ -1,5 +1,5 @@
 Invoice
-================
+=======
 
 .. autoclass:: telegram.Invoice
     :members:

--- a/docs/source/telegram.keyboardbutton.rst
+++ b/docs/source/telegram.keyboardbutton.rst
@@ -1,5 +1,5 @@
 KeyboardButton
-=======================
+==============
 
 .. autoclass:: telegram.KeyboardButton
     :members:

--- a/docs/source/telegram.keyboardbutton.rst
+++ b/docs/source/telegram.keyboardbutton.rst
@@ -1,4 +1,4 @@
-telegram.KeyboardButton
+KeyboardButton
 =======================
 
 .. autoclass:: telegram.KeyboardButton

--- a/docs/source/telegram.keyboardbuttonpolltype.rst
+++ b/docs/source/telegram.keyboardbuttonpolltype.rst
@@ -1,4 +1,4 @@
-telegram.KeyboardButtonPollType
+KeyboardButtonPollType
 ===============================
 
 .. autoclass:: telegram.KeyboardButtonPollType

--- a/docs/source/telegram.keyboardbuttonpolltype.rst
+++ b/docs/source/telegram.keyboardbuttonpolltype.rst
@@ -1,5 +1,5 @@
 KeyboardButtonPollType
-===============================
+======================
 
 .. autoclass:: telegram.KeyboardButtonPollType
     :members:

--- a/docs/source/telegram.labeledprice.rst
+++ b/docs/source/telegram.labeledprice.rst
@@ -1,5 +1,5 @@
 LabeledPrice
-=====================
+============
 
 .. autoclass:: telegram.LabeledPrice
     :members:

--- a/docs/source/telegram.labeledprice.rst
+++ b/docs/source/telegram.labeledprice.rst
@@ -1,4 +1,4 @@
-telegram.LabeledPrice
+LabeledPrice
 =====================
 
 .. autoclass:: telegram.LabeledPrice

--- a/docs/source/telegram.location.rst
+++ b/docs/source/telegram.location.rst
@@ -1,5 +1,5 @@
 Location
-=================
+========
 
 .. autoclass:: telegram.Location
     :members:

--- a/docs/source/telegram.location.rst
+++ b/docs/source/telegram.location.rst
@@ -1,4 +1,4 @@
-telegram.Location
+Location
 =================
 
 .. autoclass:: telegram.Location

--- a/docs/source/telegram.loginurl.rst
+++ b/docs/source/telegram.loginurl.rst
@@ -1,5 +1,5 @@
 LoginUrl
-=================
+========
 
 .. autoclass:: telegram.LoginUrl
     :members:

--- a/docs/source/telegram.loginurl.rst
+++ b/docs/source/telegram.loginurl.rst
@@ -1,4 +1,4 @@
-telegram.LoginUrl
+LoginUrl
 =================
 
 .. autoclass:: telegram.LoginUrl

--- a/docs/source/telegram.maskposition.rst
+++ b/docs/source/telegram.maskposition.rst
@@ -1,4 +1,4 @@
-telegram.MaskPosition
+MaskPosition
 =====================
 
 .. autoclass:: telegram.MaskPosition

--- a/docs/source/telegram.maskposition.rst
+++ b/docs/source/telegram.maskposition.rst
@@ -1,5 +1,5 @@
 MaskPosition
-=====================
+============
 
 .. autoclass:: telegram.MaskPosition
     :members:

--- a/docs/source/telegram.menubutton.rst
+++ b/docs/source/telegram.menubutton.rst
@@ -1,4 +1,4 @@
-telegram.MenuButton
+MenuButton
 ===================
 
 .. autoclass:: telegram.MenuButton

--- a/docs/source/telegram.menubutton.rst
+++ b/docs/source/telegram.menubutton.rst
@@ -1,5 +1,5 @@
 MenuButton
-===================
+==========
 
 .. autoclass:: telegram.MenuButton
     :members:

--- a/docs/source/telegram.menubuttoncommands.rst
+++ b/docs/source/telegram.menubuttoncommands.rst
@@ -1,4 +1,4 @@
-telegram.MenuButtonCommands
+MenuButtonCommands
 ===========================
 
 .. autoclass:: telegram.MenuButtonCommands

--- a/docs/source/telegram.menubuttoncommands.rst
+++ b/docs/source/telegram.menubuttoncommands.rst
@@ -1,5 +1,5 @@
 MenuButtonCommands
-===========================
+==================
 
 .. autoclass:: telegram.MenuButtonCommands
     :members:

--- a/docs/source/telegram.menubuttondefault.rst
+++ b/docs/source/telegram.menubuttondefault.rst
@@ -1,4 +1,4 @@
-telegram.MenuButtonDefault
+MenuButtonDefault
 ==========================
 
 .. autoclass:: telegram.MenuButtonDefault

--- a/docs/source/telegram.menubuttondefault.rst
+++ b/docs/source/telegram.menubuttondefault.rst
@@ -1,5 +1,5 @@
 MenuButtonDefault
-==========================
+=================
 
 .. autoclass:: telegram.MenuButtonDefault
     :members:

--- a/docs/source/telegram.menubuttonwebapp.rst
+++ b/docs/source/telegram.menubuttonwebapp.rst
@@ -1,5 +1,5 @@
 MenuButtonWebApp
-=========================
+================
 
 .. autoclass:: telegram.MenuButtonWebApp
     :members:

--- a/docs/source/telegram.menubuttonwebapp.rst
+++ b/docs/source/telegram.menubuttonwebapp.rst
@@ -1,4 +1,4 @@
-telegram.MenuButtonWebApp
+MenuButtonWebApp
 =========================
 
 .. autoclass:: telegram.MenuButtonWebApp

--- a/docs/source/telegram.message.rst
+++ b/docs/source/telegram.message.rst
@@ -1,5 +1,5 @@
 Message
-================
+=======
 
 .. autoclass:: telegram.Message
     :members:

--- a/docs/source/telegram.message.rst
+++ b/docs/source/telegram.message.rst
@@ -1,4 +1,4 @@
-telegram.Message
+Message
 ================
 
 .. autoclass:: telegram.Message

--- a/docs/source/telegram.messageautodeletetimerchanged.rst
+++ b/docs/source/telegram.messageautodeletetimerchanged.rst
@@ -1,5 +1,5 @@
 MessageAutoDeleteTimerChanged
-======================================
+=============================
 
 .. autoclass:: telegram.MessageAutoDeleteTimerChanged
     :members:

--- a/docs/source/telegram.messageautodeletetimerchanged.rst
+++ b/docs/source/telegram.messageautodeletetimerchanged.rst
@@ -1,4 +1,4 @@
-telegram.MessageAutoDeleteTimerChanged
+MessageAutoDeleteTimerChanged
 ======================================
 
 .. autoclass:: telegram.MessageAutoDeleteTimerChanged

--- a/docs/source/telegram.messageentity.rst
+++ b/docs/source/telegram.messageentity.rst
@@ -1,5 +1,5 @@
 MessageEntity
-======================
+=============
 
 .. autoclass:: telegram.MessageEntity
     :members:

--- a/docs/source/telegram.messageentity.rst
+++ b/docs/source/telegram.messageentity.rst
@@ -1,4 +1,4 @@
-telegram.MessageEntity
+MessageEntity
 ======================
 
 .. autoclass:: telegram.MessageEntity

--- a/docs/source/telegram.messageid.rst
+++ b/docs/source/telegram.messageid.rst
@@ -1,5 +1,5 @@
 MessageId
-==================
+=========
 
 .. autoclass:: telegram.MessageId
     :members:

--- a/docs/source/telegram.messageid.rst
+++ b/docs/source/telegram.messageid.rst
@@ -1,4 +1,4 @@
-telegram.MessageId
+MessageId
 ==================
 
 .. autoclass:: telegram.MessageId

--- a/docs/source/telegram.orderinfo.rst
+++ b/docs/source/telegram.orderinfo.rst
@@ -1,4 +1,4 @@
-telegram.OrderInfo
+OrderInfo
 ==================
 
 .. autoclass:: telegram.OrderInfo

--- a/docs/source/telegram.orderinfo.rst
+++ b/docs/source/telegram.orderinfo.rst
@@ -1,5 +1,5 @@
 OrderInfo
-==================
+=========
 
 .. autoclass:: telegram.OrderInfo
     :members:

--- a/docs/source/telegram.passportdata.rst
+++ b/docs/source/telegram.passportdata.rst
@@ -1,4 +1,4 @@
-telegram.PassportData
+PassportData
 =====================
 
 .. autoclass:: telegram.PassportData

--- a/docs/source/telegram.passportdata.rst
+++ b/docs/source/telegram.passportdata.rst
@@ -1,5 +1,5 @@
 PassportData
-=====================
+============
 
 .. autoclass:: telegram.PassportData
     :members:

--- a/docs/source/telegram.passportelementerror.rst
+++ b/docs/source/telegram.passportelementerror.rst
@@ -1,4 +1,4 @@
-telegram.PassportElementError
+PassportElementError
 =============================
 
 .. autoclass:: telegram.PassportElementError

--- a/docs/source/telegram.passportelementerror.rst
+++ b/docs/source/telegram.passportelementerror.rst
@@ -1,5 +1,5 @@
 PassportElementError
-=============================
+====================
 
 .. autoclass:: telegram.PassportElementError
     :members:

--- a/docs/source/telegram.passportelementerrordatafield.rst
+++ b/docs/source/telegram.passportelementerrordatafield.rst
@@ -1,4 +1,4 @@
-telegram.PassportElementErrorDataField
+PassportElementErrorDataField
 ======================================
 
 .. autoclass:: telegram.PassportElementErrorDataField

--- a/docs/source/telegram.passportelementerrordatafield.rst
+++ b/docs/source/telegram.passportelementerrordatafield.rst
@@ -1,5 +1,5 @@
 PassportElementErrorDataField
-======================================
+=============================
 
 .. autoclass:: telegram.PassportElementErrorDataField
     :members:

--- a/docs/source/telegram.passportelementerrorfile.rst
+++ b/docs/source/telegram.passportelementerrorfile.rst
@@ -1,5 +1,5 @@
 PassportElementErrorFile
-=================================
+========================
 
 .. autoclass:: telegram.PassportElementErrorFile
     :members:

--- a/docs/source/telegram.passportelementerrorfile.rst
+++ b/docs/source/telegram.passportelementerrorfile.rst
@@ -1,4 +1,4 @@
-telegram.PassportElementErrorFile
+PassportElementErrorFile
 =================================
 
 .. autoclass:: telegram.PassportElementErrorFile

--- a/docs/source/telegram.passportelementerrorfiles.rst
+++ b/docs/source/telegram.passportelementerrorfiles.rst
@@ -1,5 +1,5 @@
 PassportElementErrorFiles
-==================================
+=========================
 
 .. autoclass:: telegram.PassportElementErrorFiles
     :members:

--- a/docs/source/telegram.passportelementerrorfiles.rst
+++ b/docs/source/telegram.passportelementerrorfiles.rst
@@ -1,4 +1,4 @@
-telegram.PassportElementErrorFiles
+PassportElementErrorFiles
 ==================================
 
 .. autoclass:: telegram.PassportElementErrorFiles

--- a/docs/source/telegram.passportelementerrorfrontside.rst
+++ b/docs/source/telegram.passportelementerrorfrontside.rst
@@ -1,5 +1,5 @@
 PassportElementErrorFrontSide
-======================================
+=============================
 
 .. autoclass:: telegram.PassportElementErrorFrontSide
     :members:

--- a/docs/source/telegram.passportelementerrorfrontside.rst
+++ b/docs/source/telegram.passportelementerrorfrontside.rst
@@ -1,4 +1,4 @@
-telegram.PassportElementErrorFrontSide
+PassportElementErrorFrontSide
 ======================================
 
 .. autoclass:: telegram.PassportElementErrorFrontSide

--- a/docs/source/telegram.passportelementerrorreverseside.rst
+++ b/docs/source/telegram.passportelementerrorreverseside.rst
@@ -1,5 +1,5 @@
 PassportElementErrorReverseSide
-========================================
+===============================
 
 .. autoclass:: telegram.PassportElementErrorReverseSide
     :members:

--- a/docs/source/telegram.passportelementerrorreverseside.rst
+++ b/docs/source/telegram.passportelementerrorreverseside.rst
@@ -1,4 +1,4 @@
-telegram.PassportElementErrorReverseSide
+PassportElementErrorReverseSide
 ========================================
 
 .. autoclass:: telegram.PassportElementErrorReverseSide

--- a/docs/source/telegram.passportelementerrorselfie.rst
+++ b/docs/source/telegram.passportelementerrorselfie.rst
@@ -1,5 +1,5 @@
 PassportElementErrorSelfie
-========================================
+==========================
 
 .. autoclass:: telegram.PassportElementErrorSelfie
     :members:

--- a/docs/source/telegram.passportelementerrorselfie.rst
+++ b/docs/source/telegram.passportelementerrorselfie.rst
@@ -1,4 +1,4 @@
-telegram.PassportElementErrorSelfie
+PassportElementErrorSelfie
 ========================================
 
 .. autoclass:: telegram.PassportElementErrorSelfie

--- a/docs/source/telegram.passportelementerrortranslationfile.rst
+++ b/docs/source/telegram.passportelementerrortranslationfile.rst
@@ -1,5 +1,5 @@
 PassportElementErrorTranslationFile
-============================================
+===================================
 
 .. autoclass:: telegram.PassportElementErrorTranslationFile
     :members:

--- a/docs/source/telegram.passportelementerrortranslationfile.rst
+++ b/docs/source/telegram.passportelementerrortranslationfile.rst
@@ -1,4 +1,4 @@
-telegram.PassportElementErrorTranslationFile
+PassportElementErrorTranslationFile
 ============================================
 
 .. autoclass:: telegram.PassportElementErrorTranslationFile

--- a/docs/source/telegram.passportelementerrortranslationfiles.rst
+++ b/docs/source/telegram.passportelementerrortranslationfiles.rst
@@ -1,4 +1,4 @@
-telegram.PassportElementErrorTranslationFiles
+PassportElementErrorTranslationFiles
 =============================================
 
 .. autoclass:: telegram.PassportElementErrorTranslationFiles

--- a/docs/source/telegram.passportelementerrortranslationfiles.rst
+++ b/docs/source/telegram.passportelementerrortranslationfiles.rst
@@ -1,5 +1,5 @@
 PassportElementErrorTranslationFiles
-=============================================
+====================================
 
 .. autoclass:: telegram.PassportElementErrorTranslationFiles
     :members:

--- a/docs/source/telegram.passportelementerrorunspecified.rst
+++ b/docs/source/telegram.passportelementerrorunspecified.rst
@@ -1,4 +1,4 @@
-telegram.PassportElementErrorUnspecified
+PassportElementErrorUnspecified
 ========================================
 
 .. autoclass:: telegram.PassportElementErrorUnspecified

--- a/docs/source/telegram.passportelementerrorunspecified.rst
+++ b/docs/source/telegram.passportelementerrorunspecified.rst
@@ -1,5 +1,5 @@
 PassportElementErrorUnspecified
-========================================
+===============================
 
 .. autoclass:: telegram.PassportElementErrorUnspecified
     :members:

--- a/docs/source/telegram.passportfile.rst
+++ b/docs/source/telegram.passportfile.rst
@@ -1,5 +1,5 @@
 PassportFile
-=====================
+============
 
 .. autoclass:: telegram.PassportFile
     :members:

--- a/docs/source/telegram.passportfile.rst
+++ b/docs/source/telegram.passportfile.rst
@@ -1,4 +1,4 @@
-telegram.PassportFile
+PassportFile
 =====================
 
 .. autoclass:: telegram.PassportFile

--- a/docs/source/telegram.personaldetails.rst
+++ b/docs/source/telegram.personaldetails.rst
@@ -1,4 +1,4 @@
-telegram.PersonalDetails
+PersonalDetails
 ========================
 
 .. autoclass:: telegram.PersonalDetails

--- a/docs/source/telegram.personaldetails.rst
+++ b/docs/source/telegram.personaldetails.rst
@@ -1,5 +1,5 @@
 PersonalDetails
-========================
+===============
 
 .. autoclass:: telegram.PersonalDetails
     :members:

--- a/docs/source/telegram.photosize.rst
+++ b/docs/source/telegram.photosize.rst
@@ -1,4 +1,4 @@
-telegram.PhotoSize
+PhotoSize
 ==================
 .. Also lists methods of _BaseThumbedMedium, but not the ones of TelegramObject
 

--- a/docs/source/telegram.photosize.rst
+++ b/docs/source/telegram.photosize.rst
@@ -1,5 +1,5 @@
 PhotoSize
-==================
+=========
 .. Also lists methods of _BaseThumbedMedium, but not the ones of TelegramObject
 
 .. autoclass:: telegram.PhotoSize

--- a/docs/source/telegram.poll.rst
+++ b/docs/source/telegram.poll.rst
@@ -1,5 +1,5 @@
 Poll
-=============
+====
 
 .. autoclass:: telegram.Poll
     :members:

--- a/docs/source/telegram.poll.rst
+++ b/docs/source/telegram.poll.rst
@@ -1,4 +1,4 @@
-telegram.Poll
+Poll
 =============
 
 .. autoclass:: telegram.Poll

--- a/docs/source/telegram.pollanswer.rst
+++ b/docs/source/telegram.pollanswer.rst
@@ -1,5 +1,5 @@
 PollAnswer
-===================
+==========
 
 .. autoclass:: telegram.PollAnswer
     :members:

--- a/docs/source/telegram.pollanswer.rst
+++ b/docs/source/telegram.pollanswer.rst
@@ -1,4 +1,4 @@
-telegram.PollAnswer
+PollAnswer
 ===================
 
 .. autoclass:: telegram.PollAnswer

--- a/docs/source/telegram.polloption.rst
+++ b/docs/source/telegram.polloption.rst
@@ -1,4 +1,4 @@
-telegram.PollOption
+PollOption
 ===================
 
 .. autoclass:: telegram.PollOption

--- a/docs/source/telegram.polloption.rst
+++ b/docs/source/telegram.polloption.rst
@@ -1,5 +1,5 @@
 PollOption
-===================
+==========
 
 .. autoclass:: telegram.PollOption
     :members:

--- a/docs/source/telegram.precheckoutquery.rst
+++ b/docs/source/telegram.precheckoutquery.rst
@@ -1,4 +1,4 @@
-telegram.PreCheckoutQuery
+PreCheckoutQuery
 =========================
 
 .. autoclass:: telegram.PreCheckoutQuery

--- a/docs/source/telegram.precheckoutquery.rst
+++ b/docs/source/telegram.precheckoutquery.rst
@@ -1,5 +1,5 @@
 PreCheckoutQuery
-=========================
+================
 
 .. autoclass:: telegram.PreCheckoutQuery
     :members:

--- a/docs/source/telegram.proximityalerttriggered.rst
+++ b/docs/source/telegram.proximityalerttriggered.rst
@@ -1,5 +1,5 @@
 ProximityAlertTriggered
-================================
+=======================
 
 .. autoclass:: telegram.ProximityAlertTriggered
     :members:

--- a/docs/source/telegram.proximityalerttriggered.rst
+++ b/docs/source/telegram.proximityalerttriggered.rst
@@ -1,4 +1,4 @@
-telegram.ProximityAlertTriggered
+ProximityAlertTriggered
 ================================
 
 .. autoclass:: telegram.ProximityAlertTriggered

--- a/docs/source/telegram.replykeyboardmarkup.rst
+++ b/docs/source/telegram.replykeyboardmarkup.rst
@@ -1,4 +1,4 @@
-telegram.ReplyKeyboardMarkup
+ReplyKeyboardMarkup
 ============================
 
 .. autoclass:: telegram.ReplyKeyboardMarkup

--- a/docs/source/telegram.replykeyboardmarkup.rst
+++ b/docs/source/telegram.replykeyboardmarkup.rst
@@ -1,5 +1,5 @@
 ReplyKeyboardMarkup
-============================
+===================
 
 .. autoclass:: telegram.ReplyKeyboardMarkup
     :members:

--- a/docs/source/telegram.replykeyboardremove.rst
+++ b/docs/source/telegram.replykeyboardremove.rst
@@ -1,4 +1,4 @@
-telegram.ReplyKeyboardRemove
+ReplyKeyboardRemove
 ============================
 
 .. autoclass:: telegram.ReplyKeyboardRemove

--- a/docs/source/telegram.replykeyboardremove.rst
+++ b/docs/source/telegram.replykeyboardremove.rst
@@ -1,5 +1,5 @@
 ReplyKeyboardRemove
-============================
+===================
 
 .. autoclass:: telegram.ReplyKeyboardRemove
     :members:

--- a/docs/source/telegram.request.baserequest.rst
+++ b/docs/source/telegram.request.baserequest.rst
@@ -1,4 +1,4 @@
-telegram.request.BaseRequest
+BaseRequest
 ============================
 
 .. autoclass:: telegram.request.BaseRequest

--- a/docs/source/telegram.request.baserequest.rst
+++ b/docs/source/telegram.request.baserequest.rst
@@ -1,5 +1,5 @@
 BaseRequest
-============================
+===========
 
 .. autoclass:: telegram.request.BaseRequest
     :members:

--- a/docs/source/telegram.request.httpxrequest.rst
+++ b/docs/source/telegram.request.httpxrequest.rst
@@ -1,4 +1,4 @@
-telegram.request.HTTPXRequest
+HTTPXRequest
 =============================
 
 .. autoclass:: telegram.request.HTTPXRequest

--- a/docs/source/telegram.request.httpxrequest.rst
+++ b/docs/source/telegram.request.httpxrequest.rst
@@ -1,5 +1,5 @@
 HTTPXRequest
-=============================
+============
 
 .. autoclass:: telegram.request.HTTPXRequest
     :members:

--- a/docs/source/telegram.request.requestdata.rst
+++ b/docs/source/telegram.request.requestdata.rst
@@ -1,4 +1,4 @@
-telegram.request.RequestData
+RequestData
 ============================
 
 .. autoclass:: telegram.request.RequestData

--- a/docs/source/telegram.request.requestdata.rst
+++ b/docs/source/telegram.request.requestdata.rst
@@ -1,5 +1,5 @@
 RequestData
-============================
+===========
 
 .. autoclass:: telegram.request.RequestData
     :members:

--- a/docs/source/telegram.residentialaddress.rst
+++ b/docs/source/telegram.residentialaddress.rst
@@ -1,5 +1,5 @@
 ResidentialAddress
-===========================
+==================
 
 .. autoclass:: telegram.ResidentialAddress
     :members:

--- a/docs/source/telegram.residentialaddress.rst
+++ b/docs/source/telegram.residentialaddress.rst
@@ -1,4 +1,4 @@
-telegram.ResidentialAddress
+ResidentialAddress
 ===========================
 
 .. autoclass:: telegram.ResidentialAddress

--- a/docs/source/telegram.securedata.rst
+++ b/docs/source/telegram.securedata.rst
@@ -1,5 +1,5 @@
 SecureData
-===================
+==========
 
 .. autoclass:: telegram.SecureData
     :members:

--- a/docs/source/telegram.securedata.rst
+++ b/docs/source/telegram.securedata.rst
@@ -1,4 +1,4 @@
-telegram.SecureData
+SecureData
 ===================
 
 .. autoclass:: telegram.SecureData

--- a/docs/source/telegram.securevalue.rst
+++ b/docs/source/telegram.securevalue.rst
@@ -1,5 +1,5 @@
 SecureValue
-====================
+===========
 
 .. autoclass:: telegram.SecureValue
     :members:

--- a/docs/source/telegram.securevalue.rst
+++ b/docs/source/telegram.securevalue.rst
@@ -1,4 +1,4 @@
-telegram.SecureValue
+SecureValue
 ====================
 
 .. autoclass:: telegram.SecureValue

--- a/docs/source/telegram.sentwebappmessage.rst
+++ b/docs/source/telegram.sentwebappmessage.rst
@@ -1,4 +1,4 @@
-telegram.SentWebAppMessage
+SentWebAppMessage
 ===============================
 
 .. autoclass:: telegram.SentWebAppMessage

--- a/docs/source/telegram.sentwebappmessage.rst
+++ b/docs/source/telegram.sentwebappmessage.rst
@@ -1,5 +1,5 @@
 SentWebAppMessage
-===============================
+=================
 
 .. autoclass:: telegram.SentWebAppMessage
     :members:

--- a/docs/source/telegram.shippingaddress.rst
+++ b/docs/source/telegram.shippingaddress.rst
@@ -1,4 +1,4 @@
-telegram.ShippingAddress
+ShippingAddress
 ========================
 
 .. autoclass:: telegram.ShippingAddress

--- a/docs/source/telegram.shippingaddress.rst
+++ b/docs/source/telegram.shippingaddress.rst
@@ -1,5 +1,5 @@
 ShippingAddress
-========================
+===============
 
 .. autoclass:: telegram.ShippingAddress
     :members:

--- a/docs/source/telegram.shippingoption.rst
+++ b/docs/source/telegram.shippingoption.rst
@@ -1,4 +1,4 @@
-telegram.ShippingOption
+ShippingOption
 =======================
 
 .. autoclass:: telegram.ShippingOption

--- a/docs/source/telegram.shippingoption.rst
+++ b/docs/source/telegram.shippingoption.rst
@@ -1,5 +1,5 @@
 ShippingOption
-=======================
+==============
 
 .. autoclass:: telegram.ShippingOption
     :members:

--- a/docs/source/telegram.shippingquery.rst
+++ b/docs/source/telegram.shippingquery.rst
@@ -1,5 +1,5 @@
 ShippingQuery
-======================
+=============
 
 .. autoclass:: telegram.ShippingQuery
     :members:

--- a/docs/source/telegram.shippingquery.rst
+++ b/docs/source/telegram.shippingquery.rst
@@ -1,4 +1,4 @@
-telegram.ShippingQuery
+ShippingQuery
 ======================
 
 .. autoclass:: telegram.ShippingQuery

--- a/docs/source/telegram.sticker.rst
+++ b/docs/source/telegram.sticker.rst
@@ -1,4 +1,4 @@
-telegram.Sticker
+Sticker
 ================
 
 .. Also lists methods of _BaseThumbedMedium, but not the ones of TelegramObject

--- a/docs/source/telegram.sticker.rst
+++ b/docs/source/telegram.sticker.rst
@@ -1,5 +1,5 @@
 Sticker
-================
+=======
 
 .. Also lists methods of _BaseThumbedMedium, but not the ones of TelegramObject
 

--- a/docs/source/telegram.stickerset.rst
+++ b/docs/source/telegram.stickerset.rst
@@ -1,5 +1,5 @@
 StickerSet
-===================
+==========
 
 .. autoclass:: telegram.StickerSet
     :members:

--- a/docs/source/telegram.stickerset.rst
+++ b/docs/source/telegram.stickerset.rst
@@ -1,4 +1,4 @@
-telegram.StickerSet
+StickerSet
 ===================
 
 .. autoclass:: telegram.StickerSet

--- a/docs/source/telegram.successfulpayment.rst
+++ b/docs/source/telegram.successfulpayment.rst
@@ -1,5 +1,5 @@
 SuccessfulPayment
-==========================
+=================
 
 .. autoclass:: telegram.SuccessfulPayment
     :members:

--- a/docs/source/telegram.successfulpayment.rst
+++ b/docs/source/telegram.successfulpayment.rst
@@ -1,4 +1,4 @@
-telegram.SuccessfulPayment
+SuccessfulPayment
 ==========================
 
 .. autoclass:: telegram.SuccessfulPayment

--- a/docs/source/telegram.telegramobject.rst
+++ b/docs/source/telegram.telegramobject.rst
@@ -1,5 +1,5 @@
 TelegramObject
-=======================
+==============
 
 .. autoclass:: telegram.TelegramObject
     :members:

--- a/docs/source/telegram.telegramobject.rst
+++ b/docs/source/telegram.telegramobject.rst
@@ -1,4 +1,4 @@
-telegram.TelegramObject
+TelegramObject
 =======================
 
 .. autoclass:: telegram.TelegramObject

--- a/docs/source/telegram.update.rst
+++ b/docs/source/telegram.update.rst
@@ -1,4 +1,4 @@
-telegram.Update
+Update
 ===============
 
 .. autoclass:: telegram.Update

--- a/docs/source/telegram.update.rst
+++ b/docs/source/telegram.update.rst
@@ -1,5 +1,5 @@
 Update
-===============
+======
 
 .. autoclass:: telegram.Update
     :members:

--- a/docs/source/telegram.user.rst
+++ b/docs/source/telegram.user.rst
@@ -1,5 +1,5 @@
 User
-=============
+====
 
 .. autoclass:: telegram.User
     :members:

--- a/docs/source/telegram.user.rst
+++ b/docs/source/telegram.user.rst
@@ -1,4 +1,4 @@
-telegram.User
+User
 =============
 
 .. autoclass:: telegram.User

--- a/docs/source/telegram.userprofilephotos.rst
+++ b/docs/source/telegram.userprofilephotos.rst
@@ -1,5 +1,5 @@
 UserProfilePhotos
-==========================
+=================
 
 .. autoclass:: telegram.UserProfilePhotos
     :members:

--- a/docs/source/telegram.userprofilephotos.rst
+++ b/docs/source/telegram.userprofilephotos.rst
@@ -1,4 +1,4 @@
-telegram.UserProfilePhotos
+UserProfilePhotos
 ==========================
 
 .. autoclass:: telegram.UserProfilePhotos

--- a/docs/source/telegram.venue.rst
+++ b/docs/source/telegram.venue.rst
@@ -1,5 +1,5 @@
 Venue
-==============
+=====
 
 .. autoclass:: telegram.Venue
     :members:

--- a/docs/source/telegram.venue.rst
+++ b/docs/source/telegram.venue.rst
@@ -1,4 +1,4 @@
-telegram.Venue
+Venue
 ==============
 
 .. autoclass:: telegram.Venue

--- a/docs/source/telegram.video.rst
+++ b/docs/source/telegram.video.rst
@@ -1,5 +1,5 @@
 Video
-==============
+=====
 
 .. Also lists methods of _BaseThumbedMedium, but not the ones of TelegramObject
 

--- a/docs/source/telegram.video.rst
+++ b/docs/source/telegram.video.rst
@@ -1,4 +1,4 @@
-telegram.Video
+Video
 ==============
 
 .. Also lists methods of _BaseThumbedMedium, but not the ones of TelegramObject

--- a/docs/source/telegram.videochatended.rst
+++ b/docs/source/telegram.videochatended.rst
@@ -1,5 +1,5 @@
 VideoChatEnded
-=======================
+==============
 
 .. autoclass:: telegram.VideoChatEnded
     :members:

--- a/docs/source/telegram.videochatended.rst
+++ b/docs/source/telegram.videochatended.rst
@@ -1,4 +1,4 @@
-telegram.VideoChatEnded
+VideoChatEnded
 =======================
 
 .. autoclass:: telegram.VideoChatEnded

--- a/docs/source/telegram.videochatparticipantsinvited.rst
+++ b/docs/source/telegram.videochatparticipantsinvited.rst
@@ -1,4 +1,4 @@
-telegram.VideoChatParticipantsInvited
+VideoChatParticipantsInvited
 =====================================
 
 .. autoclass:: telegram.VideoChatParticipantsInvited

--- a/docs/source/telegram.videochatparticipantsinvited.rst
+++ b/docs/source/telegram.videochatparticipantsinvited.rst
@@ -1,5 +1,5 @@
 VideoChatParticipantsInvited
-=====================================
+============================
 
 .. autoclass:: telegram.VideoChatParticipantsInvited
     :members:

--- a/docs/source/telegram.videochatscheduled.rst
+++ b/docs/source/telegram.videochatscheduled.rst
@@ -1,7 +1,6 @@
 VideoChatScheduled
-===========================
+==================
 
 .. autoclass:: telegram.VideoChatScheduled
     :members:
     :show-inheritance:
-

--- a/docs/source/telegram.videochatscheduled.rst
+++ b/docs/source/telegram.videochatscheduled.rst
@@ -1,4 +1,4 @@
-telegram.VideoChatScheduled
+VideoChatScheduled
 ===========================
 
 .. autoclass:: telegram.VideoChatScheduled

--- a/docs/source/telegram.videochatstarted.rst
+++ b/docs/source/telegram.videochatstarted.rst
@@ -1,4 +1,4 @@
-telegram.VideoChatStarted
+VideoChatStarted
 =========================
 
 .. autoclass:: telegram.VideoChatStarted

--- a/docs/source/telegram.videochatstarted.rst
+++ b/docs/source/telegram.videochatstarted.rst
@@ -1,5 +1,5 @@
 VideoChatStarted
-=========================
+================
 
 .. autoclass:: telegram.VideoChatStarted
     :members:

--- a/docs/source/telegram.videonote.rst
+++ b/docs/source/telegram.videonote.rst
@@ -1,5 +1,5 @@
 VideoNote
-==================
+=========
 
 .. Also lists methods of _BaseThumbedMedium, but not the ones of TelegramObject
 

--- a/docs/source/telegram.videonote.rst
+++ b/docs/source/telegram.videonote.rst
@@ -1,4 +1,4 @@
-telegram.VideoNote
+VideoNote
 ==================
 
 .. Also lists methods of _BaseThumbedMedium, but not the ones of TelegramObject

--- a/docs/source/telegram.voice.rst
+++ b/docs/source/telegram.voice.rst
@@ -1,4 +1,4 @@
-telegram.Voice
+Voice
 ==============
 
 .. Also lists methods of _BaseThumbedMedium, but not the ones of TelegramObject

--- a/docs/source/telegram.voice.rst
+++ b/docs/source/telegram.voice.rst
@@ -1,5 +1,5 @@
 Voice
-==============
+=====
 
 .. Also lists methods of _BaseThumbedMedium, but not the ones of TelegramObject
 

--- a/docs/source/telegram.webappdata.rst
+++ b/docs/source/telegram.webappdata.rst
@@ -1,5 +1,5 @@
 WebAppData
-===========================
+==========
 
 .. autoclass:: telegram.WebAppData
     :members:

--- a/docs/source/telegram.webappdata.rst
+++ b/docs/source/telegram.webappdata.rst
@@ -1,4 +1,4 @@
-telegram.WebAppData
+WebAppData
 ===========================
 
 .. autoclass:: telegram.WebAppData

--- a/docs/source/telegram.webappinfo.rst
+++ b/docs/source/telegram.webappinfo.rst
@@ -1,4 +1,4 @@
-telegram.WebAppInfo
+WebAppInfo
 =========================
 
 .. autoclass:: telegram.WebAppInfo

--- a/docs/source/telegram.webappinfo.rst
+++ b/docs/source/telegram.webappinfo.rst
@@ -1,5 +1,5 @@
 WebAppInfo
-=========================
+==========
 
 .. autoclass:: telegram.WebAppInfo
     :members:

--- a/docs/source/telegram.webhookinfo.rst
+++ b/docs/source/telegram.webhookinfo.rst
@@ -1,4 +1,4 @@
-telegram.WebhookInfo
+WebhookInfo
 ====================
 
 .. autoclass:: telegram.WebhookInfo

--- a/docs/source/telegram.webhookinfo.rst
+++ b/docs/source/telegram.webhookinfo.rst
@@ -1,5 +1,5 @@
 WebhookInfo
-====================
+===========
 
 .. autoclass:: telegram.WebhookInfo
     :members:

--- a/docs/source/telegram.writeaccessallowed.rst
+++ b/docs/source/telegram.writeaccessallowed.rst
@@ -1,4 +1,4 @@
-telegram.WriteAccessAllowed
+WriteAccessAllowed
 ===========================
 
 .. autoclass:: telegram.WriteAccessAllowed

--- a/docs/source/telegram.writeaccessallowed.rst
+++ b/docs/source/telegram.writeaccessallowed.rst
@@ -1,5 +1,5 @@
 WriteAccessAllowed
-===========================
+==================
 
 .. autoclass:: telegram.WriteAccessAllowed
     :members:


### PR DESCRIPTION
As suggested in https://t.me/c/1494805131/32127. Build will be up soonish on rtd.

URLs seem to be unchanged.

Before a merge, I want to test if this would imply any changes for rulesbot.