### PR TITLE
Adding parameter test_env to bot

### DIFF
--- a/docs/source/inclusions/bot_methods.rst
+++ b/docs/source/inclusions/bot_methods.rst
@@ -390,6 +390,8 @@
       - The last name of the bot
     * - :attr:`~telegram.Bot.local_mode`
       - Whether the bot is running in local mode
+    * - :attr:`~telegram.Bot.test_env`
+      - Whether the bot should use the test endpoints
     * - :attr:`~telegram.Bot.username`
       - The username of the bot, without leading ``@``
     * - :attr:`~telegram.Bot.link`

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -207,7 +207,9 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             this is that files are uploaded using their local path in the
             `file URI scheme <https://en.wikipedia.org/wiki/File_URI_scheme>`_.
             Defaults to :obj:`False`.
-
+        test_env (:obj:`bool`, optional): If set to :obj:`True` appends /test to api route for method
+            calling. This should be set if you want to test your Mini Apps in the test environment.
+            See `Testing Mini Apps <https://core.telegram.org/bots/webapps#testing-mini-apps>`_.
             .. versionadded:: 20.0.
 
     .. include:: inclusions/bot_methods.rst
@@ -230,6 +232,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         "_request",
         "_initialized",
         "_local_mode",
+        "_test_env",
     )
 
     def __init__(
@@ -242,6 +245,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         private_key: Optional[bytes] = None,
         private_key_password: Optional[bytes] = None,
         local_mode: bool = False,
+        test_env: bool = False,
     ):
         super().__init__(api_kwargs=None)
         if not token:
@@ -251,6 +255,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         self._base_url: str = base_url + self._token
         self._base_file_url: str = base_file_url + self._token
         self._local_mode: bool = local_mode
+        self._test_env: bool = test_env
         self._bot_user: Optional[User] = None
         self._private_key: Optional[bytes] = None
         self._initialized: bool = False
@@ -407,6 +412,14 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         .. versionadded:: 20.0
         """
         return self._local_mode
+
+    @property
+    def test_env(self) -> bool:
+        """:obj:`bool`: Whether this bot is using the test endpoint.
+
+        .. versionadded:: ??
+        """
+        return self._test_env
 
     # Proper type hints are difficult because:
     # 1. cryptography doesn't have a nice base class, so it would get lengthy
@@ -639,7 +652,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         request = self._request[0] if endpoint == "getUpdates" else self._request[1]
 
         return await request.post(
-            url=f"{self._base_url}/{endpoint}",
+            url=f"{self._base_url}" +("/test" if self._test_env else "") + f"/{endpoint}",
             request_data=request_data,
             read_timeout=read_timeout,
             write_timeout=write_timeout,

--- a/telegram/ext/_applicationbuilder.py
+++ b/telegram/ext/_applicationbuilder.py
@@ -94,6 +94,7 @@ _BOT_CHECKS = [
     ("private_key", "private_key"),
     ("rate_limiter", "rate_limiter instance"),
     ("local_mode", "local_mode setting"),
+    ("test_env", "test_env setting"),
 ]
 
 _TWO_ARGS_REQ = "The parameter `{}` may only be set, if no {} was set."
@@ -167,6 +168,7 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         "_updater",
         "_write_timeout",
         "_local_mode",
+        "_test_env",
         "_http_version",
     )
 
@@ -196,6 +198,7 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         self._defaults: ODVInput[Defaults] = DEFAULT_NONE
         self._arbitrary_callback_data: Union[DefaultValue[bool], int] = DEFAULT_FALSE
         self._local_mode: DVType[bool] = DEFAULT_FALSE
+        self._test_env: DVType[bool] = DEFAULT_FALSE
         self._bot: DVInput[Bot] = DEFAULT_NONE
         self._update_queue: DVType[Queue] = DefaultValue(Queue())
 
@@ -273,6 +276,7 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
             get_updates_request=self._build_request(get_updates=True),
             rate_limiter=DefaultValue.get_value(self._rate_limiter),
             local_mode=DefaultValue.get_value(self._local_mode),
+            test_env=DefaultValue.get_value(self._test_env),
         )
 
     def _bot_check(self, name: str) -> None:
@@ -1004,6 +1008,24 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         self._bot_check("local_mode")
         self._updater_check("local_mode")
         self._local_mode = local_mode
+        return self
+
+    def test_env(self: BuilderType, test_env: bool) -> BuilderType:
+        """Specifies the value for :paramref:`~telegram.Bot.test_env` for the
+        :attr:`telegram.ext.Application.bot`.
+        If not called, will default to :obj:`False`.
+
+        .. seealso:: See `Testing Mini Apps <https://core.telegram.org/bots/webapps#testing-mini-apps>`_.
+
+        Args:
+            test_env (:obj:`bool`): Whether the bot should use the test routes for test environment
+
+        Returns:
+            :class:`ApplicationBuilder`: The same builder with the updated argument.
+        """
+        self._bot_check("test_env")
+        self._updater_check("test_env")
+        self._test_env = test_env
         return self
 
     def bot(

--- a/telegram/ext/_extbot.py
+++ b/telegram/ext/_extbot.py
@@ -180,6 +180,7 @@ class ExtBot(Bot, Generic[RLARGS]):
         defaults: Optional["Defaults"] = None,
         arbitrary_callback_data: Union[bool, int] = False,
         local_mode: bool = False,
+        test_env: bool = False,
     ):
         ...
 
@@ -196,6 +197,7 @@ class ExtBot(Bot, Generic[RLARGS]):
         defaults: Optional["Defaults"] = None,
         arbitrary_callback_data: Union[bool, int] = False,
         local_mode: bool = False,
+        test_env: bool = False,
         rate_limiter: Optional["BaseRateLimiter[RLARGS]"] = None,
     ):
         ...
@@ -212,6 +214,7 @@ class ExtBot(Bot, Generic[RLARGS]):
         defaults: Optional["Defaults"] = None,
         arbitrary_callback_data: Union[bool, int] = False,
         local_mode: bool = False,
+        test_env: bool = False,
         rate_limiter: Optional["BaseRateLimiter[RLARGS]"] = None,
     ):
         super().__init__(
@@ -223,6 +226,7 @@ class ExtBot(Bot, Generic[RLARGS]):
             private_key=private_key,
             private_key_password=private_key_password,
             local_mode=local_mode,
+            test_env=test_env,
         )
         with self._unfrozen():
             self._defaults: Optional[Defaults] = defaults


### PR DESCRIPTION

allowing to use the test environment via the new test_env parameter for the application builder.
This enables testing Web Apps as documented here: https://core.telegram.org/bots/webapps#testing-mini-apps

I tried to document as well as possible, but could need some help for coming up with tests for that.