### PR TITLE
Improve Warning Categories & Stacklevels

### DIFF
--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -273,7 +273,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
                 warning_string = "request"
 
         if warning_string:
-            warn(
+            self._warn(
                 f"You set the HTTP version for the {warning_string} HTTPXRequest instance to "
                 f"HTTP/2. The self hosted bot api instances only support HTTP/1.1. You should "
                 f"either run a HTTP proxy in front of it which supports HTTP/2 or use HTTP/1.1.",
@@ -337,6 +337,14 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         .. versionadded:: 20.0
         """
         return self._private_key
+
+    @classmethod
+    def _warn(
+        cls, message: str, category: Type[Warning] = PTBUserWarning, stacklevel: int = 0
+    ) -> None:
+        """Convencience method to issue a warning. This method is here mostly to make it easier
+        for ExtBot to add 1 level to all warning calls."""
+        warn(message=message, category=category, stacklevel=stacklevel + 1)
 
     def __reduce__(self) -> NoReturn:
         """Customizes how :func:`copy.deepcopy` processes objects of this type. Bots can not
@@ -1157,7 +1165,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
 
         """
         thumbnail_or_thumb: FileInput = warn_about_thumb_return_thumbnail(
-            deprecated_arg=thumb, new_arg=thumbnail
+            deprecated_arg=thumb, new_arg=thumbnail, warn_callback=self._warn
         )
         data: JSONDict = {
             "chat_id": chat_id,
@@ -1294,7 +1302,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
 
         """
         thumbnail_or_thumb: FileInput = warn_about_thumb_return_thumbnail(
-            deprecated_arg=thumb, new_arg=thumbnail
+            deprecated_arg=thumb, new_arg=thumbnail, warn_callback=self._warn
         )
 
         data: JSONDict = {
@@ -1531,7 +1539,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
 
         """
         thumbnail_or_thumb: FileInput = warn_about_thumb_return_thumbnail(
-            deprecated_arg=thumb, new_arg=thumbnail
+            deprecated_arg=thumb, new_arg=thumbnail, warn_callback=self._warn
         )
         data: JSONDict = {
             "chat_id": chat_id,
@@ -1664,7 +1672,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
 
         """
         thumbnail_or_thumb: FileInput = warn_about_thumb_return_thumbnail(
-            deprecated_arg=thumb, new_arg=thumbnail
+            deprecated_arg=thumb, new_arg=thumbnail, warn_callback=self._warn
         )
         data: JSONDict = {
             "chat_id": chat_id,
@@ -1807,6 +1815,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         thumbnail_or_thumb: FileInput = warn_about_thumb_return_thumbnail(
             deprecated_arg=thumb,
             new_arg=thumbnail,
+            warn_callback=self._warn,
         )
         data: JSONDict = {
             "chat_id": chat_id,
@@ -5614,11 +5623,11 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
             # only, which would have been confusing.
 
         if png_sticker:
-            warn(
+            self._warn(
                 "Since Bot API 6.6, the parameter `png_sticker` for "
                 "`upload_sticker_file` is deprecated. Please use the new parameters "
                 "`sticker` and `sticker_format` instead.",
-                stacklevel=4,
+                stacklevel=3,
                 category=PTBDeprecationWarning,
             )
 
@@ -5814,11 +5823,11 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
             # only, which would have been confusing.
 
         if any(pre_api_6_6_params.values()):
-            warn(
+            self._warn(
                 f"Since Bot API 6.6, the parameters {set(pre_api_6_6_params)} for "
                 "`create_new_sticker_set` are deprecated. Please use the new parameter "
                 "`stickers` and `sticker_format` instead.",
-                stacklevel=4,
+                stacklevel=3,
                 category=PTBDeprecationWarning,
             )
 
@@ -5986,11 +5995,11 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
             )
 
         if any(pre_api_6_6_params.values()):
-            warn(
+            self._warn(
                 f"Since Bot API 6.6, the parameters {set(pre_api_6_6_params)} for "
                 "`add_sticker_to_set` are deprecated. Please use the new parameter `sticker` "
                 "instead.",
-                stacklevel=4,
+                stacklevel=3,
                 category=PTBDeprecationWarning,
             )
 
@@ -6227,7 +6236,7 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
             :class:`telegram.error.TelegramError`
 
         """
-        warn(
+        self._warn(
             message=(
                 "Bot API 6.6 renamed the method 'setStickerSetThumb' to 'setStickerSetThumbnail', "
                 "hence method 'set_sticker_set_thumb' was renamed to 'set_sticker_set_thumbnail' "

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -342,7 +342,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
     def _warn(
         cls, message: str, category: Type[Warning] = PTBUserWarning, stacklevel: int = 0
     ) -> None:
-        """Convencience method to issue a warning. This method is here mostly to make it easier
+        """Convenience method to issue a warning. This method is here mostly to make it easier
         for ExtBot to add 1 level to all warning calls."""
         warn(message=message, category=category, stacklevel=stacklevel + 1)
 

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -343,7 +343,8 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         cls, message: str, category: Type[Warning] = PTBUserWarning, stacklevel: int = 0
     ) -> None:
         """Convenience method to issue a warning. This method is here mostly to make it easier
-        for ExtBot to add 1 level to all warning calls."""
+        for ExtBot to add 1 level to all warning calls.
+        """
         warn(message=message, category=category, stacklevel=stacklevel + 1)
 
     def __reduce__(self) -> NoReturn:

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -1168,7 +1168,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             deprecated_arg=thumb,
             new_arg=thumbnail,
             warn_callback=self._warn,
-            stacklevel=4,
+            stacklevel=3,
         )
         data: JSONDict = {
             "chat_id": chat_id,
@@ -1308,7 +1308,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             deprecated_arg=thumb,
             new_arg=thumbnail,
             warn_callback=self._warn,
-            stacklevel=4,
+            stacklevel=3,
         )
 
         data: JSONDict = {
@@ -1548,7 +1548,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             deprecated_arg=thumb,
             new_arg=thumbnail,
             warn_callback=self._warn,
-            stacklevel=4,
+            stacklevel=3,
         )
         data: JSONDict = {
             "chat_id": chat_id,
@@ -1684,7 +1684,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             deprecated_arg=thumb,
             new_arg=thumbnail,
             warn_callback=self._warn,
-            stacklevel=4,
+            stacklevel=3,
         )
         data: JSONDict = {
             "chat_id": chat_id,
@@ -1828,7 +1828,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             deprecated_arg=thumb,
             new_arg=thumbnail,
             warn_callback=self._warn,
-            stacklevel=4,
+            stacklevel=3,
         )
         data: JSONDict = {
             "chat_id": chat_id,

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -1165,7 +1165,9 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
 
         """
         thumbnail_or_thumb: FileInput = warn_about_thumb_return_thumbnail(
-            deprecated_arg=thumb, new_arg=thumbnail, warn_callback=self._warn
+            deprecated_arg=thumb,
+            new_arg=thumbnail,
+            warn_callback=self._warn,
         )
         data: JSONDict = {
             "chat_id": chat_id,

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -1168,6 +1168,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             deprecated_arg=thumb,
             new_arg=thumbnail,
             warn_callback=self._warn,
+            stacklevel=4,
         )
         data: JSONDict = {
             "chat_id": chat_id,
@@ -1304,7 +1305,10 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
 
         """
         thumbnail_or_thumb: FileInput = warn_about_thumb_return_thumbnail(
-            deprecated_arg=thumb, new_arg=thumbnail, warn_callback=self._warn
+            deprecated_arg=thumb,
+            new_arg=thumbnail,
+            warn_callback=self._warn,
+            stacklevel=4,
         )
 
         data: JSONDict = {
@@ -1541,7 +1545,10 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
 
         """
         thumbnail_or_thumb: FileInput = warn_about_thumb_return_thumbnail(
-            deprecated_arg=thumb, new_arg=thumbnail, warn_callback=self._warn
+            deprecated_arg=thumb,
+            new_arg=thumbnail,
+            warn_callback=self._warn,
+            stacklevel=4,
         )
         data: JSONDict = {
             "chat_id": chat_id,
@@ -1674,7 +1681,10 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
 
         """
         thumbnail_or_thumb: FileInput = warn_about_thumb_return_thumbnail(
-            deprecated_arg=thumb, new_arg=thumbnail, warn_callback=self._warn
+            deprecated_arg=thumb,
+            new_arg=thumbnail,
+            warn_callback=self._warn,
+            stacklevel=4,
         )
         data: JSONDict = {
             "chat_id": chat_id,
@@ -1818,6 +1828,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             deprecated_arg=thumb,
             new_arg=thumbnail,
             warn_callback=self._warn,
+            stacklevel=4,
         )
         data: JSONDict = {
             "chat_id": chat_id,

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -5619,6 +5619,7 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
                 "`upload_sticker_file` is deprecated. Please use the new parameters "
                 "`sticker` and `sticker_format` instead.",
                 stacklevel=4,
+                category=PTBDeprecationWarning,
             )
 
         data: JSONDict = {
@@ -5818,6 +5819,7 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
                 "`create_new_sticker_set` are deprecated. Please use the new parameter "
                 "`stickers` and `sticker_format` instead.",
                 stacklevel=4,
+                category=PTBDeprecationWarning,
             )
 
         data: JSONDict = {
@@ -5989,6 +5991,7 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
                 "`add_sticker_to_set` are deprecated. Please use the new parameter `sticker` "
                 "instead.",
                 stacklevel=4,
+                category=PTBDeprecationWarning,
             )
 
         data: JSONDict = {

--- a/telegram/_files/_basethumbedmedium.py
+++ b/telegram/_files/_basethumbedmedium.py
@@ -93,7 +93,7 @@ class _BaseThumbedMedium(_BaseMedium):
             deprecated_arg_name="thumb",
             new_arg_name="thumbnail",
             bot_api_version="6.6",
-            stacklevel=4,
+            stacklevel=3,
         )
 
     @property

--- a/telegram/_utils/warnings_transition.py
+++ b/telegram/_utils/warnings_transition.py
@@ -23,7 +23,6 @@ inside warnings.py.
 
 .. versionadded:: 20.2
 """
-import functools
 from typing import Any, Callable, Type
 
 from telegram._utils.warnings import warn
@@ -38,7 +37,7 @@ def warn_about_deprecated_arg_return_new_arg(
     deprecated_arg_name: str,
     new_arg_name: str,
     bot_api_version: str,
-    stacklevel: int = 3,
+    stacklevel: int = 2,
     warn_callback: Callable[[str, Type[Warning], int], None] = warn,
 ) -> Any:
     """A helper function for the transition in API when argument is renamed.
@@ -63,7 +62,7 @@ def warn_about_deprecated_arg_return_new_arg(
             f"Bot API {bot_api_version} renamed the argument '{deprecated_arg_name}' to "
             f"'{new_arg_name}'.",
             PTBDeprecationWarning,
-            stacklevel,
+            stacklevel + 1,
         )
         return deprecated_arg
 
@@ -74,7 +73,7 @@ def warn_about_deprecated_attr_in_property(
     deprecated_attr_name: str,
     new_attr_name: str,
     bot_api_version: str,
-    stacklevel: int = 3,
+    stacklevel: int = 2,
 ) -> None:
     """A helper function for the transition in API when attribute is renamed. Call from properties.
 
@@ -84,16 +83,25 @@ def warn_about_deprecated_attr_in_property(
         f"Bot API {bot_api_version} renamed the attribute '{deprecated_attr_name}' to "
         f"'{new_attr_name}'.",
         PTBDeprecationWarning,
-        stacklevel=stacklevel,
+        stacklevel=stacklevel + 1,
     )
 
 
-warn_about_thumb_return_thumbnail = functools.partial(
-    warn_about_deprecated_arg_return_new_arg,
-    deprecated_arg_name="thumb",
-    new_arg_name="thumbnail",
-    bot_api_version="6.6",
-)
-"""A helper function to warn about using a deprecated 'thumb' argument and return it or the new
-'thumbnail' argument, introduced in API 6.6.
-"""
+def warn_about_thumb_return_thumbnail(
+    deprecated_arg: Any,
+    new_arg: Any,
+    stacklevel: int = 2,
+    warn_callback: Callable[[str, Type[Warning], int], None] = warn,
+) -> Any:
+    """A helper function to warn about using a deprecated 'thumb' argument and return it or the
+    new 'thumbnail' argument, introduced in API 6.6.
+    """
+    return warn_about_deprecated_arg_return_new_arg(
+        deprecated_arg=deprecated_arg,
+        new_arg=new_arg,
+        warn_callback=warn_callback,
+        deprecated_arg_name="thumb",
+        new_arg_name="thumbnail",
+        bot_api_version="6.6",
+        stacklevel=stacklevel + 1,
+    )

--- a/telegram/_utils/warnings_transition.py
+++ b/telegram/_utils/warnings_transition.py
@@ -93,6 +93,7 @@ warn_about_thumb_return_thumbnail = functools.partial(
     deprecated_arg_name="thumb",
     new_arg_name="thumbnail",
     bot_api_version="6.6",
+    stacklevel=4,
 )
 """A helper function to warn about using a deprecated 'thumb' argument and return it or the new
 'thumbnail' argument, introduced in API 6.6.

--- a/telegram/_utils/warnings_transition.py
+++ b/telegram/_utils/warnings_transition.py
@@ -24,7 +24,7 @@ inside warnings.py.
 .. versionadded:: 20.2
 """
 import functools
-from typing import Any
+from typing import Any, Callable, Type
 
 from telegram._utils.warnings import warn
 from telegram.warnings import PTBDeprecationWarning
@@ -39,6 +39,7 @@ def warn_about_deprecated_arg_return_new_arg(
     new_arg_name: str,
     bot_api_version: str,
     stacklevel: int = 3,
+    warn_callback: Callable[[str, Type[Warning], int], None] = warn,
 ) -> Any:
     """A helper function for the transition in API when argument is renamed.
 
@@ -58,11 +59,11 @@ def warn_about_deprecated_arg_return_new_arg(
         )
 
     if deprecated_arg:
-        warn(
+        warn_callback(
             f"Bot API {bot_api_version} renamed the argument '{deprecated_arg_name}' to "
             f"'{new_arg_name}'.",
             PTBDeprecationWarning,
-            stacklevel=stacklevel,
+            stacklevel,
         )
         return deprecated_arg
 

--- a/telegram/_utils/warnings_transition.py
+++ b/telegram/_utils/warnings_transition.py
@@ -93,7 +93,6 @@ warn_about_thumb_return_thumbnail = functools.partial(
     deprecated_arg_name="thumb",
     new_arg_name="thumbnail",
     bot_api_version="6.6",
-    stacklevel=4,
 )
 """A helper function to warn about using a deprecated 'thumb' argument and return it or the new
 'thumbnail' argument, introduced in API 6.6.

--- a/telegram/ext/_conversationhandler.py
+++ b/telegram/ext/_conversationhandler.py
@@ -840,11 +840,13 @@ class ConversationHandler(BaseHandler[Update, CCT]):
                 if application.job_queue is None:
                     warn(
                         "Ignoring `conversation_timeout` because the Application has no JobQueue.",
+                        stacklevel=1,
                     )
                 elif not application.job_queue.scheduler.running:
                     warn(
                         "Ignoring `conversation_timeout` because the Applications JobQueue is "
                         "not running.",
+                        stacklevel=1,
                     )
                 elif isinstance(new_state, asyncio.Task):
                     # Add the new timeout job
@@ -931,6 +933,7 @@ class ConversationHandler(BaseHandler[Update, CCT]):
                     warn(
                         "ApplicationHandlerStop in TIMEOUT state of "
                         "ConversationHandler has no effect. Ignoring.",
+                        stacklevel=2,
                     )
 
         self._update_state(self.END, ctxt.conversation_key)

--- a/telegram/ext/_extbot.py
+++ b/telegram/ext/_extbot.py
@@ -18,7 +18,6 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represents a Telegram Bot with convenience extensions."""
-import warnings
 from copy import copy
 from datetime import datetime
 from typing import (
@@ -31,6 +30,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    Type,
     TypeVar,
     Union,
     cast,
@@ -87,11 +87,10 @@ from telegram._utils.datetime import to_timestamp
 from telegram._utils.defaultvalue import DEFAULT_NONE, DefaultValue
 from telegram._utils.logging import get_logger
 from telegram._utils.types import DVInput, FileInput, JSONDict, ODVInput, ReplyMarkup
-from telegram._utils.warnings import warn
 from telegram.ext._callbackdatacache import CallbackDataCache
 from telegram.ext._utils.types import RLARGS
 from telegram.request import BaseRequest
-from telegram.warnings import PTBDeprecationWarning
+from telegram.warnings import PTBUserWarning
 
 if TYPE_CHECKING:
     from telegram import (
@@ -234,6 +233,14 @@ class ExtBot(Bot, Generic[RLARGS]):
                 maxsize = 1024
 
             self._callback_data_cache = CallbackDataCache(bot=self, maxsize=maxsize)
+
+    @classmethod
+    def _warn(
+        cls, message: str, category: Type[Warning] = PTBUserWarning, stacklevel: int = 0
+    ) -> None:
+        """We override this method to add one more level to the stacklevel, so that the warning
+        points to the user's code, not to the PTB code."""
+        super()._warn(message=message, category=category, stacklevel=stacklevel + 2)
 
     @property
     def callback_data_cache(self) -> Optional[CallbackDataCache]:
@@ -3284,30 +3291,16 @@ class ExtBot(Bot, Generic[RLARGS]):
         api_kwargs: JSONDict = None,
         rate_limit_args: RLARGS = None,
     ) -> bool:
-        # Manually issue deprecation here to get the stacklevel right
-        # Suppress the warning issued by super().set_sticker_set_thumb just in case
-        # the user explicitly enables deprecation warnings
-        # Unfortunately this is not entirely reliable (see tests), but it's a best effort solution
-        warn(
-            message=(
-                "Bot API 6.6 renamed the method 'setStickerSetThumb' to 'setStickerSetThumbnail', "
-                "hence method 'set_sticker_set_thumb' was renamed to 'set_sticker_set_thumbnail' "
-                "in PTB."
-            ),
-            category=PTBDeprecationWarning,
-            stacklevel=2,
+        return await super().set_sticker_set_thumb(
+            name=name,
+            user_id=user_id,
+            thumb=thumb,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=self._merge_api_rl_kwargs(api_kwargs, rate_limit_args),
         )
-        with warnings.catch_warnings():
-            return await super().set_sticker_set_thumb(
-                name=name,
-                user_id=user_id,
-                thumb=thumb,
-                read_timeout=read_timeout,
-                write_timeout=write_timeout,
-                connect_timeout=connect_timeout,
-                pool_timeout=pool_timeout,
-                api_kwargs=self._merge_api_rl_kwargs(api_kwargs, rate_limit_args),
-            )
 
     async def set_webhook(
         self,

--- a/telegram/ext/_extbot.py
+++ b/telegram/ext/_extbot.py
@@ -239,7 +239,8 @@ class ExtBot(Bot, Generic[RLARGS]):
         cls, message: str, category: Type[Warning] = PTBUserWarning, stacklevel: int = 0
     ) -> None:
         """We override this method to add one more level to the stacklevel, so that the warning
-        points to the user's code, not to the PTB code."""
+        points to the user's code, not to the PTB code.
+        """
         super()._warn(message=message, category=category, stacklevel=stacklevel + 2)
 
     @property

--- a/telegram/ext/_picklepersistence.py
+++ b/telegram/ext/_picklepersistence.py
@@ -98,7 +98,10 @@ class _BotPickler(pickle.Pickler):
         if obj is self._bot:
             return _REPLACED_KNOWN_BOT
         if isinstance(obj, Bot):
-            warn("Unknown bot instance found. Will be replaced by `None` during unpickling")
+            warn(
+                "Unknown bot instance found. Will be replaced by `None` during unpickling",
+                stacklevel=2,
+            )
             return _REPLACED_UNKNOWN_BOT
         return None  # pickles as usual
 

--- a/tests/_files/test_animation.py
+++ b/tests/_files/test_animation.py
@@ -31,7 +31,10 @@ from tests.auxil.bot_method_checks import (
     check_shortcut_call,
     check_shortcut_signature,
 )
-from tests.auxil.deprecations import check_thumb_deprecation_warnings_for_args_and_attrs
+from tests.auxil.deprecations import (
+    check_thumb_deprecation_warnings_for_args_and_attrs,
+    check_thumb_deprececation_warning_for_method_args,
+)
 from tests.auxil.files import data_file
 from tests.auxil.slots import mro_slots
 
@@ -190,6 +193,19 @@ class TestAnimationWithoutRequest(TestAnimationBase):
 
         monkeypatch.setattr(bot.request, "post", make_assertion)
         assert await bot.send_animation(animation=animation, chat_id=chat_id)
+
+    @pytest.mark.parametrize("bot_class", ["Bot", "ExtBot"])
+    async def test_send_animation_thumb_deprecation_warning(
+        self, recwarn, monkeypatch, bot_class, bot, raw_bot, chat_id, animation
+    ):
+        async def make_assertion(url, request_data: RequestData, *args, **kwargs):
+            return True
+
+        bot = raw_bot if bot_class == "Bot" else bot
+
+        monkeypatch.setattr(bot.request, "post", make_assertion)
+        await bot.send_animation(chat_id, animation, thumb="thumb")
+        check_thumb_deprececation_warning_for_method_args(recwarn, __file__)
 
     async def test_send_animation_with_local_files_throws_error_with_different_thumb_and_thumbnail(
         self, bot, chat_id

--- a/tests/_files/test_animation.py
+++ b/tests/_files/test_animation.py
@@ -32,8 +32,8 @@ from tests.auxil.bot_method_checks import (
     check_shortcut_signature,
 )
 from tests.auxil.deprecations import (
+    check_thumb_deprecation_warning_for_method_args,
     check_thumb_deprecation_warnings_for_args_and_attrs,
-    check_thumb_deprececation_warning_for_method_args,
 )
 from tests.auxil.files import data_file
 from tests.auxil.slots import mro_slots
@@ -205,7 +205,7 @@ class TestAnimationWithoutRequest(TestAnimationBase):
 
         monkeypatch.setattr(bot.request, "post", make_assertion)
         await bot.send_animation(chat_id, animation, thumb="thumb")
-        check_thumb_deprececation_warning_for_method_args(recwarn, __file__)
+        check_thumb_deprecation_warning_for_method_args(recwarn, __file__)
 
     async def test_send_animation_with_local_files_throws_error_with_different_thumb_and_thumbnail(
         self, bot, chat_id

--- a/tests/_files/test_audio.py
+++ b/tests/_files/test_audio.py
@@ -32,8 +32,8 @@ from tests.auxil.bot_method_checks import (
     check_shortcut_signature,
 )
 from tests.auxil.deprecations import (
+    check_thumb_deprecation_warning_for_method_args,
     check_thumb_deprecation_warnings_for_args_and_attrs,
-    check_thumb_deprececation_warning_for_method_args,
 )
 from tests.auxil.files import data_file
 from tests.auxil.slots import mro_slots
@@ -172,7 +172,7 @@ class TestAudioWithoutRequest(TestAudioBase):
 
         monkeypatch.setattr(bot.request, "post", make_assertion)
         await bot.send_audio(chat_id, audio, thumb="thumb")
-        check_thumb_deprececation_warning_for_method_args(recwarn, __file__)
+        check_thumb_deprecation_warning_for_method_args(recwarn, __file__)
 
     async def test_send_audio_custom_filename(self, bot, chat_id, audio_file, monkeypatch):
         async def make_assertion(url, request_data: RequestData, *args, **kwargs):

--- a/tests/_files/test_audio.py
+++ b/tests/_files/test_audio.py
@@ -31,7 +31,10 @@ from tests.auxil.bot_method_checks import (
     check_shortcut_call,
     check_shortcut_signature,
 )
-from tests.auxil.deprecations import check_thumb_deprecation_warnings_for_args_and_attrs
+from tests.auxil.deprecations import (
+    check_thumb_deprecation_warnings_for_args_and_attrs,
+    check_thumb_deprececation_warning_for_method_args,
+)
 from tests.auxil.files import data_file
 from tests.auxil.slots import mro_slots
 
@@ -157,6 +160,19 @@ class TestAudioWithoutRequest(TestAudioBase):
 
         monkeypatch.setattr(bot.request, "post", make_assertion)
         assert await bot.send_audio(audio=audio, chat_id=chat_id)
+
+    @pytest.mark.parametrize("bot_class", ["Bot", "ExtBot"])
+    async def test_send_audio_thumb_deprecation_warning(
+        self, recwarn, monkeypatch, bot_class, bot, raw_bot, chat_id, audio
+    ):
+        async def make_assertion(url, request_data: RequestData, *args, **kwargs):
+            return True
+
+        bot = raw_bot if bot_class == "Bot" else bot
+
+        monkeypatch.setattr(bot.request, "post", make_assertion)
+        await bot.send_audio(chat_id, audio, thumb="thumb")
+        check_thumb_deprececation_warning_for_method_args(recwarn, __file__)
 
     async def test_send_audio_custom_filename(self, bot, chat_id, audio_file, monkeypatch):
         async def make_assertion(url, request_data: RequestData, *args, **kwargs):

--- a/tests/_files/test_document.py
+++ b/tests/_files/test_document.py
@@ -32,8 +32,8 @@ from tests.auxil.bot_method_checks import (
     check_shortcut_signature,
 )
 from tests.auxil.deprecations import (
+    check_thumb_deprecation_warning_for_method_args,
     check_thumb_deprecation_warnings_for_args_and_attrs,
-    check_thumb_deprececation_warning_for_method_args,
 )
 from tests.auxil.files import data_file
 from tests.auxil.slots import mro_slots
@@ -171,7 +171,7 @@ class TestDocumentWithoutRequest(TestDocumentBase):
 
         monkeypatch.setattr(bot.request, "post", make_assertion)
         await bot.send_document(chat_id, document, thumb="thumb")
-        check_thumb_deprececation_warning_for_method_args(recwarn, __file__)
+        check_thumb_deprecation_warning_for_method_args(recwarn, __file__)
 
     @pytest.mark.parametrize("local_mode", [True, False])
     async def test_send_document_local_files(self, monkeypatch, bot, chat_id, local_mode):

--- a/tests/_files/test_document.py
+++ b/tests/_files/test_document.py
@@ -31,7 +31,10 @@ from tests.auxil.bot_method_checks import (
     check_shortcut_call,
     check_shortcut_signature,
 )
-from tests.auxil.deprecations import check_thumb_deprecation_warnings_for_args_and_attrs
+from tests.auxil.deprecations import (
+    check_thumb_deprecation_warnings_for_args_and_attrs,
+    check_thumb_deprececation_warning_for_method_args,
+)
 from tests.auxil.files import data_file
 from tests.auxil.slots import mro_slots
 
@@ -156,6 +159,19 @@ class TestDocumentWithoutRequest(TestDocumentBase):
         )
 
         assert message
+
+    @pytest.mark.parametrize("bot_class", ["Bot", "ExtBot"])
+    async def test_send_document_thumb_deprecation_warning(
+        self, recwarn, monkeypatch, bot_class, bot, raw_bot, chat_id, document
+    ):
+        async def make_assertion(url, request_data: RequestData, *args, **kwargs):
+            return True
+
+        bot = raw_bot if bot_class == "Bot" else bot
+
+        monkeypatch.setattr(bot.request, "post", make_assertion)
+        await bot.send_document(chat_id, document, thumb="thumb")
+        check_thumb_deprececation_warning_for_method_args(recwarn, __file__)
 
     @pytest.mark.parametrize("local_mode", [True, False])
     async def test_send_document_local_files(self, monkeypatch, bot, chat_id, local_mode):

--- a/tests/_files/test_sticker.py
+++ b/tests/_files/test_sticker.py
@@ -639,10 +639,14 @@ class TestStickerSetWithoutRequest(TestStickerSetBase):
         assert a != e
         assert hash(a) != hash(e)
 
-    async def test_upload_sticker_file_warning(self, bot, monkeypatch, chat_id, recwarn):
+    @pytest.mark.parametrize("bot_class", ["Bot", "ExtBot"])
+    async def test_upload_sticker_file_warning(
+        self, bot, raw_bot, monkeypatch, chat_id, recwarn, bot_class
+    ):
         async def make_assertion(*args, **kwargs):
             return {"file_id": "file_id", "file_unique_id": "file_unique_id"}
 
+        bot = raw_bot if bot_class == "Bot" else bot
         monkeypatch.setattr(bot, "_post", make_assertion)
 
         await bot.upload_sticker_file(chat_id, "png_sticker_file_id")
@@ -703,10 +707,14 @@ class TestStickerSetWithoutRequest(TestStickerSetBase):
         finally:
             bot._local_mode = False
 
-    async def test_create_new_sticker_set_warning(self, bot, monkeypatch, chat_id, recwarn):
+    @pytest.mark.parametrize("bot_class", ["Bot", "ExtBot"])
+    async def test_create_new_sticker_set_warning(
+        self, bot, raw_bot, bot_class, monkeypatch, chat_id, recwarn
+    ):
         async def make_assertion(*args, **kwargs):
             return True
 
+        bot = raw_bot if bot_class == "Bot" else bot
         monkeypatch.setattr(bot, "_post", make_assertion)
 
         await bot.create_new_sticker_set(chat_id, "name", "title", "some_str_emoji")
@@ -835,10 +843,14 @@ class TestStickerSetWithoutRequest(TestStickerSetBase):
         )
         assert len(recwarn) == 0
 
-    async def test_add_sticker_to_set_warning(self, bot, monkeypatch, chat_id, recwarn):
+    @pytest.mark.parametrize("bot_class", ["Bot", "ExtBot"])
+    async def test_add_sticker_to_set_warning(
+        self, bot, raw_bot, monkeypatch, bot_class, chat_id, recwarn
+    ):
         async def make_assertion(*args, **kwargs):
             return True
 
+        bot = raw_bot if bot_class == "Bot" else bot
         monkeypatch.setattr(bot, "_post", make_assertion)
 
         await bot.add_sticker_to_set(chat_id, "name", "emoji", "fake_file_id")
@@ -934,17 +946,16 @@ class TestStickerSetWithoutRequest(TestStickerSetBase):
         async def _post(*args, **kwargs):
             return True
 
-        cls_name = bot.__class__.__name__
         monkeypatch.setattr(bot, "_post", _post)
         await bot.set_sticker_set_thumb("name", "user_id", "thumb")
 
-        assert len(recwarn) == 1, f"No warning for class {cls_name}!"
-        assert recwarn[0].category is PTBDeprecationWarning, f"Wrong warning for class {cls_name}!"
+        assert len(recwarn) == 1
+        assert recwarn[0].category is PTBDeprecationWarning
         assert "renamed the method 'setStickerSetThumb' to 'setStickerSetThumbnail'" in str(
             recwarn[0].message
-        ), f"Wrong message for class {cls_name}!"
+        )
 
-        assert recwarn[0].filename == __file__, f"incorrect stacklevel for class {cls_name}!"
+        assert recwarn[0].filename == __file__, "incorrect stacklevel!"
         recwarn.clear()
 
     async def test_get_file_instance_method(self, monkeypatch, sticker):

--- a/tests/_files/test_sticker.py
+++ b/tests/_files/test_sticker.py
@@ -649,6 +649,7 @@ class TestStickerSetWithoutRequest(TestStickerSetBase):
         await bot.upload_sticker_file(chat_id, "png_sticker_file_id")
         assert len(recwarn) == 1
         assert "Since Bot API 6.6, the parameter" in str(recwarn[0].message)
+        assert recwarn[0].category is PTBDeprecationWarning
         assert recwarn[0].filename == __file__
 
     async def test_upload_sticker_file_missing_required_args(self, bot, chat_id):
@@ -665,7 +666,11 @@ class TestStickerSetWithoutRequest(TestStickerSetBase):
 
     @pytest.mark.parametrize("local_mode", [True, False])
     async def test_upload_sticker_file_local_files(
-        self, monkeypatch, bot, chat_id, local_mode, recwarn
+        self,
+        monkeypatch,
+        bot,
+        chat_id,
+        local_mode,
     ):
         try:
             bot._local_mode = local_mode
@@ -705,6 +710,7 @@ class TestStickerSetWithoutRequest(TestStickerSetBase):
         await bot.create_new_sticker_set(chat_id, "name", "title", "some_str_emoji")
         assert len(recwarn) == 1
         assert "Since Bot API 6.6, the parameters" in str(recwarn[0].message)
+        assert recwarn[0].category is PTBDeprecationWarning
         assert recwarn[0].filename == __file__
 
     async def test_create_new_sticker_set_missing_required_args(self, bot, chat_id):
@@ -720,9 +726,7 @@ class TestStickerSetWithoutRequest(TestStickerSetBase):
             )
 
     @pytest.mark.parametrize("local_mode", [True, False])
-    async def test_create_new_sticker_set_local_files(
-        self, monkeypatch, bot, chat_id, local_mode, recwarn
-    ):
+    async def test_create_new_sticker_set_local_files(self, monkeypatch, bot, chat_id, local_mode):
         monkeypatch.setattr(bot, "_local_mode", local_mode)
         # For just test that the correct paths are passed as we have no local bot API set up
         test_flag = False
@@ -769,9 +773,7 @@ class TestStickerSetWithoutRequest(TestStickerSetBase):
         assert test_flag
         assert len(recwarn) in (1, 2)
 
-    async def test_create_new_sticker_all_params(
-        self, monkeypatch, bot, chat_id, mask_position, recwarn
-    ):
+    async def test_create_new_sticker_all_params(self, monkeypatch, bot, chat_id, mask_position):
         async def make_assertion_old_params(_, data, *args, **kwargs):
             assert data["user_id"] == chat_id
             assert data["name"] == "name"
@@ -804,6 +806,9 @@ class TestStickerSetWithoutRequest(TestStickerSetBase):
             sticker_type=Sticker.MASK,
         )
         assert len(recwarn) == 1
+        assert recwarn[0].filename == __file__, "wrong stacklevel"
+        assert recwarn[0].category is PTBDeprecationWarning
+        assert str(recwarn[0]) == "udaitrne"
         monkeypatch.setattr(bot, "_post", make_assertion_new_params)
         await bot.create_new_sticker_set(
             chat_id,
@@ -824,6 +829,7 @@ class TestStickerSetWithoutRequest(TestStickerSetBase):
         await bot.add_sticker_to_set(chat_id, "name", "emoji", "fake_file_id")
         assert len(recwarn) == 1
         assert "Since Bot API 6.6, the parameters" in str(recwarn[0].message)
+        assert recwarn[0].category is PTBDeprecationWarning
         assert recwarn[0].filename == __file__
 
     async def test_add_sticker_to_set_missing_required_arg(self, bot, chat_id):
@@ -835,9 +841,7 @@ class TestStickerSetWithoutRequest(TestStickerSetBase):
             await bot.add_sticker_to_set(chat_id, "name", "emojis", sticker="something")
 
     @pytest.mark.parametrize("local_mode", [True, False])
-    async def test_add_sticker_to_set_local_files(
-        self, monkeypatch, bot, chat_id, local_mode, recwarn
-    ):
+    async def test_add_sticker_to_set_local_files(self, monkeypatch, bot, chat_id, local_mode):
         monkeypatch.setattr(bot, "_local_mode", local_mode)
         # For just test that the correct paths are passed as we have no local bot API set up
         test_flag = False

--- a/tests/_files/test_video.py
+++ b/tests/_files/test_video.py
@@ -32,8 +32,8 @@ from tests.auxil.bot_method_checks import (
     check_shortcut_signature,
 )
 from tests.auxil.deprecations import (
+    check_thumb_deprecation_warning_for_method_args,
     check_thumb_deprecation_warnings_for_args_and_attrs,
-    check_thumb_deprececation_warning_for_method_args,
 )
 from tests.auxil.files import data_file
 from tests.auxil.slots import mro_slots
@@ -185,7 +185,7 @@ class TestVideoWithoutRequest(TestVideoBase):
 
         monkeypatch.setattr(bot.request, "post", make_assertion)
         await bot.send_video(chat_id, video, thumb="thumb")
-        check_thumb_deprececation_warning_for_method_args(recwarn, __file__)
+        check_thumb_deprecation_warning_for_method_args(recwarn, __file__)
 
     async def test_send_video_custom_filename(self, bot, chat_id, video_file, monkeypatch):
         async def make_assertion(url, request_data: RequestData, *args, **kwargs):

--- a/tests/_files/test_video.py
+++ b/tests/_files/test_video.py
@@ -31,7 +31,10 @@ from tests.auxil.bot_method_checks import (
     check_shortcut_call,
     check_shortcut_signature,
 )
-from tests.auxil.deprecations import check_thumb_deprecation_warnings_for_args_and_attrs
+from tests.auxil.deprecations import (
+    check_thumb_deprecation_warnings_for_args_and_attrs,
+    check_thumb_deprececation_warning_for_method_args,
+)
 from tests.auxil.files import data_file
 from tests.auxil.slots import mro_slots
 
@@ -170,6 +173,19 @@ class TestVideoWithoutRequest(TestVideoBase):
 
         monkeypatch.setattr(bot.request, "post", make_assertion)
         assert await bot.send_video(chat_id, video=video)
+
+    @pytest.mark.parametrize("bot_class", ["Bot", "ExtBot"])
+    async def test_send_video_thumb_deprecation_warning(
+        self, recwarn, monkeypatch, bot_class, bot, raw_bot, chat_id, video
+    ):
+        async def make_assertion(url, request_data: RequestData, *args, **kwargs):
+            return True
+
+        bot = raw_bot if bot_class == "Bot" else bot
+
+        monkeypatch.setattr(bot.request, "post", make_assertion)
+        await bot.send_video(chat_id, video, thumb="thumb")
+        check_thumb_deprececation_warning_for_method_args(recwarn, __file__)
 
     async def test_send_video_custom_filename(self, bot, chat_id, video_file, monkeypatch):
         async def make_assertion(url, request_data: RequestData, *args, **kwargs):

--- a/tests/_files/test_videonote.py
+++ b/tests/_files/test_videonote.py
@@ -31,8 +31,8 @@ from tests.auxil.bot_method_checks import (
     check_shortcut_signature,
 )
 from tests.auxil.deprecations import (
+    check_thumb_deprecation_warning_for_method_args,
     check_thumb_deprecation_warnings_for_args_and_attrs,
-    check_thumb_deprececation_warning_for_method_args,
 )
 from tests.auxil.files import data_file
 from tests.auxil.slots import mro_slots
@@ -163,7 +163,7 @@ class TestVideoNoteWithoutRequest(TestVideoNoteBase):
 
         monkeypatch.setattr(bot.request, "post", make_assertion)
         await bot.send_video_note(chat_id, video_note, thumb="thumb")
-        check_thumb_deprececation_warning_for_method_args(recwarn, __file__)
+        check_thumb_deprecation_warning_for_method_args(recwarn, __file__)
 
     async def test_send_video_note_custom_filename(
         self, bot, chat_id, video_note_file, monkeypatch

--- a/tests/_files/test_videonote.py
+++ b/tests/_files/test_videonote.py
@@ -30,7 +30,10 @@ from tests.auxil.bot_method_checks import (
     check_shortcut_call,
     check_shortcut_signature,
 )
-from tests.auxil.deprecations import check_thumb_deprecation_warnings_for_args_and_attrs
+from tests.auxil.deprecations import (
+    check_thumb_deprecation_warnings_for_args_and_attrs,
+    check_thumb_deprececation_warning_for_method_args,
+)
 from tests.auxil.files import data_file
 from tests.auxil.slots import mro_slots
 
@@ -148,6 +151,19 @@ class TestVideoNoteWithoutRequest(TestVideoNoteBase):
 
         monkeypatch.setattr(bot.request, "post", make_assertion)
         assert await bot.send_video_note(chat_id, video_note=video_note)
+
+    @pytest.mark.parametrize("bot_class", ["Bot", "ExtBot"])
+    async def test_send_video_note_thumb_deprecation_warning(
+        self, recwarn, monkeypatch, bot_class, bot, raw_bot, chat_id, video_note
+    ):
+        async def make_assertion(url, request_data: RequestData, *args, **kwargs):
+            return True
+
+        bot = raw_bot if bot_class == "Bot" else bot
+
+        monkeypatch.setattr(bot.request, "post", make_assertion)
+        await bot.send_video_note(chat_id, video_note, thumb="thumb")
+        check_thumb_deprececation_warning_for_method_args(recwarn, __file__)
 
     async def test_send_video_note_custom_filename(
         self, bot, chat_id, video_note_file, monkeypatch

--- a/tests/_inline/test_inlinequeryresultarticle.py
+++ b/tests/_inline/test_inlinequeryresultarticle.py
@@ -61,7 +61,7 @@ class TestInlineQueryResultArticleBase:
 
 
 class TestInlineQueryResultArticleWithoutRequest(TestInlineQueryResultArticleBase):
-    def test_slot_behaviour(self, inline_query_result_article, recwarn):
+    def test_slot_behaviour(self, inline_query_result_article):
         inst = inline_query_result_article
         for attr in inst.__slots__:
             assert getattr(inst, attr, "err") != "err", f"got extra slot '{attr}'"

--- a/tests/_inline/test_inlinequeryresultgif.py
+++ b/tests/_inline/test_inlinequeryresultgif.py
@@ -170,7 +170,7 @@ class TestInlineQueryResultGifWithoutRequest(TestInlineQueryResultGifBase):
             new_name="thumbnail_url",
         )
 
-    def test_init_throws_error_without_thumbnail_url_and_thumb_url(self, recwarn):
+    def test_init_throws_error_without_thumbnail_url_and_thumb_url(self):
         with pytest.raises(ValueError, match="You must pass either"):
             InlineQueryResultGif(
                 TestInlineQueryResultGifBase.id_,
@@ -188,7 +188,7 @@ class TestInlineQueryResultGifWithoutRequest(TestInlineQueryResultGifBase):
                 thumbnail_mime_type=TestInlineQueryResultGifBase.thumbnail_mime_type,
             )
 
-    def test_throws_value_error_with_different_deprecated_and_new_arg_thumb_url(self, recwarn):
+    def test_throws_value_error_with_different_deprecated_and_new_arg_thumb_url(self):
         with pytest.raises(
             ValueError, match="different entities as 'thumb_url' and 'thumbnail_url'"
         ):

--- a/tests/_inline/test_inlinequeryresultmpeg4gif.py
+++ b/tests/_inline/test_inlinequeryresultmpeg4gif.py
@@ -175,7 +175,7 @@ class TestInlineQueryResultMpeg4GifWithoutRequest(TestInlineQueryResultMpeg4GifB
             new_name="thumbnail_url",
         )
 
-    def test_init_throws_error_without_thumbnail_url_and_thumb_url(self, recwarn):
+    def test_init_throws_error_without_thumbnail_url_and_thumb_url(self):
         with pytest.raises(ValueError, match="You must pass either"):
             InlineQueryResultMpeg4Gif(
                 TestInlineQueryResultMpeg4GifBase.id_,

--- a/tests/_inline/test_inlinequeryresultphoto.py
+++ b/tests/_inline/test_inlinequeryresultphoto.py
@@ -142,7 +142,7 @@ class TestInlineQueryResultPhotoWithoutRequest(TestInlineQueryResultPhotoBase):
             new_name="thumbnail_url",
         )
 
-    def test_init_throws_error_without_thumbnail_url_and_thumb_url(self, recwarn):
+    def test_init_throws_error_without_thumbnail_url_and_thumb_url(self):
         with pytest.raises(ValueError, match="You must pass either"):
             InlineQueryResultPhoto(
                 TestInlineQueryResultPhotoBase.id_,

--- a/tests/_inline/test_inlinequeryresultvideo.py
+++ b/tests/_inline/test_inlinequeryresultvideo.py
@@ -157,7 +157,7 @@ class TestInlineQueryResultVideoWithoutRequest(TestInlineQueryResultVideoBase):
             new_name="thumbnail_url",
         )
 
-    def test_init_throws_error_without_thumbnail_url_and_thumb_url(self, recwarn):
+    def test_init_throws_error_without_thumbnail_url_and_thumb_url(self):
         with pytest.raises(ValueError, match="You must pass either"):
             InlineQueryResultVideo(
                 TestInlineQueryResultVideoBase.id_,

--- a/tests/auxil/deprecations.py
+++ b/tests/auxil/deprecations.py
@@ -19,7 +19,6 @@
 
 from _pytest.recwarn import WarningsRecorder
 
-from telegram._utils import warnings_transition
 from telegram.warnings import PTBDeprecationWarning
 
 
@@ -68,13 +67,13 @@ def check_thumb_deprecation_warnings_for_args_and_attrs(
 
         assert recwarn[i].filename == calling_file, (
             f'Warning for {names[i]} ("{str(recwarn[i].message)}") was issued by file '
-            f"{recwarn[i].filename}, expected {calling_file} or {warnings_transition.__file__}"
+            f"{recwarn[i].filename}, expected {calling_file}"
         )
 
     return True
 
 
-def check_thumb_deprececation_warning_for_method_args(
+def check_thumb_deprecation_warning_for_method_args(
     recwarn: WarningsRecorder,
     calling_file: str,
     deprecated_name: str = "thumb",

--- a/tests/auxil/deprecations.py
+++ b/tests/auxil/deprecations.py
@@ -72,3 +72,16 @@ def check_thumb_deprecation_warnings_for_args_and_attrs(
         )
 
     return True
+
+
+def check_thumb_deprececation_warning_for_method_args(
+    recwarn: WarningsRecorder,
+    calling_file: str,
+    deprecated_name: str = "thumb",
+    new_name: str = "thumbnail",
+):
+    """Similar as `check_thumb_deprecation_warnings_for_args_and_attrs`, but for bot methods."""
+    assert len(recwarn) == 1
+    assert recwarn[0].category is PTBDeprecationWarning
+    assert recwarn[0].filename == calling_file
+    assert f"argument '{deprecated_name}' to '{new_name}'" in str(recwarn[0].message)

--- a/tests/ext/test_application.py
+++ b/tests/ext/test_application.py
@@ -143,6 +143,7 @@ class TestApplication:
             str(recwarn[-1].message)
             == "`Application` instances should be built via the `ApplicationBuilder`."
         )
+        assert recwarn[0].category is PTBUserWarning
         assert recwarn[0].filename == __file__, "stacklevel is incorrect!"
 
     @pytest.mark.parametrize(
@@ -223,6 +224,7 @@ class TestApplication:
         assert application.job_queue is None
         assert len(recwarn) == 1
         assert str(recwarn[0].message) == expected_warning
+        assert recwarn[0].category is PTBUserWarning
         assert recwarn[0].filename == __file__, "wrong stacklevel"
 
     def test_custom_context_init(self, one_time_bot):
@@ -1207,6 +1209,7 @@ class TestApplication:
                 assert task.result() == 43
             else:
                 assert len(recwarn) == 1
+                assert recwarn[0].category is PTBUserWarning
                 assert "won't be automatically awaited" in str(recwarn[0].message)
                 assert recwarn[0].filename == __file__, "wrong stacklevel!"
                 assert not task.done()
@@ -2074,6 +2077,7 @@ class TestApplication:
         for record in recwarn:
             print(record)
             if str(record.message).startswith("Could not add signal handlers for the stop"):
+                assert record.category is PTBUserWarning
                 assert record.filename == __file__, "stacklevel is incorrect!"
                 found = True
         assert found

--- a/tests/ext/test_callbackcontext.py
+++ b/tests/ext/test_callbackcontext.py
@@ -31,6 +31,7 @@ from telegram import (
 )
 from telegram.error import TelegramError
 from telegram.ext import ApplicationBuilder, CallbackContext, Job
+from telegram.warnings import PTBUserWarning
 from tests.auxil.slots import mro_slots
 
 """
@@ -72,6 +73,7 @@ class TestCallbackContext:
         assert callback_context.job_queue is None
         assert len(recwarn) == 1
         assert str(recwarn[0].message) == expected_warning
+        assert recwarn[0].category is PTBUserWarning
         assert recwarn[0].filename == __file__, "wrong stacklevel"
 
     def test_from_update(self, app):

--- a/tests/ext/test_conversationhandler.py
+++ b/tests/ext/test_conversationhandler.py
@@ -19,6 +19,7 @@
 """Persistence of conversations is tested in test_basepersistence.py"""
 import asyncio
 import logging
+from pathlib import Path
 from warnings import filterwarnings
 
 import pytest
@@ -58,6 +59,7 @@ from telegram.ext import (
 )
 from telegram.warnings import PTBUserWarning
 from tests.auxil.build_messages import make_command_message
+from tests.auxil.files import PROJECT_ROOT_PATH
 from tests.auxil.pytest_classes import PytestBot, make_bot
 from tests.auxil.slots import mro_slots
 
@@ -458,6 +460,7 @@ class TestConversationHandler:
 
         # this for loop checks if the correct stacklevel is used when generating the warning
         for warning in recwarn:
+            assert warning.category is PTBUserWarning
             assert warning.filename == __file__, "incorrect stacklevel!"
 
     @pytest.mark.parametrize(
@@ -676,6 +679,11 @@ class TestConversationHandler:
                 print(exc)
                 raise exc
             assert len(recwarn) == 1
+            assert recwarn[0].category is PTBUserWarning
+            assert (
+                Path(recwarn[0].filename)
+                == PROJECT_ROOT_PATH / "telegram" / "ext" / "_conversationhandler.py"
+            ), "wrong stacklevel!"
             assert str(recwarn[0].message) == (
                 "'callback' returned state 69 which is unknown to the ConversationHandler xyz."
             )
@@ -1042,12 +1050,27 @@ class TestConversationHandler:
             await asyncio.sleep(0.5)
             if jq:
                 assert len(recwarn) == 1
+                assert (
+                    Path(recwarn[0].filename)
+                    == PROJECT_ROOT_PATH / "telegram" / "ext" / "_conversationhandler.py"
+                ), "wrong stacklevel!"
             else:
                 assert len(recwarn) == 2
+                assert (
+                    Path(recwarn[0].filename)
+                    == PROJECT_ROOT_PATH / "telegram" / "ext" / "_conversationhandler.py"
+                ), "wrong stacklevel!"
+                assert (
+                    Path(recwarn[1].filename)
+                    == PROJECT_ROOT_PATH / "telegram" / "ext" / "_conversationhandler.py"
+                ), "wrong stacklevel!"
+
             assert str(recwarn[0].message if jq else recwarn[1].message).startswith(
                 "Ignoring `conversation_timeout`"
             )
             assert ("is not running" if jq else "No `JobQueue` set up.") in str(recwarn[0].message)
+            for warning in recwarn:
+                assert warning.category is PTBUserWarning
             # now set app.job_queue back to it's original value
 
     async def test_schedule_job_exception(self, app, bot, user1, monkeypatch, caplog):
@@ -1363,6 +1386,11 @@ class TestConversationHandler:
             assert handler.check_update(Update(0, message=message))
             assert len(recwarn) == 1
             assert str(recwarn[0].message).startswith("ApplicationHandlerStop in TIMEOUT")
+            assert recwarn[0].category is PTBUserWarning
+            assert (
+                Path(recwarn[0].filename)
+                == PROJECT_ROOT_PATH / "telegram" / "ext" / "_jobqueue.py"
+            ), "wrong stacklevel!"
 
             await app.stop()
 

--- a/tests/ext/test_conversationhandler.py
+++ b/tests/ext/test_conversationhandler.py
@@ -1050,20 +1050,8 @@ class TestConversationHandler:
             await asyncio.sleep(0.5)
             if jq:
                 assert len(recwarn) == 1
-                assert (
-                    Path(recwarn[0].filename)
-                    == PROJECT_ROOT_PATH / "telegram" / "ext" / "_conversationhandler.py"
-                ), "wrong stacklevel!"
             else:
                 assert len(recwarn) == 2
-                assert (
-                    Path(recwarn[0].filename)
-                    == PROJECT_ROOT_PATH / "telegram" / "ext" / "_conversationhandler.py"
-                ), "wrong stacklevel!"
-                assert (
-                    Path(recwarn[1].filename)
-                    == PROJECT_ROOT_PATH / "telegram" / "ext" / "_conversationhandler.py"
-                ), "wrong stacklevel!"
 
             assert str(recwarn[0].message if jq else recwarn[1].message).startswith(
                 "Ignoring `conversation_timeout`"
@@ -1071,6 +1059,10 @@ class TestConversationHandler:
             assert ("is not running" if jq else "No `JobQueue` set up.") in str(recwarn[0].message)
             for warning in recwarn:
                 assert warning.category is PTBUserWarning
+                assert (
+                    Path(warning.filename)
+                    == PROJECT_ROOT_PATH / "telegram" / "ext" / "_conversationhandler.py"
+                ), "wrong stacklevel!"
             # now set app.job_queue back to it's original value
 
     async def test_schedule_job_exception(self, app, bot, user1, monkeypatch, caplog):

--- a/tests/ext/test_dictpersistence.py
+++ b/tests/ext/test_dictpersistence.py
@@ -91,7 +91,7 @@ class TestDictPersistence:
     """Just tests the DictPersistence interface. Integration of persistence into Applictation
     is tested in TestBasePersistence!"""
 
-    async def test_slot_behaviour(self, recwarn):
+    async def test_slot_behaviour(self):
         inst = DictPersistence()
         for attr in inst.__slots__:
             assert getattr(inst, attr, "err") != "err", f"got extra slot '{attr}'"

--- a/tests/ext/test_jobqueue.py
+++ b/tests/ext/test_jobqueue.py
@@ -26,6 +26,7 @@ import time
 import pytest
 
 from telegram.ext import ApplicationBuilder, CallbackContext, ContextTypes, Job, JobQueue
+from telegram.warnings import PTBUserWarning
 from tests.auxil.envvars import GITHUB_ACTION, TEST_WITH_OPT_DEPS
 from tests.auxil.pytest_classes import make_bot
 from tests.auxil.slots import mro_slots
@@ -359,6 +360,7 @@ class TestJobQueue:
         job_queue.run_daily(self.job_run_once, time_of_day, days=(0, 1, 2, 3))
         assert len(recwarn) == 1
         assert str(recwarn[0].message) == self.expected_warning
+        assert recwarn[0].category is PTBUserWarning
         assert recwarn[0].filename == __file__, "wrong stacklevel"
 
     @pytest.mark.parametrize("weekday", [0, 1, 2, 3, 4, 5, 6])
@@ -376,6 +378,7 @@ class TestJobQueue:
         assert scheduled_time == pytest.approx(expected_reschedule_time)
         assert len(recwarn) == 1
         assert str(recwarn[0].message) == self.expected_warning
+        assert recwarn[0].category is PTBUserWarning
         assert recwarn[0].filename == __file__, "wrong stacklevel"
 
     async def test_run_monthly(self, job_queue, timezone):

--- a/tests/ext/test_picklepersistence.py
+++ b/tests/ext/test_picklepersistence.py
@@ -27,6 +27,7 @@ import pytest
 from telegram import Chat, Message, TelegramObject, Update, User
 from telegram.ext import ContextTypes, PersistenceInput, PicklePersistence
 from telegram.warnings import PTBUserWarning
+from tests.auxil.files import PROJECT_ROOT_PATH
 from tests.auxil.pytest_classes import make_bot
 from tests.auxil.slots import mro_slots
 
@@ -891,7 +892,12 @@ class TestPicklePersistence:
         await pickle_persistence.update_chat_data(12345, data_with_bot)
         assert len(recwarn) == 1
         assert recwarn[-1].category is PTBUserWarning
+        assert recwarn[-1].category is PTBUserWarning
         assert str(recwarn[-1].message).startswith("Unknown bot instance found.")
+        assert (
+            Path(recwarn[-1].filename)
+            == PROJECT_ROOT_PATH / "telegram" / "ext" / "_picklepersistence.py"
+        ), "wrong stacklevel!"
         pp = PicklePersistence("pickletest", single_file=False, on_flush=False)
         pp.set_bot(bot)
         assert (await pp.get_chat_data())[12345]["unknown_bot_in_user"]._bot is None

--- a/tests/ext/test_picklepersistence.py
+++ b/tests/ext/test_picklepersistence.py
@@ -892,7 +892,6 @@ class TestPicklePersistence:
         await pickle_persistence.update_chat_data(12345, data_with_bot)
         assert len(recwarn) == 1
         assert recwarn[-1].category is PTBUserWarning
-        assert recwarn[-1].category is PTBUserWarning
         assert str(recwarn[-1].message).startswith("Unknown bot instance found.")
         assert (
             Path(recwarn[-1].filename)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -26,7 +26,6 @@ import re
 import socket
 import time
 from collections import defaultdict
-from pathlib import Path
 
 import pytest
 
@@ -81,7 +80,7 @@ from telegram.warnings import PTBUserWarning
 from tests.auxil.bot_method_checks import check_defaults_handling
 from tests.auxil.ci_bots import FALLBACKS
 from tests.auxil.envvars import GITHUB_ACTION, TEST_WITH_OPT_DEPS
-from tests.auxil.files import PROJECT_ROOT_PATH, data_file
+from tests.auxil.files import data_file
 from tests.auxil.networking import expect_bad_request
 from tests.auxil.pytest_classes import PytestBot, PytestExtBot, make_bot
 from tests.auxil.slots import mro_slots
@@ -1681,9 +1680,7 @@ class TestBotWithoutRequest:
         for warning in recwarn:
             print()
             print(warning)
-            assert (
-                Path(warning.filename) == PROJECT_ROOT_PATH / "telegram" / "ext" / "_extbot.py"
-            ), "wrong stacklevel!"
+            assert warning.filename == __file__, "wrong stacklevel!"
             assert warning.category is PTBUserWarning
 
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -26,6 +26,7 @@ import re
 import socket
 import time
 from collections import defaultdict
+from pathlib import Path
 
 import pytest
 
@@ -76,10 +77,11 @@ from telegram.error import BadRequest, InvalidToken, NetworkError
 from telegram.ext import ExtBot, InvalidCallbackData
 from telegram.helpers import escape_markdown
 from telegram.request import BaseRequest, HTTPXRequest, RequestData
+from telegram.warnings import PTBUserWarning
 from tests.auxil.bot_method_checks import check_defaults_handling
 from tests.auxil.ci_bots import FALLBACKS
 from tests.auxil.envvars import GITHUB_ACTION, TEST_WITH_OPT_DEPS
-from tests.auxil.files import data_file
+from tests.auxil.files import PROJECT_ROOT_PATH, data_file
 from tests.auxil.networking import expect_bad_request
 from tests.auxil.pytest_classes import PytestBot, PytestExtBot, make_bot
 from tests.auxil.slots import mro_slots
@@ -1676,6 +1678,13 @@ class TestBotWithoutRequest:
             "You set the HTTP version for the get_updates_request and request HTTPXRequest "
             "instance" in str(recwarn[2].message)
         )
+        for warning in recwarn:
+            print()
+            print(warning)
+            assert (
+                Path(warning.filename) == PROJECT_ROOT_PATH / "telegram" / "ext" / "_extbot.py"
+            ), "wrong stacklevel!"
+            assert warning.category is PTBUserWarning
 
 
 class TestBotWithRequest:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1651,22 +1651,21 @@ class TestBotWithoutRequest:
             bot.callback_data_cache.clear_callback_data()
             bot.callback_data_cache.clear_callback_queries()
 
-    async def test_http2_runtime_error(self, recwarn):
-        Bot("12345:ABCDE", base_url="http://", request=HTTPXRequest(http_version="2"))
-        Bot(
+    @pytest.mark.parametrize("bot_class", [Bot, ExtBot])
+    async def test_http2_runtime_error(self, recwarn, bot_class):
+        bot_class("12345:ABCDE", base_url="http://", request=HTTPXRequest(http_version="2"))
+        bot_class(
             "12345:ABCDE",
             base_url="http://",
             get_updates_request=HTTPXRequest(http_version="2"),
         )
-        Bot(
+        bot_class(
             "12345:ABCDE",
             base_url="http://",
             request=HTTPXRequest(http_version="2"),
             get_updates_request=HTTPXRequest(http_version="2"),
         )
-        # this exists to make sure the error is also raised by extbot
-        ExtBot("12345:ABCDE", base_url="http://", request=HTTPXRequest(http_version="2"))
-        assert len(recwarn) == 4
+        assert len(recwarn) == 3
         assert "You set the HTTP version for the request HTTPXRequest instance" in str(
             recwarn[0].message
         )
@@ -1678,8 +1677,6 @@ class TestBotWithoutRequest:
             "instance" in str(recwarn[2].message)
         )
         for warning in recwarn:
-            print()
-            print(warning)
             assert warning.filename == __file__, "wrong stacklevel!"
             assert warning.category is PTBUserWarning
 

--- a/tests/test_chatpermissions.py
+++ b/tests/test_chatpermissions.py
@@ -20,6 +20,7 @@
 import pytest
 
 from telegram import ChatPermissions, User
+from telegram.warnings import PTBDeprecationWarning
 from tests.auxil.slots import mro_slots
 
 
@@ -211,3 +212,5 @@ class TestChatPermissionsWithoutRequest(TestChatPermissionsBase):
             "In v21, granular media settings will be considered as well when comparing"
             " ChatPermissions instances."
         )
+        assert recwarn[0].category is PTBDeprecationWarning
+        assert recwarn[0].filename == __file__, "wrong stacklevel"

--- a/tests/test_keyboardbutton.py
+++ b/tests/test_keyboardbutton.py
@@ -26,6 +26,7 @@ from telegram import (
     KeyboardButtonRequestUser,
     WebAppInfo,
 )
+from telegram.warnings import PTBDeprecationWarning
 from tests.auxil.slots import mro_slots
 
 
@@ -141,3 +142,5 @@ class TestKeyboardButtonWithoutRequest(TestKeyboardButtonBase):
             "In v21, granular media settings will be considered as well when comparing"
             " ChatPermissions instances."
         )
+        assert recwarn[0].category is PTBDeprecationWarning
+        assert recwarn[0].filename == __file__, "wrong stacklevel"

--- a/tests/test_telegramobject.py
+++ b/tests/test_telegramobject.py
@@ -28,6 +28,7 @@ import pytest
 
 from telegram import Bot, BotCommand, Chat, Message, PhotoSize, TelegramObject, User
 from telegram.ext import PicklePersistence
+from telegram.warnings import PTBUserWarning
 from tests.auxil.files import data_file
 from tests.auxil.slots import mro_slots
 
@@ -222,6 +223,7 @@ class TestTelegramObject:
         assert a == b
         assert len(recwarn) == 1
         assert str(recwarn[0].message) == expected_warning
+        assert recwarn[0].category is PTBUserWarning
         assert recwarn[0].filename == __file__, "wrong stacklevel"
 
     def test_meaningful_comparison(self, recwarn):


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool! Please have a look at the below checklist. It's here to help both you and the maintainers to remember some aspects. Make sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
-->

* Fixed a few warning categories that were missed in API 6.6.
* Unifies warning handling in `Bot` and `ExtBot`, ensuring that the stacklevel is correct for both
* adds missing tests & modifies existing ones

TODO:

- [x] Update all warning tests to also check the category
- [x] Update tests to double check stacklevel in ExtBot vs Bot

