### PR TITLE
Add Missing Conversions of `type` to Corresponding Enum from `telegram.constants`

### DIFF
--- a/telegram/_botcommandscope.py
+++ b/telegram/_botcommandscope.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Dict, Final, Optional, Type, Union
 
 from telegram import constants
 from telegram._telegramobject import TelegramObject
+from telegram._utils import enum
 from telegram._utils.types import JSONDict
 
 if TYPE_CHECKING:
@@ -77,7 +78,7 @@ class BotCommandScope(TelegramObject):
 
     def __init__(self, type: str, *, api_kwargs: Optional[JSONDict] = None):
         super().__init__(api_kwargs=api_kwargs)
-        self.type: str = type
+        self.type: str = enum.get_member(constants.BotCommandScopeType, type, type)
         self._id_attrs = (self.type,)
 
         self._freeze()

--- a/telegram/_files/inputmedia.py
+++ b/telegram/_files/inputmedia.py
@@ -19,6 +19,7 @@
 """Base class for Telegram InputMedia Objects."""
 from typing import Optional, Sequence, Tuple, Union
 
+from telegram import constants
 from telegram._files.animation import Animation
 from telegram._files.audio import Audio
 from telegram._files.document import Document
@@ -27,6 +28,7 @@ from telegram._files.photosize import PhotoSize
 from telegram._files.video import Video
 from telegram._messageentity import MessageEntity
 from telegram._telegramobject import TelegramObject
+from telegram._utils import enum
 from telegram._utils.argumentparsing import parse_sequence_arg
 from telegram._utils.defaultvalue import DEFAULT_NONE
 from telegram._utils.files import parse_file_input
@@ -94,7 +96,7 @@ class InputMedia(TelegramObject):
         api_kwargs: Optional[JSONDict] = None,
     ):
         super().__init__(api_kwargs=api_kwargs)
-        self.type: str = media_type
+        self.type: str = enum.get_member(constants.InputMediaType, media_type, media_type)
         self.media: Union[str, InputFile, Animation, Audio, Document, PhotoSize, Video] = media
         self.caption: Optional[str] = caption
         self.caption_entities: Tuple[MessageEntity, ...] = parse_sequence_arg(caption_entities)

--- a/telegram/_files/sticker.py
+++ b/telegram/_files/sticker.py
@@ -24,6 +24,7 @@ from telegram._files._basethumbedmedium import _BaseThumbedMedium
 from telegram._files.file import File
 from telegram._files.photosize import PhotoSize
 from telegram._telegramobject import TelegramObject
+from telegram._utils import enum
 from telegram._utils.argumentparsing import parse_sequence_arg
 from telegram._utils.types import JSONDict
 
@@ -175,7 +176,7 @@ class Sticker(_BaseThumbedMedium):
             self.height: int = height
             self.is_animated: bool = is_animated
             self.is_video: bool = is_video
-            self.type: str = type
+            self.type: str = enum.get_member(constants.StickerType, type, type)
             # Optional
             self.emoji: Optional[str] = emoji
             self.set_name: Optional[str] = set_name

--- a/telegram/_inline/inlinequeryresult.py
+++ b/telegram/_inline/inlinequeryresult.py
@@ -23,6 +23,7 @@ from typing import Final, Optional
 
 from telegram import constants
 from telegram._telegramobject import TelegramObject
+from telegram._utils import enum
 from telegram._utils.types import JSONDict
 
 
@@ -59,7 +60,7 @@ class InlineQueryResult(TelegramObject):
         super().__init__(api_kwargs=api_kwargs)
 
         # Required
-        self.type: str = type
+        self.type: str = enum.get_member(constants.InlineQueryResultType, type, type)
         self.id: str = str(id)
 
         self._id_attrs = (self.id,)

--- a/telegram/_menubutton.py
+++ b/telegram/_menubutton.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Dict, Final, Optional, Type
 
 from telegram import constants
 from telegram._telegramobject import TelegramObject
+from telegram._utils import enum
 from telegram._utils.types import JSONDict
 from telegram._webappinfo import WebAppInfo
 
@@ -61,7 +62,7 @@ class MenuButton(TelegramObject):
         api_kwargs: Optional[JSONDict] = None,
     ):  # pylint: disable=redefined-builtin
         super().__init__(api_kwargs=api_kwargs)
-        self.type: str = type
+        self.type: str = enum.get_member(constants.MenuButtonType, type, type)
 
         self._id_attrs = (self.type,)
 

--- a/tests/_files/test_inputmedia.py
+++ b/tests/_files/test_inputmedia.py
@@ -25,6 +25,7 @@ import pytest
 
 from telegram import (
     InputFile,
+    InputMedia,
     InputMediaAnimation,
     InputMediaAudio,
     InputMediaDocument,
@@ -33,7 +34,7 @@ from telegram import (
     Message,
     MessageEntity,
 )
-from telegram.constants import ParseMode
+from telegram.constants import InputMediaType, ParseMode
 
 # noinspection PyUnresolvedReferences
 from telegram.error import BadRequest
@@ -202,6 +203,26 @@ class TestInputMediaVideoWithoutRequest(TestInputMediaVideoBase):
         )
         assert input_media_video.media == data_file("telegram.mp4").as_uri()
         assert input_media_video.thumbnail == data_file("telegram.jpg").as_uri()
+
+    def test_type_enum_conversion(self):
+        # Since we have a lot of different test classes for all the input media types, we test this
+        # conversion only here. It is independent of the specific class
+        assert (
+            type(
+                InputMedia(
+                    media_type="animation",
+                    media="media",
+                ).type
+            )
+            is InputMediaType
+        )
+        assert (
+            InputMedia(
+                media_type="unknown",
+                media="media",
+            ).type
+            == "unknown"
+        )
 
 
 class TestInputMediaPhotoBase:

--- a/tests/_files/test_sticker.py
+++ b/tests/_files/test_sticker.py
@@ -35,7 +35,7 @@ from telegram import (
     Sticker,
     StickerSet,
 )
-from telegram.constants import StickerFormat
+from telegram.constants import StickerFormat, StickerType
 from telegram.error import BadRequest, TelegramError
 from telegram.request import RequestData
 from tests.auxil.bot_method_checks import (
@@ -195,6 +195,34 @@ class TestStickerWithoutRequest(TestStickerBase):
         assert json_sticker.type == self.type
         assert json_sticker.custom_emoji_id == self.custom_emoji_id
         assert json_sticker.needs_repainting == self.needs_repainting
+
+    def test_type_enum_conversion(self):
+        assert (
+            type(
+                Sticker(
+                    file_id=self.sticker_file_id,
+                    file_unique_id=self.sticker_file_unique_id,
+                    width=self.width,
+                    height=self.height,
+                    is_animated=self.is_animated,
+                    is_video=self.is_video,
+                    type="regular",
+                ).type
+            )
+            is StickerType
+        )
+        assert (
+            Sticker(
+                file_id=self.sticker_file_id,
+                file_unique_id=self.sticker_file_unique_id,
+                width=self.width,
+                height=self.height,
+                is_animated=self.is_animated,
+                is_video=self.is_video,
+                type="unknown",
+            ).type
+            == "unknown"
+        )
 
     def test_equality(self, sticker):
         a = Sticker(

--- a/tests/_inline/test_inlinequeryresultarticle.py
+++ b/tests/_inline/test_inlinequeryresultarticle.py
@@ -22,10 +22,12 @@ import pytest
 from telegram import (
     InlineKeyboardButton,
     InlineKeyboardMarkup,
+    InlineQueryResult,
     InlineQueryResultArticle,
     InlineQueryResultAudio,
     InputTextMessageContent,
 )
+from telegram.constants import InlineQueryResultType
 from tests.auxil.slots import mro_slots
 
 
@@ -114,6 +116,26 @@ class TestInlineQueryResultArticleWithoutRequest(TestInlineQueryResultArticleBas
         assert (
             inline_query_result_article_dict["thumbnail_width"]
             == inline_query_result_article.thumbnail_width
+        )
+
+    def test_type_enum_conversion(self):
+        # Since we have a lot of different test files for all the result types, we test this
+        # conversion only here. It is independent of the specific class
+        assert (
+            type(
+                InlineQueryResult(
+                    id="id",
+                    type="article",
+                ).type
+            )
+            is InlineQueryResultType
+        )
+        assert (
+            InlineQueryResult(
+                id="id",
+                type="unknown",
+            ).type
+            == "unknown"
         )
 
     def test_equality(self):

--- a/tests/test_botcommandscope.py
+++ b/tests/test_botcommandscope.py
@@ -31,6 +31,7 @@ from telegram import (
     BotCommandScopeDefault,
     Dice,
 )
+from telegram.constants import BotCommandScopeType
 from tests.auxil.slots import mro_slots
 
 
@@ -166,6 +167,10 @@ class TestBotCommandScopeWithoutRequest:
             assert bot_command_scope["chat_id"] == bot_command_scope.chat_id
         if hasattr(bot_command_scope, "user_id"):
             assert bot_command_scope["user_id"] == bot_command_scope.user_id
+
+    def test_type_enum_conversion(self):
+        assert type(BotCommandScope("default").type) is BotCommandScopeType
+        assert BotCommandScope("unknown").type == "unknown"
 
     def test_equality(self, bot_command_scope, bot):
         a = BotCommandScope("base_type")

--- a/tests/test_menubutton.py
+++ b/tests/test_menubutton.py
@@ -28,6 +28,7 @@ from telegram import (
     MenuButtonWebApp,
     WebAppInfo,
 )
+from telegram.constants import MenuButtonType
 from tests.auxil.slots import mro_slots
 
 
@@ -144,6 +145,10 @@ class TestMenuButtonWithoutRequest(TestMenuButtonselfBase):
             assert menu_button_dict["web_app"] == menu_button.web_app.to_dict()
         if hasattr(menu_button, "text"):
             assert menu_button_dict["text"] == menu_button.text
+
+    def test_type_enum_conversion(self):
+        assert type(MenuButton("commands").type) is MenuButtonType
+        assert MenuButton("unknown").type == "unknown"
 
     def test_equality(self, menu_button, bot):
         a = MenuButton("base_type")


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

