### PR TITLE
Fix documentation version to 20.7

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -25,6 +25,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Abshar <https://github.com/abxhr>`_
 - `Alateas <https://github.com/alateas>`_
 - `Ales Dokshanin <https://github.com/alesdokshanin>`_
+- `Alexandre <https://github.com/xTudoS>`_
 - `Alizia <https://github.com/thefunkycat>`_
 - `Ambro17 <https://github.com/Ambro17>`_
 - `Andrej Zhilenkov <https://github.com/Andrej730>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ Version 20.7
 
 *Released 2023-11-27*
 
-This is the technical changelog for version 20.6. More elaborate release notes can be found in the news channel `@pythontelegrambotchannel <https://t.me/pythontelegrambotchannel>`__.
+This is the technical changelog for version 20.7. More elaborate release notes can be found in the news channel `@pythontelegrambotchannel <https://t.me/pythontelegrambotchannel>`__.
 
 New Features
 ------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 Changelog
 =========
 
-Version 20.6
+Version 20.7
 ============
 
 *Released 2023-11-27*


### PR DESCRIPTION
The documentation previously stated the version as 20.6, which was incorrect. This commit updates the version number in the documentation to reflect the correct version, 20.7.

Changes Made:
- Updated the version number in documentation from 20.6 to 20.7
