### PR TITLE
Add `Application.stop_running` and Improve Marking Updates as Read on `Updater.stop`

### DIFF
--- a/docs/source/inclusions/application_run_tip.rst
+++ b/docs/source/inclusions/application_run_tip.rst
@@ -1,7 +1,9 @@
 .. tip::
-    When combining ``python-telegram-bot`` with other :mod:`asyncio` based frameworks, using this
-    method is likely not the best choice, as it blocks the event loop until it receives a stop
-    signal as described above.
-    Instead, you can manually call the methods listed below to start and shut down the application
-    and the :attr:`~telegram.ext.Application.updater`.
-    Keeping the event loop running and listening for a stop signal is then up to you.
+    * When combining ``python-telegram-bot`` with other :mod:`asyncio` based frameworks, using this
+      method is likely not the best choice, as it blocks the event loop until it receives a stop
+      signal as described above.
+      Instead, you can manually call the methods listed below to start and shut down the application
+      and the :attr:`~telegram.ext.Application.updater`.
+      Keeping the event loop running and listening for a stop signal is then up to you.
+    * To gracefully stop the execution of this method from within a handler, job or error callback,
+      use :meth:`~telegram.ext.Application.stop_running`.

--- a/telegram/ext/_application.py
+++ b/telegram/ext/_application.py
@@ -653,6 +653,20 @@ class Application(Generic[BT, CCT, UD, CD, BD, JQ], AsyncContextManager["Applica
 
         _LOGGER.info("Application.stop() complete")
 
+    def stop_running(self) -> None:
+        """This method can be used to stop the execution of :meth:`run_polling` or
+        :meth:`run_webhook` from within a handler, job or error callback. This allows a graceful
+        shutdown of the application, i.e. the methods listed in :attr:`run_polling` and
+        :attr:`run_webhook` will still be executed.
+
+        Note:
+            If the application is not running, this method does nothing.
+        """
+        if self.running:
+            asyncio.get_running_loop().stop()
+        else:
+            _LOGGER.debug("Application is not running, stop_running() does nothing.")
+
     def run_polling(
         self,
         poll_interval: float = 0.0,

--- a/telegram/ext/_application.py
+++ b/telegram/ext/_application.py
@@ -957,7 +957,7 @@ class Application(Generic[BT, CCT, UD, CD, BD, JQ], AsyncContextManager["Applica
             loop.run_until_complete(self.start())
             loop.run_forever()
         except (KeyboardInterrupt, SystemExit):
-            pass
+            _LOGGER.debug("Application received stop signal. Shutting down.")
         except Exception as exc:
             # In case the coroutine wasn't awaited, we don't need to bother the user with a warning
             updater_coroutine.close()

--- a/telegram/ext/_application.py
+++ b/telegram/ext/_application.py
@@ -661,8 +661,12 @@ class Application(Generic[BT, CCT, UD, CD, BD, JQ], AsyncContextManager["Applica
 
         Note:
             If the application is not running, this method does nothing.
+
+        .. versionadded:: NEXT.VERSION
         """
         if self.running:
+            # This works because `__run` is using `loop.run_forever()`. If that changes, this
+            # method needs to be adapted.
             asyncio.get_running_loop().stop()
         else:
             _LOGGER.debug("Application is not running, stop_running() does nothing.")

--- a/telegram/ext/_updater.py
+++ b/telegram/ext/_updater.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from types import TracebackType
 from typing import (
     TYPE_CHECKING,
+    Any,
     AsyncContextManager,
     Callable,
     Coroutine,
@@ -121,6 +122,7 @@ class Updater(AsyncContextManager["Updater"]):
         self._httpd: Optional[WebhookServer] = None
         self.__lock = asyncio.Lock()
         self.__polling_task: Optional[asyncio.Task] = None
+        self.__polling_cleanup_cb: Optional[Callable[[], Coroutine[Any, Any, None]]] = None
 
     @property
     def running(self) -> bool:
@@ -366,6 +368,27 @@ class Updater(AsyncContextManager["Updater"]):
             ),
             name="Updater:start_polling:polling_task",
         )
+
+        # Prepare a cleanup callback to await on _stop_polling
+        # Calling get_updates one more time with the latest `offset` parameter ensures that
+        # all updates that where put into the update queue are also marked as "read" to TG,
+        # so we do not receive them again on the next startup
+        # We define this here so that we can use the same parameters as in the polling task
+        async def _get_updates_cleanup() -> None:
+            _LOGGER.debug(
+                "Calling `get_updates` one more time to mark all fetched updates as read."
+            )
+            await self.bot.get_updates(
+                offset=self._last_update_id,
+                timeout=timeout,
+                read_timeout=read_timeout,
+                connect_timeout=connect_timeout,
+                write_timeout=write_timeout,
+                pool_timeout=pool_timeout,
+                allowed_updates=allowed_updates,
+            )
+
+        self.__polling_cleanup_cb = _get_updates_cleanup
 
         if ready is not None:
             ready.set()
@@ -748,3 +771,11 @@ class Updater(AsyncContextManager["Updater"]):
                 # after start_polling(), but lets better be safe than sorry ...
 
             self.__polling_task = None
+
+            if self.__polling_cleanup_cb:
+                await self.__polling_cleanup_cb()
+            else:
+                _LOGGER.warning(
+                    "No polling cleanup callback defined. The last fetched updates may be "
+                    "fetched again on the next polling start."
+                )

--- a/telegram/ext/_updater.py
+++ b/telegram/ext/_updater.py
@@ -380,7 +380,8 @@ class Updater(AsyncContextManager["Updater"]):
             )
             await self.bot.get_updates(
                 offset=self._last_update_id,
-                timeout=timeout,
+                # We don't want to do long polling here!
+                timeout=0,
                 read_timeout=read_timeout,
                 connect_timeout=connect_timeout,
                 write_timeout=write_timeout,

--- a/telegram/ext/_updater.py
+++ b/telegram/ext/_updater.py
@@ -774,6 +774,7 @@ class Updater(AsyncContextManager["Updater"]):
 
             if self.__polling_cleanup_cb:
                 await self.__polling_cleanup_cb()
+                self.__polling_cleanup_cb = None
             else:
                 _LOGGER.warning(
                     "No polling cleanup callback defined. The last fetched updates may be "

--- a/tests/ext/test_application.py
+++ b/tests/ext/test_application.py
@@ -1464,6 +1464,9 @@ class TestApplication:
             time.sleep(0.05)
             assertions["exception_handling"] = self.received == exception.message
 
+            # So that the get_updates call on shutdown doesn't fail
+            exception_event.clear()
+
             os.kill(os.getpid(), signal.SIGINT)
             time.sleep(0.1)
 

--- a/tests/ext/test_application.py
+++ b/tests/ext/test_application.py
@@ -2176,7 +2176,7 @@ class TestApplication:
         assert len(recwarn) >= 1
         found = False
         for record in recwarn:
-            print("\t", record)
+            print(record)
             if str(record.message).startswith("Could not add signal handlers for the stop"):
                 assert record.category is PTBUserWarning
                 assert record.filename == __file__, "stacklevel is incorrect!"

--- a/tests/ext/test_updater.py
+++ b/tests/ext/test_updater.py
@@ -277,7 +277,7 @@ class TestUpdater:
         tracking_flag = False
         received_kwargs = {}
         expected_kwargs = {
-            "timeout": "timeout",
+            "timeout": 0,
             "read_timeout": "read_timeout",
             "connect_timeout": "connect_timeout",
             "write_timeout": "write_timeout",


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#checklist-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

WIP. Addresses #3718. Doesn't include a native way to restart the whole script, though, so this doesn't really *close* #3718.

The naming `stop_running` is up for discussion. May be too similar to `Application.stop`.

- [x] Added ``.. versionadded:: NEXT.VERSION``, ``.. versionchanged:: NEXT.VERSION`` or ``.. deprecated:: NEXT.VERSION`` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [x] Documented code changes according to the `CSI standard <https://standards.mousepawmedia.com/en/stable/csi.html>`__
- ~[ ] Added myself alphabetically to ``AUTHORS.rst`` (optional)~
- ~[ ] Added new classes & modules to the docs and all suitable ``__all__`` s~
- [x] Checked the `Stability Policy <https://docs.python-telegram-bot.org/stability_policy.html>`_ in case of deprecations or changes to documented behavior
