### PR TITLE
handle _get_updates_cleanup() timeout error

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -55,6 +55,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `franciscod <https://github.com/franciscod>`_
 - `gamgi <https://github.com/gamgi>`_
 - `Gauthamram Ravichandran <https://github.com/GauthamramRavichandran>`_
+- `guillemap <https://github.com/guillemap>`_
 - `Harshil <https://github.com/harshil21>`_
 - `Hugo Damer <https://github.com/HakimusGIT>`_
 - `ihoru <https://github.com/ihoru>`_

--- a/telegram/ext/_application.py
+++ b/telegram/ext/_application.py
@@ -1146,7 +1146,7 @@ class Application(Generic[BT, CCT, UD, CD, BD, JQ], AsyncContextManager["Applica
                 # application.stop() will wait for it's clean shutdown.
                 _LOGGER.warning(
                     "Fetching updates got a asyncio.CancelledError. Ignoring as this task may only"
-                    "be closed via `Application.stop`."
+                    " be closed via `Application.stop`."
                 )
 
     async def __process_update_wrapper(self, update: object) -> None:

--- a/telegram/ext/_updater.py
+++ b/telegram/ext/_updater.py
@@ -413,7 +413,7 @@ class Updater(AsyncContextManager["Updater"]):
                     allowed_updates=allowed_updates,
                 )
             except TimedOut:
-                _LOGGER.debug(
+                _LOGGER.warning(
                     "`get_updates` timed out while marking updates as read. The last fetched "
                     "updates may be fetched again on the next polling start."
                 )

--- a/telegram/ext/_updater.py
+++ b/telegram/ext/_updater.py
@@ -401,16 +401,22 @@ class Updater(AsyncContextManager["Updater"]):
             _LOGGER.debug(
                 "Calling `get_updates` one more time to mark all fetched updates as read."
             )
-            await self.bot.get_updates(
-                offset=self._last_update_id,
-                # We don't want to do long polling here!
-                timeout=2,
-                read_timeout=read_timeout,
-                connect_timeout=connect_timeout,
-                write_timeout=write_timeout,
-                pool_timeout=pool_timeout,
-                allowed_updates=allowed_updates,
-            )
+            try:
+                await self.bot.get_updates(
+                    offset=self._last_update_id,
+                    # We don't want to do long polling here!
+                    timeout=0,
+                    read_timeout=read_timeout,
+                    connect_timeout=connect_timeout,
+                    write_timeout=write_timeout,
+                    pool_timeout=pool_timeout,
+                    allowed_updates=allowed_updates,
+                )
+            except TimedOut:
+                _LOGGER.debug(
+                    "`get_updates` timed out while marking updates as read. The last fetched "
+                    "updates may be fetched again on the next polling start."
+                )
 
         self.__polling_cleanup_cb = _get_updates_cleanup
 

--- a/telegram/ext/_updater.py
+++ b/telegram/ext/_updater.py
@@ -404,7 +404,7 @@ class Updater(AsyncContextManager["Updater"]):
             await self.bot.get_updates(
                 offset=self._last_update_id,
                 # We don't want to do long polling here!
-                timeout=0,
+                timeout=2,
                 read_timeout=read_timeout,
                 connect_timeout=connect_timeout,
                 write_timeout=write_timeout,

--- a/telegram/ext/_updater.py
+++ b/telegram/ext/_updater.py
@@ -405,7 +405,7 @@ class Updater(AsyncContextManager["Updater"]):
                 await self.bot.get_updates(
                     offset=self._last_update_id,
                     # We don't want to do long polling here!
-                    timeout=0,
+                    timeout=5,
                     read_timeout=read_timeout,
                     connect_timeout=connect_timeout,
                     write_timeout=write_timeout,


### PR DESCRIPTION
This prevents the application from hanging at updater.stop() process in some cases where it is stopped using ctrl+c.

The error is found when manually initializing the application to run it alongside other asyncio frameworks, as described [here](https://github.com/python-telegram-bot/python-telegram-bot/wiki/Frequently-requested-design-patterns#running-ptb-alongside-other-asyncio-frameworks). In this case, sometimes when stopping with crtl+c the app hangs at `await application.updater.stop()` and never reaches `await application.stop()`, while showing the warning:

> Fetching updates got a asyncio.CancelledError. Ignoring as this task may onlybe closed via \`Application.stop`.

Potentially fixes https://github.com/python-telegram-bot/python-telegram-bot/issues/3397

