### PR TITLE
Fix Two Bugs in GitHub Actions Workflows

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,6 +4,6 @@ version: 1
 
 labels:
 - label: "dependencies"
-  authors: ["dependabot", "pre-commit-ci"]
+  authors: ["dependabot[bot]", "pre-commit-ci[bot]"]
 - label: "code quality ✨"
-  authors: ["pre-commit-ci"]
+  authors: ["pre-commit-ci[bot]"]

--- a/.github/workflows/dependabot-prs.yml
+++ b/.github/workflows/dependabot-prs.yml
@@ -28,6 +28,7 @@ jobs:
         find: ${{ steps.dependabot-metadata.outputs.previous-version }}
         replace: ${{ steps.dependabot-metadata.outputs.new-version }}
         regex: false
+        exclude: CHANGES.rst
 
     - name: Commit & Push Changes to PR
       uses: EndBug/add-and-commit@v9.1.3


### PR DESCRIPTION
1. The auto-labelling workflow apparently uses the wrong authors. At https://github.com/python-telegram-bot/python-telegram-bot/actions/runs/5160678227/jobs/9296943791?pr=3737 we can see tha the Author is `dependabot[bot]` and I expect the same to hold true for pre-commit-ci
2. Even though I made an argument in #3716 to replace in all files, there is one that we need to exclude: the changelog. The effect can be seen in https://github.com/python-telegram-bot/python-telegram-bot/pull/3738/commits/fb9fe5b89b16b2f29b96c98fa898c3799dbd91c5, where the workflow updated the changelog wrongly