### PR TITLE
Autogenerate "Shortcuts" admonitions

### DIFF
--- a/docs/auxil/admonition_inserter.py
+++ b/docs/auxil/admonition_inserter.py
@@ -282,7 +282,7 @@ class AdmonitionInserter:
             r"""\s*  # any number of whitespaces
             (?<=return\sawait\sself\.get_bot\(\)\.)  # lookbehind
             .+  # the method name we are looking for
-            (?=\() # lookahead: closing bracket
+            (?=\() # lookahead: opening bracket before the args of the method start
             """,
             re.VERBOSE,
         )

--- a/docs/auxil/admonition_inserter.py
+++ b/docs/auxil/admonition_inserter.py
@@ -302,7 +302,7 @@ class AdmonitionInserter:
         # that this given method is a shortcut for a Bot method
         for class_name, cls in inspect.getmembers(telegram, predicate=inspect.isclass):
 
-            # no need to inspect Bot's own methods, as Bot can't have shortcuts in But
+            # no need to inspect Bot's own methods, as Bot can't have shortcuts in Bot
             if cls is telegram.Bot:
                 continue
 

--- a/docs/auxil/admonition_inserter.py
+++ b/docs/auxil/admonition_inserter.py
@@ -299,7 +299,7 @@ class AdmonitionInserter:
             if cls is telegram.Bot:
                 continue
 
-            for method_name, method in inspect.getmembers(cls, predicate=inspect.isfunction):
+            for method_name, method in self._iter_own_public_methods(cls):
 
                 # .getsourcelines() returns a tuple. Item [1] is an int (length of line?)
                 relevant_return_lines = [
@@ -445,6 +445,19 @@ class AdmonitionInserter:
         """Generates a ReST link to a method of a telegram class."""
 
         return f":meth:`{self._generate_class_name_for_link(cls)}.{method_name}`"
+
+    @staticmethod
+    def _iter_own_public_methods(cls: type) -> Iterator[tuple[str, type]]:
+        """Iterates over methods of a class that are not protected/private,
+        not camelCase and not inherited from the parent class.
+        """
+        return (
+            m
+            for m in inspect.getmembers(cls, predicate=inspect.isfunction)  # not .ismethod
+            if not m[0].startswith("_")
+            and m[0].islower()  # to avoid camelCase methods
+            and m[0] in cls.__dict__  # method is not inherited from parent class
+        )
 
     @staticmethod
     def _iter_subclasses(cls: type) -> Iterator:

--- a/docs/auxil/admonition_inserter.py
+++ b/docs/auxil/admonition_inserter.py
@@ -308,16 +308,14 @@ class AdmonitionInserter:
 
             for method_name, method in _iter_own_public_methods(cls):
 
-                # .getsourcelines() returns a tuple. Item [1] is an int (length of line?)
-                relevant_return_lines = [
-                    line
-                    for line in inspect.getsourcelines(method)[0]
-                    if bot_method_pattern.search(line)
-                ]
+                # .getsourcelines() returns a tuple. Item [1] is an int
+                for line in inspect.getsourcelines(method)[0]:
+                    bot_method_match = bot_method_pattern.search(line)
 
-                for line in relevant_return_lines:
-                    bot_method_name = bot_method_pattern.search(line).group()
-                    bot_method = getattr(telegram.Bot, bot_method_name)
+                    if not bot_method_match:
+                        continue
+
+                    bot_method = getattr(telegram.Bot, bot_method_match.group())
 
                     link_to_shortcut_method = self._generate_link_to_method(method_name, cls)
 

--- a/docs/auxil/admonition_inserter.py
+++ b/docs/auxil/admonition_inserter.py
@@ -306,7 +306,7 @@ class AdmonitionInserter:
 
                 for line in relevant_return_lines:
                     bot_method_name = bot_method_pattern.search(line).group()
-                    bot_method = eval(f"telegram.Bot.{bot_method_name}")
+                    bot_method = getattr(telegram.Bot, bot_method_name)
 
                     link_to_shortcut_method = self._generate_link_to_method(method_name, cls)
 

--- a/docs/auxil/admonition_inserter.py
+++ b/docs/auxil/admonition_inserter.py
@@ -295,6 +295,10 @@ class AdmonitionInserter:
         # that this given method is a shortcut for a Bot method
         for class_name, cls in inspect.getmembers(telegram, predicate=inspect.isclass):
 
+            # no need to inspect Bot's own methods, as Bot can't have shortcuts in But
+            if cls is telegram.Bot:
+                continue
+
             for method_name, method in inspect.getmembers(cls, predicate=inspect.isfunction):
 
                 # .getsourcelines() returns a tuple. Item [1] is an int (length of line?)

--- a/docs/auxil/admonition_inserter.py
+++ b/docs/auxil/admonition_inserter.py
@@ -281,7 +281,7 @@ class AdmonitionInserter:
         bot_method_pattern = re.compile(
             r"""\s*  # any number of whitespaces
             (?<=return\sawait\sself\.get_bot\(\)\.)  # lookbehind
-            .+  # the method name we are looking for
+            \w+  # the method name we are looking for, letters/underscores
             (?=\() # lookahead: opening bracket before the args of the method start
             """,
             re.VERBOSE,

--- a/docs/auxil/admonition_inserter.py
+++ b/docs/auxil/admonition_inserter.py
@@ -310,9 +310,8 @@ class AdmonitionInserter:
 
                 # .getsourcelines() returns a tuple. Item [1] is an int
                 for line in inspect.getsourcelines(method)[0]:
-                    bot_method_match = bot_method_pattern.search(line)
 
-                    if not bot_method_match:
+                    if not (bot_method_match := bot_method_pattern.search(line)):
                         continue
 
                     bot_method = getattr(telegram.Bot, bot_method_match.group())

--- a/docs/auxil/sphinx_hooks.py
+++ b/docs/auxil/sphinx_hooks.py
@@ -121,16 +121,16 @@ def autodoc_process_docstring(
                 ),
             )
 
-        ADMONITION_INSERTER.insert_admonitions_for_bot_method(
-            method=typing.cast(collections.abc.Callable, obj),
+        ADMONITION_INSERTER.insert_admonitions(
+            obj=typing.cast(collections.abc.Callable, obj),
             docstring_lines=lines,
         )
 
     # 2-4) Insert "Returned in", "Available in", "Use in" admonitions into classes
     # (where applicable)
     if what == "class":
-        ADMONITION_INSERTER.insert_admonitions_for_class(
-            cls=typing.cast(type, obj),  # since "what" == class, we know it's not just object
+        ADMONITION_INSERTER.insert_admonitions(
+            obj=typing.cast(type, obj),  # since "what" == class, we know it's not just object
             docstring_lines=lines,
         )
 

--- a/docs/auxil/sphinx_hooks.py
+++ b/docs/auxil/sphinx_hooks.py
@@ -15,6 +15,7 @@
 #
 #  You should have received a copy of the GNU Lesser Public License
 #  along with this program.  If not, see [http://www.gnu.org/licenses/].
+import collections.abc
 import inspect
 import re
 import typing
@@ -76,7 +77,8 @@ def autodoc_process_docstring(
     app: Sphinx, what, name: str, obj: object, options, lines: list[str]
 ):
     """We do the following things:
-    1) Use this method to automatically insert the Keyword Args for the Bot methods.
+    1) Use this method to automatically insert the Keyword Args and "Shortcuts" admonitions
+       for the Bot methods.
 
     2) Use this method to automatically insert "Returned in" admonition into classes
        that are returned from the Bot methods
@@ -91,7 +93,7 @@ def autodoc_process_docstring(
        to the actual object here.
     """
 
-    # 1) Insert the Keyword Args for the Bot methods
+    # 1) Insert the Keyword Args and "Shortcuts" admonitions for the Bot methods
     method_name = name.split(".")[-1]
     if (
         name.startswith("telegram.Bot.")
@@ -118,6 +120,11 @@ def autodoc_process_docstring(
                     read_timeout_type=read_timeout_type[get_updates_sub],
                 ),
             )
+
+        ADMONITION_INSERTER.insert_admonitions_for_bot_method(
+            method=typing.cast(collections.abc.Callable, obj),
+            docstring_lines=lines,
+        )
 
     # 2-4) Insert "Returned in", "Available in", "Use in" admonitions into classes
     # (where applicable)

--- a/docs/source/_static/style_admonitions.css
+++ b/docs/source/_static/style_admonitions.css
@@ -56,10 +56,10 @@
   mask-image: var(--icon--use-in);
 }
 
-.admonition.returned-in > ul:hover, .admonition.available-in > ul:hover, .admonition.use-in > ul:hover {
+.admonition.returned-in > ul:hover, .admonition.available-in > ul:hover, .admonition.use-in > ul:hover, .admonition.shortcuts > ul:hover {
   cursor: move;
 }
-.admonition.returned-in > ul, .admonition.available-in > ul, .admonition.use-in > ul {
+.admonition.returned-in > ul, .admonition.available-in > ul, .admonition.use-in > ul, .admonition.shortcuts > ul {
   max-height: 200px;
   overflow-y: scroll;
 }

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -720,13 +720,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
     ) -> Message:
         """Use this method to send text messages.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.send_message`, :meth:`telegram.User.send_message`,
-            :meth:`telegram.Message.reply_text`, :meth:`telegram.Message.reply_html`,
-            :meth:`telegram.Message.reply_markdown`, :meth:`telegram.Message.reply_markdown_v2`
-
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
             text (:obj:`str`): Text of the message to be sent. Max
@@ -869,12 +862,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             As a workaround, it is still possible to use :meth:`copy_message`. However, this
             behaviour is undocumented and might be changed by Telegram.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.forward`, :meth:`telegram.Chat.forward_to`,
-            :meth:`telegram.Chat.forward_from`
-
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
             from_chat_id (:obj:`int` | :obj:`str`): Unique identifier for the chat where the
@@ -938,12 +925,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         api_kwargs: JSONDict = None,
     ) -> Message:
         """Use this method to send photos.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.reply_photo`, :meth:`telegram.Chat.send_photo`,
-            :meth:`telegram.User.send_photo`
 
         .. seealso:: :wiki:`Working with Files and Media <Working-with-Files-and-Media>`
 
@@ -1066,12 +1047,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         changed in the future.
 
         For sending voice messages, use the :meth:`send_voice` method instead.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.reply_audio`, :meth:`telegram.Chat.send_audio`,
-            :meth:`telegram.User.send_audio`
 
         .. seealso:: :wiki:`Working with Files and Media <Working-with-Files-and-Media>`
 
@@ -1197,12 +1172,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         :tg-const:`telegram.constants.FileSizeLimit.FILESIZE_UPLOAD` in size, this limit may be
         changed in the future.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.reply_document`, :meth:`telegram.Chat.send_document`,
-            :meth:`telegram.User.send_document`
-
         .. seealso:: :wiki:`Working with Files and Media <Working-with-Files-and-Media>`
 
         Args:
@@ -1315,12 +1284,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         """
         Use this method to send static ``.WEBP``, animated ``.TGS``, or video ``.WEBM`` stickers.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.reply_sticker`, :meth:`telegram.Chat.send_sticker`,
-            :meth:`telegram.User.send_sticker`
-
         .. seealso:: :wiki:`Working with Files and Media <Working-with-Files-and-Media>`
 
         Args:
@@ -1415,12 +1378,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             :paramref:`thumb` will be ignored for small video files, for which Telegram can
             easily generate thumbnails. However, this behaviour is undocumented and might be
             changed by Telegram.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.reply_video`, :meth:`telegram.Chat.send_video`,
-            :meth:`telegram.User.send_video`
 
         .. seealso:: :wiki:`Working with Files and Media <Working-with-Files-and-Media>`
 
@@ -1554,12 +1511,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             easily generate thumbnails. However, this behaviour is undocumented and might be
             changed by Telegram.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.reply_video_note`, :meth:`telegram.Chat.send_video_note`,
-            :meth:`telegram.User.send_video_note`
-
         .. seealso:: :wiki:`Working with Files and Media <Working-with-Files-and-Media>`
 
         Args:
@@ -1680,12 +1631,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             :paramref:`thumb` will be ignored for small files, for which Telegram can easily
             generate thumbnails. However, this behaviour is undocumented and might be changed
             by Telegram.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.reply_animation`, :meth:`telegram.Chat.send_animation`,
-            :meth:`telegram.User.send_animation`
 
         .. seealso:: :wiki:`Working with Files and Media <Working-with-Files-and-Media>`
 
@@ -1820,12 +1765,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             :tg-const:`telegram.constants.FileSizeLimit.FILESIZE_DOWNLOAD` voice notes will be
             sent as files.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.reply_voice`, :meth:`telegram.Chat.send_voice`,
-            :meth:`telegram.User.send_voice`
-
         .. seealso:: :wiki:`Working with Files and Media <Working-with-Files-and-Media>`
 
         Args:
@@ -1934,12 +1873,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             If you supply a :paramref:`caption` (along with either :paramref:`parse_mode` or
             :paramref:`caption_entities`), then items in :paramref:`media` must have no captions,
             and vice versa.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.reply_media_group`, :meth:`telegram.Chat.send_media_group`,
-            :meth:`telegram.User.send_media_group`
 
         .. seealso:: :wiki:`Working with Files and Media <Working-with-Files-and-Media>`
 
@@ -2070,12 +2003,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             You can either supply a :paramref:`latitude` and :paramref:`longitude` or a
             :paramref:`location`.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.reply_location`,  :meth:`telegram.Chat.send_location`,
-            :meth:`telegram.User.send_location`
-
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
             latitude (:obj:`float`, optional): Latitude of location.
@@ -2189,12 +2116,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             You can either supply a :paramref:`latitude` and :paramref:`longitude` or a
             :paramref:`location`.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.edit_live_location`,
-            :meth:`telegram.CallbackQuery.edit_message_live_location`
-
         Args:
             chat_id (:obj:`int` | :obj:`str`, optional): Required if :paramref:`inline_message_id`
                 is not specified. |chat_id_channel|
@@ -2279,12 +2200,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         """Use this method to stop updating a live location message sent by the bot or via the bot
         (for inline bots) before :paramref:`~telegram.Location.live_period` expires.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.stop_live_location`,
-            :meth:`telegram.CallbackQuery.stop_message_live_location`
-
         Args:
             chat_id (:obj:`int` | :obj:`str`, optional): Required if :paramref:`inline_message_id`
                 is not specified. |chat_id_channel|
@@ -2351,12 +2266,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
               :paramref:`google_place_id` and :paramref:`google_place_type`.
             * Foursquare details and Google Place details are mutually exclusive. However, this
               behaviour is undocumented and might be changed by Telegram.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.reply_venue`, :meth:`telegram.Chat.send_venue`,
-            :meth:`telegram.User.send_venue`
 
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
@@ -2477,12 +2386,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             :paramref:`first_name` with optionally :paramref:`last_name` and optionally
             :paramref:`vcard`.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.reply_contact`,  :meth:`telegram.Chat.send_contact`,
-            :meth:`telegram.User.send_contact`
-
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
             phone_number (:obj:`str`, optional): Contact's phone number.
@@ -2577,12 +2480,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
     ) -> Message:
         """Use this method to send a game.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.reply_game`, :meth:`telegram.Chat.send_game`,
-            :meth:`telegram.User.send_game`
-
         Args:
             chat_id (:obj:`int` | :obj:`str`): Unique identifier for the target chat.
             game_short_name (:obj:`str`): Short name of the game, serves as the unique identifier
@@ -2644,12 +2541,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         side. The status is set for 5 seconds or less (when a message arrives from your bot,
         Telegram clients clear its typing status). Telegram only recommends using this method when
         a response from the bot will take a noticeable amount of time to arrive.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.reply_chat_action`, :meth:`telegram.Chat.send_action`,
-            :meth:`telegram.User.send_chat_action`
 
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
@@ -2819,11 +2710,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             :paramref:`telegram.InlineQuery.answer.auto_pagination` set to :obj:`True`, which will
             take care of passing the correct value.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.InlineQuery.answer`
-
         .. seealso:: :wiki:`Working with Files and Media <Working-with-Files-and-Media>`
 
         Args:
@@ -2909,11 +2795,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
     ) -> UserProfilePhotos:
         """Use this method to get a list of profile pictures for a user.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.User.get_profile_photos`
-
         Args:
             user_id (:obj:`int`): Unique identifier of the target user.
             offset (:obj:`int`, optional): Sequential number of the first photo to be returned.
@@ -2969,16 +2850,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             This function may not preserve the original file name and MIME type.
             You should save the file's MIME type and name (if available) when the File object
             is received.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Animation.get_file`, :meth:`telegram.Audio.get_file`,
-            :meth:`telegram.ChatPhoto.get_big_file`, :meth:`telegram.ChatPhoto.get_small_file`,
-            :meth:`telegram.Document.get_file`, :meth:`telegram.PassportFile.get_file`,
-            :meth:`telegram.PhotoSize.get_file`, :meth:`telegram.Sticker.get_file`,
-            :meth:`telegram.Video.get_file`, :meth:`telegram.VideoNote.get_file`,
-            :meth:`telegram.Voice.get_file`
 
         .. seealso:: :wiki:`Working with Files and Media <Working-with-Files-and-Media>`
 
@@ -3040,11 +2911,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         supergroups and channels, the user will not be able to return to the group on their own
         using invite links, etc., unless unbanned first. The bot must be an administrator in the
         chat for this to work and must have the appropriate admin rights.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.ban_member`
 
         .. versionadded:: 13.7
 
@@ -3110,11 +2976,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         their channels**. The bot must be an administrator in the supergroup or channel for this
         to work and must have the appropriate administrator rights.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.ban_chat`, :meth:`telegram.Chat.ban_sender_chat`
-
         .. versionadded:: 13.9
 
         Args:
@@ -3164,11 +3025,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         join it. So if the user is a member of the chat they will also be *removed* from the chat.
         If you don't want this, use the parameter :paramref:`only_if_banned`.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.unban_member`
-
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
             user_id (:obj:`int`): Unique identifier of the target user.
@@ -3210,11 +3066,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         """Use this method to unban a previously banned channel in a supergroup or channel.
         The bot must be an administrator for this to work and must have the
         appropriate administrator rights.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.unban_chat`
 
         .. versionadded:: 13.9
 
@@ -3266,11 +3117,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         work, you must first create a game for your bot via `@BotFather <https://t.me/BotFather>`_
         and accept the terms. Otherwise, you may use links like t.me/your_bot?start=XXXX that open
         your bot with a parameter.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.CallbackQuery.answer`
 
         Args:
             callback_query_id (:obj:`str`): Unique identifier for the query to be answered.
@@ -3339,11 +3185,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
 
         Note:
             |editreplymarkup|.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.edit_text`, :meth:`telegram.CallbackQuery.edit_message_text`
 
         .. seealso:: :attr:`telegram.Game.text`
 
@@ -3422,12 +3263,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         Note:
             |editreplymarkup|
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.edit_caption`,
-            :meth:`telegram.CallbackQuery.edit_message_caption`
-
         Args:
             chat_id (:obj:`int` | :obj:`str`, optional): Required if inline_message_id is not
                 specified. |chat_id_channel|
@@ -3500,12 +3335,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         Note:
             |editreplymarkup|
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.edit_media`,
-            :meth:`telegram.CallbackQuery.edit_message_media`
-
         .. seealso:: :wiki:`Working with Files and Media <Working-with-Files-and-Media>`
 
         Args:
@@ -3565,12 +3394,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
 
         Note:
             |editreplymarkup|
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.edit_reply_markup`,
-            :meth:`telegram.CallbackQuery.edit_message_reply_markup`
 
         Args:
             chat_id (:obj:`int` | :obj:`str`, optional): Required if inline_message_id is not
@@ -3882,11 +3705,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
     ) -> bool:
         """Use this method for your bot to leave a group, supergroup or channel.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.leave`
-
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
 
@@ -3964,11 +3782,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         """
         Use this method to get a list of administrators in a chat.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.get_administrators`
-
         .. versionchanged:: 20.0
             Returns a tuple instead of a list.
 
@@ -4010,11 +3823,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
     ) -> int:
         """Use this method to get the number of members in a chat.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.get_member_count`
-
         .. versionadded:: 13.7
 
         Args:
@@ -4053,11 +3861,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
     ) -> ChatMember:
         """Use this method to get information about a member of a chat. The method is guaranteed
         to work for other users, only if the bot is an administrator in the chat.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.get_member`
 
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
@@ -4202,11 +4005,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         """
         Use this method to set the score of the specified user in a game message.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.CallbackQuery.set_game_score`
-
         .. seealso:: :attr:`telegram.Game.text`
 
         Args:
@@ -4277,12 +4075,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
 
         .. versionchanged:: 20.0
             Returns a tuple instead of a list.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.CallbackQuery.get_game_high_scores`,
-            :meth:`telegram.Message.get_game_high_scores`
 
         Args:
             user_id (:obj:`int`): Target user id.
@@ -4363,12 +4155,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             As of API 5.2 :paramref:`start_parameter` is an optional argument and therefore the
             order of the arguments had to be changed. Use keyword arguments to make sure that the
             arguments are passed correctly.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.reply_invoice`, :meth:`telegram.Chat.send_invoice`,
-            :meth:`telegram.User.send_invoice`
 
         .. versionchanged:: 13.5
             As of Bot API 5.2, the parameter :paramref:`start_parameter` is optional.
@@ -4527,11 +4313,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         :class:`telegram.Update` with a :attr:`telegram.Update.shipping_query` field to the bot.
         Use this method to reply to shipping queries.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.ShippingQuery.answer`
-
         Args:
             shipping_query_id (:obj:`str`): Unique identifier for the query to be answered.
             ok (:obj:`bool`): Specify :obj:`True` if delivery to the specified address is possible
@@ -4595,11 +4376,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         Note:
             The Bot API must receive an answer within 10 seconds after the pre-checkout
             query was sent.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.PreCheckoutQuery.answer`
 
         Args:
             pre_checkout_query_id (:obj:`str`): Unique identifier for the query to be answered.
@@ -4703,11 +4479,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         the supergroup for this to work and must have the appropriate admin rights. Pass
         :obj:`True` for all boolean parameters to lift restrictions from a user.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.restrict_member`
-
         .. seealso:: :meth:`telegram.ChatPermissions.all_permissions`
 
         Args:
@@ -4776,11 +4547,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         Use this method to promote or demote a user in a supergroup or a channel. The bot must be
         an administrator in the chat for this to work and must have the appropriate admin rights.
         Pass :obj:`False` for all boolean parameters to demote a user.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.promote_member`
 
         .. versionchanged:: 20.0
            The argument ``can_manage_voice_chats`` was renamed to
@@ -4879,11 +4645,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         administrator in the group or a supergroup for this to work and must have the
         :attr:`telegram.ChatMemberAdministrator.can_restrict_members` admin rights.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.set_permissions`
-
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_group|
             permissions (:class:`telegram.ChatPermissions`): New default chat permissions.
@@ -4923,11 +4684,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         """
         Use this method to set a custom title for administrators promoted by the bot in a
         supergroup. The bot must be an administrator for this to work.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.set_administrator_custom_title`
 
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_group|
@@ -4980,11 +4736,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             by calling the :meth:`get_chat` method. If your bot needs to generate a new primary
             invite link replacing its previous one, use :meth:`export_chat_invite_link` again.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.export_invite_link`
-
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
 
@@ -5026,11 +4777,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         Use this method to create an additional invite link for a chat. The bot must be an
         administrator in the chat for this to work and must have the appropriate admin rights.
         The link can be revoked using the method :meth:`revoke_chat_invite_link`.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.create_invite_link`
 
         .. versionadded:: 13.4
 
@@ -5108,11 +4854,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             parameters to the default values. However, since not documented, this behaviour may
             change unbeknown to PTB.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.edit_invite_link`
-
         .. versionadded:: 13.4
 
         Args:
@@ -5186,11 +4927,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         revoked, a new link is automatically generated. The bot must be an administrator in the
         chat for this to work and must have the appropriate admin rights.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.revoke_invite_link`
-
         .. versionadded:: 13.4
 
         Args:
@@ -5239,12 +4975,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         The bot must be an administrator in the chat for this to work and must have the
         :attr:`telegram.ChatPermissions.can_invite_users` administrator right.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.approve_join_request`, :meth:`telegram.ChatJoinRequest.approve`,
-            :meth:`telegram.User.approve_join_request`
-
         .. versionadded:: 13.8
 
         Args:
@@ -5288,12 +5018,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         The bot must be an administrator in the chat for this to work and must have the
         :attr:`telegram.ChatPermissions.can_invite_users` administrator right.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.decline_join_request`, :meth:`telegram.ChatJoinRequest.decline`,
-            :meth:`telegram.User.decline_join_request`
-
         .. versionadded:: 13.8
 
         Args:
@@ -5336,11 +5060,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
 
         Photos can't be changed for private chats. The bot must be an administrator in the chat
         for this to work and must have the appropriate admin rights.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.set_photo`
 
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
@@ -5389,11 +5108,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         must be an administrator in the chat for this to work and must have the appropriate admin
         rights.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.delete_photo`
-
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
 
@@ -5432,11 +5146,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         Use this method to change the title of a chat. Titles can't be changed for private chats.
         The bot must be an administrator in the chat for this to work and must have the appropriate
         admin rights.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.set_title`
 
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
@@ -5479,11 +5188,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         Use this method to change the description of a group, a supergroup or a channel. The bot
         must be an administrator in the chat for this to work and must have the appropriate admin
         rights.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.set_description`
 
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
@@ -5530,12 +5234,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         and must have the :paramref:`~telegram.ChatAdministratorRights.can_pin_messages` admin
         right in a supergroup or :attr:`~telegram.ChatMemberAdministrator.can_edit_messages` admin
         right in a channel.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.pin_message`, :meth:`telegram.Message.pin`,
-            :meth:`telegram.User.pin_message`
 
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
@@ -5586,12 +5284,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         right in a supergroup or :attr:`~telegram.ChatMemberAdministrator.can_edit_messages` admin
         right in a channel.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.unpin_message`, :meth:`telegram.Message.unpin`,
-            :meth:`telegram.User.unpin_message`
-
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
             message_id (:obj:`int`, optional): Identifier of a message to unpin. If not specified,
@@ -5633,11 +5325,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         to work and must have the :paramref:`~telegram.ChatAdministratorRights.can_pin_messages`
         admin right in a supergroup or :attr:`~telegram.ChatMemberAdministrator.can_edit_messages`
         admin right in a channel.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.unpin_all_messages`, :meth:`telegram.User.unpin_all_messages`
 
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
@@ -6220,12 +5907,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         """
         Use this method to send a native poll.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.reply_poll`, :meth:`telegram.Chat.send_poll`,
-            :meth:`telegram.User.send_poll`
-
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
             question (:obj:`str`): Poll question, :tg-const:`telegram.Poll.MIN_QUESTION_LENGTH`-
@@ -6344,11 +6025,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         """
         Use this method to stop a poll which was sent by the bot.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.stop_poll`
-
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
             message_id (:obj:`int`): Identifier of the original message with the poll.
@@ -6399,12 +6075,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
     ) -> Message:
         """
         Use this method to send an animated emoji that will display a random value.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.reply_dice`,  :meth:`telegram.Chat.send_dice`,
-            :meth:`telegram.User.send_dice`
 
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
@@ -6810,13 +6480,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         be copied. The method is analogous to the method :meth:`forward_message`, but the copied
         message doesn't have a link to the original message.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.copy`, :meth:`telegram.Chat.send_copy`,
-            :meth:`telegram.Chat.copy_message`, :meth:`telegram.User.send_copy`,
-            :meth:`telegram.User.copy_message`
-
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
             from_chat_id (:obj:`int` | :obj:`str`): Unique identifier for the chat where the
@@ -6895,11 +6558,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         """Use this method to change the bot's menu button in a private chat, or the default menu
         button.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.set_menu_button`, :meth:`telegram.User.set_menu_button`
-
         .. seealso:: :meth:`get_chat_menu_button`, :meth:`telegram.Chat.get_menu_button`
             :meth:`telegram.User.get_menu_button`
 
@@ -6940,11 +6598,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
     ) -> MenuButton:
         """Use this method to get the current value of the bot's menu button in a private chat, or
         the default menu button.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.get_menu_button`, :meth:`telegram.User.get_menu_button`
 
         .. seealso:: :meth:`set_chat_menu_button`, :meth:`telegram.Chat.set_menu_button`,
             :meth:`telegram.User.set_menu_button`
@@ -7152,11 +6805,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         an administrator in the chat for this to work and must have
         :paramref:`~telegram.ChatAdministratorRights.can_manage_topics` administrator rights.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.create_forum_topic`
-
         .. versionadded:: 20.0
 
         Args:
@@ -7218,11 +6866,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         :paramref:`~telegram.ChatAdministratorRights.can_manage_topics` administrator rights,
         unless it is the creator of the topic.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.edit_forum_topic`, :meth:`telegram.Chat.edit_forum_topic`
-
         .. versionadded:: 20.0
 
         Args:
@@ -7278,11 +6921,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         :paramref:`~telegram.ChatAdministratorRights.can_manage_topics` administrator rights,
         unless it is the creator of the topic.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.close_forum_topic`, :meth:`telegram.Chat.close_forum_topic`
-
         .. versionadded:: 20.0
 
         Args:
@@ -7328,11 +6966,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         :paramref:`~telegram.ChatAdministratorRights.can_manage_topics` administrator rights,
         unless it is the creator of the topic.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.reopen_forum_topic`, :meth:`telegram.Chat.reopen_forum_topic`
-
         .. versionadded:: 20.0
 
         Args:
@@ -7376,11 +7009,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         Use this method to delete a forum topic along with all its messages in a forum supergroup
         chat. The bot must be an administrator in the chat for this to work and must have
         :paramref:`~telegram.ChatAdministratorRights.can_delete_messages` administrator rights.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.delete_forum_topic`, :meth:`telegram.Chat.delete_forum_topic`
 
         .. versionadded:: 20.0
 
@@ -7427,12 +7055,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         :paramref:`~telegram.ChatAdministratorRights.can_pin_messages` administrator rights
         in the supergroup.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Message.unpin_all_forum_topic_messages`,
-            :meth:`telegram.Chat.unpin_all_forum_topic_messages`
-
         .. versionadded:: 20.0
 
         Args:
@@ -7477,11 +7099,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         must be an administrator in the chat for this to work and must have
         :attr:`~telegram.ChatAdministratorRights.can_manage_topics` administrator rights.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.edit_general_forum_topic`
-
         .. versionadded:: 20.0
 
         Args:
@@ -7525,11 +7142,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         be an administrator in the chat for this to work and must have
         :attr:`~telegram.ChatAdministratorRights.can_manage_topics` administrator rights.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.close_general_forum_topic`
-
         .. versionadded:: 20.0
 
         Args:
@@ -7570,11 +7182,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         be an administrator in the chat for this to work and must have
         :attr:`~telegram.ChatAdministratorRights.can_manage_topics` administrator rights.
         The topic will be automatically unhidden if it was hidden.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.reopen_general_forum_topic`
 
         .. versionadded:: 20.0
 
@@ -7617,11 +7224,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         :attr:`~telegram.ChatAdministratorRights.can_manage_topics` administrator rights.
         The topic will be automatically closed if it was open.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.hide_general_forum_topic`
-
         .. versionadded:: 20.0
 
         Args:
@@ -7661,11 +7263,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         Use this method to unhide the 'General' topic in a forum supergroup chat. The bot must
         be an administrator in the chat for this to work and must have
         :attr:`~telegram.ChatAdministratorRights.can_manage_topics` administrator rights.
-
-        .. admonition:: Shortcuts
-            :class: shortcuts
-
-            :meth:`telegram.Chat.unhide_general_forum_topic`
 
         .. versionadded:: 20.0
 

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -810,10 +810,14 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         - If the bot has :attr:`~telegram.ChatMemberAdministrator.can_delete_messages`
           permission in a supergroup or a channel, it can delete any message there.
 
-        .. admonition:: Shortcuts
-            :class: shortcuts
+        ..
+            The method CallbackQuery.delete_message() will not be found when automatically
+            generating "Shortcuts" admonitions for Bot methods because it has no calls
+            to Bot methods in its return statement(s). So it is manually included in "See also".
 
-            :meth:`telegram.Message.delete`, :meth:`telegram.CallbackQuery.delete_message`
+        .. seealso::
+            :meth:`telegram.CallbackQuery.delete_message` (calls :meth:`delete_message`
+            indirectly, via :meth:`telegram.Message.delete`)
 
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -1930,9 +1930,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         """Use this method to send a group of photos, videos, documents or audios as an album.
         Documents and audio files can be only grouped in an album with messages of the same type.
 
-        .. versionchanged:: 20.0
-            Returns a tuple instead of a list.
-
         Note:
             If you supply a :paramref:`caption` (along with either :paramref:`parse_mode` or
             :paramref:`caption_entities`), then items in :paramref:`media` must have no captions,
@@ -1945,6 +1942,9 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             :meth:`telegram.User.send_media_group`
 
         .. seealso:: :wiki:`Working with Files and Media <Working-with-Files-and-Media>`
+
+        .. versionchanged:: 20.0
+            Returns a tuple instead of a list.
 
         Args:
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
@@ -3623,9 +3623,6 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
     ) -> Tuple[Update, ...]:
         """Use this method to receive incoming updates using long polling.
 
-        .. versionchanged:: 20.0
-            Returns a tuple instead of a list.
-
         Note:
             1. This method will not work if an outgoing webhook is set up.
             2. In order to avoid getting duplicate updates, recalculate offset after each
@@ -3634,6 +3631,9 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
 
         .. seealso:: :meth:`telegram.ext.Application.run_polling`,
             :meth:`telegram.ext.Updater.start_polling`
+
+        .. versionchanged:: 20.0
+            Returns a tuple instead of a list.
 
         Args:
             offset (:obj:`int`, optional): Identifier of the first update to be returned. Must be
@@ -4270,13 +4270,13 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         Use this method to get data for high score tables. Will return the score of the specified
         user and several of their neighbors in a game.
 
-        .. versionchanged:: 20.0
-            Returns a tuple instead of a list.
-
         Note:
             This method will currently return scores for the target user, plus two of their
             closest neighbors on each side. Will also return the top three users if the user and
             his neighbors are not among them. Please note that this behavior is subject to change.
+
+        .. versionchanged:: 20.0
+            Returns a tuple instead of a list.
 
         .. admonition:: Shortcuts
             :class: shortcuts

--- a/tests/docs/admonition_inserter.py
+++ b/tests/docs/admonition_inserter.py
@@ -59,15 +59,15 @@ class TestAdmonitionInserter:
         # checking class admonitions
         for admonition_type in admonition_inserter.CLASS_ADMONITION_TYPES:
             # keys are telegram classes
-            for method in admonition_inserter.admonitions[admonition_type]:
+            for cls in admonition_inserter.admonitions[admonition_type]:
                 # Test classes crop up in AppBuilder, they can't come from code being tested.
-                if "tests.conftest" in str(method):
+                if "tests.conftest" in str(cls):
                     continue
 
-                assert isinstance(method, type)
-                assert str(method).startswith("<class 'telegram."), (
-                    rf"Class {method} does not belong to Telegram classes. Admonition:\n"
-                    rf"{admonition_inserter.admonitions[admonition_type][method]}"
+                assert isinstance(cls, type)
+                assert str(cls).startswith("<class 'telegram."), (
+                    rf"Class {cls} does not belong to Telegram classes. Admonition:\n"
+                    rf"{admonition_inserter.admonitions[admonition_type][cls]}"
                 )
 
         # checking Bot method admonitions

--- a/tests/docs/admonition_inserter.py
+++ b/tests/docs/admonition_inserter.py
@@ -22,6 +22,8 @@
 # The tests require Python 3.9+ (just like AdmonitionInserter being tested),
 # so they cannot be included in the main suite while older versions of Python are supported.
 
+import collections.abc
+
 import pytest
 
 import telegram.ext
@@ -44,23 +46,38 @@ class TestAdmonitionInserter:
 
     def test_admonitions_dict(self, admonition_inserter):
         # there are keys for every type of admonition
-        assert len(admonition_inserter.admonitions) == len(admonition_inserter.ADMONITION_TYPES)
+        assert len(admonition_inserter.admonitions) == len(
+            admonition_inserter.ALL_ADMONITION_TYPES
+        )
 
-        # for each type, there is at least one entry ({class/method: admonition text})
-        for admonition_type in admonition_inserter.ADMONITION_TYPES:
+        # for each type of admonitions, there is at least one entry
+        # ({class/method: admonition text})
+        for admonition_type in admonition_inserter.ALL_ADMONITION_TYPES:
             assert admonition_type in admonition_inserter.admonitions
             assert len(admonition_inserter.admonitions[admonition_type].keys()) > 0
 
+        # checking class admonitions
+        for admonition_type in admonition_inserter.CLASS_ADMONITION_TYPES:
             # keys are telegram classes
-            for cls in admonition_inserter.admonitions[admonition_type]:
+            for method in admonition_inserter.admonitions[admonition_type]:
                 # Test classes crop up in AppBuilder, they can't come from code being tested.
-                if "tests.conftest" in str(cls):
+                if "tests.conftest" in str(method):
                     continue
 
-                assert isinstance(cls, type)
-                assert str(cls).startswith("<class 'telegram."), (
-                    rf"Class {cls} does not belong to Telegram classes. Admonition:\n"
-                    rf"{admonition_inserter.admonitions[admonition_type][cls]}"
+                assert isinstance(method, type)
+                assert str(method).startswith("<class 'telegram."), (
+                    rf"Class {method} does not belong to Telegram classes. Admonition:\n"
+                    rf"{admonition_inserter.admonitions[admonition_type][method]}"
+                )
+
+        # checking Bot method admonitions
+        for admonition_type in admonition_inserter.METHOD_ADMONITION_TYPES:
+            for method in admonition_inserter.admonitions[admonition_type]:
+                assert isinstance(method, collections.abc.Callable)
+                assert str(method).startswith("<function Bot."), (
+                    f"Method {method} does not belong to methods that should get admonitions."
+                    "Admonition:\n"
+                    f"{admonition_inserter.admonitions[admonition_type][method]}"
                 )
 
     @pytest.mark.parametrize(
@@ -110,6 +127,13 @@ class TestAdmonitionInserter:
                 "returned_in",
                 telegram.ext.Application,
                 ":meth:`telegram.ext.ApplicationBuilder.build`",  # <class 'types.GenericAlias'>
+            ),
+            (
+                "shortcuts",
+                telegram.Bot.edit_message_caption,
+                # this method in CallbackQuery contains two return statements,
+                # one of which is with Bot
+                ":meth:`telegram.CallbackQuery.edit_message_caption`",
             ),
             (
                 "use_in",


### PR DESCRIPTION
closes #3496 (last part of it; see also #3501 and #3523 that address the same issue): automatically generates "Shortcuts" admonitions for `Bot` methods and removes manual ones.