### PR TITLE
Add `effective_name` property to `Chat` object

### DIFF
--- a/telegram/_chat.py
+++ b/telegram/_chat.py
@@ -389,9 +389,23 @@ class Chat(TelegramObject):
         self._freeze()
 
     @property
+    def effective_name(self) -> Optional[str]:
+        """
+        :obj:`str`: Convenience property. Gives :attr:`title` if not :obj:`None`,
+        else :attr:`full_name` if not :obj:`None`.
+
+        .. versionadded:: 20.1
+        """
+        if self.title is not None:
+            return self.title
+        if self.full_name is not None:
+            return self.full_name
+        return None
+
+    @property
     def full_name(self) -> Optional[str]:
         """
-        :obj:`str`: Convenience property. If :attr:`first_name` is not :obj:`None` gives,
+        :obj:`str`: Convenience property. If :attr:`first_name` is not :obj:`None`, gives
         :attr:`first_name` followed by (if available) :attr:`last_name`.
 
         Note:

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -212,6 +212,16 @@ class TestChat:
         )
         assert chat.full_name is None
 
+    def test_effective_name(self):
+        chat = Chat(id=1, type=Chat.PRIVATE, first_name="first\u2022name")
+        assert chat.effective_name == "first\u2022name"
+        chat = Chat(id=1, type=Chat.GROUP, title="group")
+        assert chat.effective_name == "group"
+        chat = Chat(id=1, type=Chat.GROUP, first_name="first\u2022name", title="group")
+        assert chat.effective_name == "group"
+        chat = Chat(id=1, type=Chat.GROUP)
+        assert chat.effective_name is None
+
     async def test_send_action(self, monkeypatch, chat):
         async def make_assertion(*_, **kwargs):
             id_ = kwargs["chat_id"] == chat.id


### PR DESCRIPTION
Fixes #3480.
<!--
Hey! You're PRing? Cool! Please have a look at the below checklist. It's here to help both you and the maintainers to remember some aspects. Make sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
-->

### Checklist for PRs

- [x] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing 