### PR TITLE
Use python 3.12rc1 in tests & add classifier

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12.0-beta.3']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12.0-rc.1']
         os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: False
     steps:

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ def get_setup_kwargs(raw=False):
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
+            "Programming Language :: Python :: 3.12",
         ],
         python_requires=">=3.8",
     )


### PR DESCRIPTION
Uses latest rc in tests.

We should also build wheels for py 3.12 on next release, as [recommended by python devs](https://pythoninsider.blogspot.com/2023/08/python-3120-release-candidate-1-released.html)
