### PR TITLE
fix CI issue (`_nonwrappers`)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 pre-commit  # needed for pre-commit hooks in the git commit command
 
 # For the test suite
-pytest==7.3.1
+pytest==7.3.2
 pytest-asyncio==0.21.0  # needed because pytest doesn't come with native support for coroutines as tests
 pytest-xdist==3.3.1  # xdist runs tests in parallel
 flaky  # Used for flaky tests (flaky decorator)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 pre-commit  # needed for pre-commit hooks in the git commit command
 
 # For the test suite
-pytest==7.3.2
+pytest==7.3.1
 pytest-asyncio==0.21.0  # needed because pytest doesn't come with native support for coroutines as tests
 pytest-xdist==3.3.1  # xdist runs tests in parallel
 flaky  # Used for flaky tests (flaky decorator)

--- a/tests/auxil/plugin_github_group.py
+++ b/tests/auxil/plugin_github_group.py
@@ -35,10 +35,10 @@ def terminal_summary_wrapper(original, plugin_name):
 
 @pytest.mark.trylast()
 def pytest_configure(config):
-    print(config.pluginmanager.hook.pytest_terminal_summary._hookimpls)
     for hookimpl in config.pluginmanager.hook.pytest_terminal_summary._hookimpls:
         if hookimpl.plugin_name in fold_plugins:
             hookimpl.function = terminal_summary_wrapper(hookimpl.function, hookimpl.plugin_name)
+
 
 class PytestPluginHelpers:
     terminal = None

--- a/tests/auxil/plugin_github_group.py
+++ b/tests/auxil/plugin_github_group.py
@@ -19,7 +19,7 @@
 import _pytest.config
 import pytest
 
-fold_plugins = set()
+fold_plugins = {"_cov": "Coverage report", "flaky": "Flaky report"}
 
 
 def terminal_summary_wrapper(original, plugin_name):
@@ -35,10 +35,12 @@ def terminal_summary_wrapper(original, plugin_name):
 
 @pytest.mark.trylast()
 def pytest_configure(config):
-    for hookimpl in config.pluginmanager.hook.pytest_terminal_summary._nonwrappers:
-        if hookimpl.plugin_name in fold_plugins:
-            hookimpl.function = terminal_summary_wrapper(hookimpl.function, hookimpl.plugin_name)
-
+    try:
+        for hookimpl in config.pluginmanager.hook.pytest_terminal_summary._nonwrappers:
+            if hookimpl.plugin_name in fold_plugins:
+                hookimpl.function = terminal_summary_wrapper(hookimpl.function, hookimpl.plugin_name)
+    except AttributeError:
+        print(vars(config.pluginmanager.hook.pytest_terminal_summary))
 
 class PytestPluginHelpers:
     terminal = None

--- a/tests/auxil/plugin_github_group.py
+++ b/tests/auxil/plugin_github_group.py
@@ -35,12 +35,10 @@ def terminal_summary_wrapper(original, plugin_name):
 
 @pytest.mark.trylast()
 def pytest_configure(config):
-    try:
-        for hookimpl in config.pluginmanager.hook.pytest_terminal_summary._hookimpls:
-            if hookimpl.plugin_name in fold_plugins:
-                hookimpl.function = terminal_summary_wrapper(hookimpl.function, hookimpl.plugin_name)
-    except AttributeError:
-        print(dir(config.pluginmanager.hook.pytest_terminal_summary))
+    print(config.pluginmanager.hook.pytest_terminal_summary._hookimpls)
+    for hookimpl in config.pluginmanager.hook.pytest_terminal_summary._hookimpls:
+        if hookimpl.plugin_name in fold_plugins:
+            hookimpl.function = terminal_summary_wrapper(hookimpl.function, hookimpl.plugin_name)
 
 class PytestPluginHelpers:
     terminal = None

--- a/tests/auxil/plugin_github_group.py
+++ b/tests/auxil/plugin_github_group.py
@@ -19,7 +19,7 @@
 import _pytest.config
 import pytest
 
-fold_plugins = {"_cov": "Coverage report", "flaky": "Flaky report"}
+fold_plugins = set()
 
 
 def terminal_summary_wrapper(original, plugin_name):

--- a/tests/auxil/plugin_github_group.py
+++ b/tests/auxil/plugin_github_group.py
@@ -40,7 +40,7 @@ def pytest_configure(config):
             if hookimpl.plugin_name in fold_plugins:
                 hookimpl.function = terminal_summary_wrapper(hookimpl.function, hookimpl.plugin_name)
     except AttributeError:
-        print(vars(config.pluginmanager.hook.pytest_terminal_summary))
+        print(dir(config.pluginmanager.hook.pytest_terminal_summary))
 
 class PytestPluginHelpers:
     terminal = None

--- a/tests/auxil/plugin_github_group.py
+++ b/tests/auxil/plugin_github_group.py
@@ -36,7 +36,7 @@ def terminal_summary_wrapper(original, plugin_name):
 @pytest.mark.trylast()
 def pytest_configure(config):
     try:
-        for hookimpl in config.pluginmanager.hook.pytest_terminal_summary._nonwrappers:
+        for hookimpl in config.pluginmanager.hook.pytest_terminal_summary._hookimpls:
             if hookimpl.plugin_name in fold_plugins:
                 hookimpl.function = terminal_summary_wrapper(hookimpl.function, hookimpl.plugin_name)
     except AttributeError:


### PR DESCRIPTION
plugin_github_group.py triggers exception when running CI tasks

`AttributeError: '_HookCaller' object has no attribute '_nonwrappers'`

This attribute is indeed absent, however the attribute `._hookimpls` contains the necessary keys.