### PR TITLE
Add missing slot to `Updater`

### DIFF
--- a/telegram/ext/_updater.py
+++ b/telegram/ext/_updater.py
@@ -102,6 +102,7 @@ class Updater(AsyncContextManager["Updater"]):
 
     __slots__ = (
         "__lock",
+        "__polling_cleanup_cb",
         "__polling_task",
         "_httpd",
         "_initialized",


### PR DESCRIPTION
Closes #4127 and https://t.me/pythontelegrambottalk/246581 and https://t.me/pythontelegrambotgroup/715736.

#### The reason why this happened is because:

1)  `Updater` is inheriting from `typing.AsyncContextManager` which defines a `__dict__` on < 3.13, and that's why there's no error.

2) The tests don't catch that because they assume there will be no `__dict__` leaving it to Python to catch the error for us (we previously used to check for `__dict__` presence)

#### We still don't fully support Python 3.13, and support for that will be added in a later PR, or once it reaches beta.

Thus, the patch is untested.