### PR TITLE
Make use of `@final`, `Final` and `Literal`

### DIFF
--- a/telegram/_botcommand.py
+++ b/telegram/_botcommand.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represents a Telegram Bot Command."""
 
-from typing import ClassVar, Optional
+from typing import Final, Optional
 
 from telegram import constants
 from telegram._telegramobject import TelegramObject
@@ -61,22 +61,22 @@ class BotCommand(TelegramObject):
 
         self._freeze()
 
-    MIN_COMMAND: ClassVar[int] = constants.BotCommandLimit.MIN_COMMAND
+    MIN_COMMAND: Final[int] = constants.BotCommandLimit.MIN_COMMAND
     """:const:`telegram.constants.BotCommandLimit.MIN_COMMAND`
 
     .. versionadded:: 20.0
     """
-    MAX_COMMAND: ClassVar[int] = constants.BotCommandLimit.MAX_COMMAND
+    MAX_COMMAND: Final[int] = constants.BotCommandLimit.MAX_COMMAND
     """:const:`telegram.constants.BotCommandLimit.MAX_COMMAND`
 
     .. versionadded:: 20.0
     """
-    MIN_DESCRIPTION: ClassVar[int] = constants.BotCommandLimit.MIN_DESCRIPTION
+    MIN_DESCRIPTION: Final[int] = constants.BotCommandLimit.MIN_DESCRIPTION
     """:const:`telegram.constants.BotCommandLimit.MIN_DESCRIPTION`
 
     .. versionadded:: 20.0
     """
-    MAX_DESCRIPTION: ClassVar[int] = constants.BotCommandLimit.MAX_DESCRIPTION
+    MAX_DESCRIPTION: Final[int] = constants.BotCommandLimit.MAX_DESCRIPTION
     """:const:`telegram.constants.BotCommandLimit.MAX_DESCRIPTION`
 
     .. versionadded:: 20.0

--- a/telegram/_botcommandscope.py
+++ b/telegram/_botcommandscope.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 # pylint: disable=redefined-builtin
 """This module contains objects representing Telegram bot command scopes."""
-from typing import TYPE_CHECKING, ClassVar, Dict, Optional, Type, Union
+from typing import TYPE_CHECKING, Dict, Final, Optional, Type, Union
 
 from telegram import constants
 from telegram._telegramobject import TelegramObject
@@ -60,19 +60,19 @@ class BotCommandScope(TelegramObject):
 
     __slots__ = ("type",)
 
-    DEFAULT: ClassVar[str] = constants.BotCommandScopeType.DEFAULT
+    DEFAULT: Final[str] = constants.BotCommandScopeType.DEFAULT
     """:const:`telegram.constants.BotCommandScopeType.DEFAULT`"""
-    ALL_PRIVATE_CHATS: ClassVar[str] = constants.BotCommandScopeType.ALL_PRIVATE_CHATS
+    ALL_PRIVATE_CHATS: Final[str] = constants.BotCommandScopeType.ALL_PRIVATE_CHATS
     """:const:`telegram.constants.BotCommandScopeType.ALL_PRIVATE_CHATS`"""
-    ALL_GROUP_CHATS: ClassVar[str] = constants.BotCommandScopeType.ALL_GROUP_CHATS
+    ALL_GROUP_CHATS: Final[str] = constants.BotCommandScopeType.ALL_GROUP_CHATS
     """:const:`telegram.constants.BotCommandScopeType.ALL_GROUP_CHATS`"""
-    ALL_CHAT_ADMINISTRATORS: ClassVar[str] = constants.BotCommandScopeType.ALL_CHAT_ADMINISTRATORS
+    ALL_CHAT_ADMINISTRATORS: Final[str] = constants.BotCommandScopeType.ALL_CHAT_ADMINISTRATORS
     """:const:`telegram.constants.BotCommandScopeType.ALL_CHAT_ADMINISTRATORS`"""
-    CHAT: ClassVar[str] = constants.BotCommandScopeType.CHAT
+    CHAT: Final[str] = constants.BotCommandScopeType.CHAT
     """:const:`telegram.constants.BotCommandScopeType.CHAT`"""
-    CHAT_ADMINISTRATORS: ClassVar[str] = constants.BotCommandScopeType.CHAT_ADMINISTRATORS
+    CHAT_ADMINISTRATORS: Final[str] = constants.BotCommandScopeType.CHAT_ADMINISTRATORS
     """:const:`telegram.constants.BotCommandScopeType.CHAT_ADMINISTRATORS`"""
-    CHAT_MEMBER: ClassVar[str] = constants.BotCommandScopeType.CHAT_MEMBER
+    CHAT_MEMBER: Final[str] = constants.BotCommandScopeType.CHAT_MEMBER
     """:const:`telegram.constants.BotCommandScopeType.CHAT_MEMBER`"""
 
     def __init__(self, type: str, *, api_kwargs: Optional[JSONDict] = None):

--- a/telegram/_botname.py
+++ b/telegram/_botname.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represent a Telegram bots name."""
-from typing import ClassVar, Optional
+from typing import Final, Optional
 
 from telegram import constants
 from telegram._telegramobject import TelegramObject
@@ -50,5 +50,5 @@ class BotName(TelegramObject):
 
         self._freeze()
 
-    MAX_LENGTH: ClassVar[int] = constants.BotNameLimit.MAX_NAME_LENGTH
+    MAX_LENGTH: Final[int] = constants.BotNameLimit.MAX_NAME_LENGTH
     """:const:`telegram.constants.BotNameLimit.MAX_NAME_LENGTH`"""

--- a/telegram/_callbackquery.py
+++ b/telegram/_callbackquery.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 # pylint: disable=redefined-builtin
 """This module contains an object that represents a Telegram CallbackQuery"""
-from typing import TYPE_CHECKING, ClassVar, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Final, Optional, Sequence, Tuple, Union
 
 from telegram import constants
 from telegram._files.location import Location
@@ -771,7 +771,7 @@ class CallbackQuery(TelegramObject):
             message_thread_id=message_thread_id,
         )
 
-    MAX_ANSWER_TEXT_LENGTH: ClassVar[
+    MAX_ANSWER_TEXT_LENGTH: Final[
         int
     ] = constants.CallbackQueryLimit.ANSWER_CALLBACK_QUERY_TEXT_LENGTH
     """

--- a/telegram/_chat.py
+++ b/telegram/_chat.py
@@ -20,7 +20,7 @@
 """This module contains an object that represents a Telegram Chat."""
 from datetime import datetime
 from html import escape
-from typing import TYPE_CHECKING, ClassVar, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Final, Optional, Sequence, Tuple, Union
 
 from telegram import constants
 from telegram._chatlocation import ChatLocation
@@ -303,18 +303,18 @@ class Chat(TelegramObject):
         "has_aggressive_anti_spam_enabled",
     )
 
-    SENDER: ClassVar[str] = constants.ChatType.SENDER
+    SENDER: Final[str] = constants.ChatType.SENDER
     """:const:`telegram.constants.ChatType.SENDER`
 
     .. versionadded:: 13.5
     """
-    PRIVATE: ClassVar[str] = constants.ChatType.PRIVATE
+    PRIVATE: Final[str] = constants.ChatType.PRIVATE
     """:const:`telegram.constants.ChatType.PRIVATE`"""
-    GROUP: ClassVar[str] = constants.ChatType.GROUP
+    GROUP: Final[str] = constants.ChatType.GROUP
     """:const:`telegram.constants.ChatType.GROUP`"""
-    SUPERGROUP: ClassVar[str] = constants.ChatType.SUPERGROUP
+    SUPERGROUP: Final[str] = constants.ChatType.SUPERGROUP
     """:const:`telegram.constants.ChatType.SUPERGROUP`"""
-    CHANNEL: ClassVar[str] = constants.ChatType.CHANNEL
+    CHANNEL: Final[str] = constants.ChatType.CHANNEL
     """:const:`telegram.constants.ChatType.CHANNEL`"""
 
     def __init__(

--- a/telegram/_chatlocation.py
+++ b/telegram/_chatlocation.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represents a location to which a chat is connected."""
 
-from typing import TYPE_CHECKING, ClassVar, Optional
+from typing import TYPE_CHECKING, Final, Optional
 
 from telegram import constants
 from telegram._files.location import Location
@@ -79,12 +79,12 @@ class ChatLocation(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    MIN_ADDRESS: ClassVar[int] = constants.LocationLimit.MIN_CHAT_LOCATION_ADDRESS
+    MIN_ADDRESS: Final[int] = constants.LocationLimit.MIN_CHAT_LOCATION_ADDRESS
     """:const:`telegram.constants.LocationLimit.MIN_CHAT_LOCATION_ADDRESS`
 
     .. versionadded:: 20.0
     """
-    MAX_ADDRESS: ClassVar[int] = constants.LocationLimit.MAX_CHAT_LOCATION_ADDRESS
+    MAX_ADDRESS: Final[int] = constants.LocationLimit.MAX_CHAT_LOCATION_ADDRESS
     """:const:`telegram.constants.LocationLimit.MAX_CHAT_LOCATION_ADDRESS`
 
     .. versionadded:: 20.0

--- a/telegram/_chatmember.py
+++ b/telegram/_chatmember.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represents a Telegram ChatMember."""
 import datetime
-from typing import TYPE_CHECKING, ClassVar, Dict, Optional, Type
+from typing import TYPE_CHECKING, Dict, Final, Optional, Type
 
 from telegram import constants
 from telegram._telegramobject import TelegramObject
@@ -74,17 +74,17 @@ class ChatMember(TelegramObject):
 
     __slots__ = ("user", "status")
 
-    ADMINISTRATOR: ClassVar[str] = constants.ChatMemberStatus.ADMINISTRATOR
+    ADMINISTRATOR: Final[str] = constants.ChatMemberStatus.ADMINISTRATOR
     """:const:`telegram.constants.ChatMemberStatus.ADMINISTRATOR`"""
-    OWNER: ClassVar[str] = constants.ChatMemberStatus.OWNER
+    OWNER: Final[str] = constants.ChatMemberStatus.OWNER
     """:const:`telegram.constants.ChatMemberStatus.OWNER`"""
-    BANNED: ClassVar[str] = constants.ChatMemberStatus.BANNED
+    BANNED: Final[str] = constants.ChatMemberStatus.BANNED
     """:const:`telegram.constants.ChatMemberStatus.BANNED`"""
-    LEFT: ClassVar[str] = constants.ChatMemberStatus.LEFT
+    LEFT: Final[str] = constants.ChatMemberStatus.LEFT
     """:const:`telegram.constants.ChatMemberStatus.LEFT`"""
-    MEMBER: ClassVar[str] = constants.ChatMemberStatus.MEMBER
+    MEMBER: Final[str] = constants.ChatMemberStatus.MEMBER
     """:const:`telegram.constants.ChatMemberStatus.MEMBER`"""
-    RESTRICTED: ClassVar[str] = constants.ChatMemberStatus.RESTRICTED
+    RESTRICTED: Final[str] = constants.ChatMemberStatus.RESTRICTED
     """:const:`telegram.constants.ChatMemberStatus.RESTRICTED`"""
 
     def __init__(

--- a/telegram/_dice.py
+++ b/telegram/_dice.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represents a Telegram Dice."""
-from typing import ClassVar, List, Optional
+from typing import Final, List, Optional
 
 from telegram import constants
 from telegram._telegramobject import TelegramObject
@@ -98,62 +98,62 @@ class Dice(TelegramObject):
 
         self._freeze()
 
-    DICE: ClassVar[str] = constants.DiceEmoji.DICE  # skipcq: PTC-W0052
+    DICE: Final[str] = constants.DiceEmoji.DICE  # skipcq: PTC-W0052
     """:const:`telegram.constants.DiceEmoji.DICE`"""
-    DARTS: ClassVar[str] = constants.DiceEmoji.DARTS
+    DARTS: Final[str] = constants.DiceEmoji.DARTS
     """:const:`telegram.constants.DiceEmoji.DARTS`"""
-    BASKETBALL: ClassVar[str] = constants.DiceEmoji.BASKETBALL
+    BASKETBALL: Final[str] = constants.DiceEmoji.BASKETBALL
     """:const:`telegram.constants.DiceEmoji.BASKETBALL`"""
-    FOOTBALL: ClassVar[str] = constants.DiceEmoji.FOOTBALL
+    FOOTBALL: Final[str] = constants.DiceEmoji.FOOTBALL
     """:const:`telegram.constants.DiceEmoji.FOOTBALL`"""
-    SLOT_MACHINE: ClassVar[str] = constants.DiceEmoji.SLOT_MACHINE
+    SLOT_MACHINE: Final[str] = constants.DiceEmoji.SLOT_MACHINE
     """:const:`telegram.constants.DiceEmoji.SLOT_MACHINE`"""
-    BOWLING: ClassVar[str] = constants.DiceEmoji.BOWLING
+    BOWLING: Final[str] = constants.DiceEmoji.BOWLING
     """
     :const:`telegram.constants.DiceEmoji.BOWLING`
 
     .. versionadded:: 13.4
     """
-    ALL_EMOJI: ClassVar[List[str]] = list(constants.DiceEmoji)
+    ALL_EMOJI: Final[List[str]] = list(constants.DiceEmoji)
     """List[:obj:`str`]: A list of all available dice emoji."""
 
-    MIN_VALUE: ClassVar[int] = constants.DiceLimit.MIN_VALUE
+    MIN_VALUE: Final[int] = constants.DiceLimit.MIN_VALUE
     """:const:`telegram.constants.DiceLimit.MIN_VALUE`
 
     .. versionadded:: 20.0
     """
 
-    MAX_VALUE_BOWLING: ClassVar[int] = constants.DiceLimit.MAX_VALUE_BOWLING
+    MAX_VALUE_BOWLING: Final[int] = constants.DiceLimit.MAX_VALUE_BOWLING
     """:const:`telegram.constants.DiceLimit.MAX_VALUE_BOWLING`
 
     .. versionadded:: 20.0
     """
 
-    MAX_VALUE_DARTS: ClassVar[int] = constants.DiceLimit.MAX_VALUE_DARTS
+    MAX_VALUE_DARTS: Final[int] = constants.DiceLimit.MAX_VALUE_DARTS
     """:const:`telegram.constants.DiceLimit.MAX_VALUE_DARTS`
 
     .. versionadded:: 20.0
     """
 
-    MAX_VALUE_DICE: ClassVar[int] = constants.DiceLimit.MAX_VALUE_DICE
+    MAX_VALUE_DICE: Final[int] = constants.DiceLimit.MAX_VALUE_DICE
     """:const:`telegram.constants.DiceLimit.MAX_VALUE_DICE`
 
     .. versionadded:: 20.0
     """
 
-    MAX_VALUE_BASKETBALL: ClassVar[int] = constants.DiceLimit.MAX_VALUE_BASKETBALL
+    MAX_VALUE_BASKETBALL: Final[int] = constants.DiceLimit.MAX_VALUE_BASKETBALL
     """:const:`telegram.constants.DiceLimit.MAX_VALUE_BASKETBALL`
 
     .. versionadded:: 20.0
     """
 
-    MAX_VALUE_FOOTBALL: ClassVar[int] = constants.DiceLimit.MAX_VALUE_FOOTBALL
+    MAX_VALUE_FOOTBALL: Final[int] = constants.DiceLimit.MAX_VALUE_FOOTBALL
     """:const:`telegram.constants.DiceLimit.MAX_VALUE_FOOTBALL`
 
     .. versionadded:: 20.0
     """
 
-    MAX_VALUE_SLOT_MACHINE: ClassVar[int] = constants.DiceLimit.MAX_VALUE_SLOT_MACHINE
+    MAX_VALUE_SLOT_MACHINE: Final[int] = constants.DiceLimit.MAX_VALUE_SLOT_MACHINE
     """:const:`telegram.constants.DiceLimit.MAX_VALUE_SLOT_MACHINE`
 
     .. versionadded:: 20.0

--- a/telegram/_files/chatphoto.py
+++ b/telegram/_files/chatphoto.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represents a Telegram ChatPhoto."""
-from typing import TYPE_CHECKING, ClassVar, Optional
+from typing import TYPE_CHECKING, Final, Optional
 
 from telegram import constants
 from telegram._telegramobject import TelegramObject
@@ -164,12 +164,12 @@ class ChatPhoto(TelegramObject):
             api_kwargs=api_kwargs,
         )
 
-    SIZE_SMALL: ClassVar[int] = constants.ChatPhotoSize.SMALL
+    SIZE_SMALL: Final[int] = constants.ChatPhotoSize.SMALL
     """:const:`telegram.constants.ChatPhotoSize.SMALL`
 
     .. versionadded:: 20.0
     """
-    SIZE_BIG: ClassVar[int] = constants.ChatPhotoSize.BIG
+    SIZE_BIG: Final[int] = constants.ChatPhotoSize.BIG
     """:const:`telegram.constants.ChatPhotoSize.BIG`
 
     .. versionadded:: 20.0

--- a/telegram/_files/location.py
+++ b/telegram/_files/location.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represents a Telegram Location."""
 
-from typing import ClassVar, Optional
+from typing import Final, Optional
 
 from telegram import constants
 from telegram._telegramobject import TelegramObject
@@ -96,17 +96,17 @@ class Location(TelegramObject):
 
         self._freeze()
 
-    HORIZONTAL_ACCURACY: ClassVar[int] = constants.LocationLimit.HORIZONTAL_ACCURACY
+    HORIZONTAL_ACCURACY: Final[int] = constants.LocationLimit.HORIZONTAL_ACCURACY
     """:const:`telegram.constants.LocationLimit.HORIZONTAL_ACCURACY`
 
     .. versionadded:: 20.0
     """
-    MIN_HEADING: ClassVar[int] = constants.LocationLimit.MIN_HEADING
+    MIN_HEADING: Final[int] = constants.LocationLimit.MIN_HEADING
     """:const:`telegram.constants.LocationLimit.MIN_HEADING`
 
     .. versionadded:: 20.0
     """
-    MAX_HEADING: ClassVar[int] = constants.LocationLimit.MAX_HEADING
+    MAX_HEADING: Final[int] = constants.LocationLimit.MAX_HEADING
     """:const:`telegram.constants.LocationLimit.MAX_HEADING`
 
     .. versionadded:: 20.0

--- a/telegram/_files/sticker.py
+++ b/telegram/_files/sticker.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains objects that represent stickers."""
-from typing import TYPE_CHECKING, ClassVar, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Final, Optional, Sequence, Tuple
 
 from telegram import constants
 from telegram._files._basethumbedmedium import _BaseThumbedMedium
@@ -192,11 +192,11 @@ class Sticker(_BaseThumbedMedium):
             self.custom_emoji_id: Optional[str] = custom_emoji_id
             self.needs_repainting: Optional[bool] = needs_repainting
 
-    REGULAR: ClassVar[str] = constants.StickerType.REGULAR
+    REGULAR: Final[str] = constants.StickerType.REGULAR
     """:const:`telegram.constants.StickerType.REGULAR`"""
-    MASK: ClassVar[str] = constants.StickerType.MASK
+    MASK: Final[str] = constants.StickerType.MASK
     """:const:`telegram.constants.StickerType.MASK`"""
-    CUSTOM_EMOJI: ClassVar[str] = constants.StickerType.CUSTOM_EMOJI
+    CUSTOM_EMOJI: Final[str] = constants.StickerType.CUSTOM_EMOJI
     """:const:`telegram.constants.StickerType.CUSTOM_EMOJI`"""
 
     @classmethod
@@ -390,13 +390,13 @@ class MaskPosition(TelegramObject):
 
     __slots__ = ("point", "scale", "x_shift", "y_shift")
 
-    FOREHEAD: ClassVar[str] = constants.MaskPosition.FOREHEAD
+    FOREHEAD: Final[str] = constants.MaskPosition.FOREHEAD
     """:const:`telegram.constants.MaskPosition.FOREHEAD`"""
-    EYES: ClassVar[str] = constants.MaskPosition.EYES
+    EYES: Final[str] = constants.MaskPosition.EYES
     """:const:`telegram.constants.MaskPosition.EYES`"""
-    MOUTH: ClassVar[str] = constants.MaskPosition.MOUTH
+    MOUTH: Final[str] = constants.MaskPosition.MOUTH
     """:const:`telegram.constants.MaskPosition.MOUTH`"""
-    CHIN: ClassVar[str] = constants.MaskPosition.CHIN
+    CHIN: Final[str] = constants.MaskPosition.CHIN
     """:const:`telegram.constants.MaskPosition.CHIN`"""
 
     def __init__(

--- a/telegram/_forcereply.py
+++ b/telegram/_forcereply.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represents a Telegram ForceReply."""
 
-from typing import ClassVar, Optional
+from typing import Final, Optional
 
 from telegram import constants
 from telegram._telegramobject import TelegramObject
@@ -93,12 +93,12 @@ class ForceReply(TelegramObject):
 
         self._freeze()
 
-    MIN_INPUT_FIELD_PLACEHOLDER: ClassVar[int] = constants.ReplyLimit.MIN_INPUT_FIELD_PLACEHOLDER
+    MIN_INPUT_FIELD_PLACEHOLDER: Final[int] = constants.ReplyLimit.MIN_INPUT_FIELD_PLACEHOLDER
     """:const:`telegram.constants.ReplyLimit.MIN_INPUT_FIELD_PLACEHOLDER`
 
     .. versionadded:: 20.0
     """
-    MAX_INPUT_FIELD_PLACEHOLDER: ClassVar[int] = constants.ReplyLimit.MAX_INPUT_FIELD_PLACEHOLDER
+    MAX_INPUT_FIELD_PLACEHOLDER: Final[int] = constants.ReplyLimit.MAX_INPUT_FIELD_PLACEHOLDER
     """:const:`telegram.constants.ReplyLimit.MAX_INPUT_FIELD_PLACEHOLDER`
 
     .. versionadded:: 20.0

--- a/telegram/_inline/inlinekeyboardbutton.py
+++ b/telegram/_inline/inlinekeyboardbutton.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represents a Telegram InlineKeyboardButton."""
 
-from typing import TYPE_CHECKING, ClassVar, Optional, Union
+from typing import TYPE_CHECKING, Final, Optional, Union
 
 from telegram import constants
 from telegram._games.callbackgame import CallbackGame
@@ -297,12 +297,12 @@ class InlineKeyboardButton(TelegramObject):
             self.callback_data = callback_data
             self._set_id_attrs()
 
-    MIN_CALLBACK_DATA: ClassVar[int] = constants.InlineKeyboardButtonLimit.MIN_CALLBACK_DATA
+    MIN_CALLBACK_DATA: Final[int] = constants.InlineKeyboardButtonLimit.MIN_CALLBACK_DATA
     """:const:`telegram.constants.InlineKeyboardButtonLimit.MIN_CALLBACK_DATA`
 
     .. versionadded:: 20.0
     """
-    MAX_CALLBACK_DATA: ClassVar[int] = constants.InlineKeyboardButtonLimit.MAX_CALLBACK_DATA
+    MAX_CALLBACK_DATA: Final[int] = constants.InlineKeyboardButtonLimit.MAX_CALLBACK_DATA
     """:const:`telegram.constants.InlineKeyboardButtonLimit.MAX_CALLBACK_DATA`
 
     .. versionadded:: 20.0

--- a/telegram/_inline/inlinequery.py
+++ b/telegram/_inline/inlinequery.py
@@ -19,7 +19,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represents a Telegram InlineQuery."""
 
-from typing import TYPE_CHECKING, Callable, ClassVar, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Callable, Final, Optional, Sequence, Union
 
 from telegram import constants
 from telegram._files.location import Location
@@ -202,27 +202,27 @@ class InlineQuery(TelegramObject):
             api_kwargs=api_kwargs,
         )
 
-    MAX_RESULTS: ClassVar[int] = constants.InlineQueryLimit.RESULTS
+    MAX_RESULTS: Final[int] = constants.InlineQueryLimit.RESULTS
     """:const:`telegram.constants.InlineQueryLimit.RESULTS`
 
     .. versionadded:: 13.2
     """
-    MIN_SWITCH_PM_TEXT_LENGTH: ClassVar[int] = constants.InlineQueryLimit.MIN_SWITCH_PM_TEXT_LENGTH
+    MIN_SWITCH_PM_TEXT_LENGTH: Final[int] = constants.InlineQueryLimit.MIN_SWITCH_PM_TEXT_LENGTH
     """:const:`telegram.constants.InlineQueryLimit.MIN_SWITCH_PM_TEXT_LENGTH`
 
     .. versionadded:: 20.0
     """
-    MAX_SWITCH_PM_TEXT_LENGTH: ClassVar[int] = constants.InlineQueryLimit.MAX_SWITCH_PM_TEXT_LENGTH
+    MAX_SWITCH_PM_TEXT_LENGTH: Final[int] = constants.InlineQueryLimit.MAX_SWITCH_PM_TEXT_LENGTH
     """:const:`telegram.constants.InlineQueryLimit.MAX_SWITCH_PM_TEXT_LENGTH`
 
     .. versionadded:: 20.0
     """
-    MAX_OFFSET_LENGTH: ClassVar[int] = constants.InlineQueryLimit.MAX_OFFSET_LENGTH
+    MAX_OFFSET_LENGTH: Final[int] = constants.InlineQueryLimit.MAX_OFFSET_LENGTH
     """:const:`telegram.constants.InlineQueryLimit.MAX_OFFSET_LENGTH`
 
     .. versionadded:: 20.0
     """
-    MAX_QUERY_LENGTH: ClassVar[int] = constants.InlineQueryLimit.MAX_QUERY_LENGTH
+    MAX_QUERY_LENGTH: Final[int] = constants.InlineQueryLimit.MAX_QUERY_LENGTH
     """:const:`telegram.constants.InlineQueryLimit.MAX_QUERY_LENGTH`
 
     .. versionadded:: 20.0

--- a/telegram/_inline/inlinequeryresult.py
+++ b/telegram/_inline/inlinequeryresult.py
@@ -19,7 +19,7 @@
 # pylint: disable=redefined-builtin
 """This module contains the classes that represent Telegram InlineQueryResult."""
 
-from typing import ClassVar, Optional
+from typing import Final, Optional
 
 from telegram import constants
 from telegram._telegramobject import TelegramObject
@@ -66,12 +66,12 @@ class InlineQueryResult(TelegramObject):
 
         self._freeze()
 
-    MIN_ID_LENGTH: ClassVar[int] = constants.InlineQueryResultLimit.MIN_ID_LENGTH
+    MIN_ID_LENGTH: Final[int] = constants.InlineQueryResultLimit.MIN_ID_LENGTH
     """:const:`telegram.constants.InlineQueryResultLimit.MIN_ID_LENGTH`
 
     .. versionadded:: 20.0
     """
-    MAX_ID_LENGTH: ClassVar[int] = constants.InlineQueryResultLimit.MAX_ID_LENGTH
+    MAX_ID_LENGTH: Final[int] = constants.InlineQueryResultLimit.MAX_ID_LENGTH
     """:const:`telegram.constants.InlineQueryResultLimit.MAX_ID_LENGTH`
 
     .. versionadded:: 20.0

--- a/telegram/_inline/inlinequeryresultlocation.py
+++ b/telegram/_inline/inlinequeryresultlocation.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains the classes that represent Telegram InlineQueryResultLocation."""
 
-from typing import TYPE_CHECKING, ClassVar, Optional
+from typing import TYPE_CHECKING, Final, Optional
 
 from telegram import constants
 from telegram._inline.inlinekeyboardmarkup import InlineKeyboardMarkup
@@ -244,37 +244,37 @@ class InlineQueryResultLocation(InlineQueryResult):
         )
         return self.thumbnail_height
 
-    HORIZONTAL_ACCURACY: ClassVar[int] = constants.LocationLimit.HORIZONTAL_ACCURACY
+    HORIZONTAL_ACCURACY: Final[int] = constants.LocationLimit.HORIZONTAL_ACCURACY
     """:const:`telegram.constants.LocationLimit.HORIZONTAL_ACCURACY`
 
     .. versionadded:: 20.0
     """
-    MIN_HEADING: ClassVar[int] = constants.LocationLimit.MIN_HEADING
+    MIN_HEADING: Final[int] = constants.LocationLimit.MIN_HEADING
     """:const:`telegram.constants.LocationLimit.MIN_HEADING`
 
     .. versionadded:: 20.0
     """
-    MAX_HEADING: ClassVar[int] = constants.LocationLimit.MAX_HEADING
+    MAX_HEADING: Final[int] = constants.LocationLimit.MAX_HEADING
     """:const:`telegram.constants.LocationLimit.MAX_HEADING`
 
     .. versionadded:: 20.0
     """
-    MIN_LIVE_PERIOD: ClassVar[int] = constants.LocationLimit.MIN_LIVE_PERIOD
+    MIN_LIVE_PERIOD: Final[int] = constants.LocationLimit.MIN_LIVE_PERIOD
     """:const:`telegram.constants.LocationLimit.MIN_LIVE_PERIOD`
 
     .. versionadded:: 20.0
     """
-    MAX_LIVE_PERIOD: ClassVar[int] = constants.LocationLimit.MAX_LIVE_PERIOD
+    MAX_LIVE_PERIOD: Final[int] = constants.LocationLimit.MAX_LIVE_PERIOD
     """:const:`telegram.constants.LocationLimit.MAX_LIVE_PERIOD`
 
     .. versionadded:: 20.0
     """
-    MIN_PROXIMITY_ALERT_RADIUS: ClassVar[int] = constants.LocationLimit.MIN_PROXIMITY_ALERT_RADIUS
+    MIN_PROXIMITY_ALERT_RADIUS: Final[int] = constants.LocationLimit.MIN_PROXIMITY_ALERT_RADIUS
     """:const:`telegram.constants.LocationLimit.MIN_PROXIMITY_ALERT_RADIUS`
 
     .. versionadded:: 20.0
     """
-    MAX_PROXIMITY_ALERT_RADIUS: ClassVar[int] = constants.LocationLimit.MAX_PROXIMITY_ALERT_RADIUS
+    MAX_PROXIMITY_ALERT_RADIUS: Final[int] = constants.LocationLimit.MAX_PROXIMITY_ALERT_RADIUS
     """:const:`telegram.constants.LocationLimit.MAX_PROXIMITY_ALERT_RADIUS`
 
     .. versionadded:: 20.0

--- a/telegram/_inline/inlinequeryresultsbutton.py
+++ b/telegram/_inline/inlinequeryresultsbutton.py
@@ -19,7 +19,7 @@
 # pylint: disable=redefined-builtin
 """This module contains the class that represent a Telegram InlineQueryResultsButton."""
 
-from typing import TYPE_CHECKING, ClassVar, Optional
+from typing import TYPE_CHECKING, Final, Optional
 
 from telegram import constants
 from telegram._telegramobject import TelegramObject
@@ -107,11 +107,11 @@ class InlineQueryResultsButton(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    MIN_START_PARAMETER_LENGTH: ClassVar[
+    MIN_START_PARAMETER_LENGTH: Final[
         int
     ] = constants.InlineQueryResultsButtonLimit.MIN_START_PARAMETER_LENGTH
     """:const:`telegram.constants.InlineQueryResultsButtonLimit.MIN_START_PARAMETER_LENGTH`"""
-    MAX_START_PARAMETER_LENGTH: ClassVar[
+    MAX_START_PARAMETER_LENGTH: Final[
         int
     ] = constants.InlineQueryResultsButtonLimit.MAX_START_PARAMETER_LENGTH
     """:const:`telegram.constants.InlineQueryResultsButtonLimit.MAX_START_PARAMETER_LENGTH`"""

--- a/telegram/_inline/inputlocationmessagecontent.py
+++ b/telegram/_inline/inputlocationmessagecontent.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains the classes that represent Telegram InputLocationMessageContent."""
 
-from typing import ClassVar, Optional
+from typing import Final, Optional
 
 from telegram import constants
 from telegram._inline.inputmessagecontent import InputMessageContent
@@ -106,37 +106,37 @@ class InputLocationMessageContent(InputMessageContent):
 
             self._id_attrs = (self.latitude, self.longitude)
 
-    HORIZONTAL_ACCURACY: ClassVar[int] = constants.LocationLimit.HORIZONTAL_ACCURACY
+    HORIZONTAL_ACCURACY: Final[int] = constants.LocationLimit.HORIZONTAL_ACCURACY
     """:const:`telegram.constants.LocationLimit.HORIZONTAL_ACCURACY`
 
     .. versionadded:: 20.0
     """
-    MIN_HEADING: ClassVar[int] = constants.LocationLimit.MIN_HEADING
+    MIN_HEADING: Final[int] = constants.LocationLimit.MIN_HEADING
     """:const:`telegram.constants.LocationLimit.MIN_HEADING`
 
     .. versionadded:: 20.0
     """
-    MAX_HEADING: ClassVar[int] = constants.LocationLimit.MAX_HEADING
+    MAX_HEADING: Final[int] = constants.LocationLimit.MAX_HEADING
     """:const:`telegram.constants.LocationLimit.MAX_HEADING`
 
     .. versionadded:: 20.0
     """
-    MIN_LIVE_PERIOD: ClassVar[int] = constants.LocationLimit.MIN_LIVE_PERIOD
+    MIN_LIVE_PERIOD: Final[int] = constants.LocationLimit.MIN_LIVE_PERIOD
     """:const:`telegram.constants.LocationLimit.MIN_LIVE_PERIOD`
 
     .. versionadded:: 20.0
     """
-    MAX_LIVE_PERIOD: ClassVar[int] = constants.LocationLimit.MAX_LIVE_PERIOD
+    MAX_LIVE_PERIOD: Final[int] = constants.LocationLimit.MAX_LIVE_PERIOD
     """:const:`telegram.constants.LocationLimit.MAX_LIVE_PERIOD`
 
     .. versionadded:: 20.0
     """
-    MIN_PROXIMITY_ALERT_RADIUS: ClassVar[int] = constants.LocationLimit.MIN_PROXIMITY_ALERT_RADIUS
+    MIN_PROXIMITY_ALERT_RADIUS: Final[int] = constants.LocationLimit.MIN_PROXIMITY_ALERT_RADIUS
     """:const:`telegram.constants.LocationLimit.MIN_PROXIMITY_ALERT_RADIUS`
 
     .. versionadded:: 20.0
     """
-    MAX_PROXIMITY_ALERT_RADIUS: ClassVar[int] = constants.LocationLimit.MAX_PROXIMITY_ALERT_RADIUS
+    MAX_PROXIMITY_ALERT_RADIUS: Final[int] = constants.LocationLimit.MAX_PROXIMITY_ALERT_RADIUS
     """:const:`telegram.constants.LocationLimit.MAX_PROXIMITY_ALERT_RADIUS`
 
     .. versionadded:: 20.0

--- a/telegram/_menubutton.py
+++ b/telegram/_menubutton.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains objects related to Telegram menu buttons."""
-from typing import TYPE_CHECKING, ClassVar, Dict, Optional, Type
+from typing import TYPE_CHECKING, Dict, Final, Optional, Type
 
 from telegram import constants
 from telegram._telegramobject import TelegramObject
@@ -95,11 +95,11 @@ class MenuButton(TelegramObject):
             return _class_mapping[data.pop("type")].de_json(data, bot=bot)
         return super().de_json(data=data, bot=bot)
 
-    COMMANDS: ClassVar[str] = constants.MenuButtonType.COMMANDS
+    COMMANDS: Final[str] = constants.MenuButtonType.COMMANDS
     """:const:`telegram.constants.MenuButtonType.COMMANDS`"""
-    WEB_APP: ClassVar[str] = constants.MenuButtonType.WEB_APP
+    WEB_APP: Final[str] = constants.MenuButtonType.WEB_APP
     """:const:`telegram.constants.MenuButtonType.WEB_APP`"""
-    DEFAULT: ClassVar[str] = constants.MenuButtonType.DEFAULT
+    DEFAULT: Final[str] = constants.MenuButtonType.DEFAULT
     """:const:`telegram.constants.MenuButtonType.DEFAULT`"""
 
 

--- a/telegram/_messageentity.py
+++ b/telegram/_messageentity.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represents a Telegram MessageEntity."""
 
-from typing import TYPE_CHECKING, ClassVar, List, Optional
+from typing import TYPE_CHECKING, Final, List, Optional
 
 from telegram import constants
 from telegram._telegramobject import TelegramObject
@@ -130,45 +130,45 @@ class MessageEntity(TelegramObject):
 
         return super().de_json(data=data, bot=bot)
 
-    MENTION: ClassVar[str] = constants.MessageEntityType.MENTION
+    MENTION: Final[str] = constants.MessageEntityType.MENTION
     """:const:`telegram.constants.MessageEntityType.MENTION`"""
-    HASHTAG: ClassVar[str] = constants.MessageEntityType.HASHTAG
+    HASHTAG: Final[str] = constants.MessageEntityType.HASHTAG
     """:const:`telegram.constants.MessageEntityType.HASHTAG`"""
-    CASHTAG: ClassVar[str] = constants.MessageEntityType.CASHTAG
+    CASHTAG: Final[str] = constants.MessageEntityType.CASHTAG
     """:const:`telegram.constants.MessageEntityType.CASHTAG`"""
-    PHONE_NUMBER: ClassVar[str] = constants.MessageEntityType.PHONE_NUMBER
+    PHONE_NUMBER: Final[str] = constants.MessageEntityType.PHONE_NUMBER
     """:const:`telegram.constants.MessageEntityType.PHONE_NUMBER`"""
-    BOT_COMMAND: ClassVar[str] = constants.MessageEntityType.BOT_COMMAND
+    BOT_COMMAND: Final[str] = constants.MessageEntityType.BOT_COMMAND
     """:const:`telegram.constants.MessageEntityType.BOT_COMMAND`"""
-    URL: ClassVar[str] = constants.MessageEntityType.URL
+    URL: Final[str] = constants.MessageEntityType.URL
     """:const:`telegram.constants.MessageEntityType.URL`"""
-    EMAIL: ClassVar[str] = constants.MessageEntityType.EMAIL
+    EMAIL: Final[str] = constants.MessageEntityType.EMAIL
     """:const:`telegram.constants.MessageEntityType.EMAIL`"""
-    BOLD: ClassVar[str] = constants.MessageEntityType.BOLD
+    BOLD: Final[str] = constants.MessageEntityType.BOLD
     """:const:`telegram.constants.MessageEntityType.BOLD`"""
-    ITALIC: ClassVar[str] = constants.MessageEntityType.ITALIC
+    ITALIC: Final[str] = constants.MessageEntityType.ITALIC
     """:const:`telegram.constants.MessageEntityType.ITALIC`"""
-    CODE: ClassVar[str] = constants.MessageEntityType.CODE
+    CODE: Final[str] = constants.MessageEntityType.CODE
     """:const:`telegram.constants.MessageEntityType.CODE`"""
-    PRE: ClassVar[str] = constants.MessageEntityType.PRE
+    PRE: Final[str] = constants.MessageEntityType.PRE
     """:const:`telegram.constants.MessageEntityType.PRE`"""
-    TEXT_LINK: ClassVar[str] = constants.MessageEntityType.TEXT_LINK
+    TEXT_LINK: Final[str] = constants.MessageEntityType.TEXT_LINK
     """:const:`telegram.constants.MessageEntityType.TEXT_LINK`"""
-    TEXT_MENTION: ClassVar[str] = constants.MessageEntityType.TEXT_MENTION
+    TEXT_MENTION: Final[str] = constants.MessageEntityType.TEXT_MENTION
     """:const:`telegram.constants.MessageEntityType.TEXT_MENTION`"""
-    UNDERLINE: ClassVar[str] = constants.MessageEntityType.UNDERLINE
+    UNDERLINE: Final[str] = constants.MessageEntityType.UNDERLINE
     """:const:`telegram.constants.MessageEntityType.UNDERLINE`"""
-    STRIKETHROUGH: ClassVar[str] = constants.MessageEntityType.STRIKETHROUGH
+    STRIKETHROUGH: Final[str] = constants.MessageEntityType.STRIKETHROUGH
     """:const:`telegram.constants.MessageEntityType.STRIKETHROUGH`"""
-    SPOILER: ClassVar[str] = constants.MessageEntityType.SPOILER
+    SPOILER: Final[str] = constants.MessageEntityType.SPOILER
     """:const:`telegram.constants.MessageEntityType.SPOILER`
 
     .. versionadded:: 13.10
     """
-    CUSTOM_EMOJI: ClassVar[str] = constants.MessageEntityType.CUSTOM_EMOJI
+    CUSTOM_EMOJI: Final[str] = constants.MessageEntityType.CUSTOM_EMOJI
     """:const:`telegram.constants.MessageEntityType.CUSTOM_EMOJI`
 
     .. versionadded:: 20.0
     """
-    ALL_TYPES: ClassVar[List[str]] = list(constants.MessageEntityType)
+    ALL_TYPES: Final[List[str]] = list(constants.MessageEntityType)
     """List[:obj:`str`]: A list of all available message entity types."""

--- a/telegram/_payment/invoice.py
+++ b/telegram/_payment/invoice.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represents a Telegram Invoice."""
 
-from typing import ClassVar, Optional
+from typing import Final, Optional
 
 from telegram import constants
 from telegram._telegramobject import TelegramObject
@@ -95,37 +95,37 @@ class Invoice(TelegramObject):
 
         self._freeze()
 
-    MIN_TITLE_LENGTH: ClassVar[int] = constants.InvoiceLimit.MIN_TITLE_LENGTH
+    MIN_TITLE_LENGTH: Final[int] = constants.InvoiceLimit.MIN_TITLE_LENGTH
     """:const:`telegram.constants.InvoiceLimit.MIN_TITLE_LENGTH`
 
     .. versionadded:: 20.0
     """
-    MAX_TITLE_LENGTH: ClassVar[int] = constants.InvoiceLimit.MAX_TITLE_LENGTH
+    MAX_TITLE_LENGTH: Final[int] = constants.InvoiceLimit.MAX_TITLE_LENGTH
     """:const:`telegram.constants.InvoiceLimit.MAX_TITLE_LENGTH`
 
     .. versionadded:: 20.0
     """
-    MIN_DESCRIPTION_LENGTH: ClassVar[int] = constants.InvoiceLimit.MIN_DESCRIPTION_LENGTH
+    MIN_DESCRIPTION_LENGTH: Final[int] = constants.InvoiceLimit.MIN_DESCRIPTION_LENGTH
     """:const:`telegram.constants.InvoiceLimit.MIN_DESCRIPTION_LENGTH`
 
     .. versionadded:: 20.0
     """
-    MAX_DESCRIPTION_LENGTH: ClassVar[int] = constants.InvoiceLimit.MAX_DESCRIPTION_LENGTH
+    MAX_DESCRIPTION_LENGTH: Final[int] = constants.InvoiceLimit.MAX_DESCRIPTION_LENGTH
     """:const:`telegram.constants.InvoiceLimit.MAX_DESCRIPTION_LENGTH`
 
     .. versionadded:: 20.0
     """
-    MIN_PAYLOAD_LENGTH: ClassVar[int] = constants.InvoiceLimit.MIN_PAYLOAD_LENGTH
+    MIN_PAYLOAD_LENGTH: Final[int] = constants.InvoiceLimit.MIN_PAYLOAD_LENGTH
     """:const:`telegram.constants.InvoiceLimit.MIN_PAYLOAD_LENGTH`
 
     .. versionadded:: 20.0
     """
-    MAX_PAYLOAD_LENGTH: ClassVar[int] = constants.InvoiceLimit.MAX_PAYLOAD_LENGTH
+    MAX_PAYLOAD_LENGTH: Final[int] = constants.InvoiceLimit.MAX_PAYLOAD_LENGTH
     """:const:`telegram.constants.InvoiceLimit.MAX_PAYLOAD_LENGTH`
 
     .. versionadded:: 20.0
     """
-    MAX_TIP_AMOUNTS: ClassVar[int] = constants.InvoiceLimit.MAX_TIP_AMOUNTS
+    MAX_TIP_AMOUNTS: Final[int] = constants.InvoiceLimit.MAX_TIP_AMOUNTS
     """:const:`telegram.constants.InvoiceLimit.MAX_TIP_AMOUNTS`
 
     .. versionadded:: 20.0

--- a/telegram/_poll.py
+++ b/telegram/_poll.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represents a Telegram Poll."""
 import datetime
-from typing import TYPE_CHECKING, ClassVar, Dict, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Dict, Final, List, Optional, Sequence, Tuple
 
 from telegram import constants
 from telegram._messageentity import MessageEntity
@@ -65,12 +65,12 @@ class PollOption(TelegramObject):
 
         self._freeze()
 
-    MIN_LENGTH: ClassVar[int] = constants.PollLimit.MIN_OPTION_LENGTH
+    MIN_LENGTH: Final[int] = constants.PollLimit.MIN_OPTION_LENGTH
     """:const:`telegram.constants.PollLimit.MIN_OPTION_LENGTH`
 
     .. versionadded:: 20.0
     """
-    MAX_LENGTH: ClassVar[int] = constants.PollLimit.MAX_OPTION_LENGTH
+    MAX_LENGTH: Final[int] = constants.PollLimit.MAX_OPTION_LENGTH
     """:const:`telegram.constants.PollLimit.MAX_OPTION_LENGTH`
 
     .. versionadded:: 20.0
@@ -350,56 +350,56 @@ class Poll(TelegramObject):
             if entity.type in types
         }
 
-    REGULAR: ClassVar[str] = constants.PollType.REGULAR
+    REGULAR: Final[str] = constants.PollType.REGULAR
     """:const:`telegram.constants.PollType.REGULAR`"""
-    QUIZ: ClassVar[str] = constants.PollType.QUIZ
+    QUIZ: Final[str] = constants.PollType.QUIZ
     """:const:`telegram.constants.PollType.QUIZ`"""
-    MAX_EXPLANATION_LENGTH: ClassVar[int] = constants.PollLimit.MAX_EXPLANATION_LENGTH
+    MAX_EXPLANATION_LENGTH: Final[int] = constants.PollLimit.MAX_EXPLANATION_LENGTH
     """:const:`telegram.constants.PollLimit.MAX_EXPLANATION_LENGTH`
 
     .. versionadded:: 20.0
     """
-    MAX_EXPLANATION_LINE_FEEDS: ClassVar[int] = constants.PollLimit.MAX_EXPLANATION_LINE_FEEDS
+    MAX_EXPLANATION_LINE_FEEDS: Final[int] = constants.PollLimit.MAX_EXPLANATION_LINE_FEEDS
     """:const:`telegram.constants.PollLimit.MAX_EXPLANATION_LINE_FEEDS`
 
     .. versionadded:: 20.0
     """
-    MIN_OPEN_PERIOD: ClassVar[int] = constants.PollLimit.MIN_OPEN_PERIOD
+    MIN_OPEN_PERIOD: Final[int] = constants.PollLimit.MIN_OPEN_PERIOD
     """:const:`telegram.constants.PollLimit.MIN_OPEN_PERIOD`
 
     .. versionadded:: 20.0
     """
-    MAX_OPEN_PERIOD: ClassVar[int] = constants.PollLimit.MAX_OPEN_PERIOD
+    MAX_OPEN_PERIOD: Final[int] = constants.PollLimit.MAX_OPEN_PERIOD
     """:const:`telegram.constants.PollLimit.MAX_OPEN_PERIOD`
 
     .. versionadded:: 20.0
     """
-    MIN_QUESTION_LENGTH: ClassVar[int] = constants.PollLimit.MIN_QUESTION_LENGTH
+    MIN_QUESTION_LENGTH: Final[int] = constants.PollLimit.MIN_QUESTION_LENGTH
     """:const:`telegram.constants.PollLimit.MIN_QUESTION_LENGTH`
 
     .. versionadded:: 20.0
     """
-    MAX_QUESTION_LENGTH: ClassVar[int] = constants.PollLimit.MAX_QUESTION_LENGTH
+    MAX_QUESTION_LENGTH: Final[int] = constants.PollLimit.MAX_QUESTION_LENGTH
     """:const:`telegram.constants.PollLimit.MAX_QUESTION_LENGTH`
 
     .. versionadded:: 20.0
     """
-    MIN_OPTION_LENGTH: ClassVar[int] = constants.PollLimit.MIN_OPTION_LENGTH
+    MIN_OPTION_LENGTH: Final[int] = constants.PollLimit.MIN_OPTION_LENGTH
     """:const:`telegram.constants.PollLimit.MIN_OPTION_LENGTH`
 
     .. versionadded:: 20.0
     """
-    MAX_OPTION_LENGTH: ClassVar[int] = constants.PollLimit.MAX_OPTION_LENGTH
+    MAX_OPTION_LENGTH: Final[int] = constants.PollLimit.MAX_OPTION_LENGTH
     """:const:`telegram.constants.PollLimit.MAX_OPTION_LENGTH`
 
     .. versionadded:: 20.0
     """
-    MIN_OPTION_NUMBER: ClassVar[int] = constants.PollLimit.MIN_OPTION_NUMBER
+    MIN_OPTION_NUMBER: Final[int] = constants.PollLimit.MIN_OPTION_NUMBER
     """:const:`telegram.constants.PollLimit.MIN_OPTION_NUMBER`
 
     .. versionadded:: 20.0
     """
-    MAX_OPTION_NUMBER: ClassVar[int] = constants.PollLimit.MAX_OPTION_NUMBER
+    MAX_OPTION_NUMBER: Final[int] = constants.PollLimit.MAX_OPTION_NUMBER
     """:const:`telegram.constants.PollLimit.MAX_OPTION_NUMBER`
 
     .. versionadded:: 20.0

--- a/telegram/_replykeyboardmarkup.py
+++ b/telegram/_replykeyboardmarkup.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represents a Telegram ReplyKeyboardMarkup."""
 
-from typing import ClassVar, Optional, Sequence, Tuple, Union
+from typing import Final, Optional, Sequence, Tuple, Union
 
 from telegram import constants
 from telegram._keyboardbutton import KeyboardButton
@@ -346,12 +346,12 @@ class ReplyKeyboardMarkup(TelegramObject):
             **kwargs,  # type: ignore[arg-type]
         )
 
-    MIN_INPUT_FIELD_PLACEHOLDER: ClassVar[int] = constants.ReplyLimit.MIN_INPUT_FIELD_PLACEHOLDER
+    MIN_INPUT_FIELD_PLACEHOLDER: Final[int] = constants.ReplyLimit.MIN_INPUT_FIELD_PLACEHOLDER
     """:const:`telegram.constants.ReplyLimit.MIN_INPUT_FIELD_PLACEHOLDER`
 
     .. versionadded:: 20.0
     """
-    MAX_INPUT_FIELD_PLACEHOLDER: ClassVar[int] = constants.ReplyLimit.MAX_INPUT_FIELD_PLACEHOLDER
+    MAX_INPUT_FIELD_PLACEHOLDER: Final[int] = constants.ReplyLimit.MAX_INPUT_FIELD_PLACEHOLDER
     """:const:`telegram.constants.ReplyLimit.MAX_INPUT_FIELD_PLACEHOLDER`
 
     .. versionadded:: 20.0

--- a/telegram/_update.py
+++ b/telegram/_update.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represents a Telegram Update."""
 
-from typing import TYPE_CHECKING, ClassVar, List, Optional
+from typing import TYPE_CHECKING, Final, List, Optional
 
 from telegram import constants
 from telegram._callbackquery import CallbackQuery
@@ -171,55 +171,55 @@ class Update(TelegramObject):
         "chat_join_request",
     )
 
-    MESSAGE: ClassVar[str] = constants.UpdateType.MESSAGE
+    MESSAGE: Final[str] = constants.UpdateType.MESSAGE
     """:const:`telegram.constants.UpdateType.MESSAGE`
 
     .. versionadded:: 13.5"""
-    EDITED_MESSAGE: ClassVar[str] = constants.UpdateType.EDITED_MESSAGE
+    EDITED_MESSAGE: Final[str] = constants.UpdateType.EDITED_MESSAGE
     """:const:`telegram.constants.UpdateType.EDITED_MESSAGE`
 
     .. versionadded:: 13.5"""
-    CHANNEL_POST: ClassVar[str] = constants.UpdateType.CHANNEL_POST
+    CHANNEL_POST: Final[str] = constants.UpdateType.CHANNEL_POST
     """:const:`telegram.constants.UpdateType.CHANNEL_POST`
 
     .. versionadded:: 13.5"""
-    EDITED_CHANNEL_POST: ClassVar[str] = constants.UpdateType.EDITED_CHANNEL_POST
+    EDITED_CHANNEL_POST: Final[str] = constants.UpdateType.EDITED_CHANNEL_POST
     """:const:`telegram.constants.UpdateType.EDITED_CHANNEL_POST`
 
     .. versionadded:: 13.5"""
-    INLINE_QUERY: ClassVar[str] = constants.UpdateType.INLINE_QUERY
+    INLINE_QUERY: Final[str] = constants.UpdateType.INLINE_QUERY
     """:const:`telegram.constants.UpdateType.INLINE_QUERY`
 
     .. versionadded:: 13.5"""
-    CHOSEN_INLINE_RESULT: ClassVar[str] = constants.UpdateType.CHOSEN_INLINE_RESULT
+    CHOSEN_INLINE_RESULT: Final[str] = constants.UpdateType.CHOSEN_INLINE_RESULT
     """:const:`telegram.constants.UpdateType.CHOSEN_INLINE_RESULT`
 
     .. versionadded:: 13.5"""
-    CALLBACK_QUERY: ClassVar[str] = constants.UpdateType.CALLBACK_QUERY
+    CALLBACK_QUERY: Final[str] = constants.UpdateType.CALLBACK_QUERY
     """:const:`telegram.constants.UpdateType.CALLBACK_QUERY`
 
     .. versionadded:: 13.5"""
-    SHIPPING_QUERY: ClassVar[str] = constants.UpdateType.SHIPPING_QUERY
+    SHIPPING_QUERY: Final[str] = constants.UpdateType.SHIPPING_QUERY
     """:const:`telegram.constants.UpdateType.SHIPPING_QUERY`
 
     .. versionadded:: 13.5"""
-    PRE_CHECKOUT_QUERY: ClassVar[str] = constants.UpdateType.PRE_CHECKOUT_QUERY
+    PRE_CHECKOUT_QUERY: Final[str] = constants.UpdateType.PRE_CHECKOUT_QUERY
     """:const:`telegram.constants.UpdateType.PRE_CHECKOUT_QUERY`
 
     .. versionadded:: 13.5"""
-    POLL: ClassVar[str] = constants.UpdateType.POLL
+    POLL: Final[str] = constants.UpdateType.POLL
     """:const:`telegram.constants.UpdateType.POLL`
 
     .. versionadded:: 13.5"""
-    POLL_ANSWER: ClassVar[str] = constants.UpdateType.POLL_ANSWER
+    POLL_ANSWER: Final[str] = constants.UpdateType.POLL_ANSWER
     """:const:`telegram.constants.UpdateType.POLL_ANSWER`
 
     .. versionadded:: 13.5"""
-    MY_CHAT_MEMBER: ClassVar[str] = constants.UpdateType.MY_CHAT_MEMBER
+    MY_CHAT_MEMBER: Final[str] = constants.UpdateType.MY_CHAT_MEMBER
     """:const:`telegram.constants.UpdateType.MY_CHAT_MEMBER`
 
     .. versionadded:: 13.5"""
-    CHAT_MEMBER: ClassVar[str] = constants.UpdateType.CHAT_MEMBER
+    CHAT_MEMBER: Final[str] = constants.UpdateType.CHAT_MEMBER
     """:const:`telegram.constants.UpdateType.CHAT_MEMBER`
 
     .. versionadded:: 13.5"""
@@ -227,7 +227,7 @@ class Update(TelegramObject):
     """:const:`telegram.constants.UpdateType.CHAT_JOIN_REQUEST`
 
     .. versionadded:: 13.8"""
-    ALL_TYPES: ClassVar[List[str]] = list(constants.UpdateType)
+    ALL_TYPES: Final[List[str]] = list(constants.UpdateType)
     """List[:obj:`str`]: A list of all available update types.
 
     .. versionadded:: 13.5"""

--- a/telegram/_update.py
+++ b/telegram/_update.py
@@ -223,7 +223,7 @@ class Update(TelegramObject):
     """:const:`telegram.constants.UpdateType.CHAT_MEMBER`
 
     .. versionadded:: 13.5"""
-    CHAT_JOIN_REQUEST = constants.UpdateType.CHAT_JOIN_REQUEST
+    CHAT_JOIN_REQUEST: Final[str] = constants.UpdateType.CHAT_JOIN_REQUEST
     """:const:`telegram.constants.UpdateType.CHAT_JOIN_REQUEST`
 
     .. versionadded:: 13.8"""

--- a/telegram/_utils/types.py
+++ b/telegram/_utils/types.py
@@ -24,7 +24,18 @@ Warning:
     the changelog.
 """
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any, Collection, Dict, Optional, Tuple, TypeVar, Union
+from typing import (
+    IO,
+    TYPE_CHECKING,
+    Any,
+    Collection,
+    Dict,
+    Literal,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 if TYPE_CHECKING:
     from telegram import (
@@ -75,3 +86,8 @@ FieldTuple = Tuple[str, bytes, str]
 """Alias for return type of `InputFile.field_tuple`."""
 UploadFileDict = Dict[str, FieldTuple]
 """Dictionary containing file data to be uploaded to the API."""
+
+HTTPVersion = Literal["1.1", "2.0"]
+"""Allowed HTTP versions.
+
+.. versionadded:: NEXT.VERSION"""

--- a/telegram/_version.py
+++ b/telegram/_version.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 # pylint: disable=missing-module-docstring
-from typing import NamedTuple
+from typing import Final, NamedTuple
 
 __all__ = ("__version__", "__version_info__", "__bot_api_version__", "__bot_api_version_info__")
 
@@ -50,8 +50,10 @@ class Version(NamedTuple):
         return version
 
 
-__version_info__ = Version(major=20, minor=3, micro=0, releaselevel="final", serial=0)
-__version__ = str(__version_info__)
+__version_info__: Final[Version] = Version(
+    major=20, minor=3, micro=0, releaselevel="final", serial=0
+)
+__version__: Final[str] = str(__version_info__)
 
 # # SETUP.PY MARKER
 # Lines above this line will be `exec`-cuted in setup.py. Make sure that this only contains
@@ -59,5 +61,7 @@ __version__ = str(__version_info__)
 
 from telegram import constants  # noqa: E402  # pylint: disable=wrong-import-position
 
-__bot_api_version__ = constants.BOT_API_VERSION
-__bot_api_version_info__ = constants.BOT_API_VERSION_INFO
+__bot_api_version__: Final[str] = constants.BOT_API_VERSION
+__bot_api_version_info__: Final[
+    constants._BotAPIVersion
+] = constants.BOT_API_VERSION_INFO  # pylint: disable=protected-access

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -86,7 +86,7 @@ __all__ = [
 ]
 
 import sys
-from typing import List, NamedTuple
+from typing import Final, List, NamedTuple
 
 from telegram._utils.enum import IntEnum, StringEnum
 
@@ -116,19 +116,19 @@ class _BotAPIVersion(NamedTuple):
 #: :data:`telegram.__bot_api_version_info__`.
 #:
 #: .. versionadded:: 20.0
-BOT_API_VERSION_INFO = _BotAPIVersion(major=6, minor=7)
+BOT_API_VERSION_INFO: Final[_BotAPIVersion] = _BotAPIVersion(major=6, minor=7)
 #: :obj:`str`: Telegram Bot API
 #: version supported by this version of `python-telegram-bot`. Also available as
 #: :data:`telegram.__bot_api_version__`.
 #:
 #: .. versionadded:: 13.4
-BOT_API_VERSION = str(BOT_API_VERSION_INFO)
+BOT_API_VERSION: Final[str] = str(BOT_API_VERSION_INFO)
 
 # constants above this line are tested
 
 #: List[:obj:`int`]: Ports supported by
 #:  :paramref:`telegram.Bot.set_webhook.url`.
-SUPPORTED_WEBHOOK_PORTS: List[int] = [443, 80, 88, 8443]
+SUPPORTED_WEBHOOK_PORTS: Final[List[int]] = [443, 80, 88, 8443]
 
 
 class BotCommandLimit(IntEnum):

--- a/telegram/ext/_applicationbuilder.py
+++ b/telegram/ext/_applicationbuilder.py
@@ -34,14 +34,14 @@ from typing import (
 
 from telegram._bot import Bot
 from telegram._utils.defaultvalue import DEFAULT_FALSE, DEFAULT_NONE, DefaultValue
-from telegram._utils.types import DVInput, DVType, FilePathInput, ODVInput
+from telegram._utils.types import DVInput, DVType, FilePathInput, HTTPVersion, ODVInput
 from telegram.ext._application import Application
 from telegram.ext._baseupdateprocessor import BaseUpdateProcessor, SimpleUpdateProcessor
 from telegram.ext._contexttypes import ContextTypes
 from telegram.ext._extbot import ExtBot
 from telegram.ext._jobqueue import JobQueue
 from telegram.ext._updater import Updater
-from telegram.ext._utils.types import BD, BT, CCT, CD, JQ, UD, HTTPVersion
+from telegram.ext._utils.types import BD, BT, CCT, CD, JQ, UD
 from telegram.request import BaseRequest
 from telegram.request._httpxrequest import HTTPXRequest
 

--- a/telegram/ext/_applicationbuilder.py
+++ b/telegram/ext/_applicationbuilder.py
@@ -26,7 +26,6 @@ from typing import (
     Coroutine,
     Dict,
     Generic,
-    Literal,
     Optional,
     Type,
     TypeVar,
@@ -42,7 +41,7 @@ from telegram.ext._contexttypes import ContextTypes
 from telegram.ext._extbot import ExtBot
 from telegram.ext._jobqueue import JobQueue
 from telegram.ext._updater import Updater
-from telegram.ext._utils.types import BD, BT, CCT, CD, JQ, UD
+from telegram.ext._utils.types import BD, BT, CCT, CD, JQ, UD, HTTPVersion
 from telegram.request import BaseRequest
 from telegram.request._httpxrequest import HTTPXRequest
 
@@ -565,7 +564,7 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         self._pool_timeout = pool_timeout
         return self
 
-    def http_version(self: BuilderType, http_version: Literal["1.1", "2"]) -> BuilderType:
+    def http_version(self: BuilderType, http_version: HTTPVersion) -> BuilderType:
         """Sets the HTTP protocol version which is used for the
         :paramref:`~telegram.request.HTTPXRequest.http_version` parameter of
         :attr:`telegram.Bot.request`. By default, HTTP/1.1 is used.
@@ -725,7 +724,7 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         return self
 
     def get_updates_http_version(
-        self: BuilderType, get_updates_http_version: Literal["1.1", "2"]
+        self: BuilderType, get_updates_http_version: HTTPVersion
     ) -> BuilderType:
         """Sets the HTTP protocol version which is used for the
         :paramref:`~telegram.request.HTTPXRequest.http_version` parameter which is used in the

--- a/telegram/ext/_applicationbuilder.py
+++ b/telegram/ext/_applicationbuilder.py
@@ -26,6 +26,7 @@ from typing import (
     Coroutine,
     Dict,
     Generic,
+    Literal,
     Optional,
     Type,
     TypeVar,
@@ -240,7 +241,7 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         return HTTPXRequest(
             connection_pool_size=connection_pool_size,
             proxy_url=proxy_url,
-            http_version=http_version,
+            http_version=http_version,  # type: ignore[arg-type]
             **effective_timeouts,
         )
 
@@ -564,7 +565,7 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         self._pool_timeout = pool_timeout
         return self
 
-    def http_version(self: BuilderType, http_version: str) -> BuilderType:
+    def http_version(self: BuilderType, http_version: Literal["1.1", "2"]) -> BuilderType:
         """Sets the HTTP protocol version which is used for the
         :paramref:`~telegram.request.HTTPXRequest.http_version` parameter of
         :attr:`telegram.Bot.request`. By default, HTTP/1.1 is used.
@@ -723,7 +724,9 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         self._get_updates_pool_timeout = get_updates_pool_timeout
         return self
 
-    def get_updates_http_version(self: BuilderType, get_updates_http_version: str) -> BuilderType:
+    def get_updates_http_version(
+        self: BuilderType, get_updates_http_version: Literal["1.1", "2"]
+    ) -> BuilderType:
         """Sets the HTTP protocol version which is used for the
         :paramref:`~telegram.request.HTTPXRequest.http_version` parameter which is used in the
         :meth:`telegram.Bot.get_updates` request. By default, HTTP/1.1 is used.

--- a/telegram/ext/_baseupdateprocessor.py
+++ b/telegram/ext/_baseupdateprocessor.py
@@ -20,7 +20,7 @@
 from abc import ABC, abstractmethod
 from asyncio import BoundedSemaphore
 from types import TracebackType
-from typing import Any, Awaitable, Optional, Type
+from typing import Any, Awaitable, Optional, Type, final
 
 
 class BaseUpdateProcessor(ABC):
@@ -88,6 +88,7 @@ class BaseUpdateProcessor(ABC):
             :meth:`initialize`
         """
 
+    @final
     async def process_update(
         self,
         update: object,

--- a/telegram/ext/_chatmemberhandler.py
+++ b/telegram/ext/_chatmemberhandler.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains the ChatMemberHandler class."""
-from typing import ClassVar, Optional, TypeVar
+from typing import Final, Optional, TypeVar
 
 from telegram import Update
 from telegram._utils.defaultvalue import DEFAULT_TRUE
@@ -71,11 +71,11 @@ class ChatMemberHandler(BaseHandler[Update, CCT]):
     """
 
     __slots__ = ("chat_member_types",)
-    MY_CHAT_MEMBER: ClassVar[int] = -1
+    MY_CHAT_MEMBER: Final[int] = -1
     """:obj:`int`: Used as a constant to handle only :attr:`telegram.Update.my_chat_member`."""
-    CHAT_MEMBER: ClassVar[int] = 0
+    CHAT_MEMBER: Final[int] = 0
     """:obj:`int`: Used as a constant to handle only :attr:`telegram.Update.chat_member`."""
-    ANY_CHAT_MEMBER: ClassVar[int] = 1
+    ANY_CHAT_MEMBER: Final[int] = 1
     """:obj:`int`: Used as a constant to handle both :attr:`telegram.Update.my_chat_member`
     and :attr:`telegram.Update.chat_member`."""
 

--- a/telegram/ext/_conversationhandler.py
+++ b/telegram/ext/_conversationhandler.py
@@ -23,8 +23,8 @@ from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
-    ClassVar,
     Dict,
+    Final,
     Generic,
     List,
     NoReturn,
@@ -283,13 +283,13 @@ class ConversationHandler(BaseHandler[Update, CCT]):
         "timeout_jobs",
     )
 
-    END: ClassVar[int] = -1
+    END: Final[int] = -1
     """:obj:`int`: Used as a constant to return when a conversation is ended."""
-    TIMEOUT: ClassVar[int] = -2
+    TIMEOUT: Final[int] = -2
     """:obj:`int`: Used as a constant to handle state when a conversation is timed out
     (exceeded :attr:`conversation_timeout`).
     """
-    WAITING: ClassVar[int] = -3
+    WAITING: Final[int] = -3
     """:obj:`int`: Used as a constant to handle state when a conversation is still waiting on the
     previous :attr:`block=False <block>` handler to finish."""
 

--- a/telegram/ext/_utils/trackingdict.py
+++ b/telegram/ext/_utils/trackingdict.py
@@ -26,7 +26,7 @@ Warning:
     the changelog.
 """
 from collections import UserDict
-from typing import ClassVar, Generic, List, Mapping, Optional, Set, Tuple, TypeVar, Union
+from typing import Final, Generic, List, Mapping, Optional, Set, Tuple, TypeVar, Union
 
 from telegram._utils.defaultvalue import DEFAULT_NONE, DefaultValue
 
@@ -45,7 +45,7 @@ class TrackingDict(UserDict, Generic[_KT, _VT]):
         * deleting values is considered writing
     """
 
-    DELETED: ClassVar = object()
+    DELETED: Final = object()
     """Special marker indicating that an entry was deleted."""
 
     __slots__ = ("_write_access_keys",)

--- a/telegram/ext/_utils/types.py
+++ b/telegram/ext/_utils/types.py
@@ -32,6 +32,7 @@ from typing import (
     Coroutine,
     Dict,
     List,
+    Literal,
     MutableMapping,
     Tuple,
     TypeVar,
@@ -114,3 +115,8 @@ RLARGS = TypeVar("RLARGS")
 
 .. versionadded:: 20.0"""
 FilterDataDict = Dict[str, List[Any]]
+
+HTTPVersion = Literal["1.1", "2.0"]
+"""Allowed HTTP versions.
+
+.. versionadded:: NEXT.VERSION"""

--- a/telegram/ext/_utils/types.py
+++ b/telegram/ext/_utils/types.py
@@ -32,7 +32,6 @@ from typing import (
     Coroutine,
     Dict,
     List,
-    Literal,
     MutableMapping,
     Tuple,
     TypeVar,
@@ -115,8 +114,3 @@ RLARGS = TypeVar("RLARGS")
 
 .. versionadded:: 20.0"""
 FilterDataDict = Dict[str, List[Any]]
-
-HTTPVersion = Literal["1.1", "2.0"]
-"""Allowed HTTP versions.
-
-.. versionadded:: NEXT.VERSION"""

--- a/telegram/request/_baserequest.py
+++ b/telegram/request/_baserequest.py
@@ -22,7 +22,7 @@ import asyncio
 import json
 from http import HTTPStatus
 from types import TracebackType
-from typing import AsyncContextManager, ClassVar, List, Optional, Tuple, Type, TypeVar, Union
+from typing import AsyncContextManager, Final, List, Optional, Tuple, Type, TypeVar, Union, final
 
 from telegram._utils.defaultvalue import DEFAULT_NONE as _DEFAULT_NONE
 from telegram._utils.defaultvalue import DefaultValue
@@ -84,10 +84,10 @@ class BaseRequest(
 
     __slots__ = ()
 
-    USER_AGENT: ClassVar[str] = f"python-telegram-bot v{ptb_ver} (https://python-telegram-bot.org)"
+    USER_AGENT: Final[str] = f"python-telegram-bot v{ptb_ver} (https://python-telegram-bot.org)"
     """:obj:`str`: A description that can be used as user agent for requests made to the Bot API.
     """
-    DEFAULT_NONE: ClassVar[DefaultValue[None]] = _DEFAULT_NONE
+    DEFAULT_NONE: Final[DefaultValue[None]] = _DEFAULT_NONE
     """:class:`object`: A special object that indicates that an argument of a function was not
     explicitly passed. Used for the timeout parameters of :meth:`post` and :meth:`do_request`.
 
@@ -125,6 +125,7 @@ class BaseRequest(
     async def shutdown(self) -> None:
         """Stop & clear resources used by this class. Must be implemented by a subclass."""
 
+    @final
     async def post(
         self,
         url: str,
@@ -179,6 +180,7 @@ class BaseRequest(
         # see https://core.telegram.org/bots/api#making-requests
         return json_data["result"]
 
+    @final
     async def retrieve(
         self,
         url: str,

--- a/telegram/request/_httpxrequest.py
+++ b/telegram/request/_httpxrequest.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains methods to make POST and GET requests using the httpx library."""
-from typing import Literal, Optional, Tuple
+from typing import Optional, Tuple
 
 import httpx
 
@@ -25,6 +25,7 @@ from telegram._utils.defaultvalue import DefaultValue
 from telegram._utils.logging import get_logger
 from telegram._utils.types import ODVInput
 from telegram.error import NetworkError, TimedOut
+from telegram.ext._utils.types import HTTPVersion
 from telegram.request._baserequest import BaseRequest
 from telegram.request._requestdata import RequestData
 
@@ -101,7 +102,7 @@ class HTTPXRequest(BaseRequest):
         write_timeout: Optional[float] = 5.0,
         connect_timeout: Optional[float] = 5.0,
         pool_timeout: Optional[float] = 1.0,
-        http_version: Literal["1.1", "2"] = "1.1",
+        http_version: HTTPVersion = "1.1",
     ):
         self._http_version = http_version
         timeout = httpx.Timeout(

--- a/telegram/request/_httpxrequest.py
+++ b/telegram/request/_httpxrequest.py
@@ -23,9 +23,8 @@ import httpx
 
 from telegram._utils.defaultvalue import DefaultValue
 from telegram._utils.logging import get_logger
-from telegram._utils.types import ODVInput
+from telegram._utils.types import HTTPVersion, ODVInput
 from telegram.error import NetworkError, TimedOut
-from telegram.ext._utils.types import HTTPVersion
 from telegram.request._baserequest import BaseRequest
 from telegram.request._requestdata import RequestData
 

--- a/telegram/request/_httpxrequest.py
+++ b/telegram/request/_httpxrequest.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains methods to make POST and GET requests using the httpx library."""
-from typing import Optional, Tuple
+from typing import Literal, Optional, Tuple
 
 import httpx
 
@@ -101,7 +101,7 @@ class HTTPXRequest(BaseRequest):
         write_timeout: Optional[float] = 5.0,
         connect_timeout: Optional[float] = 5.0,
         pool_timeout: Optional[float] = 1.0,
-        http_version: str = "1.1",
+        http_version: Literal["1.1", "2"] = "1.1",
     ):
         self._http_version = http_version
         timeout = httpx.Timeout(


### PR DESCRIPTION
Closes #3735

* Mostly changes `ClassVar` to `Final` for all constants
* Adds some limited usage of the `@final` decorator for `Base{UpdateProcessor, Request}`
* Uses `Literal` for the `http_version` argument of `HTTPXRequest`. Otherwise, `Literal` is not used due to python/typing/issues/781

If there are more places, where `@final` or `Literal` are useful, please do point them out :)