### PR TITLE
add notes on running `post_` methods explicitly

### DIFF
--- a/telegram/ext/_applicationbuilder.py
+++ b/telegram/ext/_applicationbuilder.py
@@ -1095,7 +1095,8 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         Note:
             If you implement custom logic that implies that you will **not** be using
             :meth:`Application.run_polling` or :meth:`Application.run_webhook` to run
-            your application (e.g. in :any:`Custom Webhook Example <examples.customwebhookbot>`),
+            your application (like e.g. in
+            :any:`Custom Webhook Bot Example <examples.customwebhookbot>`),
             make sure that you explicitly call this method.
 
         .. seealso:: :meth:`post_stop`, :meth:`post_shutdown`
@@ -1139,7 +1140,8 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         Note:
             If you implement custom logic that implies that you will **not** be using
             :meth:`Application.run_polling` or :meth:`Application.run_webhook` to run
-            your application (e.g. in :any:`Custom Webhook Example <examples.customwebhookbot>`),
+            your application (like e.g. in
+            :any:`Custom Webhook Bot Example <examples.customwebhookbot>`),
             make sure that you explicitly call this method.
 
         .. seealso:: :meth:`post_init`, :meth:`post_stop`
@@ -1185,7 +1187,8 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         Note:
             If you implement custom logic that implies that you will **not** be using
             :meth:`Application.run_polling` or :meth:`Application.run_webhook` to run
-            your application (e.g. in :any:`Custom Webhook Example <examples.customwebhookbot>`),
+            your application (like e.g. in
+            :any:`Custom Webhook Bot Example <examples.customwebhookbot>`),
             make sure that you explicitly call this method.
 
         .. seealso:: :meth:`post_init`, :meth:`post_shutdown`

--- a/telegram/ext/_applicationbuilder.py
+++ b/telegram/ext/_applicationbuilder.py
@@ -1092,6 +1092,12 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
 
                 application = Application.builder().token("TOKEN").post_init(post_init).build()
 
+        Note:
+            If you implement custom logic that implies that you will **not** be using
+            :meth:`Application.run_polling` or :meth:`Application.run_webhook` to run
+            your application (e.g. in :any:`Custom Webhook Example <examples.customwebhookbot>`),
+            make sure that you explicitly call this method.
+
         .. seealso:: :meth:`post_stop`, :meth:`post_shutdown`
 
         Args:
@@ -1129,6 +1135,12 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
                                         .token("TOKEN")
                                         .post_shutdown(post_shutdown)
                                         .build()
+
+        Note:
+            If you implement custom logic that implies that you will **not** be using
+            :meth:`Application.run_polling` or :meth:`Application.run_webhook` to run
+            your application (e.g. in :any:`Custom Webhook Example <examples.customwebhookbot>`),
+            make sure that you explicitly call this method.
 
         .. seealso:: :meth:`post_init`, :meth:`post_stop`
 
@@ -1169,6 +1181,12 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
                                         .token("TOKEN")
                                         .post_stop(post_stop)
                                         .build()
+
+        Note:
+            If you implement custom logic that implies that you will **not** be using
+            :meth:`Application.run_polling` or :meth:`Application.run_webhook` to run
+            your application (e.g. in :any:`Custom Webhook Example <examples.customwebhookbot>`),
+            make sure that you explicitly call this method.
 
         .. seealso:: :meth:`post_init`, :meth:`post_shutdown`
 


### PR DESCRIPTION
As discussed in dev group, I added a note stating that in cases like [custom webhook example](https://docs.python-telegram-bot.org/en/stable/examples.customwebhookbot.html) user should explicitly call `post_` methods.