### PR TITLE
Relax Upper Bound for `httpx` Dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     -   id: ruff
         name: ruff
         additional_dependencies:
-          - httpx~=0.27.0
+          - httpx~=0.27
           - tornado~=6.4
           - APScheduler~=3.10.4
           - cachetools~=5.3.3
@@ -33,7 +33,7 @@ repos:
     -   id: pylint
         files: ^(?!(tests|docs)).*\.py$
         additional_dependencies:
-          - httpx~=0.27.0
+          - httpx~=0.27
           - tornado~=6.4
           - APScheduler~=3.10.4
           - cachetools~=5.3.3
@@ -49,7 +49,7 @@ repos:
           - types-pytz
           - types-cryptography
           - types-cachetools
-          - httpx~=0.27.0
+          - httpx~=0.27
           - tornado~=6.4
           - APScheduler~=3.10.4
           - cachetools~=5.3.3

--- a/README.rst
+++ b/README.rst
@@ -135,7 +135,7 @@ As these features are *optional*, the corresponding 3rd party dependencies are n
 Instead, they are listed as optional dependencies.
 This allows to avoid unnecessary dependency conflicts for users who don't need the optional features.
 
-The only required dependency is `httpx ~= 0.27.0 <https://www.python-httpx.org>`_ for
+The only required dependency is `httpx ~= 0.27 <https://www.python-httpx.org>`_ for
 ``telegram.request.HTTPXRequest``, the default networking backend.
 
 ``python-telegram-bot`` is most useful when used along with additional libraries.

--- a/README_RAW.rst
+++ b/README_RAW.rst
@@ -136,7 +136,7 @@ As these features are *optional*, the corresponding 3rd party dependencies are n
 Instead, they are listed as optional dependencies.
 This allows to avoid unnecessary dependency conflicts for users who don't need the optional features.
 
-The only required dependency is `httpx ~= 0.27.0 <https://www.python-httpx.org>`_ for
+The only required dependency is `httpx ~= 0.27 <https://www.python-httpx.org>`_ for
 ``telegram.request.HTTPXRequest``, the default networking backend.
 
 ``python-telegram-bot`` is most useful when used along with additional libraries.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@
 # When dependencies release new versions and tests succeed, we should try to expand the allowed
 # versions and only increase the lower bound if necessary
 
-# httpx has no stable release yet, so let's be cautious for now
-httpx ~= 0.27.0
+# httpx has no stable release yet, but we've had no stability problems since v20.0a0 either
+# Since there have been requests to relax the bound a bit, we allow versions < 1.0.0
+httpx ~= 0.27


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

PoC for closing #4147 in case we decide to go ahead with that.
Creating the PR already to check if tests succeed so that we can maybe already get it into v21.
