### PR TITLE
Fix Persistency Issue with Ended Conversations

### DIFF
--- a/telegram/ext/_conversationhandler.py
+++ b/telegram/ext/_conversationhandler.py
@@ -626,6 +626,8 @@ class ConversationHandler(BaseHandler[Update, CCT]):
 
         # Since CH.END is stored as normal state, we need to properly parse it here in order to
         # actually end the conversation, i.e. delete the key from the _conversations dict
+        # This also makes sure that these entries are deleted from the persisted data on the next
+        # run of Application.update_persistence
         for key, state in stored_data.items():
             if state == self.END:
                 self._update_state(new_state=self.END, key=key)

--- a/telegram/ext/_conversationhandler.py
+++ b/telegram/ext/_conversationhandler.py
@@ -621,9 +621,14 @@ class ConversationHandler(BaseHandler[Update, CCT]):
         self._conversations.update(current_conversations)
         # above might be partly overridden but that's okay since we warn about that in
         # add_handler
-        self._conversations.update_no_track(
-            await application.persistence.get_conversations(self.name)
-        )
+        stored_data = await application.persistence.get_conversations(self.name)
+        self._conversations.update_no_track(stored_data)
+
+        # Since CH.END is stored as normal state, we need to properly parse it here in order to
+        # actually end the conversation, i.e. delete the key from the _conversations dict
+        for key, state in stored_data.items():
+            if state == self.END:
+                self._update_state(new_state=self.END, key=key)
 
         out = {self.name: self._conversations}
 


### PR DESCRIPTION
Fixes a bug in persistency of conversations:

CH.END is persited as other states, however `CH._update_state` expects to completely delete keys once they reach that state. So I now call `CH._state_update` manually in `_initialize_persistence`.

Tests still missng.

Reference: https://t.me/pythontelegrambotgroup/707714

- ~[ ] Added ``.. versionadded:: NEXT.VERSION``, ``.. versionchanged:: NEXT.VERSION`` or ``.. deprecated:: NEXT.VERSION`` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)~
- [x] Created new or adapted existing unit tests
- [x] Documented code changes according to the `CSI standard <https://standards.mousepawmedia.com/en/stable/csi.html>`__
- [x] Added myself alphabetically to ``AUTHORS.rst`` (optional)
- ~[ ] Added new classes & modules to the docs and all suitable ``__all__`` s~
- [x] Checked the `Stability Policy <https://docs.python-telegram-bot.org/stability_policy.html>`_ in case of deprecations or changes to documented behavior