### PR TITLE
Improve `BaseHandler.__repr__` for Callbacks without `__qualname__`

### DIFF
--- a/telegram/ext/_basehandler.py
+++ b/telegram/ext/_basehandler.py
@@ -105,7 +105,11 @@ class BaseHandler(Generic[UT, CCT], ABC):
         Returns:
             :obj:`str`
         """
-        return build_repr_with_selected_attrs(self, callback=self.callback.__qualname__)
+        try:
+            callback_name = self.callback.__qualname__
+        except AttributeError:
+            callback_name = repr(self.callback)
+        return build_repr_with_selected_attrs(self, callback=callback_name)
 
     @abstractmethod
     def check_update(self, update: object) -> Optional[Union[bool, object]]:

--- a/tests/ext/test_basehandler.py
+++ b/tests/ext/test_basehandler.py
@@ -52,3 +52,23 @@ class TestHandler:
 
         sh = SubclassHandler()
         assert repr(sh) == "SubclassHandler[callback=TestHandler.test_repr.<locals>.some_func]"
+
+    def test_repr_no_qualname(self):
+        class ClassBasedCallback:
+            async def __call__(self, *args, **kwargs):
+                pass
+
+            def __repr__(self):
+                return "Repr of ClassBasedCallback"
+
+        class SubclassHandler(BaseHandler):
+            __slots__ = ()
+
+            def __init__(self):
+                super().__init__(callback=ClassBasedCallback())
+
+            def check_update(self, update: object):
+                pass
+
+        sh = SubclassHandler()
+        assert repr(sh) == "SubclassHandler[callback=Repr of ClassBasedCallback]"


### PR DESCRIPTION
Fixes a small issue that came up in https://github.com/python-telegram-bot/python-telegram-bot/issues/3887#issuecomment-1765374459.

FYI @sometastycake