### PR TITLE
Fixed referenced variable in docstring of AIORateLimiter

### DIFF
--- a/telegram/ext/_aioratelimiter.py
+++ b/telegram/ext/_aioratelimiter.py
@@ -105,7 +105,7 @@ class AIORateLimiter(BaseRateLimiter[int]):
             to groups and channels per :paramref:`group_time_period`.  When set to 0, no rate
             limiting will be applied. Defaults to 20.
         group_time_period (:obj:`float`): The time period (in seconds) during which the
-            :paramref:`group_time_period` is enforced.  When set to 0, no rate limiting will be
+            :paramref:`group_max_rate` is enforced.  When set to 0, no rate limiting will be
             applied. Defaults to 60.
         max_retries (:obj:`int`): The maximum number of retries to be made in case of a
             :exc:`~telegram.error.RetryAfter` exception.


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool! Please have a look at the below checklist. It's here to help both you and the maintainers to remember some aspects. Make sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
-->

This PR just fixes a messed-up parameter reference in the docstring of the `AIORateLimiter` class. Well, I hope I didn't mess it up myself in case that was actually on purpose. :)