### PR TITLE
Add .. seealso doc sections in `ApplicationBuilder`.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -21,6 +21,7 @@ Contributors
 
 The following wonderful people contributed directly or indirectly to this project:
 
+- `Abdelrahman <https://github.com/aelkheir>`_
 - `Abshar <https://github.com/abxhr>`_
 - `Alateas <https://github.com/alateas>`_
 - `Ales Dokshanin <https://github.com/alesdokshanin>`_

--- a/telegram/ext/_applicationbuilder.py
+++ b/telegram/ext/_applicationbuilder.py
@@ -473,6 +473,8 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
 
         .. include:: inclusions/pool_size_tip.rst
 
+        .. seealso:: :meth:`get_updates_connection_pool_size`
+
         Args:
             connection_pool_size (:obj:`int`): The size of the connection pool.
 
@@ -506,6 +508,8 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         :paramref:`~telegram.request.HTTPXRequest.connect_timeout` parameter of
         :attr:`telegram.Bot.request`. Defaults to ``5.0``.
 
+        .. seealso:: :meth:`get_updates_connect_timeout`
+
         Args:
             connect_timeout (:obj:`float`): See
                 :paramref:`telegram.request.HTTPXRequest.connect_timeout` for more information.
@@ -522,6 +526,8 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         :paramref:`~telegram.request.HTTPXRequest.read_timeout` parameter of
         :attr:`telegram.Bot.request`. Defaults to ``5.0``.
 
+        .. seealso:: :meth:`get_updates_read_timeout`
+
         Args:
             read_timeout (:obj:`float`): See
                 :paramref:`telegram.request.HTTPXRequest.read_timeout` for more information.
@@ -537,6 +543,8 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         """Sets the write operation timeout for the
         :paramref:`~telegram.request.HTTPXRequest.write_timeout` parameter of
         :attr:`telegram.Bot.request`. Defaults to ``5.0``.
+
+        .. seealso:: :meth:`get_updates_write_timeout`
 
         Args:
             write_timeout (:obj:`float`): See
@@ -555,6 +563,8 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         :attr:`telegram.Bot.request`. Defaults to ``1.0``.
 
         .. include:: inclusions/pool_size_tip.rst
+
+        .. seealso:: :meth:`get_updates_pool_timeout`
 
         Args:
             pool_timeout (:obj:`float`): See
@@ -629,6 +639,8 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         :paramref:`telegram.request.HTTPXRequest.connection_pool_size` parameter which is used
         for the :meth:`telegram.Bot.get_updates` request. Defaults to ``1``.
 
+        .. seealso:: :meth:`connection_pool_size`
+
         Args:
             get_updates_connection_pool_size (:obj:`int`): The size of the connection pool.
 
@@ -664,6 +676,8 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         :paramref:`telegram.request.HTTPXRequest.connect_timeout` parameter which is used for
         the :meth:`telegram.Bot.get_updates` request. Defaults to ``5.0``.
 
+        .. seealso:: :meth:`connect_timeout`
+
         Args:
             get_updates_connect_timeout (:obj:`float`): See
                 :paramref:`telegram.request.HTTPXRequest.connect_timeout` for more information.
@@ -681,6 +695,8 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         """Sets the waiting timeout for the
         :paramref:`telegram.request.HTTPXRequest.read_timeout` parameter which is used for the
         :meth:`telegram.Bot.get_updates` request. Defaults to ``5.0``.
+
+        .. seealso:: :meth:`read_timeout`
 
         Args:
             get_updates_read_timeout (:obj:`float`): See
@@ -700,6 +716,8 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         :paramref:`telegram.request.HTTPXRequest.write_timeout` parameter which is used for
         the :meth:`telegram.Bot.get_updates` request. Defaults to ``5.0``.
 
+        .. seealso:: :meth:`write_timeout`
+
         Args:
             get_updates_write_timeout (:obj:`float`): See
                 :paramref:`telegram.request.HTTPXRequest.write_timeout` for more information.
@@ -717,6 +735,8 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         """Sets the connection pool's connection freeing timeout for the
         :paramref:`~telegram.request.HTTPXRequest.pool_timeout` parameter which is used for the
         :meth:`telegram.Bot.get_updates` request. Defaults to ``1.0``.
+
+        .. seealso:: :meth:`pool_timeout`
 
         Args:
             get_updates_pool_timeout (:obj:`float`): See


### PR DESCRIPTION
Closes #3825

- [ ] Added .. versionadded:: NEXT.VERSION, .. versionchanged:: NEXT.VERSION or .. deprecated:: NEXT.VERSION to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [ ] Created new or adapted existing unit tests
- [ ] Documented code changes according to the CSI standard
- [x] Added myself alphabetically to AUTHORS.rst (optional)
- [ ] Added new classes & modules to the docs and all suitable `__all__` s
- [ ] Checked the Stability Policy in case of deprecations or changes to documented behavior

Hi, did not wish for my first contribution to be docs :pensive:. But I know they're just as important, so ..

#### Affected methods:

`connect_timeout` / `get_updates_connect_timeout`  
`connection_pool_size` / `get_updates_connection_pool_size`  
`pool_timeout` / `get_updates_pool_timeout`  
`read_timeout` / `get_updates_read_timeout`  
`write_tiemout` / `get_updates_write_tiemout`

#### Already documented correctely

~~`proxy_url` / `get_updates_proxy_url`~~  
~~`request` / `get_updates_requset`~~  
~~`http_version` / `get_updates_http_version`~~

Ran `sphinx-build` and the new `See also` sections seemed to be working fine.

I also added my self to the authors list. Thanks.
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#checklist-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

