### PR TITLE
Remove `@_log` decorator by logging in `Bot._do_post`

### DIFF
--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -318,7 +318,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
                 )
             self._private_key = serialization.load_pem_private_key(
                 private_key, password=private_key_password, backend=default_backend()
-            )
+            ) # type: ignore[assignment]
 
         self._freeze()
 

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -332,7 +332,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
                 )
             self._private_key = serialization.load_pem_private_key(
                 private_key, password=private_key_password, backend=default_backend()
-            )  # type: ignore[assignment]
+            )
 
         self._freeze()
 

--- a/telegram/_chat.py
+++ b/telegram/_chat.py
@@ -1167,7 +1167,7 @@ class Chat(TelegramObject):
         """
         return await self.get_bot().set_chat_administrator_custom_title(
             chat_id=self.id,
-            user_id=user_id,
+            user_id=int(user_id),
             custom_title=custom_title,
             read_timeout=read_timeout,
             write_timeout=write_timeout,

--- a/telegram/_message.py
+++ b/telegram/_message.py
@@ -2835,7 +2835,7 @@ class Message(MaybeInaccessibleMessage):
             do_quote, quote, reply_to_message_id, reply_parameters
         )
         return await self.get_bot().send_game(
-            chat_id=chat_id,
+            chat_id=int(chat_id),
             game_short_name=game_short_name,
             disable_notification=disable_notification,
             reply_parameters=effective_reply_parameters,

--- a/telegram/_message.py
+++ b/telegram/_message.py
@@ -2835,7 +2835,7 @@ class Message(MaybeInaccessibleMessage):
             do_quote, quote, reply_to_message_id, reply_parameters
         )
         return await self.get_bot().send_game(
-            chat_id=int(chat_id),
+            chat_id=chat_id,  # type: ignore[arg-type]
             game_short_name=game_short_name,
             disable_notification=disable_notification,
             reply_parameters=effective_reply_parameters,

--- a/telegram/_passport/passportfile.py
+++ b/telegram/_passport/passportfile.py
@@ -203,5 +203,6 @@ class PassportFile(TelegramObject):
             pool_timeout=pool_timeout,
             api_kwargs=api_kwargs,
         )
-        file.set_credentials(self._credentials)
+        if self._credentials is not None:
+            file.set_credentials(self._credentials)
         return file

--- a/telegram/ext/_extbot.py
+++ b/telegram/ext/_extbot.py
@@ -750,7 +750,9 @@ class ExtBot(Bot, Generic[RLARGS]):
         return await super().stop_poll(
             chat_id=chat_id,
             message_id=message_id,
-            reply_markup=self._replace_keyboard(reply_markup),
+            reply_markup=cast(
+                Optional["InlineKeyboardMarkup"], self._replace_keyboard(reply_markup)
+            ),
             read_timeout=read_timeout,
             write_timeout=write_timeout,
             connect_timeout=connect_timeout,

--- a/telegram/ext/_extbot.py
+++ b/telegram/ext/_extbot.py
@@ -113,6 +113,7 @@ if TYPE_CHECKING:
     from telegram.ext import BaseRateLimiter, Defaults
 
 HandledTypes = TypeVar("HandledTypes", bound=Union[Message, CallbackQuery, Chat])
+KT = TypeVar("KT", bound=ReplyMarkup)
 
 
 class ExtBot(Bot, Generic[RLARGS]):
@@ -485,7 +486,9 @@ class ExtBot(Bot, Generic[RLARGS]):
 
                 data[key] = new_value
 
-    def _replace_keyboard(self, reply_markup: Optional[ReplyMarkup]) -> Optional[ReplyMarkup]:
+    def _replace_keyboard(
+        self, reply_markup: Optional[KT]
+    ) -> Optional[Union[KT, InlineKeyboardMarkup]]:
         # If the reply_markup is an inline keyboard and we allow arbitrary callback data, let the
         # CallbackDataCache build a new keyboard with the data replaced. Otherwise return the input
         if isinstance(reply_markup, InlineKeyboardMarkup) and self.callback_data_cache is not None:
@@ -750,9 +753,7 @@ class ExtBot(Bot, Generic[RLARGS]):
         return await super().stop_poll(
             chat_id=chat_id,
             message_id=message_id,
-            reply_markup=cast(
-                Optional["InlineKeyboardMarkup"], self._replace_keyboard(reply_markup)
-            ),
+            reply_markup=self._replace_keyboard(reply_markup),
             read_timeout=read_timeout,
             write_timeout=write_timeout,
             connect_timeout=connect_timeout,

--- a/telegram/ext/_updater.py
+++ b/telegram/ext/_updater.py
@@ -770,7 +770,7 @@ class Updater(AsyncContextManager["Updater"]):
             if drop_pending_updates:
                 _LOGGER.debug("Dropping pending updates from Telegram server")
             await self.bot.set_webhook(
-                url=webhook_url,
+                url=webhook_url if webhook_url is not None else "",
                 certificate=cert,
                 allowed_updates=allowed_updates,
                 ip_address=ip_address,

--- a/telegram/ext/_updater.py
+++ b/telegram/ext/_updater.py
@@ -770,7 +770,7 @@ class Updater(AsyncContextManager["Updater"]):
             if drop_pending_updates:
                 _LOGGER.debug("Dropping pending updates from Telegram server")
             await self.bot.set_webhook(
-                url=webhook_url if webhook_url is not None else "",
+                url=webhook_url,  # type: ignore[arg-type]
                 certificate=cert,
                 allowed_updates=allowed_updates,
                 ip_address=ip_address,

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -431,7 +431,9 @@ class TestBotWithoutRequest:
     @bot_methods(include_do_api_request=True)
     def test_coroutine_functions(self, bot_class, bot_method_name, bot_method):
         """Check that all bot methods are defined as async def  ..."""
-        assert inspect.iscoroutinefunction(bot_method), f"{bot_method_name} must be a coroutine function"
+        assert inspect.iscoroutinefunction(
+            bot_method
+        ), f"{bot_method_name} must be a coroutine function"
 
     @bot_methods(include_do_api_request=True)
     def test_api_kwargs_and_timeouts_present(self, bot_class, bot_method_name, bot_method):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -431,8 +431,7 @@ class TestBotWithoutRequest:
     @bot_methods(include_do_api_request=True)
     def test_coroutine_functions(self, bot_class, bot_method_name, bot_method):
         """Check that all bot methods are defined as async def  ..."""
-        meth = getattr(bot_method, "__wrapped__", bot_method)  # to unwrap the @_log decorator
-        assert inspect.iscoroutinefunction(meth), f"{bot_method_name} must be a coroutine function"
+        assert inspect.iscoroutinefunction(bot_method), f"{bot_method_name} must be a coroutine function"
 
     @bot_methods(include_do_api_request=True)
     def test_api_kwargs_and_timeouts_present(self, bot_class, bot_method_name, bot_method):


### PR DESCRIPTION
closes #4010

Trying to fix the annoying absence of type hinting for every function wrapped in the _log decorator.
```py
# TODO: After https://youtrack.jetbrains.com/issue/PY-50952 is fixed, we can revisit this and
# consider adding Paramspec from typing_extensions to properly fix this. Currently a workaround
```
This solution should also be compatible with older versions of Python.

I have opted to put all the imports inside the **TYPE_CHEKING** branch. This requires the use of strings in the type annotations. 
It is easy to go with the opposite approach.

Changes should be transparent to the end-user and not affect them in any way, except for the added support of static typing.