### PR TITLE
Add `invoice_payload` filtering

### DIFF
--- a/telegram/ext/_precheckoutqueryhandler.py
+++ b/telegram/ext/_precheckoutqueryhandler.py
@@ -20,7 +20,7 @@
 
 
 import re
-from typing import Optional, TypeVar, Union
+from typing import Optional, Pattern, TypeVar, Union
 
 from telegram import Update
 from telegram._utils.defaultvalue import DEFAULT_TRUE
@@ -77,7 +77,7 @@ class PreCheckoutQueryHandler(BaseHandler[Update, CCT]):
     def __init__(
         self,
         callback: HandlerCallback[Update, CCT, RT],
-        pattern: Optional[Union[str, re.Pattern[str]]] = None,
+        pattern: Optional[Union[str, Pattern[str]]] = None,
         block: DVType[bool] = DEFAULT_TRUE,
     ):
         super().__init__(callback, block=block)
@@ -85,7 +85,7 @@ class PreCheckoutQueryHandler(BaseHandler[Update, CCT]):
         if isinstance(pattern, str):
             pattern = re.compile(pattern)
 
-        self.pattern: Optional[Union[str, re.Pattern[str]]] = pattern
+        self.pattern: Optional[Union[str, Pattern[str]]] = pattern
 
     def check_update(self, update: object) -> bool:
         """Determines whether an update should be passed to this handler's :attr:`callback`.

--- a/telegram/ext/_precheckoutqueryhandler.py
+++ b/telegram/ext/_precheckoutqueryhandler.py
@@ -100,8 +100,6 @@ class PreCheckoutQueryHandler(BaseHandler[Update, CCT]):
         if isinstance(update, Update) and update.pre_checkout_query:
             invoice_payload = update.pre_checkout_query.invoice_payload
             if self.pattern:
-                if invoice_payload is None:
-                    return False
                 if re.match(self.pattern, invoice_payload):
                     return True
             else:

--- a/telegram/ext/_precheckoutqueryhandler.py
+++ b/telegram/ext/_precheckoutqueryhandler.py
@@ -50,9 +50,8 @@ class PreCheckoutQueryHandler(BaseHandler[Update, CCT]):
 
             The return value of the callback is usually ignored except for the special case of
             :class:`telegram.ext.ConversationHandler`.
-        pattern (:func:`re.Pattern <re.compile>` | :obj:`callable` | :obj:`type`): Optional.
-            Regex pattern, callback or type to test
-            :attr:`telegram.PreCheckoutQuery.invoice_payload` against.
+        pattern (:obj:`str` | :func:`re.Pattern <re.compile>`, optional): Optional. Regex pattern
+            to test :attr:`telegram.PreCheckoutQuery.invoice_payload` against.
 
             .. versionadded:: NEXT.VERSION
         block (:obj:`bool`, optional): Determines whether the return value of the callback should
@@ -63,9 +62,8 @@ class PreCheckoutQueryHandler(BaseHandler[Update, CCT]):
 
     Attributes:
         callback (:term:`coroutine function`): The callback function for this handler.
-        pattern (:func:`re.Pattern <re.compile>` | :obj:`callable` | :obj:`type`): Optional.
-            Regex pattern, callback or type to test
-            :attr:`telegram.PreCheckoutQuery.invoice_payload` against.
+        pattern (:obj:`str` | :func:`re.Pattern <re.compile>`, optional): Optional. Regex pattern
+            to test :attr:`telegram.PreCheckoutQuery.invoice_payload` against.
 
             .. versionadded:: NEXT.VERSION
         block (:obj:`bool`): Determines whether the callback will run in a blocking way..

--- a/telegram/ext/_precheckoutqueryhandler.py
+++ b/telegram/ext/_precheckoutqueryhandler.py
@@ -20,7 +20,7 @@
 
 
 import re
-from typing import Optional, Pattern, TypeVar, Union
+from typing import Optional, Pattern, TypeVar
 
 from telegram import Update
 from telegram._utils.defaultvalue import DEFAULT_TRUE
@@ -50,23 +50,23 @@ class PreCheckoutQueryHandler(BaseHandler[Update, CCT]):
 
             The return value of the callback is usually ignored except for the special case of
             :class:`telegram.ext.ConversationHandler`.
-        pattern (:obj:`str` | :func:`re.Pattern <re.compile>`, optional): Optional. Regex pattern
-            to test :attr:`telegram.PreCheckoutQuery.invoice_payload` against.
-
-            .. versionadded:: NEXT.VERSION
         block (:obj:`bool`, optional): Determines whether the return value of the callback should
             be awaited before processing the next handler in
             :meth:`telegram.ext.Application.process_update`. Defaults to :obj:`True`.
 
             .. seealso:: :wiki:`Concurrency`
-
-    Attributes:
-        callback (:term:`coroutine function`): The callback function for this handler.
         pattern (:obj:`str` | :func:`re.Pattern <re.compile>`, optional): Optional. Regex pattern
             to test :attr:`telegram.PreCheckoutQuery.invoice_payload` against.
 
             .. versionadded:: NEXT.VERSION
+
+    Attributes:
+        callback (:term:`coroutine function`): The callback function for this handler.
         block (:obj:`bool`): Determines whether the callback will run in a blocking way..
+        pattern (:obj:`str` | :func:`re.Pattern <re.compile>`, optional): Optional. Regex pattern
+            to test :attr:`telegram.PreCheckoutQuery.invoice_payload` against.
+
+            .. versionadded:: NEXT.VERSION
 
     """
 
@@ -75,15 +75,12 @@ class PreCheckoutQueryHandler(BaseHandler[Update, CCT]):
     def __init__(
         self,
         callback: HandlerCallback[Update, CCT, RT],
-        pattern: Optional[Union[str, Pattern[str]]] = None,
         block: DVType[bool] = DEFAULT_TRUE,
+        pattern: Optional[Pattern[str]] = None,
     ):
         super().__init__(callback, block=block)
 
-        if isinstance(pattern, str):
-            pattern = re.compile(pattern)
-
-        self.pattern: Optional[Union[str, Pattern[str]]] = pattern
+        self.pattern: Optional[Pattern[str]] = re.compile(pattern) if pattern is not None else None
 
     def check_update(self, update: object) -> bool:
         """Determines whether an update should be passed to this handler's :attr:`callback`.
@@ -98,7 +95,7 @@ class PreCheckoutQueryHandler(BaseHandler[Update, CCT]):
         if isinstance(update, Update) and update.pre_checkout_query:
             invoice_payload = update.pre_checkout_query.invoice_payload
             if self.pattern:
-                if re.match(self.pattern, invoice_payload):
+                if self.pattern.match(invoice_payload):
                     return True
             else:
                 return True

--- a/telegram/ext/_precheckoutqueryhandler.py
+++ b/telegram/ext/_precheckoutqueryhandler.py
@@ -20,7 +20,7 @@
 
 
 import re
-from typing import Optional, Pattern, TypeVar
+from typing import Optional, Pattern, TypeVar, Union
 
 from telegram import Update
 from telegram._utils.defaultvalue import DEFAULT_TRUE
@@ -76,7 +76,7 @@ class PreCheckoutQueryHandler(BaseHandler[Update, CCT]):
         self,
         callback: HandlerCallback[Update, CCT, RT],
         block: DVType[bool] = DEFAULT_TRUE,
-        pattern: Optional[Pattern[str]] = None,
+        pattern: Optional[Union[str, Pattern[str]]] = None,
     ):
         super().__init__(callback, block=block)
 

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -75,6 +75,7 @@ __all__ = (
     "Sticker",
     "STORY",
     "SUCCESSFUL_PAYMENT",
+    "SuccessfulPayment",
     "SenderChat",
     "StatusUpdate",
     "TEXT",

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -2277,8 +2277,9 @@ class SuccessfulPayment(MessageFilter):
         :attr:`telegram.ext.filters.SUCCESSFUL_PAYMENT`
 
     Args:
-        invoice_payloads (List[:obj:`str`] | Tuple[:obj:`str`], optional): Which invoice payloads
-        to allow. Only exact matches are allowed. If not specified, will allow any invoice payload.
+        invoice_payloads (List[:obj:`str`] | Tuple[:obj:`str`], optional): Which
+            invoice payloads to allow. Only exact matches are allowed. If not
+            specified, will allow any invoice payload.
 
     .. versionadded:: NEXT.VERSION
     """

--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -2265,14 +2265,44 @@ STORY = _Story(name="filters.STORY")
 """
 
 
-class _SuccessfulPayment(MessageFilter):
-    __slots__ = ()
+class SuccessfulPayment(MessageFilter):
+    """Successful Payment Messages. If a list of invoice payloads is passed, it filters
+    messages to only allow those whose `invoice_payload` is appearing in the given list.
+
+    Examples:
+        `MessageHandler(filters.SuccessfulPayment(['Custom-Payload']), callback_method)`
+
+    .. seealso::
+        :attr:`telegram.ext.filters.SUCCESSFUL_PAYMENT`
+
+    Args:
+        invoice_payloads (List[:obj:`str`] | Tuple[:obj:`str`], optional): Which invoice payloads
+        to allow. Only exact matches are allowed. If not specified, will allow any invoice payload.
+
+    .. versionadded:: NEXT.VERSION
+    """
+
+    __slots__ = ("invoice_payloads",)
+
+    def __init__(self, invoice_payloads: Optional[Union[List[str], Tuple[str, ...]]] = None):
+        self.invoice_payloads: Optional[Sequence[str]] = invoice_payloads
+        super().__init__(
+            name=f"filters.SuccessfulPayment({invoice_payloads})"
+            if invoice_payloads
+            else "filters.SUCCESSFUL_PAYMENT"
+        )
 
     def filter(self, message: Message) -> bool:
-        return bool(message.successful_payment)
+        if self.invoice_payloads is None:
+            return bool(message.successful_payment)
+        return (
+            payment.invoice_payload in self.invoice_payloads
+            if (payment := message.successful_payment)
+            else False
+        )
 
 
-SUCCESSFUL_PAYMENT = _SuccessfulPayment(name="filters.SUCCESSFUL_PAYMENT")
+SUCCESSFUL_PAYMENT = SuccessfulPayment()
 """Messages that contain :attr:`telegram.Message.successful_payment`."""
 
 

--- a/tests/ext/test_filters.py
+++ b/tests/ext/test_filters.py
@@ -31,6 +31,7 @@ from telegram import (
     Message,
     MessageEntity,
     Sticker,
+    SuccessfulPayment,
     Update,
     User,
 )
@@ -1876,6 +1877,13 @@ class TestFilters:
         assert not filters.SUCCESSFUL_PAYMENT.check_update(update)
         update.message.successful_payment = "test"
         assert filters.SUCCESSFUL_PAYMENT.check_update(update)
+
+    def test_filters_successful_payment_payloads(self, update):
+        update.message.successful_payment = SuccessfulPayment(
+            "USD", 100, "custom-payload", "123", "123"
+        )
+        assert filters.SuccessfulPayment(("custom-payload",)).check_update(update)
+        assert not filters.SuccessfulPayment(["test1"]).check_update(update)
 
     def test_filters_passport_data(self, update):
         assert not filters.PASSPORT_DATA.check_update(update)

--- a/tests/ext/test_filters.py
+++ b/tests/ext/test_filters.py
@@ -1879,11 +1879,22 @@ class TestFilters:
         assert filters.SUCCESSFUL_PAYMENT.check_update(update)
 
     def test_filters_successful_payment_payloads(self, update):
+        assert not filters.SuccessfulPayment(("custom-payload",)).check_update(update)
+        assert not filters.SuccessfulPayment().check_update(update)
+
         update.message.successful_payment = SuccessfulPayment(
             "USD", 100, "custom-payload", "123", "123"
         )
         assert filters.SuccessfulPayment(("custom-payload",)).check_update(update)
+        assert filters.SuccessfulPayment().check_update(update)
         assert not filters.SuccessfulPayment(["test1"]).check_update(update)
+
+    def test_filters_successful_payment_repr(self):
+        f = filters.SuccessfulPayment()
+        assert str(f) == "filters.SUCCESSFUL_PAYMENT"
+
+        f = filters.SuccessfulPayment(["payload1", "payload2"])
+        assert str(f) == "filters.SuccessfulPayment(['payload1', 'payload2'])"
 
     def test_filters_passport_data(self, update):
         assert not filters.PASSPORT_DATA.check_update(update)

--- a/tests/ext/test_precheckoutqueryhandler.py
+++ b/tests/ext/test_precheckoutqueryhandler.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 import asyncio
+import re
 
 import pytest
 
@@ -109,6 +110,15 @@ class TestPreCheckoutQueryHandler:
     def test_with_pattern(self, pre_checkout_query):
         handler = PreCheckoutQueryHandler(self.callback, pattern=".*voice.*")
 
+        assert handler.check_update(pre_checkout_query)
+
+        pre_checkout_query.pre_checkout_query.invoice_payload = "nothing here"
+        assert not handler.check_update(pre_checkout_query)
+
+    def test_with_compiled_pattern(self, pre_checkout_query):
+        handler = PreCheckoutQueryHandler(self.callback, pattern=re.compile(r".*payload"))
+
+        pre_checkout_query.pre_checkout_query.invoice_payload = "invoice_payload"
         assert handler.check_update(pre_checkout_query)
 
         pre_checkout_query.pre_checkout_query.invoice_payload = "nothing here"


### PR DESCRIPTION
Closes #3752

- [x]  Added ``.. versionadded:: NEXT.VERSION``, ``.. versionchanged:: NEXT.VERSION`` or ``.. deprecated:: NEXT.VERSION`` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x]  Created new or adapted existing unit tests
- [x]  Documented code changes according to the `CSI standard <https://standards.mousepawmedia.com/en/stable/csi.html>`__
- [ ]  ~Added myself alphabetically to ``AUTHORS.rst`` (optional)~
- [x]  Added new classes & modules to the docs and all suitable ``__all__`` s
- [ ]  Checked the `Stability Policy <https://docs.python-telegram-bot.org/stability_policy.html>`_ in case of deprecations or changes to documented behavior

why not add `collect_additional_context` in `PreCheckoutQueryHandler` to store the match since we're adding a `pattern` argument. i can do it if you approve.

