### PR TITLE
Use `dict` instead of literal

### DIFF
--- a/telegram/request/_httpxrequest.py
+++ b/telegram/request/_httpxrequest.py
@@ -117,13 +117,15 @@ class HTTPXRequest(BaseRequest):
 
         http1 = http_version == "1.1"
 
-        self._client_kwargs = {
-            "timeout": timeout,
-            "proxies": proxy_url,
-            "limits": limits,
-            "http1": http1,
-            "http2": not http1,
-        }
+        # See https://github.com/python-telegram-bot/python-telegram-bot/pull/3542
+        # for why we need to use `dict()` here.
+        self._client_kwargs = dict(  # pylint: disable=use-dict-literal
+            timeout=timeout,
+            proxies=proxy_url,
+            limits=limits,
+            http1=http1,
+            http2=not http1,
+        )
 
         try:
             self._client = self._build_client()


### PR DESCRIPTION
Fix the CI problem on py3.11 + windows introduced in #3537 
See #3542 for details on why I chose this solution