### PR TITLE
Fix annotation of decrypted_secret

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -123,6 +123,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Vorobjev Simon <https://github.com/simonvorobjev>`_
 - `Wagner Macedo <https://github.com/wagnerluis1982>`_
 - `wjt <https://github.com/wjt>`_
+- `Wonseok Oh <https://github.com/marinelay>`_
 - `Yaw Danso <https://github.com/dglitxh>`_
 - `Yao Kuan <https://github.com/thatguylah>`_
 - `zeroone2numeral2 <https://github.com/zeroone2numeral2>`_

--- a/telegram/_passport/credentials.py
+++ b/telegram/_passport/credentials.py
@@ -153,15 +153,15 @@ class EncryptedCredentials(TelegramObject):
 
         self._id_attrs = (self.data, self.hash, self.secret)
 
-        self._decrypted_secret: Optional[str] = None
+        self._decrypted_secret: Optional[bytes] = None
         self._decrypted_data: Optional[Credentials] = None
 
         self._freeze()
 
     @property
-    def decrypted_secret(self) -> str:
+    def decrypted_secret(self) -> bytes:
         """
-        :obj:`str`: Lazily decrypt and return secret.
+        :obj:`bytes`: Lazily decrypt and return secret.
 
         Raises:
             telegram.error.PassportDecryptionError: Decryption failed. Usually due to bad


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

Close #4198 
Fix type annotation of `self._decrypted_secret` from str to bytes