### PR TITLE
Correct `KeyboardButton` `__eq__` warning message

### DIFF
--- a/telegram/_keyboardbutton.py
+++ b/telegram/_keyboardbutton.py
@@ -163,8 +163,8 @@ class KeyboardButton(TelegramObject):
 
     def __eq__(self, other: object) -> bool:
         warn(
-            "In v21, granular media settings will be considered as well when comparing"
-            " ChatPermissions instances.",
+            "In v21, `request_user` and `request_chat` will be considered as well when comparing"
+            " KeyboardButton instances.",
             PTBDeprecationWarning,
             stacklevel=2,
         )

--- a/tests/test_keyboardbutton.py
+++ b/tests/test_keyboardbutton.py
@@ -139,8 +139,8 @@ class TestKeyboardButtonWithoutRequest(TestKeyboardButtonBase):
         assert keyboard_button == keyboard_button
 
         assert str(recwarn[0].message) == (
-            "In v21, granular media settings will be considered as well when comparing"
-            " ChatPermissions instances."
+            "In v21, `request_user` and `request_chat` will be considered as well when comparing"
+            " KeyboardButton instances."
         )
         assert recwarn[0].category is PTBDeprecationWarning
         assert recwarn[0].filename == __file__, "wrong stacklevel"


### PR DESCRIPTION
Corrects the incorrect warning message when comparing instances of `KeyboardButton`, which missed to see in #3530 
