### PR TITLE
Feature #3798: Check commands for args

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -120,6 +120,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Wagner Macedo <https://github.com/wagnerluis1982>`_
 - `wjt <https://github.com/wjt>`_
 - `Yaw Danso <https://github.com/dglitxh>`_
+- `Yao Kuan <https://github.com/thatguylah>`_
 - `zeroone2numeral2 <https://github.com/zeroone2numeral2>`_
 - `zeshuaro <https://github.com/zeshuaro>`_
 - `zpavloudis <https://github.com/zpavloudis>`_

--- a/telegram/ext/_commandhandler.py
+++ b/telegram/ext/_commandhandler.py
@@ -148,13 +148,14 @@ class CommandHandler(BaseHandler[Update, CCT]):
 
         condition = (
             ArgsCondition.HAS_ARGS_NONE
-            if self.has_args is None
+            if (self.has_args is None)
             else ArgsCondition.HAS_ARGS_TRUE_ARGS_PRESENT
-            if self.has_args and args
+            if (self.has_args is True and args)
+            # Must specify is True, otherwise if has_args is int, it will default to Truthy value.
             else ArgsCondition.HAS_ARGS_FALSE_ARGS_ABSENT
-            if not self.has_args and not args
+            if (self.has_args is False and not args)
             else ArgsCondition.HAS_ARGS_NUM
-            if isinstance(self.has_args, int) and len(args) == self.has_args
+            if (isinstance(self.has_args, int) and len(args) == self.has_args)
             else ArgsCondition.HAS_INVALID_ARGS
         )
 
@@ -196,9 +197,6 @@ class CommandHandler(BaseHandler[Update, CCT]):
                 _valid = self._check_correct_args(args)
                 if _valid is False:
                     return None
-                # if _valid: TODO: Implement condition if has_args and args are True.
-                #     raise ValueError("CommandHandler: args are not valid")
-                #     return None  # args does not match what developer specified, returning None.
 
                 filter_result = self.filters.check_update(update)
                 if filter_result:

--- a/telegram/ext/_commandhandler.py
+++ b/telegram/ext/_commandhandler.py
@@ -89,6 +89,12 @@ class CommandHandler(BaseHandler[Update, CCT]):
             :meth:`telegram.ext.Application.process_update`. Defaults to :obj:`True`.
 
             .. seealso:: :wiki:`Concurrency`
+        has_args (:obj:`bool` | :obj:`int`, optional):
+            Determines whether the command handler should process the update or not.
+            If :obj:`True`, the handler will process any non-zero number of args.
+            If :obj:`False`, the handler will only process if there are no args.
+            if :obj:`int`, the handler will only process if there are exactly that many args.
+            Defaults to :obj:`None`, which means the handler will process any or no args.
 
     Raises:
         :exc:`ValueError`: When the command is too long or has illegal chars.
@@ -101,6 +107,9 @@ class CommandHandler(BaseHandler[Update, CCT]):
         block (:obj:`bool`): Determines whether the return value of the callback should be
             awaited before processing the next handler in
             :meth:`telegram.ext.Application.process_update`.
+        has_args (:obj:`bool` | :obj:`int` | None):
+            Optional argument, otherwise all implementations of :class:`CommandHandler` will break.
+            Defaults to :obj:`None`, which means the handler will process any args or no args.
     """
 
     __slots__ = ("commands", "filters", "has_args")

--- a/tests/ext/test_commandhandler.py
+++ b/tests/ext/test_commandhandler.py
@@ -181,7 +181,11 @@ class TestCommandHandler(BaseTest):
 
     @pytest.mark.parametrize(
         "cmd",
-        ["way_too_longcommand1234567yes_way_toooooooLong", "ïñválídletters", "invalid #&* chars"],
+        [
+            "way_too_longcommand1234567yes_way_toooooooLong",
+            "ïñválídletters",
+            "invalid #&* chars",
+        ],
         ids=["too long", "invalid letter", "invalid characters"],
     )
     def test_invalid_commands(self, cmd):
@@ -259,3 +263,22 @@ class TestCommandHandler(BaseTest):
             self.callback_regex2, filters=filters.Regex("one") & filters.Regex("two")
         )
         await self._test_context_args_or_regex(app, handler, command)
+
+    def test_command_has_args(self, bot):
+        """Test CHs with optional has_args specified."""
+        handler_true = CommandHandler(["test"], self.callback_basic, has_args=True)
+        handler_false = CommandHandler(["test"], self.callback_basic, has_args=False)
+        handler_int_one = CommandHandler(["test"], self.callback_basic, has_args=1)
+        handler_int_two = CommandHandler(["test"], self.callback_basic, has_args=2)
+
+        assert is_match(handler_true, make_command_update("/test helloworld", bot=bot))
+        assert not is_match(handler_true, make_command_update("/test", bot=bot))
+
+        assert is_match(handler_false, make_command_update("/test", bot=bot))
+        assert not is_match(handler_false, make_command_update("/test helloworld", bot=bot))
+
+        assert is_match(handler_int_one, make_command_update("/test helloworld", bot=bot))
+        assert not is_match(handler_int_one, make_command_update("/test hello world", bot=bot))
+
+        assert is_match(handler_int_two, make_command_update("/test hello world", bot=bot))
+        assert not is_match(handler_int_two, make_command_update("/test helloworld", bot=bot))


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#checklist-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

closes #3798

CommandHandler allows an optional `has_args` argument that defaults to `None`, but can optionally accept either `True`, `False` or any `int`. 
- Used an `Enum` for mapping this logic inside an internal method `_check_correct_args` of `class CommandHandler` 
-  In `check_update` method, right before sending to `filters` for filters parsing, it `_check_correct_args` and if `_valid` then it does nothing and passes to `filters` 
- if however `_valid` is False, it early returns `None` before it hits filters parsing. 
- Implemented test cases in `test_commandhandler.py` for `has_args` 
- All test cases passed. 👍 

Let me know if i need to refactor or add to more documentation that i am not aware about. ☺️ 
