### PR TITLE
Improve error message for `NetworkError`

### DIFF
--- a/telegram/request/_httpxrequest.py
+++ b/telegram/request/_httpxrequest.py
@@ -201,6 +201,6 @@ class HTTPXRequest(BaseRequest):
         except httpx.HTTPError as err:
             # HTTPError must come last as its the base httpx exception class
             # TODO p4: do something smart here; for now just raise NetworkError
-            raise NetworkError(f"httpx HTTPError: {err}") from err
+            raise NetworkError(f"httpx.{err.__class__.__name__}: {err}") from err
 
         return res.status_code, res.content

--- a/telegram/request/_httpxrequest.py
+++ b/telegram/request/_httpxrequest.py
@@ -201,6 +201,9 @@ class HTTPXRequest(BaseRequest):
         except httpx.HTTPError as err:
             # HTTPError must come last as its the base httpx exception class
             # TODO p4: do something smart here; for now just raise NetworkError
+
+            # We include the class name for easier debugging. Especially useful if the error
+            # message of `err` is empty.
             raise NetworkError(f"httpx.{err.__class__.__name__}: {err}") from err
 
         return res.status_code, res.content


### PR DESCRIPTION
Improves the error message for `NetworkErrors` raised in `HTTPXRequest` to also include the error type name. This is especially useful if the error raised by httpx has an empty error message.

### Checklist for PRs

- [ ] ~Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)~
- [x] Created new or adapted existing unit tests
- [x] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- [ ] ~Added myself alphabetically to `AUTHORS.rst` (optional)~
- [ ] ~Added new classes & modules to the docs and all suitable `__all__` s~
