### PR TITLE
Add Rich Equality Comparison to `WriteAccessAllowed`

### DIFF
--- a/telegram/_writeaccessallowed.py
+++ b/telegram/_writeaccessallowed.py
@@ -28,7 +28,12 @@ class WriteAccessAllowed(TelegramObject):
     This object represents a service message about a user allowing a bot to write messages after
     adding the bot to the attachment menu or launching a Web App from a link.
 
+    Objects of this class are comparable in terms of equality. Two objects of this class are
+    considered equal, if their :attr:`web_app_name` is equal.
+
     .. versionadded:: 20.0
+    .. versionchanged:: NEXT.VERSION
+       Added custom equality comparison for objects of this class.
 
     Args:
         web_app_name (:obj:`str`, optional): Name of the Web App which was launched from a link.
@@ -49,5 +54,7 @@ class WriteAccessAllowed(TelegramObject):
     ):
         super().__init__(api_kwargs=api_kwargs)
         self.web_app_name: Optional[str] = web_app_name
+
+        self._id_attrs = (self.web_app_name,)
 
         self._freeze()

--- a/tests/test_writeaccessallowed.py
+++ b/tests/test_writeaccessallowed.py
@@ -36,3 +36,22 @@ class TestWriteAccessAllowed:
         action = WriteAccessAllowed()
         action_dict = action.to_dict()
         assert action_dict == {}
+
+    def test_equality(self):
+        a = WriteAccessAllowed()
+        b = WriteAccessAllowed()
+        c = WriteAccessAllowed(web_app_name="foo")
+        d = WriteAccessAllowed(web_app_name="foo")
+        e = WriteAccessAllowed(web_app_name="bar")
+
+        assert a == b
+        assert hash(a) == hash(b)
+
+        assert a != c
+        assert hash(a) != hash(c)
+
+        assert c == d
+        assert hash(c) == hash(d)
+
+        assert c != e
+        assert hash(c) != hash(e)


### PR DESCRIPTION
Closes #3909

- [x] Added ``.. versionadded:: NEXT.VERSION``, ``.. versionchanged:: NEXT.VERSION`` or ``.. deprecated:: NEXT.VERSION`` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [x] Documented code changes according to the `CSI standard <https://standards.mousepawmedia.com/en/stable/csi.html>`__
- ~Added myself alphabetically to ``AUTHORS.rst`` (optional)~
- ~Added new classes & modules to the docs and all suitable ``__all__`` s~
-  [x] Checked the `Stability Policy <https://docs.python-telegram-bot.org/stability_policy.html>`_ in case of deprecations or changes to documented behavior