### PR TITLE
Remove `__ne__` from `Defaults`

### DIFF
--- a/telegram/ext/_defaults.py
+++ b/telegram/ext/_defaults.py
@@ -239,6 +239,3 @@ class Defaults:
         if isinstance(other, Defaults):
             return all(getattr(self, attr) == getattr(other, attr) for attr in self.__slots__)
         return False
-
-    def __ne__(self, other: object) -> bool:
-        return not self == other

--- a/tests/ext/test_defaults.py
+++ b/tests/ext/test_defaults.py
@@ -28,7 +28,7 @@ from tests.auxil.envvars import TEST_WITH_OPT_DEPS
 from tests.auxil.slots import mro_slots
 
 
-class TestDefault:
+class TestDefaults:
     def test_slot_behaviour(self):
         a = Defaults(parse_mode="HTML", quote=True)
         for attr in a.__slots__:


### PR DESCRIPTION
`__ne__` in `Defaults` was redundant here, that is the default python behaviour.

Also moves `test_defaults.py` file to the correct location.

