### PR TITLE
Add Parameter `socket_options` to `HTTPXRequest`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
           - --jobs=0
 
         additional_dependencies:
-          - httpx~=0.24.1
+          - httpx~=0.25.0
           - tornado~=6.3.3
           - APScheduler~=3.10.4
           - cachetools~=5.3.1
@@ -44,7 +44,7 @@ repos:
           - types-pytz
           - types-cryptography
           - types-cachetools
-          - httpx~=0.24.1
+          - httpx~=0.25.0
           - tornado~=6.3.3
           - APScheduler~=3.10.4
           - cachetools~=5.3.1
@@ -83,7 +83,7 @@ repos:
         name: ruff
         files: ^(telegram|examples|tests)/.*\.py$
         additional_dependencies:
-          - httpx~=0.24.1
+          - httpx~=0.25.0
           - tornado~=6.3.3
           - APScheduler~=3.10.4
           - cachetools~=5.3.1

--- a/telegram/request/_httpxrequest.py
+++ b/telegram/request/_httpxrequest.py
@@ -147,15 +147,13 @@ class HTTPXRequest(BaseRequest):
             if socket_options
             else None
         )
-        # See https://github.com/python-telegram-bot/python-telegram-bot/pull/3542
-        # for why we need to use `dict()` here.
-        self._client_kwargs = dict(  # pylint: disable=use-dict-literal
-            timeout=timeout,
-            proxies=proxy_url,
-            limits=limits,
-            transport=transport,
+        self._client_kwargs = {
+            "timeout": timeout,
+            "proxies": proxy_url,
+            "limits": limits,
+            "transport": transport,
             **http_kwargs,
-        )
+        }
 
         try:
             self._client = self._build_client()

--- a/telegram/request/_httpxrequest.py
+++ b/telegram/request/_httpxrequest.py
@@ -97,13 +97,14 @@ class HTTPXRequest(BaseRequest):
 
             .. versionchanged:: 20.5
                 Accept ``"2"`` as a valid value.
-        socket_options (Collection[Tuple], optional): A collection of socket options to set on
-            the underlying socket. For each entry, the first two elements must be integers
-            representing the socket level and the socket option, respectively. The third element
-            must be either an integer or a bytes-like object representing the value to set.
-            Alternatively, the entry can be a 4-tuple, where the third element is :obj:`None` and
-            the fourth element is an integer representing the timeout to set.
-            Defaults to :obj:`None`.
+        socket_options (Collection[:obj:`tuple`], optional): Socket options to be passed to the
+            underlying `library \
+            <https://www.encode.io/httpcore/async/#httpcore.AsyncConnectionPool.__init__>`_.
+
+            Note:
+                The values accepted by this parameter depend on the operating system.
+                This is a low-level parameter and should only be used if you are familiar with
+                these concepts.
 
             .. versionadded:: NEXT.VERSION
 

--- a/tests/ext/test_applicationbuilder.py
+++ b/tests/ext/test_applicationbuilder.py
@@ -91,6 +91,7 @@ class TestApplicationBuilder:
             limits: object
             http1: object
             http2: object
+            transport: object = None
 
         monkeypatch.setattr(httpx, "AsyncClient", Client)
 
@@ -322,6 +323,7 @@ class TestApplicationBuilder:
             limits: object
             http1: object
             http2: object
+            transport: object = None
 
         monkeypatch.setattr(httpx, "AsyncClient", Client)
 

--- a/tests/request/test_request.py
+++ b/tests/request/test_request.py
@@ -28,6 +28,7 @@ from typing import Any, Callable, Coroutine, Tuple
 
 import httpx
 import pytest
+from httpx import AsyncHTTPTransport
 
 from telegram._utils.defaultvalue import DEFAULT_NONE
 from telegram.error import (
@@ -617,6 +618,24 @@ class TestHTTPXRequestWithoutRequest:
                 )
 
             assert exc_info.value.__cause__ is pool_timeout
+
+    async def test_socket_opts(self, monkeypatch):
+        transport_kwargs = {}
+        transport_init = AsyncHTTPTransport.__init__
+
+        def init_transport(*args, **kwargs):
+            nonlocal transport_kwargs
+            transport_kwargs = kwargs.copy()
+            transport_init(*args, **kwargs)
+
+        monkeypatch.setattr(AsyncHTTPTransport, "__init__", init_transport)
+
+        HTTPXRequest()
+        assert "socket_options" not in transport_kwargs
+
+        transport_kwargs = {}
+        HTTPXRequest(socket_options=((1, 2, 3),))
+        assert transport_kwargs["socket_options"] == ((1, 2, 3),)
 
 
 @pytest.mark.skipif(not TEST_WITH_OPT_DEPS, reason="No need to run this twice")

--- a/tests/request/test_request.py
+++ b/tests/request/test_request.py
@@ -367,6 +367,7 @@ class TestHTTPXRequestWithoutRequest:
             limits: object
             http1: object
             http2: object
+            transport: object = None
 
         monkeypatch.setattr(httpx, "AsyncClient", Client)
 


### PR DESCRIPTION
Closes #2965

TBH I'm not quite sure if I got the parameter description right, as I've never really worked with socket options. @tsnoam if you could kindly have a look at the descrption, that would be a great help :)

- [ ] Once merged, the dev wiki section on https://github.com/python-telegram-bot/python-telegram-bot/wiki/Handling-network-errors#socket-options should be updated