### PR TITLE
Added copy button in docs

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -102,6 +102,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Sahil Sharma <https://github.com/sahilsharma811>`_
 - `Sascha <https://github.com/saschalalala>`_
 - `Shelomentsev D <https://github.com/shelomentsevd>`_
+- `Shivam Saini <https://github.com/shivamsn97>`_
 - `Simon Schürrle <https://github.com/SitiSchu>`_
 - `sooyhwang <https://github.com/sooyhwang>`_
 - `syntx <https://github.com/syntx>`_

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -4,3 +4,4 @@ furo==2022.12.7
 git+https://github.com/harshil21/furo-sphinx-search@be5cfa221a01f6e259bb2bb1f76d6ede7ffc1f11#egg=furo-sphinx-search
 sphinx-paramlinks==0.5.4
 sphinxcontrib-mermaid==0.7.1
+sphinx-copybutton==0.5.1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,6 +46,7 @@ extensions = [
     "sphinx.ext.linkcode",
     "sphinx.ext.extlinks",
     "sphinx_paramlinks",
+    "sphinx_copybutton",
     "sphinxcontrib.mermaid",
     "sphinx_search.extension",
 ]


### PR DESCRIPTION
Fixes issue #3486  Added copy button on docs using sphinx-copybutton (https://sphinx-copybutton.readthedocs.io/en/latest/)

Changed to branch as per discussion in #3491 