### PR TITLE
Make `can_*_stories` arguments required

### DIFF
--- a/telegram/_chatadministratorrights.py
+++ b/telegram/_chatadministratorrights.py
@@ -44,6 +44,11 @@ class ChatAdministratorRights(TelegramObject):
         :attr:`can_post_stories`, :attr:`can_edit_stories`, and :attr:`can_delete_stories` are
         considered as well when comparing objects of this type in terms of equality.
 
+    .. versionchanged:: NEXT.VERSION
+        As of this version, :attr:`can_post_stories`, :attr:`can_edit_stories`,
+        and :attr:`can_delete_stories` is now required. Thus, the order of arguments had to be
+        changed.
+
     Args:
         is_anonymous (:obj:`bool`): :obj:`True`, if the user's presence in the chat is hidden.
         can_manage_chat (:obj:`bool`): :obj:`True`, if the administrator can access the chat event
@@ -169,13 +174,13 @@ class ChatAdministratorRights(TelegramObject):
         can_promote_members: bool,
         can_change_info: bool,
         can_invite_users: bool,
+        can_post_stories: bool,
+        can_edit_stories: bool,
+        can_delete_stories: bool,
         can_post_messages: Optional[bool] = None,
         can_edit_messages: Optional[bool] = None,
         can_pin_messages: Optional[bool] = None,
         can_manage_topics: Optional[bool] = None,
-        can_post_stories: Optional[bool] = None,
-        can_edit_stories: Optional[bool] = None,
-        can_delete_stories: Optional[bool] = None,
         *,
         api_kwargs: Optional[JSONDict] = None,
     ) -> None:
@@ -189,12 +194,6 @@ class ChatAdministratorRights(TelegramObject):
         self.can_promote_members: bool = can_promote_members
         self.can_change_info: bool = can_change_info
         self.can_invite_users: bool = can_invite_users
-        # Not actually optionals but because of backwards compatability we pretend they are
-        if can_post_stories is None or can_edit_stories is None or can_delete_stories is None:
-            raise TypeError(
-                "As of v21.0 can_post_stories, can_edit_stories and can_delete_stories"
-                " must be set in order to create this object."
-            )
         self.can_post_stories: bool = can_post_stories
         self.can_edit_stories: bool = can_edit_stories
         self.can_delete_stories: bool = can_delete_stories

--- a/telegram/_chatmember.py
+++ b/telegram/_chatmember.py
@@ -191,6 +191,11 @@ class ChatMemberAdministrator(ChatMember):
        * The argument :paramref:`can_manage_topics` was added, which changes the position of the
          optional argument :paramref:`custom_title`.
 
+    .. versionchanged:: NEXT.VERSION
+        As of this version, :attr:`can_post_stories`, :attr:`can_edit_stories`,
+        and :attr:`can_delete_stories` is now required. Thus, the order of arguments had to be
+        changed.
+
     Args:
         user (:class:`telegram.User`): Information about the user.
         can_be_edited (:obj:`bool`): :obj:`True`, if the bot
@@ -340,14 +345,14 @@ class ChatMemberAdministrator(ChatMember):
         can_promote_members: bool,
         can_change_info: bool,
         can_invite_users: bool,
+        can_post_stories: bool,
+        can_edit_stories: bool,
+        can_delete_stories: bool,
         can_post_messages: Optional[bool] = None,
         can_edit_messages: Optional[bool] = None,
         can_pin_messages: Optional[bool] = None,
         can_manage_topics: Optional[bool] = None,
         custom_title: Optional[str] = None,
-        can_post_stories: Optional[bool] = None,
-        can_edit_stories: Optional[bool] = None,
-        can_delete_stories: Optional[bool] = None,
         *,
         api_kwargs: Optional[JSONDict] = None,
     ):
@@ -362,12 +367,6 @@ class ChatMemberAdministrator(ChatMember):
             self.can_promote_members: bool = can_promote_members
             self.can_change_info: bool = can_change_info
             self.can_invite_users: bool = can_invite_users
-            # Not actually optionals but because of backwards compatability we pretend they are
-            if can_post_stories is None or can_edit_stories is None or can_delete_stories is None:
-                raise TypeError(
-                    "As of 21.0 can_post_stories, can_edit_stories and can_delete_stories "
-                    "must be set in order to create this object."
-                )
             self.can_post_stories: bool = can_post_stories
             self.can_edit_stories: bool = can_edit_stories
             self.can_delete_stories: bool = can_delete_stories

--- a/tests/test_chatadministratorrights.py
+++ b/tests/test_chatadministratorrights.py
@@ -98,38 +98,23 @@ class TestChatAdministratorRightsWithoutRequest:
         a = ChatAdministratorRights(
             True,
             *((False,) * 11),
-            can_post_stories=False,
-            can_edit_stories=False,
-            can_delete_stories=False,
         )
         b = ChatAdministratorRights(
             True,
             *((False,) * 11),
-            can_post_stories=False,
-            can_edit_stories=False,
-            can_delete_stories=False,
         )
         c = ChatAdministratorRights(
             *(False,) * 12,
-            can_post_stories=False,
-            can_edit_stories=False,
-            can_delete_stories=False,
         )
         d = ChatAdministratorRights(
             True,
             True,
             *((False,) * 10),
-            can_post_stories=False,
-            can_edit_stories=False,
-            can_delete_stories=False,
         )
         e = ChatAdministratorRights(
             True,
             True,
             *((False,) * 10),
-            can_post_stories=False,
-            can_edit_stories=False,
-            can_delete_stories=False,
         )
 
         assert a == b
@@ -156,9 +141,8 @@ class TestChatAdministratorRightsWithoutRequest:
             True,
             True,
             True,
-            can_post_stories=True,
-            can_edit_stories=True,
-            can_delete_stories=True,
+            True,
+            True,
         )
         t = ChatAdministratorRights.all_rights()
         # if the dirs are the same, the attributes will all be there
@@ -181,9 +165,9 @@ class TestChatAdministratorRightsWithoutRequest:
             False,
             False,
             False,
-            can_post_stories=False,
-            can_edit_stories=False,
-            can_delete_stories=False,
+            False,
+            False,
+            False,
         )
         t = ChatAdministratorRights.no_rights()
         # if the dirs are the same, the attributes will all be there
@@ -194,19 +178,3 @@ class TestChatAdministratorRightsWithoutRequest:
             assert t[key] is False
         # and as a finisher, make sure the default is different.
         assert f != t
-
-    def test_depreciation_typeerror(self):
-        with pytest.raises(TypeError, match="must be set in order"):
-            ChatAdministratorRights(
-                *(False,) * 12,
-            )
-        with pytest.raises(TypeError, match="must be set in order"):
-            ChatAdministratorRights(*(False,) * 12, can_edit_stories=True)
-        with pytest.raises(TypeError, match="must be set in order"):
-            ChatAdministratorRights(*(False,) * 12, can_post_stories=True)
-        with pytest.raises(TypeError, match="must be set in order"):
-            ChatAdministratorRights(*(False,) * 12, can_delete_stories=True)
-        with pytest.raises(TypeError, match="must be set in order"):
-            ChatAdministratorRights(*(False,) * 12, can_edit_stories=True, can_post_stories=True)
-        with pytest.raises(TypeError, match="must be set in order"):
-            ChatAdministratorRights(*(False,) * 12, can_delete_stories=True, can_post_stories=True)

--- a/tests/test_chatmember.py
+++ b/tests/test_chatmember.py
@@ -89,14 +89,14 @@ def chat_member_administrator():
         CMDefaults.can_promote_members,
         CMDefaults.can_change_info,
         CMDefaults.can_invite_users,
+        CMDefaults.can_post_stories,
+        CMDefaults.can_edit_stories,
+        CMDefaults.can_delete_stories,
         CMDefaults.can_post_messages,
         CMDefaults.can_edit_messages,
         CMDefaults.can_pin_messages,
         CMDefaults.can_manage_topics,
         CMDefaults.custom_title,
-        CMDefaults.can_post_stories,
-        CMDefaults.can_edit_stories,
-        CMDefaults.can_delete_stories,
     )
 
 
@@ -302,19 +302,3 @@ class TestChatMemberTypesWithoutRequest:
 
         assert c != e
         assert hash(c) != hash(e)
-
-    def test_deprecation_typeerror(self, chat_member_type):
-        with pytest.raises(TypeError, match="must be set in order"):
-            ChatMemberAdministrator(
-                *(False,) * 12,
-            )
-        with pytest.raises(TypeError, match="must be set in order"):
-            ChatMemberAdministrator(*(False,) * 12, can_edit_stories=True)
-        with pytest.raises(TypeError, match="must be set in order"):
-            ChatMemberAdministrator(*(False,) * 12, can_post_stories=True)
-        with pytest.raises(TypeError, match="must be set in order"):
-            ChatMemberAdministrator(*(False,) * 12, can_delete_stories=True)
-        with pytest.raises(TypeError, match="must be set in order"):
-            ChatMemberAdministrator(*(False,) * 12, can_edit_stories=True, can_post_stories=True)
-        with pytest.raises(TypeError, match="must be set in order"):
-            ChatMemberAdministrator(*(False,) * 12, can_delete_stories=True, can_post_stories=True)

--- a/tests/test_chatmemberupdated.py
+++ b/tests/test_chatmemberupdated.py
@@ -54,7 +54,6 @@ def old_chat_member(user):
 def new_chat_member(user):
     return ChatMemberAdministrator(
         user,
-        TestChatMemberUpdatedBase.new_status,
         True,
         True,
         True,
@@ -64,9 +63,10 @@ def new_chat_member(user):
         True,
         True,
         True,
-        can_post_stories=True,
-        can_edit_stories=True,
-        can_delete_stories=True,
+        True,
+        True,
+        True,
+        custom_title=TestChatMemberUpdatedBase.new_status,
     )
 
 

--- a/tests/test_official/exceptions.py
+++ b/tests/test_official/exceptions.py
@@ -132,9 +132,6 @@ def ptb_extra_params(object_name: str) -> set[str]:
 # Mostly due to the value being fixed anyway
 PTB_IGNORED_PARAMS = {
     r"InlineQueryResult\w+": {"type"},
-    # TODO: Remove this in v21.0 (API 7.1) when this can stop being optional
-    r"ChatAdministratorRights": {"can_post_stories", "can_edit_stories", "can_delete_stories"},
-    r"ChatMemberAdministrator": {"can_post_stories", "can_edit_stories", "can_delete_stories"},
     r"ChatMember\w+": {"status"},
     r"PassportElementError\w+": {"source"},
     "ForceReply": {"force_reply"},
@@ -169,11 +166,7 @@ def ignored_param_requirements(object_name: str) -> set[str]:
 
 
 # Arguments that are optional arguments for now for backwards compatibility
-BACKWARDS_COMPAT_KWARGS: dict[str, set[str]] = {
-    # TODO: Remove this in v21.0 (API 7.1) when this can stop being optional
-    r"ChatAdministratorRights": {"can_post_stories", "can_edit_stories", "can_delete_stories"},
-    r"ChatMemberAdministrator": {"can_post_stories", "can_edit_stories", "can_delete_stories"},
-}
+BACKWARDS_COMPAT_KWARGS: dict[str, set[str]] = {}
 
 
 def backwards_compat_kwargs(object_name: str) -> set[str]:


### PR DESCRIPTION
We missed to make the `can_*_stories` arguments required as they should've been in v21, so now we are doing it for v21.1. 

To be merged after #4180 