### PR TITLE
Extend Allowed Values for HTTP Version

### DIFF
--- a/telegram/_utils/types.py
+++ b/telegram/_utils/types.py
@@ -87,7 +87,7 @@ FieldTuple = Tuple[str, bytes, str]
 UploadFileDict = Dict[str, FieldTuple]
 """Dictionary containing file data to be uploaded to the API."""
 
-HTTPVersion = Literal["1.1", "2.0"]
+HTTPVersion = Literal["1.1", "2.0", "2"]
 """Allowed HTTP versions.
 
 .. versionadded:: 20.4"""

--- a/telegram/ext/_applicationbuilder.py
+++ b/telegram/ext/_applicationbuilder.py
@@ -592,8 +592,8 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
             Reset the default version to 1.1.
 
         Args:
-            http_version (:obj:`str`): Pass ``"2"`` if you'd like to use HTTP/2 for making
-                requests to Telegram. Defaults to ``"1.1"``, in which case HTTP/1.1 is used.
+            http_version (:obj:`str`): Pass ``"2"`` or ``"2.0"`` if you'd like to use HTTP/2 for
+                making requests to Telegram. Defaults to ``"1.1"``, in which case HTTP/1.1 is used.
 
         Returns:
             :class:`ApplicationBuilder`: The same builder with the updated argument.
@@ -751,8 +751,9 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
             Reset the default version to 1.1.
 
         Args:
-            get_updates_http_version (:obj:`str`): Pass ``"2"`` if you'd like to use HTTP/2 for
-                making requests to Telegram. Defaults to ``"1.1"``, in which case HTTP/1.1 is used.
+            get_updates_http_version (:obj:`str`): Pass ``"2"`` or ``"2.0"`` if you'd like to use
+                HTTP/2 for making requests to Telegram. Defaults to ``"1.1"``, in which case
+                HTTP/1.1 is used.
 
         Returns:
             :class:`ApplicationBuilder`: The same builder with the updated argument.

--- a/telegram/ext/_applicationbuilder.py
+++ b/telegram/ext/_applicationbuilder.py
@@ -595,6 +595,9 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
             http_version (:obj:`str`): Pass ``"2"`` or ``"2.0"`` if you'd like to use HTTP/2 for
                 making requests to Telegram. Defaults to ``"1.1"``, in which case HTTP/1.1 is used.
 
+                .. versionchanged:: NEXT.VERSION
+                    Accept ``"2"`` as a valid value.
+
         Returns:
             :class:`ApplicationBuilder`: The same builder with the updated argument.
         """
@@ -754,6 +757,9 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
             get_updates_http_version (:obj:`str`): Pass ``"2"`` or ``"2.0"`` if you'd like to use
                 HTTP/2 for making requests to Telegram. Defaults to ``"1.1"``, in which case
                 HTTP/1.1 is used.
+
+                .. versionchanged:: NEXT.VERSION
+                    Accept ``"2"`` as a valid value.
 
         Returns:
             :class:`ApplicationBuilder`: The same builder with the updated argument.

--- a/telegram/request/_httpxrequest.py
+++ b/telegram/request/_httpxrequest.py
@@ -82,8 +82,8 @@ class HTTPXRequest(BaseRequest):
                 With a finite pool timeout, you must expect :exc:`telegram.error.TimedOut`
                 exceptions to be thrown when more requests are made simultaneously than there are
                 connections in the connection pool!
-        http_version (:obj:`str`, optional): If ``"2"``, HTTP/2 will be used instead of HTTP/1.1.
-            Defaults to ``"1.1"``.
+        http_version (:obj:`str`, optional): If ``"2"`` or ``"2.0"``, HTTP/2 will be used instead
+            of HTTP/1.1. Defaults to ``"1.1"``.
 
             .. versionadded:: 20.1
             .. versionchanged:: 20.2
@@ -115,8 +115,8 @@ class HTTPXRequest(BaseRequest):
             max_keepalive_connections=connection_pool_size,
         )
 
-        if http_version not in ("1.1", "2"):
-            raise ValueError("`http_version` must be either '1.1' or '2'.")
+        if http_version not in ("1.1", "2", "2.0"):
+            raise ValueError("`http_version` must be either '1.1', '2.0' or '2'.")
 
         http1 = http_version == "1.1"
 

--- a/telegram/request/_httpxrequest.py
+++ b/telegram/request/_httpxrequest.py
@@ -89,6 +89,9 @@ class HTTPXRequest(BaseRequest):
             .. versionchanged:: 20.2
                 Reset the default version to 1.1.
 
+            .. versionchanged:: NEXT.VERSION
+                Accept ``"2"`` as a valid value.
+
     """
 
     __slots__ = ("_client", "_client_kwargs", "_http_version")

--- a/tests/request/test_request.py
+++ b/tests/request/test_request.py
@@ -85,8 +85,9 @@ class TestNoSocksHTTP2WithoutRequest:
 
 @pytest.mark.skipif(not TEST_WITH_OPT_DEPS, reason="Optional dependencies not installed")
 class TestHTTP2WithRequest:
-    async def test_http_2_response(self):
-        httpx_request = HTTPXRequest(http_version="2")
+    @pytest.mark.parametrize("http_version", ["2", "2.0"])
+    async def test_http_2_response(self, http_version):
+        httpx_request = HTTPXRequest(http_version=http_version)
         async with httpx_request:
             resp = await httpx_request._client.request(
                 url="https://python-telegram-bot.org",


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#checklist-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

Closes #3821

- [x] Added .. versionadded:: NEXT.VERSION, .. versionchanged:: NEXT.VERSION or .. deprecated:: NEXT.VERSION to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- ~[ ] Documented code changes according to the CSI standard~
- ~[ ]Added myself alphabetically to AUTHORS.rst (optional)~
- ~[ ]Added new classes & modules to the docs and all suitable __all__ s~
- [x] Checked the Stability Policy in case of deprecations or changes to documented behavior