### PR TITLE
Removed deprecated warning message

### DIFF
--- a/telegram/ext/_jobqueue.py
+++ b/telegram/ext/_jobqueue.py
@@ -589,13 +589,6 @@ class JobQueue(Generic[CCT]):
             queue.
 
         """
-        # TODO: After v20.0, we should remove this warning.
-        if days != tuple(range(7)):  # checks if user passed a custom value
-            warn(
-                "Prior to v20.0 the `days` parameter was not aligned to that of cron's weekday "
-                "scheme. We recommend double checking if the passed value is correct.",
-                stacklevel=2,
-            )
         if not job_kwargs:
             job_kwargs = {}
 


### PR DESCRIPTION
In the _jobqueue.py file, we removed a deprecated warning message that is no longer needed after v20.0. This warning was about the `days` parameter not being aligned with cron's weekday scheme.

<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

