### PR TITLE
Fix Docs Search in Sphinx 6.0+

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,6 +1,6 @@
 sphinx==6.1.2
 sphinx-pypi-upload
 furo==2022.12.7
-git+https://github.com/harshil21/furo-sphinx-search@795c6a340d19a4bfa3a7f5634335f7385e50d065#egg=furo-sphinx-search
+git+https://github.com/harshil21/furo-sphinx-search@bf9c87e170b86d23d5a60384ba6691cbbee6ae0a#egg=furo-sphinx-search
 sphinx-paramlinks==0.5.4
 sphinxcontrib-mermaid==0.7.1

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,7 +1,7 @@
 sphinx==6.1.3
 sphinx-pypi-upload
 furo==2022.12.7
-git+https://github.com/harshil21/furo-sphinx-search@bf9c87e170b86d23d5a60384ba6691cbbee6ae0a#egg=furo-sphinx-search
+git+https://github.com/harshil21/furo-sphinx-search@01efc7be422d7dc02390aab9be68d6f5ce1a5618#egg=furo-sphinx-search
 sphinx-paramlinks==0.5.4
 sphinxcontrib-mermaid==0.7.1
 sphinx-copybutton==0.5.1

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,6 +1,6 @@
-sphinx==5.3.0
+sphinx==6.1.2
 sphinx-pypi-upload
 furo==2022.12.7
-git+https://github.com/harshil21/furo-sphinx-search@be5cfa221a01f6e259bb2bb1f76d6ede7ffc1f11#egg=furo-sphinx-search
+git+https://github.com/harshil21/furo-sphinx-search@795c6a340d19a4bfa3a7f5634335f7385e50d065#egg=furo-sphinx-search
 sphinx-paramlinks==0.5.4
 sphinxcontrib-mermaid==0.7.1

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,4 +1,4 @@
-sphinx==6.1.2
+sphinx==6.1.3
 sphinx-pypi-upload
 furo==2022.12.7
 git+https://github.com/harshil21/furo-sphinx-search@bf9c87e170b86d23d5a60384ba6691cbbee6ae0a#egg=furo-sphinx-search

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,7 +34,7 @@ version = "20.0"  # telegram.__version__[:3]
 release = "20.0"  # telegram.__version__
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "5.1.1"
+needs_sphinx = "6.1.2"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -220,12 +220,7 @@ html_favicon = "ptb-logo_1024.ico"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
-html_css_files = [
-    "style_external_link.css",
-    "style_mermaid_diagrams.css",
-    "style_sidebar_brand.css",
-    "style_general.css",
-]
+html_css_files = ["style_external_link.css", "style_mermaid_diagrams.css"]
 
 html_permalinks_icon = "¶"  # Furo's default permalink icon is `#` which doesn't look great imo.
 
@@ -268,7 +263,7 @@ latex_logo = "ptb-logo_1024.png"
 # (source start file, name, description, authors, manual section).
 man_pages = [(master_doc, "python-telegram-bot", "python-telegram-bot Documentation", [author], 1)]
 
-# rtd_sphinx_search_file_type = "un-minified"  # Configuration for furo-sphinx-search
+rtd_sphinx_search_file_type = "un-minified"  # Configuration for furo-sphinx-search
 
 # -- Options for Texinfo output -------------------------------------------
 
@@ -349,7 +344,7 @@ class TGConstXRefRole(PyXRefRole):
             return title, target
         except Exception as exc:
             sphinx_logger.exception(
-                f"%s:%d: WARNING: Did not convert reference %s due to an exception.",
+                "%s:%d: WARNING: Did not convert reference %s due to an exception.",
                 refnode.source,
                 refnode.line,
                 refnode.rawsource,
@@ -514,7 +509,7 @@ def _git_branch() -> str:
         return output.decode().strip()
     except Exception as exc:
         sphinx_logger.exception(
-            f"Failed to get a description of the current commit. Falling back to `master`.",
+            "Failed to get a description of the current commit. Falling back to `master`.",
             exc_info=exc,
         )
         return "master"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ version = "20.0"  # telegram.__version__[:3]
 release = "20.0"  # telegram.__version__
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "6.1.2"
+needs_sphinx = "6.1.3"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,7 +34,7 @@ version = "20.0"  # telegram.__version__[:3]
 release = "20.0"  # telegram.__version__
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "6.1.2"
+needs_sphinx = "5.1.1"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -220,7 +220,12 @@ html_favicon = "ptb-logo_1024.ico"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
-html_css_files = ["style_external_link.css", "style_mermaid_diagrams.css"]
+html_css_files = [
+    "style_external_link.css",
+    "style_mermaid_diagrams.css",
+    "style_sidebar_brand.css",
+    "style_general.css",
+]
 
 html_permalinks_icon = "¶"  # Furo's default permalink icon is `#` which doesn't look great imo.
 
@@ -263,7 +268,7 @@ latex_logo = "ptb-logo_1024.png"
 # (source start file, name, description, authors, manual section).
 man_pages = [(master_doc, "python-telegram-bot", "python-telegram-bot Documentation", [author], 1)]
 
-rtd_sphinx_search_file_type = "un-minified"  # Configuration for furo-sphinx-search
+# rtd_sphinx_search_file_type = "un-minified"  # Configuration for furo-sphinx-search
 
 # -- Options for Texinfo output -------------------------------------------
 
@@ -344,7 +349,7 @@ class TGConstXRefRole(PyXRefRole):
             return title, target
         except Exception as exc:
             sphinx_logger.exception(
-                "%s:%d: WARNING: Did not convert reference %s due to an exception.",
+                f"%s:%d: WARNING: Did not convert reference %s due to an exception.",
                 refnode.source,
                 refnode.line,
                 refnode.rawsource,
@@ -509,7 +514,7 @@ def _git_branch() -> str:
         return output.decode().strip()
     except Exception as exc:
         sphinx_logger.exception(
-            "Failed to get a description of the current commit. Falling back to `master`.",
+            f"Failed to get a description of the current commit. Falling back to `master`.",
             exc_info=exc,
         )
         return "master"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,7 +34,7 @@ version = "20.0"  # telegram.__version__[:3]
 release = "20.0"  # telegram.__version__
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "5.1.1"
+needs_sphinx = "6.1.2"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -268,7 +268,7 @@ latex_logo = "ptb-logo_1024.png"
 # (source start file, name, description, authors, manual section).
 man_pages = [(master_doc, "python-telegram-bot", "python-telegram-bot Documentation", [author], 1)]
 
-# rtd_sphinx_search_file_type = "un-minified"  # Configuration for furo-sphinx-search
+rtd_sphinx_search_file_type = "un-minified"  # Configuration for furo-sphinx-search
 
 # -- Options for Texinfo output -------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -268,7 +268,7 @@ latex_logo = "ptb-logo_1024.png"
 # (source start file, name, description, authors, manual section).
 man_pages = [(master_doc, "python-telegram-bot", "python-telegram-bot Documentation", [author], 1)]
 
-rtd_sphinx_search_file_type = "un-minified"  # Configuration for furo-sphinx-search
+# rtd_sphinx_search_file_type = "un-minified"  # Configuration for furo-sphinx-search
 
 # -- Options for Texinfo output -------------------------------------------
 


### PR DESCRIPTION
Fixes doc search in sphinx 6.0+. (~This is not fixed at readthedocs-sphinx-search yet~ Was fixed and merged into my fork)

Build at: https://docs.python-telegram-bot.org/en/doc-improve-search

Changelog at: https://github.com/harshil21/furo-sphinx-search/commits/main (see commit msgs)

Todo now that I started this again:
- [ ] ~Sort search results such that highlighted results on the left are prioritized over ones only on the right~
- [ ] ~Experimental: Prefix search if only one word has been typed, so we get better results.~

