### PR TITLE
Run locking job only once per day

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -3,7 +3,6 @@ name: 'Lock Closed Threads'
 on:
   schedule:
     - cron: '8 4 * * *'
-    - cron: '42 17 * * *'
 
 jobs:
   lock:


### PR DESCRIPTION
… as the worklow is failing every now and then due to rate limits