### PR TITLE
Deprecate `filters.CHAT`

### DIFF
--- a/telegram/ext/filters.py
+++ b/telegram/ext/filters.py
@@ -877,7 +877,11 @@ class _Chat(MessageFilter):
 
 
 CHAT = _Chat(name="filters.CHAT")
-"""This filter filters *any* message that has a :attr:`telegram.Message.chat`."""
+"""This filter filters *any* message that has a :attr:`telegram.Message.chat`.
+
+.. deprecated:: NEXT.VERSION
+   This filter has no effect since :attr:`telegram.Message.chat` is always present.
+"""
 
 
 class ChatType:  # A convenience namespace for Chat types.


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->
 Closes #4062
