### PR TITLE
Handle Exceptions in building `CallbackContext`

### DIFF
--- a/telegram/ext/_application.py
+++ b/telegram/ext/_application.py
@@ -1248,13 +1248,24 @@ class Application(Generic[BT, CCT, UD, CD, BD, JQ], AsyncContextManager["Applica
         context = None
         any_blocking = False  # Flag which is set to True if any handler specifies block=True
 
-        for handlers in self.handlers.values():
+        for handlers in self.handlers.values():  # pylint: disable=too-many-nested-blocks
             try:
                 for handler in handlers:
                     check = handler.check_update(update)  # Should the handler handle this update?
                     if not (check is None or check is False):  # if yes,
                         if not context:  # build a context if not already built
-                            context = self.context_types.context.from_update(update, self)
+                            try:
+                                context = self.context_types.context.from_update(update, self)
+                            except Exception as exc:
+                                _LOGGER.critical(
+                                    (
+                                        "Error while building CallbackContext for update %s. "
+                                        "Update will not be processed."
+                                    ),
+                                    update,
+                                    exc_info=exc,
+                                )
+                                return
                             await context.refresh_data()
                         coroutine: Coroutine = handler.handle_update(update, self, check, context)
 
@@ -1809,13 +1820,25 @@ class Application(Generic[BT, CCT, UD, CD, BD, JQ], AsyncContextManager["Applica
                 callback,
                 block,
             ) in self.error_handlers.items():
-                context = self.context_types.context.from_error(
-                    update=update,
-                    error=error,
-                    application=self,
-                    job=job,
-                    coroutine=coroutine,
-                )
+                try:
+                    context = self.context_types.context.from_error(
+                        update=update,
+                        error=error,
+                        application=self,
+                        job=job,
+                        coroutine=coroutine,
+                    )
+                except Exception as exc:
+                    _LOGGER.critical(
+                        (
+                            "Error while building CallbackContext for exception %s. "
+                            "Exception will not be processed by error handlers."
+                        ),
+                        error,
+                        exc_info=exc,
+                    )
+                    return False
+
                 if not block or (  # If error handler has `block=False`, create a Task to run cb
                     block is DEFAULT_TRUE
                     and isinstance(self.bot, ExtBot)

--- a/telegram/ext/_jobqueue.py
+++ b/telegram/ext/_jobqueue.py
@@ -31,6 +31,7 @@ try:
 except ImportError:
     APS_AVAILABLE = False
 
+from telegram._utils.logging import get_logger
 from telegram._utils.repr import build_repr_with_selected_attrs
 from telegram._utils.types import JSONDict
 from telegram.ext._extbot import ExtBot
@@ -44,6 +45,7 @@ if TYPE_CHECKING:
 
 
 _ALL_DAYS = tuple(range(7))
+_LOGGER = get_logger(__name__)
 
 
 class JobQueue(Generic[CCT]):
@@ -953,7 +955,16 @@ class Job(Generic[CCT]):
         self, application: "Application[Any, CCT, Any, Any, Any, JobQueue[CCT]]"
     ) -> None:
         try:
-            context = application.context_types.context.from_job(self, application)
+            try:
+                context = application.context_types.context.from_job(self, application)
+            except Exception as exc:
+                _LOGGER.critical(
+                    "Error while building CallbackContext for job %s. Job will not be run.",
+                    self._job,
+                    exc_info=exc,
+                )
+                return
+
             await context.refresh_data()
             await self.callback(context)
         except Exception as exc:


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

Explicitly catches and logs exceptions in creating Callback context objects. Relevant particularly if the user uses a custom class that overrides from_update. Since from_error calls from_update, exceptions in from_update can currently completely shut down update processing *and* error handling. See https://t.me/pythontelegrambottalk/253238 for reference.
Work in progress, e.g. tests are still missing.
