### PR TITLE
fix error with `Literal`, causing tests/docs to fail

### DIFF
--- a/docs/auxil/admonition_inserter.py
+++ b/docs/auxil/admonition_inserter.py
@@ -528,7 +528,11 @@ class AdmonitionInserter:
         # For custom generics like telegram.ext._application.Application[~BT, ~CCT, ~UD...].
         # This must come before the check for isinstance(type) because GenericAlias can also be
         # recognized as type if it belongs to <class 'types.GenericAlias'>.
-        elif str(type(arg)) in ("<class 'typing._GenericAlias'>", "<class 'types.GenericAlias'>"):
+        elif str(type(arg)) in (
+            "<class 'typing._GenericAlias'>",
+            "<class 'types.GenericAlias'>",
+            "<class 'typing._LiteralGenericAlias'>",
+        ):
             if "telegram" in str(arg):
                 # get_origin() of telegram.ext._application.Application[~BT, ~CCT, ~UD...]
                 # will produce <class 'telegram.ext._application.Application'>


### PR DESCRIPTION
Fix test failure caused by introduction of `Literal` types.