### PR TITLE
Update bot.py

### DIFF
--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -2425,7 +2425,7 @@ class Bot(TelegramObject):
         limit: int = 100,
         timeout: ODVInput[float] = DEFAULT_NONE,
         api_kwargs: JSONDict = None,
-    ) -> Optional[UserProfilePhotos]:
+    ) -> UserProfilePhotos:
         """Use this method to get a list of profile pictures for a user.
 
         Args:


### PR DESCRIPTION
Fix Bot.get_user_profile_photos return type according to the docs:
https://docs.python-telegram-bot.org/en/v13.13/telegram.bot.html?highlight=get_user_profile_photos#telegram.Bot.get_user_profile_photos

Old: `Optional[telegram.UserProfilePhotos]`
New: `telegram.UserProfilePhotos`
