### PR TITLE
Add `do_process` in `BaseHandler`

### DIFF
--- a/telegram/ext/_application.py
+++ b/telegram/ext/_application.py
@@ -1179,31 +1179,12 @@ class Application(Generic[BT, CCT, UD, CD, BD, JQ], AsyncContextManager["Applica
         for handlers in self.handlers.values():
             try:
                 for handler in handlers:
-                    check = handler.check_update(update)  # Should the handler handle this update?
-                    if not (check is None or check is False):  # if yes,
-                        if not context:  # build a context if not already built
-                            context = self.context_types.context.from_update(update, self)
-                            await context.refresh_data()
-                        coroutine: Coroutine = handler.handle_update(update, self, check, context)
-
-                        if not handler.block or (  # if handler is running with block=False,
-                            handler.block is DEFAULT_TRUE
-                            and isinstance(self.bot, ExtBot)
-                            and self.bot.defaults
-                            and not self.bot.defaults.block
-                        ):
-                            self.create_task(
-                                coroutine,
-                                update=update,
-                                name=(
-                                    f"Application:{self.bot.id}:process_update_non_blocking"
-                                    f":{handler}"
-                                ),
-                            )
-                        else:
-                            any_blocking = True
-                            await coroutine
-                        break  # Only a max of 1 handler per group is handled
+                    processed, context, _cur_blocking = await handler.do_process(
+                        context, update, self
+                    )
+                    if processed:
+                        any_blocking |= _cur_blocking
+                        break
 
             # Stop processing with any other handler.
             except ApplicationHandlerStop:
@@ -1221,6 +1202,42 @@ class Application(Generic[BT, CCT, UD, CD, BD, JQ], AsyncContextManager["Applica
             # blocking handler - the non-blocking handlers mark the update again when finished
             # (in __create_task_callback)
             self._mark_for_persistence_update(update=update)
+
+    def _check_should_create_async_task(
+        self, handler: BaseHandler[Any, CCT]
+    ) -> Optional[Union[bool, object]]:
+        return not handler.block or (  # if handler is running with block=False
+            handler.block is DEFAULT_TRUE
+            and isinstance(self.bot, ExtBot)
+            and self.bot.defaults
+            and not self.bot.defaults.block
+        )
+
+    async def do_process_update(
+        self, handler: BaseHandler[Any, CCT], update: object, coroutine: Coroutine
+    ) -> bool:
+        """Called by a handle to truely process an update.
+
+        Args:
+            handler (:class:`telegram.ext.BaseHandler`): The handler that be responsible for
+                this update.
+            update (:class:`telegram.Update` | :obj:`object` | \
+                :class:`telegram.error.TelegramError`): The update to process.
+            coroutine (:obj:`Coroutine`): The task that to be processed.
+
+        Returns:
+            :obj:`bool`: Whether the handling process is blocking.
+
+        """
+        if self._check_should_create_async_task(handler):
+            self.create_task(
+                coroutine,
+                update=update,
+                name=(f"Application:{self.bot.id}:do_process_update_non_blocking:{handler}"),
+            )
+            return False
+        await coroutine
+        return True
 
     def add_handler(self, handler: BaseHandler[Any, CCT], group: int = DEFAULT_GROUP) -> None:
         """Register a handler.


### PR DESCRIPTION
In the `process_update` method of the class `Application`, the handler is called through a "check then run" approach, where the "check" and "run" steps are two different calls. If this piece of code is moved to the `BaseHandler` as a method `do_process`, users can choose to override this method to implement a customized processing of the update. For instance, by inheriting the `ConversationHandler` and overriding it like this:

```python
async def do_process(self, context, update, app):
    async with self._some_async_lock:
        super().do_process(context, update, app)
```

One can achieve a simple (but inefficient) concurrent version of `ConversationHandler`. With a slightly more complex implementation an efficient `ConversationHandler` is also possible.

This PR only refactors the code and does not introduce new things.


<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->
