### PR TITLE
Rename Parameter `proxy_url` to `proxy` and Support `httpx.Proxy` as Input

### DIFF
--- a/telegram/ext/_applicationbuilder.py
+++ b/telegram/ext/_applicationbuilder.py
@@ -32,9 +32,12 @@ from typing import (
     Union,
 )
 
+import httpx
+
 from telegram._bot import Bot
 from telegram._utils.defaultvalue import DEFAULT_FALSE, DEFAULT_NONE, DefaultValue
 from telegram._utils.types import DVInput, DVType, FilePathInput, HTTPVersion, ODVInput
+from telegram._utils.warnings import warn
 from telegram.ext._application import Application
 from telegram.ext._baseupdateprocessor import BaseUpdateProcessor, SimpleUpdateProcessor
 from telegram.ext._contexttypes import ContextTypes
@@ -44,6 +47,7 @@ from telegram.ext._updater import Updater
 from telegram.ext._utils.types import BD, BT, CCT, CD, JQ, UD
 from telegram.request import BaseRequest
 from telegram.request._httpxrequest import HTTPXRequest
+from telegram.warnings import PTBDeprecationWarning
 
 if TYPE_CHECKING:
     from telegram.ext import BasePersistence, BaseRateLimiter, CallbackContext, Defaults
@@ -66,14 +70,14 @@ _BOT_CHECKS = [
     ("request", "request instance"),
     ("get_updates_request", "get_updates_request instance"),
     ("connection_pool_size", "connection_pool_size"),
-    ("proxy_url", "proxy_url"),
+    ("proxy", "proxy"),
     ("pool_timeout", "pool_timeout"),
     ("connect_timeout", "connect_timeout"),
     ("read_timeout", "read_timeout"),
     ("write_timeout", "write_timeout"),
     ("http_version", "http_version"),
     ("get_updates_connection_pool_size", "get_updates_connection_pool_size"),
-    ("get_updates_proxy_url", "get_updates_proxy_url"),
+    ("get_updates_proxy", "get_updates_proxy"),
     ("get_updates_pool_timeout", "get_updates_pool_timeout"),
     ("get_updates_connect_timeout", "get_updates_connect_timeout"),
     ("get_updates_read_timeout", "get_updates_read_timeout"),
@@ -136,7 +140,7 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         "_get_updates_connect_timeout",
         "_get_updates_connection_pool_size",
         "_get_updates_pool_timeout",
-        "_get_updates_proxy_url",
+        "_get_updates_proxy",
         "_get_updates_read_timeout",
         "_get_updates_request",
         "_get_updates_write_timeout",
@@ -149,7 +153,7 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         "_post_stop",
         "_private_key",
         "_private_key_password",
-        "_proxy_url",
+        "_proxy",
         "_rate_limiter",
         "_read_timeout",
         "_request",
@@ -166,14 +170,14 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         self._base_url: DVType[str] = DefaultValue("https://api.telegram.org/bot")
         self._base_file_url: DVType[str] = DefaultValue("https://api.telegram.org/file/bot")
         self._connection_pool_size: DVInput[int] = DEFAULT_NONE
-        self._proxy_url: DVInput[str] = DEFAULT_NONE
+        self._proxy: DVInput[Union[str, httpx.Proxy, httpx.URL]] = DEFAULT_NONE
         self._connect_timeout: ODVInput[float] = DEFAULT_NONE
         self._read_timeout: ODVInput[float] = DEFAULT_NONE
         self._write_timeout: ODVInput[float] = DEFAULT_NONE
         self._pool_timeout: ODVInput[float] = DEFAULT_NONE
         self._request: DVInput[BaseRequest] = DEFAULT_NONE
         self._get_updates_connection_pool_size: DVInput[int] = DEFAULT_NONE
-        self._get_updates_proxy_url: DVInput[str] = DEFAULT_NONE
+        self._get_updates_proxy: DVInput[Union[str, httpx.Proxy, httpx.URL]] = DEFAULT_NONE
         self._get_updates_connect_timeout: ODVInput[float] = DEFAULT_NONE
         self._get_updates_read_timeout: ODVInput[float] = DEFAULT_NONE
         self._get_updates_write_timeout: ODVInput[float] = DEFAULT_NONE
@@ -214,7 +218,7 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         if not isinstance(getattr(self, f"{prefix}request"), DefaultValue):
             return getattr(self, f"{prefix}request")
 
-        proxy_url = DefaultValue.get_value(getattr(self, f"{prefix}proxy_url"))
+        proxy = DefaultValue.get_value(getattr(self, f"{prefix}proxy"))
         if get_updates:
             connection_pool_size = (
                 DefaultValue.get_value(getattr(self, f"{prefix}connection_pool_size")) or 1
@@ -239,7 +243,7 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
 
         return HTTPXRequest(
             connection_pool_size=connection_pool_size,
-            proxy_url=proxy_url,
+            proxy=proxy,
             http_version=http_version,  # type: ignore[arg-type]
             **effective_timeouts,
         )
@@ -419,8 +423,8 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         if not isinstance(getattr(self, f"_{prefix}connection_pool_size"), DefaultValue):
             raise RuntimeError(_TWO_ARGS_REQ.format(name, "connection_pool_size"))
 
-        if not isinstance(getattr(self, f"_{prefix}proxy_url"), DefaultValue):
-            raise RuntimeError(_TWO_ARGS_REQ.format(name, "proxy_url"))
+        if not isinstance(getattr(self, f"_{prefix}proxy"), DefaultValue):
+            raise RuntimeError(_TWO_ARGS_REQ.format(name, "proxy"))
 
         if not isinstance(getattr(self, f"_{prefix}http_version"), DefaultValue):
             raise RuntimeError(_TWO_ARGS_REQ.format(name, "http_version"))
@@ -486,21 +490,45 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         return self
 
     def proxy_url(self: BuilderType, proxy_url: str) -> BuilderType:
-        """Sets the proxy for the :paramref:`~telegram.request.HTTPXRequest.proxy_url`
-        parameter of :attr:`telegram.Bot.request`. Defaults to :obj:`None`.
+        """Legacy name for :meth:`proxy`, kept for backward compatibility.
 
+        .. seealso:: :meth:`get_updates_proxy`
 
-        .. seealso:: :meth:`get_updates_proxy_url`
+        .. deprecated:: NEXT.VERSION
 
         Args:
-            proxy_url (:obj:`str`): The URL to the proxy server. See
-                :paramref:`telegram.request.HTTPXRequest.proxy_url` for more information.
+            proxy_url (:obj:`str` | ``httpx.Proxy`` | ``httpx.URL``): See
+                :paramref:`telegram.ext.ApplicationBuilder.proxy.proxy`.
 
         Returns:
             :class:`ApplicationBuilder`: The same builder with the updated argument.
         """
-        self._request_param_check(name="proxy_url", get_updates=False)
-        self._proxy_url = proxy_url
+        warn(
+            "`ApplicationBuilder.proxy_url` is deprecated since version "
+            "Next.VERSION. Use `ApplicationBuilder.proxy` instead.",
+            PTBDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.proxy(proxy_url)
+
+    def proxy(self: BuilderType, proxy: Union[str, httpx.Proxy, httpx.URL]) -> BuilderType:
+        """Sets the proxy for the :paramref:`~telegram.request.HTTPXRequest.proxy`
+        parameter of :attr:`telegram.Bot.request`. Defaults to :obj:`None`.
+
+        .. seealso:: :meth:`get_updates_proxy`
+
+        .. versionadded:: NEXT.VERSION
+
+        Args:
+            proxy (:obj:`str` | ``httpx.Proxy`` | ``httpx.URL``): The URL to a proxy
+                server, a ``httpx.Proxy`` object or a ``httpx.URL`` object. See
+                :paramref:`telegram.request.HTTPXRequest.proxy` for more information.
+
+        Returns:
+            :class:`ApplicationBuilder`: The same builder with the updated argument.
+        """
+        self._request_param_check(name="proxy", get_updates=False)
+        self._proxy = proxy
         return self
 
     def connect_timeout(self: BuilderType, connect_timeout: Optional[float]) -> BuilderType:
@@ -655,21 +683,47 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         return self
 
     def get_updates_proxy_url(self: BuilderType, get_updates_proxy_url: str) -> BuilderType:
-        """Sets the proxy for the :paramref:`telegram.request.HTTPXRequest.proxy_url`
-        parameter which is used for :meth:`telegram.Bot.get_updates`. Defaults to :obj:`None`.
+        """Legacy name for :meth:`get_updates_proxy`, kept for backward compatibility.
 
+        .. seealso:: :meth:`proxy`
 
-        .. seealso:: :meth:`proxy_url`
+        .. deprecated:: NEXT.VERSION
 
         Args:
-            get_updates_proxy_url (:obj:`str`): The URL to the proxy server. See
-                :paramref:`telegram.request.HTTPXRequest.proxy_url` for more information.
+            get_updates_proxy_url (:obj:`str` | ``httpx.Proxy`` | ``httpx.URL``): See
+                :paramref:`telegram.ext.ApplicationBuilder.get_updates_proxy.get_updates_proxy`.
 
         Returns:
             :class:`ApplicationBuilder`: The same builder with the updated argument.
         """
-        self._request_param_check(name="proxy_url", get_updates=True)
-        self._get_updates_proxy_url = get_updates_proxy_url
+        warn(
+            "`ApplicationBuilder.get_updates_proxy_url` is deprecated since version "
+            "Next.VERSION. Use `ApplicationBuilder.proxy` instead.",
+            PTBDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.get_updates_proxy(get_updates_proxy_url)
+
+    def get_updates_proxy(
+        self: BuilderType, get_updates_proxy: Union[str, httpx.Proxy, httpx.URL]
+    ) -> BuilderType:
+        """Sets the proxy for the :paramref:`telegram.request.HTTPXRequest.proxy`
+        parameter which is used for :meth:`telegram.Bot.get_updates`. Defaults to :obj:`None`.
+
+        .. seealso:: :meth:`proxy`
+
+        .. versionadded:: NEXT.VERSION
+
+        Args:
+            proxy (:obj:`str` | ``httpx.Proxy`` | ``httpx.URL``): The URL to a proxy server,
+                a ``httpx.Proxy`` object or a ``httpx.URL`` object. See
+                :paramref:`telegram.request.HTTPXRequest.proxy` for more information.
+
+        Returns:
+            :class:`ApplicationBuilder`: The same builder with the updated argument.
+        """
+        self._request_param_check(name="proxy", get_updates=True)
+        self._get_updates_proxy = get_updates_proxy
         return self
 
     def get_updates_connect_timeout(

--- a/telegram/ext/_applicationbuilder.py
+++ b/telegram/ext/_applicationbuilder.py
@@ -505,7 +505,7 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         """
         warn(
             "`ApplicationBuilder.proxy_url` is deprecated since version "
-            "Next.VERSION. Use `ApplicationBuilder.proxy` instead.",
+            "NEXT.VERSION. Use `ApplicationBuilder.proxy` instead.",
             PTBDeprecationWarning,
             stacklevel=2,
         )
@@ -698,7 +698,7 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         """
         warn(
             "`ApplicationBuilder.get_updates_proxy_url` is deprecated since version "
-            "Next.VERSION. Use `ApplicationBuilder.proxy` instead.",
+            "NEXT.VERSION. Use `ApplicationBuilder.get_updates_proxy` instead.",
             PTBDeprecationWarning,
             stacklevel=2,
         )

--- a/telegram/request/_httpxrequest.py
+++ b/telegram/request/_httpxrequest.py
@@ -109,6 +109,8 @@ class HTTPXRequest(BaseRequest):
             Note:
                 * The proxy URL can also be set via the environment variables ``HTTPS_PROXY`` or
                   ``ALL_PROXY``. See `the docs of httpx`_ for more info.
+                * HTTPS proxies can be configured by passing a ``httpx.Proxy`` object with
+                  a corresponding ``ssl_context``.
                 * For Socks5 support, additional dependencies are required. Make sure to install
                   PTB via :command:`pip install "python-telegram-bot[socks]"` in this case.
                 * Socks5 proxies can not be set via environment variables.
@@ -124,7 +126,7 @@ class HTTPXRequest(BaseRequest):
     def __init__(
         self,
         connection_pool_size: int = 1,
-        proxy_url: Optional[Union[str, httpx.Proxy]] = None,
+        proxy_url: Optional[Union[str, httpx.Proxy, httpx.URL]] = None,
         read_timeout: Optional[float] = 5.0,
         write_timeout: Optional[float] = 5.0,
         connect_timeout: Optional[float] = 5.0,

--- a/telegram/request/_httpxrequest.py
+++ b/telegram/request/_httpxrequest.py
@@ -102,9 +102,9 @@ class HTTPXRequest(BaseRequest):
                 these concepts.
 
             .. versionadded:: NEXT.VERSION
-        proxy (:obj:`str` | ``httpx.Proxy``, optional): The URL to a proxy server or an
-            ``httpx.Proxy`` object. For example ``'http://127.0.0.1:3128'`` or
-            ``'socks5://127.0.0.1:3128'``. Defaults to :obj:`None`.
+        proxy (:obj:`str` | ``httpx.Proxy`` | ``httpx.URL``, optional): The URL to a proxy server,
+            a ``httpx.Proxy`` object or a ``httpx.URL`` object. For example
+            ``'http://127.0.0.1:3128'`` or ``'socks5://127.0.0.1:3128'``. Defaults to :obj:`None`.
 
             Note:
                 * The proxy URL can also be set via the environment variables ``HTTPS_PROXY`` or
@@ -131,7 +131,7 @@ class HTTPXRequest(BaseRequest):
         pool_timeout: Optional[float] = 1.0,
         http_version: HTTPVersion = "1.1",
         socket_options: Optional[Collection[_SocketOpt]] = None,
-        proxy: Optional[Union[str, httpx.Proxy]] = None,
+        proxy: Optional[Union[str, httpx.Proxy, httpx.URL]] = None,
     ):
         if proxy_url is not None and proxy is not None:
             raise ValueError("The parameters `proxy_url` and `proxy` are mutually exclusive.")

--- a/telegram/request/_httpxrequest.py
+++ b/telegram/request/_httpxrequest.py
@@ -17,16 +17,18 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains methods to make POST and GET requests using the httpx library."""
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import httpx
 
 from telegram._utils.defaultvalue import DefaultValue
 from telegram._utils.logging import get_logger
 from telegram._utils.types import HTTPVersion, ODVInput
+from telegram._utils.warnings import warn
 from telegram.error import NetworkError, TimedOut
 from telegram.request._baserequest import BaseRequest
 from telegram.request._requestdata import RequestData
+from telegram.warnings import PTBDeprecationWarning
 
 # Note to future devs:
 # Proxies are currently only tested manually. The httpx development docs have a nice guide on that:
@@ -49,17 +51,10 @@ class HTTPXRequest(BaseRequest):
             Note:
                 Independent of the value, one additional connection will be reserved for
                 :meth:`telegram.Bot.get_updates`.
-        proxy_url (:obj:`str`, optional): The URL to the proxy server. For example
-            ``'http://127.0.0.1:3128'`` or ``'socks5://127.0.0.1:3128'``. Defaults to :obj:`None`.
+        proxy_url (:obj:`str`, optional): Legacy name for :paramref:`proxy`, kept for backward
+            compatibility. Defaults to :obj:`None`.
 
-            Note:
-                * The proxy URL can also be set via the environment variables ``HTTPS_PROXY`` or
-                  ``ALL_PROXY``. See `the docs of httpx`_ for more info.
-                * For Socks5 support, additional dependencies are required. Make sure to install
-                  PTB via :command:`pip install "python-telegram-bot[socks]"` in this case.
-                * Socks5 proxies can not be set via environment variables.
-
-            .. _the docs of httpx: https://www.python-httpx.org/environment_variables/#proxies
+            .. deprecated:: NEXT.VERSION
         read_timeout (:obj:`float` | :obj:`None`, optional): If passed, specifies the maximum
             amount of time (in seconds) to wait for a response from Telegram's server.
             This value is used unless a different value is passed to :meth:`do_request`.
@@ -91,6 +86,20 @@ class HTTPXRequest(BaseRequest):
 
             .. versionchanged:: 20.5
                 Accept ``"2"`` as a valid value.
+        proxy (:obj:`str` | ``httpx.Proxy``, optional): The URL to a proxy server or an
+            ``httpx.Proxy`` object. For example ``'http://127.0.0.1:3128'`` or
+            ``'socks5://127.0.0.1:3128'``. Defaults to :obj:`None`.
+
+            Note:
+                * The proxy URL can also be set via the environment variables ``HTTPS_PROXY`` or
+                  ``ALL_PROXY``. See `the docs of httpx`_ for more info.
+                * For Socks5 support, additional dependencies are required. Make sure to install
+                  PTB via :command:`pip install "python-telegram-bot[socks]"` in this case.
+                * Socks5 proxies can not be set via environment variables.
+
+            .. _the docs of httpx: https://www.python-httpx.org/environment_variables/#proxies
+
+            .. versionadded:: NEXT.VERSION
 
     """
 
@@ -99,13 +108,26 @@ class HTTPXRequest(BaseRequest):
     def __init__(
         self,
         connection_pool_size: int = 1,
-        proxy_url: Optional[str] = None,
+        proxy_url: Optional[Union[str, httpx.Proxy]] = None,
         read_timeout: Optional[float] = 5.0,
         write_timeout: Optional[float] = 5.0,
         connect_timeout: Optional[float] = 5.0,
         pool_timeout: Optional[float] = 1.0,
         http_version: HTTPVersion = "1.1",
+        proxy: Optional[Union[str, httpx.Proxy]] = None,
     ):
+        if proxy_url is not None and proxy is not None:
+            raise ValueError("The parameters `proxy_url` and `proxy` are mutually exclusive.")
+
+        if proxy_url is not None:
+            proxy = proxy_url
+            warn(
+                "The parameter `proxy_url` is deprecated since version NEXT.VERSION. Use `proxy` "
+                "instead.",
+                PTBDeprecationWarning,
+                stacklevel=2,
+            )
+
         self._http_version = http_version
         timeout = httpx.Timeout(
             connect=connect_timeout,
@@ -127,7 +149,7 @@ class HTTPXRequest(BaseRequest):
         # for why we need to use `dict()` here.
         self._client_kwargs = dict(  # pylint: disable=use-dict-literal  # noqa: C408
             timeout=timeout,
-            proxies=proxy_url,
+            proxies=proxy,
             limits=limits,
             http1=http1,
             http2=not http1,

--- a/tests/request/test_request.py
+++ b/tests/request/test_request.py
@@ -360,7 +360,9 @@ class TestHTTPXRequestWithoutRequest:
     def _reset(self):
         self.test_flag = None
 
-    def test_init(self, monkeypatch):
+    # We parametrize this to make sure that the legacy `proxy_url` argument is still supported
+    @pytest.mark.parametrize("proxy_argument", ["proxy", "proxy_url"])
+    def test_init(self, monkeypatch, proxy_argument):
         @dataclass
         class Client:
             timeout: object
@@ -381,14 +383,15 @@ class TestHTTPXRequestWithoutRequest:
         assert request._client.http1 is True
         assert not request._client.http2
 
-        request = HTTPXRequest(
-            connection_pool_size=42,
-            proxy="proxy",
-            connect_timeout=43,
-            read_timeout=44,
-            write_timeout=45,
-            pool_timeout=46,
-        )
+        kwargs = {
+            "connection_pool_size": 42,
+            proxy_argument: "proxy",
+            "connect_timeout": 43,
+            "read_timeout": 44,
+            "write_timeout": 45,
+            "pool_timeout": 46,
+        }
+        request = HTTPXRequest(**kwargs)
         assert request._client.proxies == "proxy"
         assert request._client.limits == httpx.Limits(
             max_connections=42, max_keepalive_connections=42

--- a/tests/request/test_request.py
+++ b/tests/request/test_request.py
@@ -42,6 +42,7 @@ from telegram.error import (
     TimedOut,
 )
 from telegram.request._httpxrequest import HTTPXRequest
+from telegram.warnings import PTBDeprecationWarning
 from tests.auxil.envvars import TEST_WITH_OPT_DEPS
 from tests.auxil.slots import mro_slots
 
@@ -78,7 +79,7 @@ async def httpx_request():
 class TestNoSocksHTTP2WithoutRequest:
     async def test_init(self, bot):
         with pytest.raises(RuntimeError, match=r"python-telegram-bot\[socks\]"):
-            HTTPXRequest(proxy_url="socks5://foo")
+            HTTPXRequest(proxy="socks5://foo")
         with pytest.raises(RuntimeError, match=r"python-telegram-bot\[http2\]"):
             HTTPXRequest(http_version="2")
 
@@ -117,7 +118,7 @@ class TestRequestWithoutRequest:
 
         # Make sure that other exceptions are forwarded
         with pytest.raises(ImportError, match=r"Other Error Message"):
-            HTTPXRequest(proxy_url="socks5://foo")
+            HTTPXRequest(proxy="socks5://foo")
 
     def test_slot_behaviour(self):
         inst = HTTPXRequest()
@@ -380,17 +381,28 @@ class TestHTTPXRequestWithoutRequest:
 
         request = HTTPXRequest(
             connection_pool_size=42,
-            proxy_url="proxy_url",
+            proxy="proxy",
             connect_timeout=43,
             read_timeout=44,
             write_timeout=45,
             pool_timeout=46,
         )
-        assert request._client.proxies == "proxy_url"
+        assert request._client.proxies == "proxy"
         assert request._client.limits == httpx.Limits(
             max_connections=42, max_keepalive_connections=42
         )
         assert request._client.timeout == httpx.Timeout(connect=43, read=44, write=45, pool=46)
+
+    def test_proxy_mutually_exclusive(self):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            HTTPXRequest(proxy="proxy", proxy_url="proxy_url")
+
+    def test_proxy_url_deprecation_warning(self, recwarn):
+        HTTPXRequest(proxy_url="http://127.0.0.1:3128")
+        assert len(recwarn) == 1
+        assert recwarn[0].category is PTBDeprecationWarning
+        assert "`proxy_url` is deprecated" in str(recwarn[0].message)
+        assert recwarn[0].filename == __file__, "incorrect stacklevel"
 
     async def test_multiple_inits_and_shutdowns(self, monkeypatch):
         self.test_flag = defaultdict(int)


### PR DESCRIPTION
Closes #3844

<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

