### PR TITLE
Bump pytest-asyncio to 0.23.6

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ pre-commit  # needed for pre-commit hooks in the git commit command
 
 # For the test suite
 pytest==8.1.1
-pytest-asyncio==0.21.2  # needed because pytest doesn't come with native support for coroutines as tests
+pytest-asyncio==0.23.6  # needed because pytest doesn't come with native support for coroutines as tests
 pytest-xdist==3.6.1  # xdist runs tests in parallel
 flaky  # Used for flaky tests (flaky decorator)
 beautifulsoup4  # used in test_official for parsing tg docs


### PR DESCRIPTION
I noticed that 0.23.* is out since 12/23 but dependabot for some reasons doesn't update to that. wanted to at least check if that's working as well