### PR TITLE
Removed deprecated warning message in new major version

### DIFF
--- a/telegram/ext/_jobqueue.py
+++ b/telegram/ext/_jobqueue.py
@@ -33,7 +33,6 @@ except ImportError:
 
 from telegram._utils.repr import build_repr_with_selected_attrs
 from telegram._utils.types import JSONDict
-from telegram._utils.warnings import warn
 from telegram.ext._extbot import ExtBot
 from telegram.ext._utils.types import CCT, JobCallback
 

--- a/telegram/ext/_jobqueue.py
+++ b/telegram/ext/_jobqueue.py
@@ -587,13 +587,6 @@ class JobQueue(Generic[CCT]):
             queue.
 
         """
-        # TODO: After v20.0, we should remove this warning.
-        if days != tuple(range(7)):  # checks if user passed a custom value
-            warn(
-                "Prior to v20.0 the `days` parameter was not aligned to that of cron's weekday "
-                "scheme. We recommend double checking if the passed value is correct.",
-                stacklevel=2,
-            )
         if not job_kwargs:
             job_kwargs = {}
 

--- a/tests/ext/test_jobqueue.py
+++ b/tests/ext/test_jobqueue.py
@@ -26,7 +26,6 @@ import time
 import pytest
 
 from telegram.ext import ApplicationBuilder, CallbackContext, ContextTypes, Defaults, Job, JobQueue
-from telegram.warnings import PTBUserWarning
 from tests.auxil.envvars import GITHUB_ACTION, TEST_WITH_OPT_DEPS
 from tests.auxil.pytest_classes import make_bot
 from tests.auxil.slots import mro_slots


### PR DESCRIPTION
In the `_jobqueue.py` file, we removed a deprecated warning message that is no longer needed after v20.0. This warning was about the days parameter not being aligned with cron's weekday scheme.

As written out in [this comment](https://github.com/python-telegram-bot/python-telegram-bot/issues/4008#issuecomment-1854578113) of #4008, this warning needs to be removed in the next major version (v21).