### PR TITLE
Fix Bug With Parameter `message_thread_id` of `Message.reply_text`

### DIFF
--- a/telegram/_message.py
+++ b/telegram/_message.py
@@ -1462,7 +1462,7 @@ class Message(MaybeInaccessibleMessage):
         quote_index: Optional[int] = None,
         target_chat_id: Optional[Union[int, str]] = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
     ) -> _ReplyKwargs:
         """
         Builds a dictionary with the keys ``chat_id`` and ``reply_parameters``. This dictionary can
@@ -1587,11 +1587,22 @@ class Message(MaybeInaccessibleMessage):
     def _parse_message_thread_id(
         self,
         chat_id: Union[str, int],
-        message_thread_id: Optional[int] = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
     ) -> Optional[int]:
-        return message_thread_id or (
-            self.message_thread_id if chat_id in {self.chat_id, self.chat.username} else None
-        )
+        # values set by user have the highest priority
+        if not isinstance(message_thread_id, DefaultValue):
+            return message_thread_id
+
+        # self.message_thread_id can be used for send_*.param.message_thread_id only if the
+        # thread is a forum topic. It does not work if the thread is a chain of replies to a
+        # message in a normal group. In that case, self.message_thread_id is just the message_id
+        # of the first message in the chain.
+        if not self.is_topic_message:
+            return None
+
+        # Setting message_thread_id=self.message_thread_id only makes sense if we're replying in
+        # the same chat.
+        return self.message_thread_id if chat_id in {self.chat_id, self.chat.username} else None
 
     async def reply_text(
         self,
@@ -1601,7 +1612,7 @@ class Message(MaybeInaccessibleMessage):
         reply_markup: Optional[ReplyMarkup] = None,
         entities: Optional[Sequence["MessageEntity"]] = None,
         protect_content: ODVInput[bool] = DEFAULT_NONE,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
         link_preview_options: ODVInput["LinkPreviewOptions"] = DEFAULT_NONE,
         reply_parameters: Optional["ReplyParameters"] = None,
         *,
@@ -1677,7 +1688,7 @@ class Message(MaybeInaccessibleMessage):
         reply_markup: Optional[ReplyMarkup] = None,
         entities: Optional[Sequence["MessageEntity"]] = None,
         protect_content: ODVInput[bool] = DEFAULT_NONE,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
         link_preview_options: ODVInput["LinkPreviewOptions"] = DEFAULT_NONE,
         reply_parameters: Optional["ReplyParameters"] = None,
         *,
@@ -1759,7 +1770,7 @@ class Message(MaybeInaccessibleMessage):
         reply_markup: Optional[ReplyMarkup] = None,
         entities: Optional[Sequence["MessageEntity"]] = None,
         protect_content: ODVInput[bool] = DEFAULT_NONE,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
         link_preview_options: ODVInput["LinkPreviewOptions"] = DEFAULT_NONE,
         reply_parameters: Optional["ReplyParameters"] = None,
         *,
@@ -1837,7 +1848,7 @@ class Message(MaybeInaccessibleMessage):
         reply_markup: Optional[ReplyMarkup] = None,
         entities: Optional[Sequence["MessageEntity"]] = None,
         protect_content: ODVInput[bool] = DEFAULT_NONE,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
         link_preview_options: ODVInput["LinkPreviewOptions"] = DEFAULT_NONE,
         reply_parameters: Optional["ReplyParameters"] = None,
         *,
@@ -1915,7 +1926,7 @@ class Message(MaybeInaccessibleMessage):
         ],
         disable_notification: ODVInput[bool] = DEFAULT_NONE,
         protect_content: ODVInput[bool] = DEFAULT_NONE,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
         reply_parameters: Optional["ReplyParameters"] = None,
         *,
         reply_to_message_id: Optional[int] = None,
@@ -1994,7 +2005,7 @@ class Message(MaybeInaccessibleMessage):
         parse_mode: ODVInput[str] = DEFAULT_NONE,
         caption_entities: Optional[Sequence["MessageEntity"]] = None,
         protect_content: ODVInput[bool] = DEFAULT_NONE,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
         has_spoiler: Optional[bool] = None,
         reply_parameters: Optional["ReplyParameters"] = None,
         *,
@@ -2076,7 +2087,7 @@ class Message(MaybeInaccessibleMessage):
         parse_mode: ODVInput[str] = DEFAULT_NONE,
         caption_entities: Optional[Sequence["MessageEntity"]] = None,
         protect_content: ODVInput[bool] = DEFAULT_NONE,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
         thumbnail: Optional[FileInput] = None,
         reply_parameters: Optional["ReplyParameters"] = None,
         *,
@@ -2159,7 +2170,7 @@ class Message(MaybeInaccessibleMessage):
         disable_content_type_detection: Optional[bool] = None,
         caption_entities: Optional[Sequence["MessageEntity"]] = None,
         protect_content: ODVInput[bool] = DEFAULT_NONE,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
         thumbnail: Optional[FileInput] = None,
         reply_parameters: Optional["ReplyParameters"] = None,
         *,
@@ -2242,7 +2253,7 @@ class Message(MaybeInaccessibleMessage):
         reply_markup: Optional[ReplyMarkup] = None,
         caption_entities: Optional[Sequence["MessageEntity"]] = None,
         protect_content: ODVInput[bool] = DEFAULT_NONE,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
         has_spoiler: Optional[bool] = None,
         thumbnail: Optional[FileInput] = None,
         reply_parameters: Optional["ReplyParameters"] = None,
@@ -2323,7 +2334,7 @@ class Message(MaybeInaccessibleMessage):
         disable_notification: ODVInput[bool] = DEFAULT_NONE,
         reply_markup: Optional[ReplyMarkup] = None,
         protect_content: ODVInput[bool] = DEFAULT_NONE,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
         emoji: Optional[str] = None,
         reply_parameters: Optional["ReplyParameters"] = None,
         *,
@@ -2401,7 +2412,7 @@ class Message(MaybeInaccessibleMessage):
         supports_streaming: Optional[bool] = None,
         caption_entities: Optional[Sequence["MessageEntity"]] = None,
         protect_content: ODVInput[bool] = DEFAULT_NONE,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
         has_spoiler: Optional[bool] = None,
         thumbnail: Optional[FileInput] = None,
         reply_parameters: Optional["ReplyParameters"] = None,
@@ -2485,7 +2496,7 @@ class Message(MaybeInaccessibleMessage):
         disable_notification: ODVInput[bool] = DEFAULT_NONE,
         reply_markup: Optional[ReplyMarkup] = None,
         protect_content: ODVInput[bool] = DEFAULT_NONE,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
         thumbnail: Optional[FileInput] = None,
         reply_parameters: Optional["ReplyParameters"] = None,
         *,
@@ -2564,7 +2575,7 @@ class Message(MaybeInaccessibleMessage):
         parse_mode: ODVInput[str] = DEFAULT_NONE,
         caption_entities: Optional[Sequence["MessageEntity"]] = None,
         protect_content: ODVInput[bool] = DEFAULT_NONE,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
         reply_parameters: Optional["ReplyParameters"] = None,
         *,
         reply_to_message_id: Optional[int] = None,
@@ -2644,7 +2655,7 @@ class Message(MaybeInaccessibleMessage):
         heading: Optional[int] = None,
         proximity_alert_radius: Optional[int] = None,
         protect_content: ODVInput[bool] = DEFAULT_NONE,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
         reply_parameters: Optional["ReplyParameters"] = None,
         *,
         reply_to_message_id: Optional[int] = None,
@@ -2727,7 +2738,7 @@ class Message(MaybeInaccessibleMessage):
         google_place_id: Optional[str] = None,
         google_place_type: Optional[str] = None,
         protect_content: ODVInput[bool] = DEFAULT_NONE,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
         reply_parameters: Optional["ReplyParameters"] = None,
         *,
         reply_to_message_id: Optional[int] = None,
@@ -2808,7 +2819,7 @@ class Message(MaybeInaccessibleMessage):
         reply_markup: Optional[ReplyMarkup] = None,
         vcard: Optional[str] = None,
         protect_content: ODVInput[bool] = DEFAULT_NONE,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
         reply_parameters: Optional["ReplyParameters"] = None,
         *,
         reply_to_message_id: Optional[int] = None,
@@ -2893,7 +2904,7 @@ class Message(MaybeInaccessibleMessage):
         close_date: Optional[Union[int, datetime.datetime]] = None,
         explanation_entities: Optional[Sequence["MessageEntity"]] = None,
         protect_content: ODVInput[bool] = DEFAULT_NONE,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
         reply_parameters: Optional["ReplyParameters"] = None,
         *,
         reply_to_message_id: Optional[int] = None,
@@ -2973,7 +2984,7 @@ class Message(MaybeInaccessibleMessage):
         reply_markup: Optional[ReplyMarkup] = None,
         emoji: Optional[str] = None,
         protect_content: ODVInput[bool] = DEFAULT_NONE,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
         reply_parameters: Optional["ReplyParameters"] = None,
         *,
         reply_to_message_id: Optional[int] = None,
@@ -3039,7 +3050,7 @@ class Message(MaybeInaccessibleMessage):
     async def reply_chat_action(
         self,
         action: str,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
         *,
         read_timeout: ODVInput[float] = DEFAULT_NONE,
         write_timeout: ODVInput[float] = DEFAULT_NONE,
@@ -3086,7 +3097,7 @@ class Message(MaybeInaccessibleMessage):
         disable_notification: ODVInput[bool] = DEFAULT_NONE,
         reply_markup: Optional["InlineKeyboardMarkup"] = None,
         protect_content: ODVInput[bool] = DEFAULT_NONE,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
         reply_parameters: Optional["ReplyParameters"] = None,
         *,
         reply_to_message_id: Optional[int] = None,
@@ -3177,7 +3188,7 @@ class Message(MaybeInaccessibleMessage):
         max_tip_amount: Optional[int] = None,
         suggested_tip_amounts: Optional[Sequence[int]] = None,
         protect_content: ODVInput[bool] = DEFAULT_NONE,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
         reply_parameters: Optional["ReplyParameters"] = None,
         *,
         reply_to_message_id: Optional[int] = None,
@@ -3387,7 +3398,7 @@ class Message(MaybeInaccessibleMessage):
         disable_notification: ODVInput[bool] = DEFAULT_NONE,
         reply_markup: Optional[ReplyMarkup] = None,
         protect_content: ODVInput[bool] = DEFAULT_NONE,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
         reply_parameters: Optional["ReplyParameters"] = None,
         *,
         reply_to_message_id: Optional[int] = None,

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -69,6 +69,8 @@ from telegram import (
     WebAppData,
 )
 from telegram._utils.datetime import UTC
+from telegram._utils.defaultvalue import DEFAULT_NONE
+from telegram._utils.types import ODVInput
 from telegram.constants import ChatAction, ParseMode
 from telegram.ext import Defaults
 from telegram.warnings import PTBDeprecationWarning
@@ -502,35 +504,38 @@ class TestMessageWithoutRequest(TestMessageBase):
 
         monkeypatch.setattr(message.get_bot(), bot_method_name, extract_message_thread_id)
 
-        message.message_thread_id = None
-        message_thread_id = await method(*args)
-        assert message_thread_id is None
+        for is_topic_message in (True, False):
+            message.is_topic_message = is_topic_message
 
-        message.message_thread_id = 99
-        message_thread_id = await method(*args)
-        assert message_thread_id == 99
+            message.message_thread_id = None
+            message_thread_id = await method(*args)
+            assert message_thread_id is None
 
-        message_thread_id = await method(*args, message_thread_id=50)
-        assert message_thread_id == 50
+            message.message_thread_id = 99
+            message_thread_id = await method(*args)
+            assert message_thread_id == (99 if is_topic_message else None)
 
-        if bot_method_name == "send_chat_action":
-            return
+            message_thread_id = await method(*args, message_thread_id=50)
+            assert message_thread_id == 50
 
-        message_thread_id = await method(
-            *args,
-            do_quote=message.build_reply_arguments(
-                target_chat_id=123,
-            ),
-        )
-        assert message_thread_id is None
+            if bot_method_name == "send_chat_action":
+                return
 
-        message_thread_id = await method(
-            *args,
-            do_quote=message.build_reply_arguments(
-                target_chat_id=message.chat_id,
-            ),
-        )
-        assert message_thread_id == message.message_thread_id
+            message_thread_id = await method(
+                *args,
+                do_quote=message.build_reply_arguments(
+                    target_chat_id=123,
+                ),
+            )
+            assert message_thread_id is None
+
+            message_thread_id = await method(
+                *args,
+                do_quote=message.build_reply_arguments(
+                    target_chat_id=message.chat_id,
+                ),
+            )
+            assert message_thread_id == (message.message_thread_id if is_topic_message else None)
 
     def test_slot_behaviour(self):
         message = Message(
@@ -1396,6 +1401,7 @@ class TestMessageWithoutRequest(TestMessageBase):
             Bot.send_message,
             ["chat_id", "reply_to_message_id", "business_connection_id"],
             ["quote", "do_quote", "reply_to_message_id"],
+            annotation_overrides={"message_thread_id": (ODVInput[int], DEFAULT_NONE)},
         )
         assert await check_shortcut_call(
             message.reply_text,
@@ -1404,7 +1410,9 @@ class TestMessageWithoutRequest(TestMessageBase):
             skip_params=["reply_to_message_id"],
             shortcut_kwargs=["business_connection_id"],
         )
-        assert await check_defaults_handling(message.reply_text, message.get_bot())
+        assert await check_defaults_handling(
+            message.reply_text, message.get_bot(), no_default_kwargs={"message_thread_id"}
+        )
 
         monkeypatch.setattr(message.get_bot(), "send_message", make_assertion)
         assert await message.reply_text("test")
@@ -1435,6 +1443,7 @@ class TestMessageWithoutRequest(TestMessageBase):
             Bot.send_message,
             ["chat_id", "parse_mode", "reply_to_message_id", "business_connection_id"],
             ["quote", "do_quote", "reply_to_message_id"],
+            annotation_overrides={"message_thread_id": (ODVInput[int], DEFAULT_NONE)},
         )
         assert await check_shortcut_call(
             message.reply_text,
@@ -1443,7 +1452,9 @@ class TestMessageWithoutRequest(TestMessageBase):
             skip_params=["reply_to_message_id"],
             shortcut_kwargs=["business_connection_id"],
         )
-        assert await check_defaults_handling(message.reply_text, message.get_bot())
+        assert await check_defaults_handling(
+            message.reply_text, message.get_bot(), no_default_kwargs={"message_thread_id"}
+        )
 
         text_markdown = self.test_message.text_markdown
         assert text_markdown == test_md_string
@@ -1478,6 +1489,7 @@ class TestMessageWithoutRequest(TestMessageBase):
             Bot.send_message,
             ["chat_id", "parse_mode", "reply_to_message_id", "business_connection_id"],
             ["quote", "do_quote", "reply_to_message_id"],
+            annotation_overrides={"message_thread_id": (ODVInput[int], DEFAULT_NONE)},
         )
         assert await check_shortcut_call(
             message.reply_text,
@@ -1486,7 +1498,9 @@ class TestMessageWithoutRequest(TestMessageBase):
             skip_params=["reply_to_message_id"],
             shortcut_kwargs=["business_connection_id"],
         )
-        assert await check_defaults_handling(message.reply_text, message.get_bot())
+        assert await check_defaults_handling(
+            message.reply_text, message.get_bot(), no_default_kwargs={"message_thread_id"}
+        )
 
         text_markdown = self.test_message_v2.text_markdown_v2
         assert text_markdown == test_md_string
@@ -1526,6 +1540,7 @@ class TestMessageWithoutRequest(TestMessageBase):
             Bot.send_message,
             ["chat_id", "parse_mode", "reply_to_message_id", "business_connection_id"],
             ["quote", "do_quote", "reply_to_message_id"],
+            annotation_overrides={"message_thread_id": (ODVInput[int], DEFAULT_NONE)},
         )
         assert await check_shortcut_call(
             message.reply_text,
@@ -1534,7 +1549,9 @@ class TestMessageWithoutRequest(TestMessageBase):
             skip_params=["reply_to_message_id"],
             shortcut_kwargs=["business_connection_id"],
         )
-        assert await check_defaults_handling(message.reply_text, message.get_bot())
+        assert await check_defaults_handling(
+            message.reply_text, message.get_bot(), no_default_kwargs={"message_thread_id"}
+        )
 
         text_html = self.test_message_v2.text_html
         assert text_html == test_html_string
@@ -1560,6 +1577,7 @@ class TestMessageWithoutRequest(TestMessageBase):
             Bot.send_media_group,
             ["chat_id", "reply_to_message_id", "business_connection_id"],
             ["quote", "do_quote", "reply_to_message_id"],
+            annotation_overrides={"message_thread_id": (ODVInput[int], DEFAULT_NONE)},
         )
         assert await check_shortcut_call(
             message.reply_media_group,
@@ -1568,7 +1586,9 @@ class TestMessageWithoutRequest(TestMessageBase):
             skip_params=["reply_to_message_id"],
             shortcut_kwargs=["business_connection_id"],
         )
-        assert await check_defaults_handling(message.reply_media_group, message.get_bot())
+        assert await check_defaults_handling(
+            message.reply_media_group, message.get_bot(), no_default_kwargs={"message_thread_id"}
+        )
 
         monkeypatch.setattr(message.get_bot(), "send_media_group", make_assertion)
         assert await message.reply_media_group(media="reply_media_group")
@@ -1599,6 +1619,7 @@ class TestMessageWithoutRequest(TestMessageBase):
             Bot.send_photo,
             ["chat_id", "reply_to_message_id", "business_connection_id"],
             ["quote", "do_quote", "reply_to_message_id"],
+            annotation_overrides={"message_thread_id": (ODVInput[int], DEFAULT_NONE)},
         )
         assert await check_shortcut_call(
             message.reply_photo,
@@ -1607,7 +1628,9 @@ class TestMessageWithoutRequest(TestMessageBase):
             skip_params=["reply_to_message_id"],
             shortcut_kwargs=["business_connection_id"],
         )
-        assert await check_defaults_handling(message.reply_photo, message.get_bot())
+        assert await check_defaults_handling(
+            message.reply_photo, message.get_bot(), no_default_kwargs={"message_thread_id"}
+        )
 
         monkeypatch.setattr(message.get_bot(), "send_photo", make_assertion)
         assert await message.reply_photo(photo="test_photo")
@@ -1630,6 +1653,7 @@ class TestMessageWithoutRequest(TestMessageBase):
             Bot.send_audio,
             ["chat_id", "reply_to_message_id", "business_connection_id"],
             ["quote", "do_quote", "reply_to_message_id"],
+            annotation_overrides={"message_thread_id": (ODVInput[int], DEFAULT_NONE)},
         )
         assert await check_shortcut_call(
             message.reply_audio,
@@ -1638,7 +1662,9 @@ class TestMessageWithoutRequest(TestMessageBase):
             skip_params=["reply_to_message_id"],
             shortcut_kwargs=["business_connection_id"],
         )
-        assert await check_defaults_handling(message.reply_audio, message.get_bot())
+        assert await check_defaults_handling(
+            message.reply_audio, message.get_bot(), no_default_kwargs={"message_thread_id"}
+        )
 
         monkeypatch.setattr(message.get_bot(), "send_audio", make_assertion)
         assert await message.reply_audio(audio="test_audio")
@@ -1661,6 +1687,7 @@ class TestMessageWithoutRequest(TestMessageBase):
             Bot.send_document,
             ["chat_id", "reply_to_message_id", "business_connection_id"],
             ["quote", "do_quote", "reply_to_message_id"],
+            annotation_overrides={"message_thread_id": (ODVInput[int], DEFAULT_NONE)},
         )
         assert await check_shortcut_call(
             message.reply_document,
@@ -1669,7 +1696,9 @@ class TestMessageWithoutRequest(TestMessageBase):
             skip_params=["reply_to_message_id"],
             shortcut_kwargs=["business_connection_id"],
         )
-        assert await check_defaults_handling(message.reply_document, message.get_bot())
+        assert await check_defaults_handling(
+            message.reply_document, message.get_bot(), no_default_kwargs={"message_thread_id"}
+        )
 
         monkeypatch.setattr(message.get_bot(), "send_document", make_assertion)
         assert await message.reply_document(document="test_document")
@@ -1692,6 +1721,7 @@ class TestMessageWithoutRequest(TestMessageBase):
             Bot.send_animation,
             ["chat_id", "reply_to_message_id", "business_connection_id"],
             ["quote", "do_quote", "reply_to_message_id"],
+            annotation_overrides={"message_thread_id": (ODVInput[int], DEFAULT_NONE)},
         )
         assert await check_shortcut_call(
             message.reply_animation,
@@ -1700,7 +1730,9 @@ class TestMessageWithoutRequest(TestMessageBase):
             skip_params=["reply_to_message_id"],
             shortcut_kwargs=["business_connection_id"],
         )
-        assert await check_defaults_handling(message.reply_animation, message.get_bot())
+        assert await check_defaults_handling(
+            message.reply_animation, message.get_bot(), no_default_kwargs={"message_thread_id"}
+        )
 
         monkeypatch.setattr(message.get_bot(), "send_animation", make_assertion)
         assert await message.reply_animation(animation="test_animation")
@@ -1723,6 +1755,7 @@ class TestMessageWithoutRequest(TestMessageBase):
             Bot.send_sticker,
             ["chat_id", "reply_to_message_id", "business_connection_id"],
             ["quote", "do_quote", "reply_to_message_id"],
+            annotation_overrides={"message_thread_id": (ODVInput[int], DEFAULT_NONE)},
         )
         assert await check_shortcut_call(
             message.reply_sticker,
@@ -1731,7 +1764,9 @@ class TestMessageWithoutRequest(TestMessageBase):
             skip_params=["reply_to_message_id"],
             shortcut_kwargs=["business_connection_id"],
         )
-        assert await check_defaults_handling(message.reply_sticker, message.get_bot())
+        assert await check_defaults_handling(
+            message.reply_sticker, message.get_bot(), no_default_kwargs={"message_thread_id"}
+        )
 
         monkeypatch.setattr(message.get_bot(), "send_sticker", make_assertion)
         assert await message.reply_sticker(sticker="test_sticker")
@@ -1754,6 +1789,7 @@ class TestMessageWithoutRequest(TestMessageBase):
             Bot.send_video,
             ["chat_id", "reply_to_message_id", "business_connection_id"],
             ["quote", "do_quote", "reply_to_message_id"],
+            annotation_overrides={"message_thread_id": (ODVInput[int], DEFAULT_NONE)},
         )
         assert await check_shortcut_call(
             message.reply_video,
@@ -1762,7 +1798,9 @@ class TestMessageWithoutRequest(TestMessageBase):
             skip_params=["reply_to_message_id"],
             shortcut_kwargs=["business_connection_id"],
         )
-        assert await check_defaults_handling(message.reply_video, message.get_bot())
+        assert await check_defaults_handling(
+            message.reply_video, message.get_bot(), no_default_kwargs={"message_thread_id"}
+        )
 
         monkeypatch.setattr(message.get_bot(), "send_video", make_assertion)
         assert await message.reply_video(video="test_video")
@@ -1785,6 +1823,7 @@ class TestMessageWithoutRequest(TestMessageBase):
             Bot.send_video_note,
             ["chat_id", "reply_to_message_id", "business_connection_id"],
             ["quote", "do_quote", "reply_to_message_id"],
+            annotation_overrides={"message_thread_id": (ODVInput[int], DEFAULT_NONE)},
         )
         assert await check_shortcut_call(
             message.reply_video_note,
@@ -1793,7 +1832,9 @@ class TestMessageWithoutRequest(TestMessageBase):
             skip_params=["reply_to_message_id"],
             shortcut_kwargs=["business_connection_id"],
         )
-        assert await check_defaults_handling(message.reply_video_note, message.get_bot())
+        assert await check_defaults_handling(
+            message.reply_video_note, message.get_bot(), no_default_kwargs={"message_thread_id"}
+        )
 
         monkeypatch.setattr(message.get_bot(), "send_video_note", make_assertion)
         assert await message.reply_video_note(video_note="test_video_note")
@@ -1816,6 +1857,7 @@ class TestMessageWithoutRequest(TestMessageBase):
             Bot.send_voice,
             ["chat_id", "reply_to_message_id", "business_connection_id"],
             ["quote", "do_quote", "reply_to_message_id"],
+            annotation_overrides={"message_thread_id": (ODVInput[int], DEFAULT_NONE)},
         )
         assert await check_shortcut_call(
             message.reply_voice,
@@ -1824,7 +1866,9 @@ class TestMessageWithoutRequest(TestMessageBase):
             skip_params=["reply_to_message_id"],
             shortcut_kwargs=["business_connection_id"],
         )
-        assert await check_defaults_handling(message.reply_voice, message.get_bot())
+        assert await check_defaults_handling(
+            message.reply_voice, message.get_bot(), no_default_kwargs={"message_thread_id"}
+        )
 
         monkeypatch.setattr(message.get_bot(), "send_voice", make_assertion)
         assert await message.reply_voice(voice="test_voice")
@@ -1847,6 +1891,7 @@ class TestMessageWithoutRequest(TestMessageBase):
             Bot.send_location,
             ["chat_id", "reply_to_message_id", "business_connection_id"],
             ["quote", "do_quote", "reply_to_message_id"],
+            annotation_overrides={"message_thread_id": (ODVInput[int], DEFAULT_NONE)},
         )
         assert await check_shortcut_call(
             message.reply_location,
@@ -1855,7 +1900,9 @@ class TestMessageWithoutRequest(TestMessageBase):
             skip_params=["reply_to_message_id"],
             shortcut_kwargs=["business_connection_id"],
         )
-        assert await check_defaults_handling(message.reply_location, message.get_bot())
+        assert await check_defaults_handling(
+            message.reply_location, message.get_bot(), no_default_kwargs={"message_thread_id"}
+        )
 
         monkeypatch.setattr(message.get_bot(), "send_location", make_assertion)
         assert await message.reply_location(location="test_location")
@@ -1878,6 +1925,7 @@ class TestMessageWithoutRequest(TestMessageBase):
             Bot.send_venue,
             ["chat_id", "reply_to_message_id", "business_connection_id"],
             ["quote", "do_quote", "reply_to_message_id"],
+            annotation_overrides={"message_thread_id": (ODVInput[int], DEFAULT_NONE)},
         )
         assert await check_shortcut_call(
             message.reply_venue,
@@ -1886,7 +1934,9 @@ class TestMessageWithoutRequest(TestMessageBase):
             skip_params=["reply_to_message_id"],
             shortcut_kwargs=["business_connection_id"],
         )
-        assert await check_defaults_handling(message.reply_venue, message.get_bot())
+        assert await check_defaults_handling(
+            message.reply_venue, message.get_bot(), no_default_kwargs={"message_thread_id"}
+        )
 
         monkeypatch.setattr(message.get_bot(), "send_venue", make_assertion)
         assert await message.reply_venue(venue="test_venue")
@@ -1909,6 +1959,7 @@ class TestMessageWithoutRequest(TestMessageBase):
             Bot.send_contact,
             ["chat_id", "reply_to_message_id", "business_connection_id"],
             ["quote", "do_quote", "reply_to_message_id"],
+            annotation_overrides={"message_thread_id": (ODVInput[int], DEFAULT_NONE)},
         )
         assert await check_shortcut_call(
             message.reply_contact,
@@ -1917,7 +1968,9 @@ class TestMessageWithoutRequest(TestMessageBase):
             skip_params=["reply_to_message_id"],
             shortcut_kwargs=["business_connection_id"],
         )
-        assert await check_defaults_handling(message.reply_contact, message.get_bot())
+        assert await check_defaults_handling(
+            message.reply_contact, message.get_bot(), no_default_kwargs={"message_thread_id"}
+        )
 
         monkeypatch.setattr(message.get_bot(), "send_contact", make_assertion)
         assert await message.reply_contact(contact="test_contact")
@@ -1941,6 +1994,7 @@ class TestMessageWithoutRequest(TestMessageBase):
             Bot.send_poll,
             ["chat_id", "reply_to_message_id", "business_connection_id"],
             ["quote", "do_quote", "reply_to_message_id"],
+            annotation_overrides={"message_thread_id": (ODVInput[int], DEFAULT_NONE)},
         )
         assert await check_shortcut_call(
             message.reply_poll,
@@ -1949,7 +2003,9 @@ class TestMessageWithoutRequest(TestMessageBase):
             skip_params=["reply_to_message_id"],
             shortcut_kwargs=["business_connection_id"],
         )
-        assert await check_defaults_handling(message.reply_poll, message.get_bot())
+        assert await check_defaults_handling(
+            message.reply_poll, message.get_bot(), no_default_kwargs={"message_thread_id"}
+        )
 
         monkeypatch.setattr(message.get_bot(), "send_poll", make_assertion)
         assert await message.reply_poll(question="test_poll", options=["1", "2", "3"])
@@ -1972,6 +2028,7 @@ class TestMessageWithoutRequest(TestMessageBase):
             Bot.send_dice,
             ["chat_id", "reply_to_message_id", "business_connection_id"],
             ["quote", "do_quote", "reply_to_message_id"],
+            annotation_overrides={"message_thread_id": (ODVInput[int], DEFAULT_NONE)},
         )
         assert await check_shortcut_call(
             message.reply_dice,
@@ -1980,7 +2037,9 @@ class TestMessageWithoutRequest(TestMessageBase):
             skip_params=["reply_to_message_id"],
             shortcut_kwargs=["business_connection_id"],
         )
-        assert await check_defaults_handling(message.reply_dice, message.get_bot())
+        assert await check_defaults_handling(
+            message.reply_dice, message.get_bot(), no_default_kwargs={"message_thread_id"}
+        )
 
         monkeypatch.setattr(message.get_bot(), "send_dice", make_assertion)
         assert await message.reply_dice(disable_notification=True)
@@ -2007,6 +2066,7 @@ class TestMessageWithoutRequest(TestMessageBase):
             Bot.send_chat_action,
             ["chat_id", "reply_to_message_id", "business_connection_id"],
             [],
+            annotation_overrides={"message_thread_id": (ODVInput[int], DEFAULT_NONE)},
         )
         assert await check_shortcut_call(
             message.reply_chat_action,
@@ -2014,7 +2074,9 @@ class TestMessageWithoutRequest(TestMessageBase):
             "send_chat_action",
             shortcut_kwargs=["business_connection_id"],
         )
-        assert await check_defaults_handling(message.reply_chat_action, message.get_bot())
+        assert await check_defaults_handling(
+            message.reply_chat_action, message.get_bot(), no_default_kwargs={"message_thread_id"}
+        )
 
         monkeypatch.setattr(message.get_bot(), "send_chat_action", make_assertion)
         assert await message.reply_chat_action(action=ChatAction.TYPING)
@@ -2038,6 +2100,7 @@ class TestMessageWithoutRequest(TestMessageBase):
             Bot.send_game,
             ["chat_id", "reply_to_message_id", "business_connection_id"],
             ["quote", "do_quote", "reply_to_message_id"],
+            annotation_overrides={"message_thread_id": (ODVInput[int], DEFAULT_NONE)},
         )
         assert await check_shortcut_call(
             message.reply_game,
@@ -2046,7 +2109,9 @@ class TestMessageWithoutRequest(TestMessageBase):
             skip_params=["reply_to_message_id"],
             shortcut_kwargs=["business_connection_id"],
         )
-        assert await check_defaults_handling(message.reply_game, message.get_bot())
+        assert await check_defaults_handling(
+            message.reply_game, message.get_bot(), no_default_kwargs={"message_thread_id"}
+        )
 
         monkeypatch.setattr(message.get_bot(), "send_game", make_assertion)
         assert await message.reply_game(game_short_name="test_game")
@@ -2078,6 +2143,7 @@ class TestMessageWithoutRequest(TestMessageBase):
             Bot.send_invoice,
             ["chat_id", "reply_to_message_id", "business_connection_id"],
             ["quote", "do_quote", "reply_to_message_id"],
+            annotation_overrides={"message_thread_id": (ODVInput[int], DEFAULT_NONE)},
         )
         assert await check_shortcut_call(
             message.reply_invoice,
@@ -2086,7 +2152,9 @@ class TestMessageWithoutRequest(TestMessageBase):
             skip_params=["reply_to_message_id"],
             shortcut_kwargs=["business_connection_id"],
         )
-        assert await check_defaults_handling(message.reply_invoice, message.get_bot())
+        assert await check_defaults_handling(
+            message.reply_invoice, message.get_bot(), no_default_kwargs={"message_thread_id"}
+        )
 
         monkeypatch.setattr(message.get_bot(), "send_invoice", make_assertion)
         assert await message.reply_invoice(
@@ -2204,6 +2272,7 @@ class TestMessageWithoutRequest(TestMessageBase):
             Bot.copy_message,
             ["chat_id", "reply_to_message_id", "business_connection_id"],
             ["quote", "do_quote", "reply_to_message_id"],
+            annotation_overrides={"message_thread_id": (ODVInput[int], DEFAULT_NONE)},
         )
         assert await check_shortcut_call(message.copy, message.get_bot(), "copy_message")
         assert await check_defaults_handling(message.copy, message.get_bot())

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -532,12 +532,13 @@ class TestMessageWithoutRequest(TestMessageBase):
             )
             assert message_thread_id is None
 
-            message_thread_id = await method(
-                *args,
-                do_quote=message.build_reply_arguments(
-                    target_chat_id=message.chat_id,
-                ),
-            )
+            for target_chat_id in (message.chat_id, message.chat.username):
+                message_thread_id = await method(
+                    *args,
+                    do_quote=message.build_reply_arguments(
+                        target_chat_id=target_chat_id,
+                    ),
+                )
             assert message_thread_id == (message.message_thread_id if is_topic_message else None)
 
     def test_slot_behaviour(self):

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -518,6 +518,9 @@ class TestMessageWithoutRequest(TestMessageBase):
             message_thread_id = await method(*args, message_thread_id=50)
             assert message_thread_id == 50
 
+            message_thread_id = await method(*args, message_thread_id=None)
+            assert message_thread_id is None
+
             if bot_method_name == "send_chat_action":
                 return
 


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

closes #4205 as discussed therein.

Also ensures that passing `m_t_id=None` actually overrides the default behavior
