### PR TITLE
Issue warning in `run_daily` only if `days` parameter was passed

### DIFF
--- a/telegram/ext/_jobqueue.py
+++ b/telegram/ext/_jobqueue.py
@@ -461,10 +461,6 @@ class JobQueue:
                 .. versionchanged:: 20.0
                     Changed day of the week mapping of 0-6 from monday-sunday to sunday-saturday.
 
-                .. versionchanged:: 20.1
-                    The warning about the change of day of week mapping is now only shown if this
-                    parameter was passed.
-
             data (:obj:`object`, optional): Additional data needed for the callback function.
                 Can be accessed through :attr:`Job.data` in the callback. Defaults to
                 :obj:`None`.

--- a/telegram/ext/_jobqueue.py
+++ b/telegram/ext/_jobqueue.py
@@ -460,6 +460,11 @@ class JobQueue:
 
                 .. versionchanged:: 20.0
                     Changed day of the week mapping of 0-6 from monday-sunday to sunday-saturday.
+
+                .. versionchanged:: 20.1
+                    The warning about the change of day of week mapping is now only shown if this
+                    parameter was passed.
+
             data (:obj:`object`, optional): Additional data needed for the callback function.
                 Can be accessed through :attr:`Job.data` in the callback. Defaults to
                 :obj:`None`.
@@ -487,12 +492,13 @@ class JobQueue:
             queue.
 
         """
-        # TODO: After v20.0, we should remove the this warning.
-        warn(
-            "Prior to v20.0 the `days` parameter was not aligned to that of cron's weekday scheme."
-            "We recommend double checking if the passed value is correct.",
-            stacklevel=2,
-        )
+        # TODO: After v20.0, we should remove this warning.
+        if days != tuple(range(7)):  # checks if user passed a custom value
+            warn(
+                "Prior to v20.0 the `days` parameter was not aligned to that of cron's weekday "
+                "scheme. We recommend double checking if the passed value is correct.",
+                stacklevel=2,
+            )
         if not job_kwargs:
             job_kwargs = {}
 


### PR DESCRIPTION
As discussed in private chat, this was done to reduce users getting confused on why they got this warning if they never used the days parameter in the first place.

### Checklist for PRs

- [x] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [x] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- [ ] ~Added myself alphabetically to `AUTHORS.rst` (optional)~
- [ ] ~Added new classes & modules to the docs and all suitable `__all__` s~
