### PR TITLE
Upgrade Furo to support sphinx 7

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,4 +1,4 @@
-sphinx==6.1.3
+sphinx==7.0.1
 sphinx-pypi-upload
 furo==2023.5.20
 git+https://github.com/harshil21/furo-sphinx-search@01efc7be422d7dc02390aab9be68d6f5ce1a5618#egg=furo-sphinx-search

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,6 +1,6 @@
 sphinx==6.1.3
 sphinx-pypi-upload
-furo==2023.3.27
+furo==2023.5.20
 git+https://github.com/harshil21/furo-sphinx-search@01efc7be422d7dc02390aab9be68d6f5ce1a5618#egg=furo-sphinx-search
 sphinx-paramlinks==0.5.4
 sphinxcontrib-mermaid==0.8.1


### PR DESCRIPTION
Upgrades the furo version, so we can now also upgrade the sphinx version.
