### PR TITLE
`Message.reply_*` to reply to same topic when in groups.

### DIFF
--- a/telegram/_message.py
+++ b/telegram/_message.py
@@ -1592,8 +1592,6 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
-        message_thread_id = message_thread_id or self.message_thread_id
-
         return await self.get_bot().send_message(
             chat_id=chat_id,
             text=text,
@@ -1606,7 +1604,7 @@ class Message(MaybeInaccessibleMessage):
             allow_sending_without_reply=allow_sending_without_reply,
             entities=entities,
             protect_content=protect_content,
-            message_thread_id=message_thread_id,
+            message_thread_id=message_thread_id or self.message_thread_id,
             read_timeout=read_timeout,
             write_timeout=write_timeout,
             connect_timeout=connect_timeout,
@@ -1673,8 +1671,6 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
-        message_thread_id = message_thread_id or self.message_thread_id
-
         return await self.get_bot().send_message(
             chat_id=chat_id,
             text=text,
@@ -1687,7 +1683,7 @@ class Message(MaybeInaccessibleMessage):
             allow_sending_without_reply=allow_sending_without_reply,
             entities=entities,
             protect_content=protect_content,
-            message_thread_id=message_thread_id,
+            message_thread_id=message_thread_id or self.message_thread_id,
             read_timeout=read_timeout,
             write_timeout=write_timeout,
             connect_timeout=connect_timeout,
@@ -1750,8 +1746,6 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
-        message_thread_id = message_thread_id or self.message_thread_id
-
         return await self.get_bot().send_message(
             chat_id=chat_id,
             text=text,
@@ -1764,7 +1758,7 @@ class Message(MaybeInaccessibleMessage):
             allow_sending_without_reply=allow_sending_without_reply,
             entities=entities,
             protect_content=protect_content,
-            message_thread_id=message_thread_id,
+            message_thread_id=message_thread_id or self.message_thread_id,
             read_timeout=read_timeout,
             write_timeout=write_timeout,
             connect_timeout=connect_timeout,
@@ -1827,8 +1821,6 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
-        message_thread_id = message_thread_id or self.message_thread_id
-
         return await self.get_bot().send_message(
             chat_id=chat_id,
             text=text,
@@ -1841,7 +1833,7 @@ class Message(MaybeInaccessibleMessage):
             allow_sending_without_reply=allow_sending_without_reply,
             entities=entities,
             protect_content=protect_content,
-            message_thread_id=message_thread_id,
+            message_thread_id=message_thread_id or self.message_thread_id,
             read_timeout=read_timeout,
             write_timeout=write_timeout,
             connect_timeout=connect_timeout,
@@ -1905,8 +1897,6 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
-        message_thread_id = message_thread_id or self.message_thread_id
-
         return await self.get_bot().send_media_group(
             chat_id=chat_id,
             media=media,
@@ -1919,7 +1909,7 @@ class Message(MaybeInaccessibleMessage):
             api_kwargs=api_kwargs,
             allow_sending_without_reply=allow_sending_without_reply,
             protect_content=protect_content,
-            message_thread_id=message_thread_id,
+            message_thread_id=message_thread_id or self.message_thread_id,
             caption=caption,
             parse_mode=parse_mode,
             caption_entities=caption_entities,
@@ -1980,8 +1970,6 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
-        message_thread_id = message_thread_id or self.message_thread_id
-
         return await self.get_bot().send_photo(
             chat_id=chat_id,
             photo=photo,
@@ -1994,7 +1982,7 @@ class Message(MaybeInaccessibleMessage):
             caption_entities=caption_entities,
             filename=filename,
             protect_content=protect_content,
-            message_thread_id=message_thread_id,
+            message_thread_id=message_thread_id or self.message_thread_id,
             read_timeout=read_timeout,
             write_timeout=write_timeout,
             connect_timeout=connect_timeout,
@@ -2061,8 +2049,6 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
-        message_thread_id = message_thread_id or self.message_thread_id
-
         return await self.get_bot().send_audio(
             chat_id=chat_id,
             audio=audio,
@@ -2078,7 +2064,7 @@ class Message(MaybeInaccessibleMessage):
             caption_entities=caption_entities,
             filename=filename,
             protect_content=protect_content,
-            message_thread_id=message_thread_id,
+            message_thread_id=message_thread_id or self.message_thread_id,
             read_timeout=read_timeout,
             write_timeout=write_timeout,
             connect_timeout=connect_timeout,
@@ -2143,8 +2129,6 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
-        message_thread_id = message_thread_id or self.message_thread_id
-
         return await self.get_bot().send_document(
             chat_id=chat_id,
             document=document,
@@ -2163,7 +2147,7 @@ class Message(MaybeInaccessibleMessage):
             allow_sending_without_reply=allow_sending_without_reply,
             caption_entities=caption_entities,
             protect_content=protect_content,
-            message_thread_id=message_thread_id,
+            message_thread_id=message_thread_id or self.message_thread_id,
             thumbnail=thumbnail,
         )
 
@@ -2226,8 +2210,6 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
-        message_thread_id = message_thread_id or self.message_thread_id
-
         return await self.get_bot().send_animation(
             chat_id=chat_id,
             animation=animation,
@@ -2248,7 +2230,7 @@ class Message(MaybeInaccessibleMessage):
             caption_entities=caption_entities,
             filename=filename,
             protect_content=protect_content,
-            message_thread_id=message_thread_id,
+            message_thread_id=message_thread_id or self.message_thread_id,
             has_spoiler=has_spoiler,
             thumbnail=thumbnail,
         )
@@ -2304,8 +2286,6 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
-        message_thread_id = message_thread_id or self.message_thread_id
-
         return await self.get_bot().send_sticker(
             chat_id=chat_id,
             sticker=sticker,
@@ -2319,7 +2299,7 @@ class Message(MaybeInaccessibleMessage):
             api_kwargs=api_kwargs,
             allow_sending_without_reply=allow_sending_without_reply,
             protect_content=protect_content,
-            message_thread_id=message_thread_id,
+            message_thread_id=message_thread_id or self.message_thread_id,
             emoji=emoji,
         )
 
@@ -2383,8 +2363,6 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
-        message_thread_id = message_thread_id or self.message_thread_id
-
         return await self.get_bot().send_video(
             chat_id=chat_id,
             video=video,
@@ -2406,7 +2384,7 @@ class Message(MaybeInaccessibleMessage):
             caption_entities=caption_entities,
             filename=filename,
             protect_content=protect_content,
-            message_thread_id=message_thread_id,
+            message_thread_id=message_thread_id or self.message_thread_id,
             has_spoiler=has_spoiler,
             thumbnail=thumbnail,
         )
@@ -2465,8 +2443,6 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
-        message_thread_id = message_thread_id or self.message_thread_id
-
         return await self.get_bot().send_video_note(
             chat_id=chat_id,
             video_note=video_note,
@@ -2483,7 +2459,7 @@ class Message(MaybeInaccessibleMessage):
             allow_sending_without_reply=allow_sending_without_reply,
             filename=filename,
             protect_content=protect_content,
-            message_thread_id=message_thread_id,
+            message_thread_id=message_thread_id or self.message_thread_id,
             thumbnail=thumbnail,
         )
 
@@ -2542,8 +2518,6 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
-        message_thread_id = message_thread_id or self.message_thread_id
-
         return await self.get_bot().send_voice(
             chat_id=chat_id,
             voice=voice,
@@ -2562,7 +2536,7 @@ class Message(MaybeInaccessibleMessage):
             caption_entities=caption_entities,
             filename=filename,
             protect_content=protect_content,
-            message_thread_id=message_thread_id,
+            message_thread_id=message_thread_id or self.message_thread_id,
         )
 
     async def reply_location(
@@ -2621,8 +2595,6 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
-        message_thread_id = message_thread_id or self.message_thread_id
-
         return await self.get_bot().send_location(
             chat_id=chat_id,
             latitude=latitude,
@@ -2642,7 +2614,7 @@ class Message(MaybeInaccessibleMessage):
             proximity_alert_radius=proximity_alert_radius,
             allow_sending_without_reply=allow_sending_without_reply,
             protect_content=protect_content,
-            message_thread_id=message_thread_id,
+            message_thread_id=message_thread_id or self.message_thread_id,
         )
 
     async def reply_venue(
@@ -2703,8 +2675,6 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
-        message_thread_id = message_thread_id or self.message_thread_id
-
         return await self.get_bot().send_venue(
             chat_id=chat_id,
             latitude=latitude,
@@ -2726,7 +2696,7 @@ class Message(MaybeInaccessibleMessage):
             google_place_type=google_place_type,
             allow_sending_without_reply=allow_sending_without_reply,
             protect_content=protect_content,
-            message_thread_id=message_thread_id,
+            message_thread_id=message_thread_id or self.message_thread_id,
         )
 
     async def reply_contact(
@@ -2783,8 +2753,6 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
-        message_thread_id = message_thread_id or self.message_thread_id
-
         return await self.get_bot().send_contact(
             chat_id=chat_id,
             phone_number=phone_number,
@@ -2802,7 +2770,7 @@ class Message(MaybeInaccessibleMessage):
             api_kwargs=api_kwargs,
             allow_sending_without_reply=allow_sending_without_reply,
             protect_content=protect_content,
-            message_thread_id=message_thread_id,
+            message_thread_id=message_thread_id or self.message_thread_id,
         )
 
     async def reply_poll(
@@ -2866,8 +2834,6 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
-        message_thread_id = message_thread_id or self.message_thread_id
-
         return await self.get_bot().send_poll(
             chat_id=chat_id,
             question=question,
@@ -2892,7 +2858,7 @@ class Message(MaybeInaccessibleMessage):
             allow_sending_without_reply=allow_sending_without_reply,
             explanation_entities=explanation_entities,
             protect_content=protect_content,
-            message_thread_id=message_thread_id,
+            message_thread_id=message_thread_id or self.message_thread_id,
         )
 
     async def reply_dice(
@@ -2945,8 +2911,6 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
-        message_thread_id = message_thread_id or self.message_thread_id
-
         return await self.get_bot().send_dice(
             chat_id=chat_id,
             disable_notification=disable_notification,
@@ -2960,7 +2924,7 @@ class Message(MaybeInaccessibleMessage):
             api_kwargs=api_kwargs,
             allow_sending_without_reply=allow_sending_without_reply,
             protect_content=protect_content,
-            message_thread_id=message_thread_id,
+            message_thread_id=message_thread_id or self.message_thread_id,
         )
 
     async def reply_chat_action(
@@ -3057,8 +3021,6 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
-        message_thread_id = message_thread_id or self.message_thread_id
-
         return await self.get_bot().send_game(
             chat_id=chat_id,
             game_short_name=game_short_name,
@@ -3072,7 +3034,7 @@ class Message(MaybeInaccessibleMessage):
             api_kwargs=api_kwargs,
             allow_sending_without_reply=allow_sending_without_reply,
             protect_content=protect_content,
-            message_thread_id=message_thread_id,
+            message_thread_id=message_thread_id or self.message_thread_id,
         )
 
     async def reply_invoice(
@@ -3157,8 +3119,6 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
-        message_thread_id = message_thread_id or self.message_thread_id
-
         return await self.get_bot().send_invoice(
             chat_id=chat_id,
             title=title,
@@ -3192,7 +3152,7 @@ class Message(MaybeInaccessibleMessage):
             max_tip_amount=max_tip_amount,
             suggested_tip_amounts=suggested_tip_amounts,
             protect_content=protect_content,
-            message_thread_id=message_thread_id,
+            message_thread_id=message_thread_id or self.message_thread_id,
         )
 
     async def forward(
@@ -3358,8 +3318,6 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
-        message_thread_id = message_thread_id or self.message_thread_id
-
         return await self.get_bot().copy_message(
             chat_id=chat_id,
             from_chat_id=from_chat_id,
@@ -3377,7 +3335,7 @@ class Message(MaybeInaccessibleMessage):
             pool_timeout=pool_timeout,
             api_kwargs=api_kwargs,
             protect_content=protect_content,
-            message_thread_id=message_thread_id,
+            message_thread_id=message_thread_id or self.message_thread_id,
         )
 
     async def edit_text(

--- a/telegram/_message.py
+++ b/telegram/_message.py
@@ -1538,6 +1538,15 @@ class Message(MaybeInaccessibleMessage):
 
         return chat_id, effective_reply_parameters
 
+    def _parse_message_thread_id(
+        self,
+        chat_id: Union[str, int],
+        message_thread_id: Optional[int] = None,
+    ) -> Optional[int]:
+        return message_thread_id or (
+            self.message_thread_id if chat_id in {self.chat_id, self.chat.username} else None
+        )
+
     async def reply_text(
         self,
         text: str,
@@ -1592,6 +1601,7 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = self._parse_message_thread_id(chat_id, message_thread_id)
         return await self.get_bot().send_message(
             chat_id=chat_id,
             text=text,
@@ -1604,7 +1614,7 @@ class Message(MaybeInaccessibleMessage):
             allow_sending_without_reply=allow_sending_without_reply,
             entities=entities,
             protect_content=protect_content,
-            message_thread_id=message_thread_id or self.message_thread_id,
+            message_thread_id=message_thread_id,
             read_timeout=read_timeout,
             write_timeout=write_timeout,
             connect_timeout=connect_timeout,
@@ -1671,6 +1681,7 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = self._parse_message_thread_id(chat_id, message_thread_id)
         return await self.get_bot().send_message(
             chat_id=chat_id,
             text=text,
@@ -1683,7 +1694,7 @@ class Message(MaybeInaccessibleMessage):
             allow_sending_without_reply=allow_sending_without_reply,
             entities=entities,
             protect_content=protect_content,
-            message_thread_id=message_thread_id or self.message_thread_id,
+            message_thread_id=message_thread_id,
             read_timeout=read_timeout,
             write_timeout=write_timeout,
             connect_timeout=connect_timeout,
@@ -1746,6 +1757,7 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = self._parse_message_thread_id(chat_id, message_thread_id)
         return await self.get_bot().send_message(
             chat_id=chat_id,
             text=text,
@@ -1758,7 +1770,7 @@ class Message(MaybeInaccessibleMessage):
             allow_sending_without_reply=allow_sending_without_reply,
             entities=entities,
             protect_content=protect_content,
-            message_thread_id=message_thread_id or self.message_thread_id,
+            message_thread_id=message_thread_id,
             read_timeout=read_timeout,
             write_timeout=write_timeout,
             connect_timeout=connect_timeout,
@@ -1821,6 +1833,7 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = self._parse_message_thread_id(chat_id, message_thread_id)
         return await self.get_bot().send_message(
             chat_id=chat_id,
             text=text,
@@ -1833,7 +1846,7 @@ class Message(MaybeInaccessibleMessage):
             allow_sending_without_reply=allow_sending_without_reply,
             entities=entities,
             protect_content=protect_content,
-            message_thread_id=message_thread_id or self.message_thread_id,
+            message_thread_id=message_thread_id,
             read_timeout=read_timeout,
             write_timeout=write_timeout,
             connect_timeout=connect_timeout,
@@ -1897,6 +1910,7 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = self._parse_message_thread_id(chat_id, message_thread_id)
         return await self.get_bot().send_media_group(
             chat_id=chat_id,
             media=media,
@@ -1909,7 +1923,7 @@ class Message(MaybeInaccessibleMessage):
             api_kwargs=api_kwargs,
             allow_sending_without_reply=allow_sending_without_reply,
             protect_content=protect_content,
-            message_thread_id=message_thread_id or self.message_thread_id,
+            message_thread_id=message_thread_id,
             caption=caption,
             parse_mode=parse_mode,
             caption_entities=caption_entities,
@@ -1970,6 +1984,7 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = self._parse_message_thread_id(chat_id, message_thread_id)
         return await self.get_bot().send_photo(
             chat_id=chat_id,
             photo=photo,
@@ -1982,7 +1997,7 @@ class Message(MaybeInaccessibleMessage):
             caption_entities=caption_entities,
             filename=filename,
             protect_content=protect_content,
-            message_thread_id=message_thread_id or self.message_thread_id,
+            message_thread_id=message_thread_id,
             read_timeout=read_timeout,
             write_timeout=write_timeout,
             connect_timeout=connect_timeout,
@@ -2049,6 +2064,7 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = self._parse_message_thread_id(chat_id, message_thread_id)
         return await self.get_bot().send_audio(
             chat_id=chat_id,
             audio=audio,
@@ -2064,7 +2080,7 @@ class Message(MaybeInaccessibleMessage):
             caption_entities=caption_entities,
             filename=filename,
             protect_content=protect_content,
-            message_thread_id=message_thread_id or self.message_thread_id,
+            message_thread_id=message_thread_id,
             read_timeout=read_timeout,
             write_timeout=write_timeout,
             connect_timeout=connect_timeout,
@@ -2129,6 +2145,7 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = self._parse_message_thread_id(chat_id, message_thread_id)
         return await self.get_bot().send_document(
             chat_id=chat_id,
             document=document,
@@ -2147,7 +2164,7 @@ class Message(MaybeInaccessibleMessage):
             allow_sending_without_reply=allow_sending_without_reply,
             caption_entities=caption_entities,
             protect_content=protect_content,
-            message_thread_id=message_thread_id or self.message_thread_id,
+            message_thread_id=message_thread_id,
             thumbnail=thumbnail,
         )
 
@@ -2210,6 +2227,7 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = self._parse_message_thread_id(chat_id, message_thread_id)
         return await self.get_bot().send_animation(
             chat_id=chat_id,
             animation=animation,
@@ -2230,7 +2248,7 @@ class Message(MaybeInaccessibleMessage):
             caption_entities=caption_entities,
             filename=filename,
             protect_content=protect_content,
-            message_thread_id=message_thread_id or self.message_thread_id,
+            message_thread_id=message_thread_id,
             has_spoiler=has_spoiler,
             thumbnail=thumbnail,
         )
@@ -2286,6 +2304,7 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = self._parse_message_thread_id(chat_id, message_thread_id)
         return await self.get_bot().send_sticker(
             chat_id=chat_id,
             sticker=sticker,
@@ -2299,7 +2318,7 @@ class Message(MaybeInaccessibleMessage):
             api_kwargs=api_kwargs,
             allow_sending_without_reply=allow_sending_without_reply,
             protect_content=protect_content,
-            message_thread_id=message_thread_id or self.message_thread_id,
+            message_thread_id=message_thread_id,
             emoji=emoji,
         )
 
@@ -2363,6 +2382,7 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = self._parse_message_thread_id(chat_id, message_thread_id)
         return await self.get_bot().send_video(
             chat_id=chat_id,
             video=video,
@@ -2384,7 +2404,7 @@ class Message(MaybeInaccessibleMessage):
             caption_entities=caption_entities,
             filename=filename,
             protect_content=protect_content,
-            message_thread_id=message_thread_id or self.message_thread_id,
+            message_thread_id=message_thread_id,
             has_spoiler=has_spoiler,
             thumbnail=thumbnail,
         )
@@ -2443,6 +2463,7 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = self._parse_message_thread_id(chat_id, message_thread_id)
         return await self.get_bot().send_video_note(
             chat_id=chat_id,
             video_note=video_note,
@@ -2459,7 +2480,7 @@ class Message(MaybeInaccessibleMessage):
             allow_sending_without_reply=allow_sending_without_reply,
             filename=filename,
             protect_content=protect_content,
-            message_thread_id=message_thread_id or self.message_thread_id,
+            message_thread_id=message_thread_id,
             thumbnail=thumbnail,
         )
 
@@ -2536,7 +2557,7 @@ class Message(MaybeInaccessibleMessage):
             caption_entities=caption_entities,
             filename=filename,
             protect_content=protect_content,
-            message_thread_id=message_thread_id or self.message_thread_id,
+            message_thread_id=message_thread_id,
         )
 
     async def reply_location(
@@ -2595,6 +2616,7 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = self._parse_message_thread_id(chat_id, message_thread_id)
         return await self.get_bot().send_location(
             chat_id=chat_id,
             latitude=latitude,
@@ -2614,7 +2636,7 @@ class Message(MaybeInaccessibleMessage):
             proximity_alert_radius=proximity_alert_radius,
             allow_sending_without_reply=allow_sending_without_reply,
             protect_content=protect_content,
-            message_thread_id=message_thread_id or self.message_thread_id,
+            message_thread_id=message_thread_id,
         )
 
     async def reply_venue(
@@ -2675,6 +2697,7 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = self._parse_message_thread_id(chat_id, message_thread_id)
         return await self.get_bot().send_venue(
             chat_id=chat_id,
             latitude=latitude,
@@ -2696,7 +2719,7 @@ class Message(MaybeInaccessibleMessage):
             google_place_type=google_place_type,
             allow_sending_without_reply=allow_sending_without_reply,
             protect_content=protect_content,
-            message_thread_id=message_thread_id or self.message_thread_id,
+            message_thread_id=message_thread_id,
         )
 
     async def reply_contact(
@@ -2753,6 +2776,7 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = self._parse_message_thread_id(chat_id, message_thread_id)
         return await self.get_bot().send_contact(
             chat_id=chat_id,
             phone_number=phone_number,
@@ -2770,7 +2794,7 @@ class Message(MaybeInaccessibleMessage):
             api_kwargs=api_kwargs,
             allow_sending_without_reply=allow_sending_without_reply,
             protect_content=protect_content,
-            message_thread_id=message_thread_id or self.message_thread_id,
+            message_thread_id=message_thread_id,
         )
 
     async def reply_poll(
@@ -2834,6 +2858,7 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = self._parse_message_thread_id(chat_id, message_thread_id)
         return await self.get_bot().send_poll(
             chat_id=chat_id,
             question=question,
@@ -2858,7 +2883,7 @@ class Message(MaybeInaccessibleMessage):
             allow_sending_without_reply=allow_sending_without_reply,
             explanation_entities=explanation_entities,
             protect_content=protect_content,
-            message_thread_id=message_thread_id or self.message_thread_id,
+            message_thread_id=message_thread_id,
         )
 
     async def reply_dice(
@@ -2911,6 +2936,7 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = self._parse_message_thread_id(chat_id, message_thread_id)
         return await self.get_bot().send_dice(
             chat_id=chat_id,
             disable_notification=disable_notification,
@@ -2924,7 +2950,7 @@ class Message(MaybeInaccessibleMessage):
             api_kwargs=api_kwargs,
             allow_sending_without_reply=allow_sending_without_reply,
             protect_content=protect_content,
-            message_thread_id=message_thread_id or self.message_thread_id,
+            message_thread_id=message_thread_id,
         )
 
     async def reply_chat_action(
@@ -2960,7 +2986,7 @@ class Message(MaybeInaccessibleMessage):
         """
         return await self.get_bot().send_chat_action(
             chat_id=self.chat_id,
-            message_thread_id=message_thread_id or self.message_thread_id,
+            message_thread_id=self._parse_message_thread_id(self.chat_id, message_thread_id),
             action=action,
             read_timeout=read_timeout,
             write_timeout=write_timeout,
@@ -3021,6 +3047,7 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = self._parse_message_thread_id(chat_id, message_thread_id)
         return await self.get_bot().send_game(
             chat_id=chat_id,
             game_short_name=game_short_name,
@@ -3034,7 +3061,7 @@ class Message(MaybeInaccessibleMessage):
             api_kwargs=api_kwargs,
             allow_sending_without_reply=allow_sending_without_reply,
             protect_content=protect_content,
-            message_thread_id=message_thread_id or self.message_thread_id,
+            message_thread_id=message_thread_id,
         )
 
     async def reply_invoice(
@@ -3119,6 +3146,7 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = self._parse_message_thread_id(chat_id, message_thread_id)
         return await self.get_bot().send_invoice(
             chat_id=chat_id,
             title=title,
@@ -3152,7 +3180,7 @@ class Message(MaybeInaccessibleMessage):
             max_tip_amount=max_tip_amount,
             suggested_tip_amounts=suggested_tip_amounts,
             protect_content=protect_content,
-            message_thread_id=message_thread_id or self.message_thread_id,
+            message_thread_id=message_thread_id,
         )
 
     async def forward(
@@ -3318,6 +3346,7 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = self._parse_message_thread_id(chat_id, message_thread_id)
         return await self.get_bot().copy_message(
             chat_id=chat_id,
             from_chat_id=from_chat_id,
@@ -3335,7 +3364,7 @@ class Message(MaybeInaccessibleMessage):
             pool_timeout=pool_timeout,
             api_kwargs=api_kwargs,
             protect_content=protect_content,
-            message_thread_id=message_thread_id or self.message_thread_id,
+            message_thread_id=message_thread_id,
         )
 
     async def edit_text(

--- a/telegram/_message.py
+++ b/telegram/_message.py
@@ -824,6 +824,9 @@ class Message(MaybeInaccessibleMessage):
     .. |blockquote_no_md1_support| replace:: Since block quotation entities are not supported
        by :attr:`~telegram.constants.ParseMode.MARKDOWN`, this method now raises a
        :exc:`ValueError` when encountering a block quotation.
+
+    .. |reply_same_thread| replace:: If :paramref:`message_thread_id` is not provided,
+       this will reply to the same thread (topic) of the original message.
     """
 
     # fmt: on
@@ -1560,9 +1563,17 @@ class Message(MaybeInaccessibleMessage):
     ) -> "Message":
         """Shortcut for::
 
-             await bot.send_message(update.effective_message.chat_id, *args, **kwargs)
+             await bot.send_message(
+                 update.effective_message.chat_id,
+                 message_thread_id=update.effective_message.message_thread_id,
+                 *args,
+                 **kwargs,
+             )
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_message`.
+
+        .. versionchanged:: NEXT.VERSION
+                |reply_same_thread|
 
         Keyword Args:
             quote (:obj:`bool`, optional): |reply_quote|
@@ -1581,6 +1592,8 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = message_thread_id or self.message_thread_id
+
         return await self.get_bot().send_message(
             chat_id=chat_id,
             text=text,
@@ -1627,6 +1640,7 @@ class Message(MaybeInaccessibleMessage):
 
             await bot.send_message(
                 update.effective_message.chat_id,
+                message_thread_id=update.effective_message.message_thread_id,
                 parse_mode=ParseMode.MARKDOWN,
                 *args,
                 **kwargs,
@@ -1635,6 +1649,9 @@ class Message(MaybeInaccessibleMessage):
         Sends a message with Markdown version 1 formatting.
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_message`.
+
+        .. versionchanged:: NEXT.VERSION
+                |reply_same_thread|
 
         Note:
             :tg-const:`telegram.constants.ParseMode.MARKDOWN` is a legacy mode, retained by
@@ -1656,6 +1673,8 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = message_thread_id or self.message_thread_id
+
         return await self.get_bot().send_message(
             chat_id=chat_id,
             text=text,
@@ -1702,6 +1721,7 @@ class Message(MaybeInaccessibleMessage):
 
             await bot.send_message(
                 update.effective_message.chat_id,
+                message_thread_id=update.effective_message.message_thread_id,
                 parse_mode=ParseMode.MARKDOWN_V2,
                 *args,
                 **kwargs,
@@ -1710,6 +1730,9 @@ class Message(MaybeInaccessibleMessage):
         Sends a message with markdown version 2 formatting.
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_message`.
+
+        .. versionchanged:: NEXT.VERSION
+                |reply_same_thread|
 
         Keyword Args:
             quote (:obj:`bool`, optional): |reply_quote|
@@ -1727,6 +1750,8 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = message_thread_id or self.message_thread_id
+
         return await self.get_bot().send_message(
             chat_id=chat_id,
             text=text,
@@ -1773,6 +1798,7 @@ class Message(MaybeInaccessibleMessage):
 
             await bot.send_message(
                 update.effective_message.chat_id,
+                message_thread_id=update.effective_message.message_thread_id,
                 parse_mode=ParseMode.HTML,
                 *args,
                 **kwargs,
@@ -1781,6 +1807,9 @@ class Message(MaybeInaccessibleMessage):
         Sends a message with HTML formatting.
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_message`.
+
+        .. versionchanged:: NEXT.VERSION
+                |reply_same_thread|
 
         Keyword Args:
             quote (:obj:`bool`, optional): |reply_quote|
@@ -1798,6 +1827,8 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = message_thread_id or self.message_thread_id
+
         return await self.get_bot().send_message(
             chat_id=chat_id,
             text=text,
@@ -1843,9 +1874,17 @@ class Message(MaybeInaccessibleMessage):
     ) -> Tuple["Message", ...]:
         """Shortcut for::
 
-             await bot.send_media_group(update.effective_message.chat_id, *args, **kwargs)
+             await bot.send_media_group(
+                 update.effective_message.chat_id,
+                 message_thread_id=update.effective_message.message_thread_id,
+                 *args,
+                 **kwargs,
+             )
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_media_group`.
+
+        .. versionchanged:: NEXT.VERSION
+                |reply_same_thread|
 
         Keyword Args:
             quote (:obj:`bool`, optional): |reply_quote|
@@ -1866,6 +1905,8 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = message_thread_id or self.message_thread_id
+
         return await self.get_bot().send_media_group(
             chat_id=chat_id,
             media=media,
@@ -1910,9 +1951,17 @@ class Message(MaybeInaccessibleMessage):
     ) -> "Message":
         """Shortcut for::
 
-             await bot.send_photo(update.effective_message.chat_id, *args, **kwargs)
+             await bot.send_photo(
+                 update.effective_message.chat_id,
+                 message_thread_id=update.effective_message.message_thread_id,
+                 *args,
+                 **kwargs,
+             )
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_photo`.
+
+        .. versionchanged:: NEXT.VERSION
+                |reply_same_thread|
 
         Keyword Args:
             quote (:obj:`bool`, optional): |reply_quote|
@@ -1931,6 +1980,8 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = message_thread_id or self.message_thread_id
+
         return await self.get_bot().send_photo(
             chat_id=chat_id,
             photo=photo,
@@ -1981,9 +2032,17 @@ class Message(MaybeInaccessibleMessage):
     ) -> "Message":
         """Shortcut for::
 
-             await bot.send_audio(update.effective_message.chat_id, *args, **kwargs)
+             await bot.send_audio(
+                 update.effective_message.chat_id,
+                 message_thread_id=update.effective_message.message_thread_id,
+                 *args,
+                 **kwargs,
+             )
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_audio`.
+
+        .. versionchanged:: NEXT.VERSION
+                |reply_same_thread|
 
         Keyword Args:
             quote (:obj:`bool`, optional): |reply_quote|
@@ -2002,6 +2061,8 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = message_thread_id or self.message_thread_id
+
         return await self.get_bot().send_audio(
             chat_id=chat_id,
             audio=audio,
@@ -2053,9 +2114,17 @@ class Message(MaybeInaccessibleMessage):
     ) -> "Message":
         """Shortcut for::
 
-             await bot.send_document(update.effective_message.chat_id, *args, **kwargs)
+             await bot.send_document(
+                 update.effective_message.chat_id,
+                 message_thread_id=update.effective_message.message_thread_id,
+                 *args,
+                 **kwargs,
+             )
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_document`.
+
+        .. versionchanged:: NEXT.VERSION
+                |reply_same_thread|
 
         Keyword Args:
             quote (:obj:`bool`, optional): |reply_quote|
@@ -2074,6 +2143,8 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = message_thread_id or self.message_thread_id
+
         return await self.get_bot().send_document(
             chat_id=chat_id,
             document=document,
@@ -2126,9 +2197,17 @@ class Message(MaybeInaccessibleMessage):
     ) -> "Message":
         """Shortcut for::
 
-             await bot.send_animation(update.effective_message.chat_id, *args, **kwargs)
+             await bot.send_animation(
+                 update.effective_message.chat_id,
+                 message_thread_id=update.effective_message.message_thread_id,
+                 *args,
+                 **kwargs,
+             )
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_animation`.
+
+        .. versionchanged:: NEXT.VERSION
+                |reply_same_thread|
 
         Keyword Args:
             quote (:obj:`bool`, optional): |reply_quote|
@@ -2147,6 +2226,8 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = message_thread_id or self.message_thread_id
+
         return await self.get_bot().send_animation(
             chat_id=chat_id,
             animation=animation,
@@ -2194,9 +2275,17 @@ class Message(MaybeInaccessibleMessage):
     ) -> "Message":
         """Shortcut for::
 
-             await bot.send_sticker(update.effective_message.chat_id, *args, **kwargs)
+             await bot.send_sticker(
+                 update.effective_message.chat_id,
+                 message_thread_id=update.effective_message.message_thread_id,
+                 *args,
+                 **kwargs,
+             )
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_sticker`.
+
+        .. versionchanged:: NEXT.VERSION
+                |reply_same_thread|
 
         Keyword Args:
             quote (:obj:`bool`, optional): |reply_quote|
@@ -2215,6 +2304,8 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = message_thread_id or self.message_thread_id
+
         return await self.get_bot().send_sticker(
             chat_id=chat_id,
             sticker=sticker,
@@ -2263,9 +2354,17 @@ class Message(MaybeInaccessibleMessage):
     ) -> "Message":
         """Shortcut for::
 
-             await bot.send_video(update.effective_message.chat_id, *args, **kwargs)
+             await bot.send_video(
+                 update.effective_message.chat_id,
+                 message_thread_id=update.effective_message.message_thread_id,
+                 *args,
+                 **kwargs,
+             )
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_video`.
+
+        .. versionchanged:: NEXT.VERSION
+                |reply_same_thread|
 
         Keyword Args:
             quote (:obj:`bool`, optional): |reply_quote|
@@ -2284,6 +2383,8 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = message_thread_id or self.message_thread_id
+
         return await self.get_bot().send_video(
             chat_id=chat_id,
             video=video,
@@ -2335,9 +2436,17 @@ class Message(MaybeInaccessibleMessage):
     ) -> "Message":
         """Shortcut for::
 
-             await bot.send_video_note(update.effective_message.chat_id, *args, **kwargs)
+             await bot.send_video_note(
+                 update.effective_message.chat_id,
+                 message_thread_id=update.effective_message.message_thread_id,
+                 *args,
+                 **kwargs,
+             )
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_video_note`.
+
+        .. versionchanged:: NEXT.VERSION
+                |reply_same_thread|
 
         Keyword Args:
             quote (:obj:`bool`, optional): |reply_quote|
@@ -2356,6 +2465,8 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = message_thread_id or self.message_thread_id
+
         return await self.get_bot().send_video_note(
             chat_id=chat_id,
             video_note=video_note,
@@ -2402,9 +2513,17 @@ class Message(MaybeInaccessibleMessage):
     ) -> "Message":
         """Shortcut for::
 
-             await bot.send_voice(update.effective_message.chat_id, *args, **kwargs)
+             await bot.send_voice(
+                 update.effective_message.chat_id,
+                 message_thread_id=update.effective_message.message_thread_id,
+                 *args,
+                 **kwargs,
+             )
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_voice`.
+
+        .. versionchanged:: NEXT.VERSION
+                |reply_same_thread|
 
         Keyword Args:
             quote (:obj:`bool`, optional): |reply_quote|
@@ -2423,6 +2542,8 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = message_thread_id or self.message_thread_id
+
         return await self.get_bot().send_voice(
             chat_id=chat_id,
             voice=voice,
@@ -2471,9 +2592,17 @@ class Message(MaybeInaccessibleMessage):
     ) -> "Message":
         """Shortcut for::
 
-             await bot.send_location(update.effective_message.chat_id, *args, **kwargs)
+             await bot.send_location(
+                 update.effective_message.chat_id,
+                 message_thread_id=update.effective_message.message_thread_id,
+                 *args,
+                 **kwargs,
+             )
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_location`.
+
+        .. versionchanged:: NEXT.VERSION
+                |reply_same_thread|
 
         Keyword Args:
             quote (:obj:`bool`, optional): |reply_quote|
@@ -2492,6 +2621,8 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = message_thread_id or self.message_thread_id
+
         return await self.get_bot().send_location(
             chat_id=chat_id,
             latitude=latitude,
@@ -2543,9 +2674,17 @@ class Message(MaybeInaccessibleMessage):
     ) -> "Message":
         """Shortcut for::
 
-             await bot.send_venue(update.effective_message.chat_id, *args, **kwargs)
+             await bot.send_venue(
+                 update.effective_message.chat_id,
+                 message_thread_id=update.effective_message.message_thread_id,
+                 *args,
+                 **kwargs,
+             )
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_venue`.
+
+        .. versionchanged:: NEXT.VERSION
+                |reply_same_thread|
 
         Keyword Args:
             quote (:obj:`bool`, optional): |reply_quote|
@@ -2564,6 +2703,8 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = message_thread_id or self.message_thread_id
+
         return await self.get_bot().send_venue(
             chat_id=chat_id,
             latitude=latitude,
@@ -2613,9 +2754,17 @@ class Message(MaybeInaccessibleMessage):
     ) -> "Message":
         """Shortcut for::
 
-             await bot.send_contact(update.effective_message.chat_id, *args, **kwargs)
+             await bot.send_contact(
+                 update.effective_message.chat_id,
+                 message_thread_id=update.effective_message.message_thread_id,
+                 *args,
+                 **kwargs,
+             )
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_contact`.
+
+        .. versionchanged:: NEXT.VERSION
+                |reply_same_thread|
 
         Keyword Args:
             quote (:obj:`bool`, optional): |reply_quote|
@@ -2634,6 +2783,8 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = message_thread_id or self.message_thread_id
+
         return await self.get_bot().send_contact(
             chat_id=chat_id,
             phone_number=phone_number,
@@ -2686,9 +2837,17 @@ class Message(MaybeInaccessibleMessage):
     ) -> "Message":
         """Shortcut for::
 
-             await bot.send_poll(update.effective_message.chat_id, *args, **kwargs)
+             await bot.send_poll(
+                 update.effective_message.chat_id,
+                 message_thread_id=update.effective_message.message_thread_id,
+                 *args,
+                 **kwargs,
+             )
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_poll`.
+
+        .. versionchanged:: NEXT.VERSION
+                |reply_same_thread|
 
         Keyword Args:
             quote (:obj:`bool`, optional): |reply_quote|
@@ -2707,6 +2866,8 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = message_thread_id or self.message_thread_id
+
         return await self.get_bot().send_poll(
             chat_id=chat_id,
             question=question,
@@ -2755,9 +2916,17 @@ class Message(MaybeInaccessibleMessage):
     ) -> "Message":
         """Shortcut for::
 
-             await bot.send_dice(update.effective_message.chat_id, *args, **kwargs)
+             await bot.send_dice(
+                 update.effective_message.chat_id,
+                 message_thread_id=update.effective_message.message_thread_id,
+                 *args,
+                 **kwargs,
+             )
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_dice`.
+
+        .. versionchanged:: NEXT.VERSION
+                |reply_same_thread|
 
         Keyword Args:
             quote (:obj:`bool`, optional): |reply_quote|
@@ -2776,6 +2945,8 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = message_thread_id or self.message_thread_id
+
         return await self.get_bot().send_dice(
             chat_id=chat_id,
             disable_notification=disable_notification,
@@ -2805,9 +2976,17 @@ class Message(MaybeInaccessibleMessage):
     ) -> bool:
         """Shortcut for::
 
-             await bot.send_chat_action(update.effective_message.chat_id, *args, **kwargs)
+             await bot.send_chat_action(
+                 update.effective_message.chat_id,
+                 message_thread_id=update.effective_message.message_thread_id,
+                 *args,
+                 **kwargs,
+             )
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_chat_action`.
+
+        .. versionchanged:: NEXT.VERSION
+                |reply_same_thread|
 
         .. versionadded:: 13.2
 
@@ -2817,7 +2996,7 @@ class Message(MaybeInaccessibleMessage):
         """
         return await self.get_bot().send_chat_action(
             chat_id=self.chat_id,
-            message_thread_id=message_thread_id,
+            message_thread_id=message_thread_id or self.message_thread_id,
             action=action,
             read_timeout=read_timeout,
             write_timeout=write_timeout,
@@ -2847,9 +3026,17 @@ class Message(MaybeInaccessibleMessage):
     ) -> "Message":
         """Shortcut for::
 
-             await bot.send_game(update.effective_message.chat_id, *args, **kwargs)
+             await bot.send_game(
+                 update.effective_message.chat_id,
+                 message_thread_id=update.effective_message.message_thread_id,
+                 *args,
+                 **kwargs,
+             )
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_game`.
+
+        .. versionchanged:: NEXT.VERSION
+                |reply_same_thread|
 
         Keyword Args:
             quote (:obj:`bool`, optional): |reply_quote|
@@ -2870,6 +3057,8 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = message_thread_id or self.message_thread_id
+
         return await self.get_bot().send_game(
             chat_id=chat_id,
             game_short_name=game_short_name,
@@ -2927,9 +3116,17 @@ class Message(MaybeInaccessibleMessage):
     ) -> "Message":
         """Shortcut for::
 
-             await bot.send_invoice(update.effective_message.chat_id, *args, **kwargs)
+             await bot.send_invoice(
+                 update.effective_message.chat_id,
+                 message_thread_id=update.effective_message.message_thread_id,
+                 *args,
+                 **kwargs,
+             )
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_invoice`.
+
+        .. versionchanged:: NEXT.VERSION
+                |reply_same_thread|
 
         Warning:
             As of API 5.2 :paramref:`start_parameter <telegram.Bot.send_invoice.start_parameter>`
@@ -2960,6 +3157,8 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = message_thread_id or self.message_thread_id
+
         return await self.get_bot().send_invoice(
             chat_id=chat_id,
             title=title,
@@ -3130,12 +3329,16 @@ class Message(MaybeInaccessibleMessage):
 
              await bot.copy_message(
                  chat_id=message.chat.id,
+                 message_thread_id=update.effective_message.message_thread_id,
                  message_id=message_id,
                  *args,
                  **kwargs
              )
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.copy_message`.
+
+        .. versionchanged:: NEXT.VERSION
+                |reply_same_thread|
 
         Keyword Args:
             quote (:obj:`bool`, optional): |reply_quote|
@@ -3155,6 +3358,8 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = message_thread_id or self.message_thread_id
+
         return await self.get_bot().copy_message(
             chat_id=chat_id,
             from_chat_id=from_chat_id,

--- a/telegram/_message.py
+++ b/telegram/_message.py
@@ -2539,6 +2539,7 @@ class Message(MaybeInaccessibleMessage):
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(
             do_quote, quote, reply_to_message_id, reply_parameters
         )
+        message_thread_id = self._parse_message_thread_id(chat_id, message_thread_id)
         return await self.get_bot().send_voice(
             chat_id=chat_id,
             voice=voice,

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -482,6 +482,46 @@ class TestMessageWithoutRequest(TestMessageBase):
         if reply_parameters is None or reply_parameters.message_id != 42:
             pytest.fail(f"reply_parameters is {reply_parameters} but should be 42")
 
+    @staticmethod
+    async def check_thread_id_parsing(
+        message: Message, method, bot_method_name: str, args, monkeypatch
+    ):
+        """Used in testing reply_* below. Makes sure that meassage_thread_id is parsed
+        correctly."""
+
+        async def make_assertion(*args, **kwargs):
+            return kwargs.get("message_thread_id")
+
+        monkeypatch.setattr(message.get_bot(), bot_method_name, make_assertion)
+
+        message.message_thread_id = None
+        message_thread_id = await method(*args)
+        assert message_thread_id is None
+
+        message.message_thread_id = 99
+        message_thread_id = await method(*args)
+        assert message_thread_id == 99
+
+        message_thread_id = await method(*args, message_thread_id=50)
+        assert message_thread_id == 50
+
+        if bot_method_name != "send_chat_action":
+            message_thread_id = await method(
+                *args,
+                do_quote=message.build_reply_arguments(
+                    target_chat_id=123,
+                ),
+            )
+            assert message_thread_id is None
+
+            message_thread_id = await method(
+                *args,
+                do_quote=message.build_reply_arguments(
+                    target_chat_id=3,
+                ),
+            )
+            assert message_thread_id == 99
+
     def test_slot_behaviour(self):
         message = Message(
             message_id=TestMessageBase.id_,
@@ -1361,6 +1401,10 @@ class TestMessageWithoutRequest(TestMessageBase):
             message, message.reply_text, "send_message", ["test"], monkeypatch
         )
 
+        await self.check_thread_id_parsing(
+            message, message.reply_text, "send_message", ["test"], monkeypatch
+        )
+
     async def test_reply_markdown(self, monkeypatch, message):
         test_md_string = (
             r"Test for <*bold*, _ita_\__lic_, `code`, "
@@ -1394,6 +1438,10 @@ class TestMessageWithoutRequest(TestMessageBase):
 
         monkeypatch.setattr(message.get_bot(), "send_message", make_assertion)
         assert await message.reply_markdown(self.test_message.text_markdown)
+
+        await self.check_thread_id_parsing(
+            message, message.reply_markdown, "send_message", ["test"], monkeypatch
+        )
 
     async def test_reply_markdown_v2(self, monkeypatch, message):
         test_md_string = (
@@ -1434,6 +1482,10 @@ class TestMessageWithoutRequest(TestMessageBase):
         assert await message.reply_markdown_v2(self.test_message_v2.text_markdown_v2)
         await self.check_quote_parsing(
             message, message.reply_markdown_v2, "send_message", [test_md_string], monkeypatch
+        )
+
+        await self.check_thread_id_parsing(
+            message, message.reply_markdown_v2, "send_message", ["test"], monkeypatch
         )
 
     async def test_reply_html(self, monkeypatch, message):
@@ -1479,6 +1531,10 @@ class TestMessageWithoutRequest(TestMessageBase):
             message, message.reply_html, "send_message", [test_html_string], monkeypatch
         )
 
+        await self.check_thread_id_parsing(
+            message, message.reply_html, "send_message", ["test"], monkeypatch
+        )
+
     async def test_reply_media_group(self, monkeypatch, message):
         async def make_assertion(*_, **kwargs):
             id_ = kwargs["chat_id"] == message.chat_id
@@ -1502,6 +1558,14 @@ class TestMessageWithoutRequest(TestMessageBase):
         monkeypatch.setattr(message.get_bot(), "send_media_group", make_assertion)
         assert await message.reply_media_group(media="reply_media_group")
         await self.check_quote_parsing(
+            message,
+            message.reply_media_group,
+            "send_media_group",
+            ["reply_media_group"],
+            monkeypatch,
+        )
+
+        await self.check_thread_id_parsing(
             message,
             message.reply_media_group,
             "send_media_group",
@@ -1535,6 +1599,10 @@ class TestMessageWithoutRequest(TestMessageBase):
             message, message.reply_photo, "send_photo", ["test_photo"], monkeypatch
         )
 
+        await self.check_thread_id_parsing(
+            message, message.reply_photo, "send_photo", ["test_photo"], monkeypatch
+        )
+
     async def test_reply_audio(self, monkeypatch, message):
         async def make_assertion(*_, **kwargs):
             id_ = kwargs["chat_id"] == message.chat_id
@@ -1558,6 +1626,10 @@ class TestMessageWithoutRequest(TestMessageBase):
         monkeypatch.setattr(message.get_bot(), "send_audio", make_assertion)
         assert await message.reply_audio(audio="test_audio")
         await self.check_quote_parsing(
+            message, message.reply_audio, "send_audio", ["test_audio"], monkeypatch
+        )
+
+        await self.check_thread_id_parsing(
             message, message.reply_audio, "send_audio", ["test_audio"], monkeypatch
         )
 
@@ -1587,6 +1659,10 @@ class TestMessageWithoutRequest(TestMessageBase):
             message, message.reply_document, "send_document", ["test_document"], monkeypatch
         )
 
+        await self.check_thread_id_parsing(
+            message, message.reply_document, "send_document", ["test_document"], monkeypatch
+        )
+
     async def test_reply_animation(self, monkeypatch, message):
         async def make_assertion(*_, **kwargs):
             id_ = kwargs["chat_id"] == message.chat_id
@@ -1610,6 +1686,10 @@ class TestMessageWithoutRequest(TestMessageBase):
         monkeypatch.setattr(message.get_bot(), "send_animation", make_assertion)
         assert await message.reply_animation(animation="test_animation")
         await self.check_quote_parsing(
+            message, message.reply_animation, "send_animation", ["test_animation"], monkeypatch
+        )
+
+        await self.check_thread_id_parsing(
             message, message.reply_animation, "send_animation", ["test_animation"], monkeypatch
         )
 
@@ -1639,6 +1719,10 @@ class TestMessageWithoutRequest(TestMessageBase):
             message, message.reply_sticker, "send_sticker", ["test_sticker"], monkeypatch
         )
 
+        await self.check_thread_id_parsing(
+            message, message.reply_sticker, "send_sticker", ["test_sticker"], monkeypatch
+        )
+
     async def test_reply_video(self, monkeypatch, message):
         async def make_assertion(*_, **kwargs):
             id_ = kwargs["chat_id"] == message.chat_id
@@ -1662,6 +1746,10 @@ class TestMessageWithoutRequest(TestMessageBase):
         monkeypatch.setattr(message.get_bot(), "send_video", make_assertion)
         assert await message.reply_video(video="test_video")
         await self.check_quote_parsing(
+            message, message.reply_video, "send_video", ["test_video"], monkeypatch
+        )
+
+        await self.check_thread_id_parsing(
             message, message.reply_video, "send_video", ["test_video"], monkeypatch
         )
 
@@ -1691,6 +1779,10 @@ class TestMessageWithoutRequest(TestMessageBase):
             message, message.reply_video_note, "send_video_note", ["test_video_note"], monkeypatch
         )
 
+        await self.check_thread_id_parsing(
+            message, message.reply_video_note, "send_video_note", ["test_video_note"], monkeypatch
+        )
+
     async def test_reply_voice(self, monkeypatch, message):
         async def make_assertion(*_, **kwargs):
             id_ = kwargs["chat_id"] == message.chat_id
@@ -1714,6 +1806,10 @@ class TestMessageWithoutRequest(TestMessageBase):
         monkeypatch.setattr(message.get_bot(), "send_voice", make_assertion)
         assert await message.reply_voice(voice="test_voice")
         await self.check_quote_parsing(
+            message, message.reply_voice, "send_voice", ["test_voice"], monkeypatch
+        )
+
+        await self.check_thread_id_parsing(
             message, message.reply_voice, "send_voice", ["test_voice"], monkeypatch
         )
 
@@ -1743,6 +1839,10 @@ class TestMessageWithoutRequest(TestMessageBase):
             message, message.reply_location, "send_location", ["test_location"], monkeypatch
         )
 
+        await self.check_thread_id_parsing(
+            message, message.reply_location, "send_location", ["test_location"], monkeypatch
+        )
+
     async def test_reply_venue(self, monkeypatch, message):
         async def make_assertion(*_, **kwargs):
             id_ = kwargs["chat_id"] == message.chat_id
@@ -1766,6 +1866,10 @@ class TestMessageWithoutRequest(TestMessageBase):
         monkeypatch.setattr(message.get_bot(), "send_venue", make_assertion)
         assert await message.reply_venue(venue="test_venue")
         await self.check_quote_parsing(
+            message, message.reply_venue, "send_venue", ["test_venue"], monkeypatch
+        )
+
+        await self.check_thread_id_parsing(
             message, message.reply_venue, "send_venue", ["test_venue"], monkeypatch
         )
 
@@ -1795,6 +1899,10 @@ class TestMessageWithoutRequest(TestMessageBase):
             message, message.reply_contact, "send_contact", ["test_contact"], monkeypatch
         )
 
+        await self.check_thread_id_parsing(
+            message, message.reply_contact, "send_contact", ["test_contact"], monkeypatch
+        )
+
     async def test_reply_poll(self, monkeypatch, message):
         async def make_assertion(*_, **kwargs):
             id_ = kwargs["chat_id"] == message.chat_id
@@ -1816,6 +1924,10 @@ class TestMessageWithoutRequest(TestMessageBase):
         monkeypatch.setattr(message.get_bot(), "send_poll", make_assertion)
         assert await message.reply_poll(question="test_poll", options=["1", "2", "3"])
         await self.check_quote_parsing(
+            message, message.reply_poll, "send_poll", ["test_poll", ["1", "2", "3"]], monkeypatch
+        )
+
+        await self.check_thread_id_parsing(
             message, message.reply_poll, "send_poll", ["test_poll", ["1", "2", "3"]], monkeypatch
         )
 
@@ -1846,6 +1958,10 @@ class TestMessageWithoutRequest(TestMessageBase):
             monkeypatch,
         )
 
+        await self.check_thread_id_parsing(
+            message, message.reply_dice, "send_dice", [], monkeypatch
+        )
+
     async def test_reply_action(self, monkeypatch, message: Message):
         async def make_assertion(*_, **kwargs):
             id_ = kwargs["chat_id"] == message.chat_id
@@ -1862,6 +1978,14 @@ class TestMessageWithoutRequest(TestMessageBase):
 
         monkeypatch.setattr(message.get_bot(), "send_chat_action", make_assertion)
         assert await message.reply_chat_action(action=ChatAction.TYPING)
+
+        await self.check_thread_id_parsing(
+            message,
+            message.reply_chat_action,
+            "send_chat_action",
+            [ChatAction.TYPING],
+            monkeypatch,
+        )
 
     async def test_reply_game(self, monkeypatch, message):
         async def make_assertion(*_, **kwargs):
@@ -1884,6 +2008,14 @@ class TestMessageWithoutRequest(TestMessageBase):
         assert await message.reply_game(game_short_name="test_game")
         await self.check_quote_parsing(
             message, message.reply_game, "send_game", ["test_game"], monkeypatch
+        )
+
+        await self.check_thread_id_parsing(
+            message,
+            message.reply_game,
+            "send_game",
+            ["test_game"],
+            monkeypatch,
         )
 
     async def test_reply_invoice(self, monkeypatch, message):
@@ -1921,6 +2053,14 @@ class TestMessageWithoutRequest(TestMessageBase):
             "prices",
         )
         await self.check_quote_parsing(
+            message,
+            message.reply_invoice,
+            "send_invoice",
+            ["title", "description", "payload", "provider_token", "currency", "prices"],
+            monkeypatch,
+        )
+
+        await self.check_thread_id_parsing(
             message,
             message.reply_invoice,
             "send_invoice",
@@ -2035,6 +2175,14 @@ class TestMessageWithoutRequest(TestMessageBase):
             protect_content=protected,
         )
         await self.check_quote_parsing(
+            message,
+            message.reply_copy,
+            "copy_message",
+            [123456, 456789],
+            monkeypatch,
+        )
+
+        await self.check_thread_id_parsing(
             message,
             message.reply_copy,
             "copy_message",


### PR DESCRIPTION
Closes #4139.

- [x] Added ``.. versionadded:: NEXT.VERSION``, ``.. versionchanged:: NEXT.VERSION`` or ``.. deprecated:: NEXT.VERSION`` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [ ] ~Documented code changes according to the `CSI standard <https://standards.mousepawmedia.com/en/stable/csi.html>`__~
- [ ] ~Added myself alphabetically to ``AUTHORS.rst`` (optional)~
- [ ] ~Added new classes & modules to the docs and all suitable ``__all__`` s~
- [ ] ~Checked the `Stability Policy <https://docs.python-telegram-bot.org/stability_policy.html>`_ in case of deprecations or changes to documented behavior~
