### PR TITLE
Introduce Typing context manager, utility class

### DIFF
--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -100,6 +100,7 @@ from telegram._utils.warnings_transition import warn_about_thumb_return_thumbnai
 from telegram._webhookinfo import WebhookInfo
 from telegram.constants import InlineQueryLimit
 from telegram.error import InvalidToken
+from telegram.ext._typing import Typing
 from telegram.request import BaseRequest, RequestData
 from telegram.request._httpxrequest import HTTPXRequest
 from telegram.request._requestparameter import RequestParameter
@@ -731,6 +732,23 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         )
         self._bot_user = User.de_json(result, self)
         return self._bot_user  # type: ignore[return-value]
+
+    @_log
+    def typing(self, chat_id: Union[int, str]) -> Typing:
+        """Use this method to create a context manager to send typing action.
+
+        .. code:: python
+            async with context.bot.typing():
+                # code
+
+        Args:
+            chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
+
+        Returns:
+            :class:`telegram.ext.Typing`: typing context manager instance.
+
+        """
+        return Typing(self, chat_id)
 
     @_log
     async def send_message(

--- a/telegram/ext/_typing.py
+++ b/telegram/ext/_typing.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# A library that provides a Python interface to the Telegram Bot API
+# Copyright (C) 2015-2023
+# Daniyar Yeralin <devs@python-telegram-bot.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+"""This module contains the class Typing, which sends typing action for Telegram bots intuitive."""
+import asyncio
+import contextlib
+from types import TracebackType
+from typing import Optional, Type, Union
+
+from telegram import Bot
+from telegram.constants import ChatAction
+
+
+def _typing_callback(fut: asyncio.Future) -> None:
+    """
+    Dummy handler for typing task future.
+
+    :param fut: The asyncio.Future object.
+    """
+    with contextlib.suppress(asyncio.CancelledError, Exception):
+        fut.exception()
+
+
+class Typing:
+    """This is a context manager, utility class, which sends repeated ``ChatAction.TYPING``
+    action every 5 seconds until the exit.
+
+    .. code:: python
+        async with context.bot.typing():
+            # code
+
+    Args:
+        bot (:class:`telegram.Bot`): The bot instance to send typing action.
+        chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
+
+    """
+
+    def __init__(self, bot: Bot, chat_id: Union[int, str]) -> None:
+        self.bot = bot
+        self.chat_id = chat_id
+        self.loop = asyncio.get_running_loop()
+        self.task: asyncio.Task
+
+    async def typing_action(self) -> None:
+        """
+        Coroutine that sends a "typing..." action to the chat every 5 seconds.
+        """
+        while True:
+            await self.bot.send_chat_action(chat_id=self.chat_id, action=ChatAction.TYPING)
+            await asyncio.sleep(5.0)
+
+    async def __aenter__(self) -> None:
+        """
+        Coroutine that sets up the typing action task when entering an async context.
+        """
+        self.task = self.loop.create_task(self.typing_action())
+        self.task.add_done_callback(_typing_callback)
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        """
+        Coroutine that cancels the typing action task when exiting an async context.
+
+        :param exc_type: The type of exception raised, if any.
+        :param exc_val: The value of the exception raised, if any.
+        :param exc_tb: The traceback of the exception raised, if any.
+        """
+        self.task.cancel()


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool! Please have a look at the below checklist. It's here to help both you and the maintainers to remember some aspects. Make sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
-->

### Checklist for PRs

- [ ] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [ ] Created new or adapted existing unit tests
- [ ] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)
- [ ] Added new classes & modules to the docs and all suitable `__all__` s


### If the PR contains API changes (otherwise, you can delete this passage)

    - [ ] Added or updated documentation for the changed class(es) and/or method(s)
    - [ ] Added or updated `bot_methods.rst`
    - [ ] Updated the Bot API version number in all places: `README.rst` and `README_RAW.rst` (including the badge), as well as `telegram.constants.BOT_API_VERSION_INFO`

---

### Notice:
Before I add doc strings and unit tests, I'd like to share this draft PR to be reviewed. I wanted to understand if this feature would be met well by the maintainers.

### Description: 
This PR introduces `Typing` class with additional `bot.typing()` method which is a context manager used for sending "typing..." action every 5 seconds until the context manager exits.

### Usage:
```python
async def message(update: Update, context: CallbackContext) -> None:
    async with context.bot.typing(chat_id=update.effective_chat.id):
        # some expensive operation
    await context.bot.send_message(chat_id=update.effective_chat.id,
                                   text=response)
```