### PR TITLE
list `__repr__` in `:special-members:` so they are shown in Sphinx

### DIFF
--- a/docs/source/telegram.bot.rst
+++ b/docs/source/telegram.bot.rst
@@ -4,4 +4,4 @@ Bot
 .. autoclass:: telegram.Bot
     :members:
     :show-inheritance:
-    :special-members: __reduce__, __deepcopy__
+    :special-members: __repr__, __reduce__, __deepcopy__

--- a/docs/source/telegram.ext.application.rst
+++ b/docs/source/telegram.ext.application.rst
@@ -4,3 +4,4 @@ Application
 .. autoclass:: telegram.ext.Application
     :members:
     :show-inheritance:
+    :special-members: __repr__

--- a/docs/source/telegram.ext.basehandler.rst
+++ b/docs/source/telegram.ext.basehandler.rst
@@ -4,3 +4,4 @@ BaseHandler
 .. autoclass:: telegram.ext.BaseHandler
     :members:
     :show-inheritance:
+    :special-members: __repr__

--- a/docs/source/telegram.ext.conversationhandler.rst
+++ b/docs/source/telegram.ext.conversationhandler.rst
@@ -4,3 +4,4 @@ ConversationHandler
 .. autoclass:: telegram.ext.ConversationHandler
     :members:
     :show-inheritance:
+    :special-members: __repr__

--- a/docs/source/telegram.ext.extbot.rst
+++ b/docs/source/telegram.ext.extbot.rst
@@ -4,3 +4,4 @@ ExtBot
 .. autoclass:: telegram.ext.ExtBot
     :show-inheritance:
     :members: insert_callback_data, defaults, rate_limiter, initialize, shutdown, callback_data_cache
+    :special-members: __repr__

--- a/docs/source/telegram.ext.job.rst
+++ b/docs/source/telegram.ext.job.rst
@@ -4,4 +4,4 @@ Job
 .. autoclass:: telegram.ext.Job
     :members:
     :show-inheritance:
-    :special-members: __call__
+    :special-members: __call__, __repr__

--- a/docs/source/telegram.ext.jobqueue.rst
+++ b/docs/source/telegram.ext.jobqueue.rst
@@ -4,3 +4,4 @@ JobQueue
 .. autoclass:: telegram.ext.JobQueue
     :members:
     :show-inheritance:
+    :special-members: __repr__

--- a/docs/source/telegram.ext.updater.rst
+++ b/docs/source/telegram.ext.updater.rst
@@ -4,3 +4,4 @@ Updater
 .. autoclass:: telegram.ext.Updater
     :members:
     :show-inheritance:
+    :special-members: __repr__


### PR DESCRIPTION
closes #3889 (work was unfinished in #3826: `__repr__()` methods were added but not rendered by Sphinx)