### PR TITLE
Api 7.3 InputPollOption

### DIFF
--- a/docs/source/telegram.at-tree.rst
+++ b/docs/source/telegram.at-tree.rst
@@ -77,6 +77,7 @@ Available Types
     telegram.inputmediadocument
     telegram.inputmediaphoto
     telegram.inputmediavideo
+    telegram.inputpolloption
     telegram.inputsticker
     telegram.keyboardbutton
     telegram.keyboardbuttonpolltype

--- a/docs/source/telegram.inputpolloption.rst
+++ b/docs/source/telegram.inputpolloption.rst
@@ -1,0 +1,6 @@
+InputPollOption
+===============
+
+.. autoclass:: telegram.InputPollOption
+    :members:
+    :show-inheritance:

--- a/telegram/__init__.py
+++ b/telegram/__init__.py
@@ -131,6 +131,7 @@ __all__ = (
     "InputMediaPhoto",
     "InputMediaVideo",
     "InputMessageContent",
+    "InputPollOption",
     "InputSticker",
     "InputTextMessageContent",
     "InputVenueMessageContent",
@@ -403,7 +404,7 @@ from ._payment.shippingaddress import ShippingAddress
 from ._payment.shippingoption import ShippingOption
 from ._payment.shippingquery import ShippingQuery
 from ._payment.successfulpayment import SuccessfulPayment
-from ._poll import Poll, PollAnswer, PollOption
+from ._poll import InputPollOption, Poll, PollAnswer, PollOption
 from ._proximityalerttriggered import ProximityAlertTriggered
 from ._reaction import ReactionCount, ReactionType, ReactionTypeCustomEmoji, ReactionTypeEmoji
 from ._reply import ExternalReplyInfo, ReplyParameters, TextQuote

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -6815,7 +6815,7 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         self,
         chat_id: Union[int, str],
         question: str,
-        options: Sequence[Union[str, InputPollOption]],
+        options: Sequence[Union[str, "InputPollOption"]],
         is_anonymous: Optional[bool] = None,
         type: Optional[str] = None,  # pylint: disable=redefined-builtin
         allows_multiple_answers: Optional[bool] = None,

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -6947,7 +6947,10 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         data: JSONDict = {
             "chat_id": chat_id,
             "question": question,
-            "options": [option if isinstance(option, str) else option for option in options],
+            "options": [
+                InputPollOption(option) if isinstance(option, str) else option
+                for option in options
+            ],
             "explanation_parse_mode": explanation_parse_mode,
             "is_anonymous": is_anonymous,
             "type": type,

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -6848,7 +6848,7 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
             question (:obj:`str`): Poll question, :tg-const:`telegram.Poll.MIN_QUESTION_LENGTH`-
                 :tg-const:`telegram.Poll.MAX_QUESTION_LENGTH` characters.
-            options (Sequence[:obj:`str` | :class:`telegram.InputPollOption]): Sequence of
+            options (Sequence[:obj:`str` | :class:`telegram.InputPollOption`]): Sequence of
                 :tg-const:`telegram.Poll.MIN_OPTION_NUMBER`-
                 :tg-const:`telegram.Poll.MAX_OPTION_NUMBER` answer options. Each option may either
                 be a string with

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -84,7 +84,7 @@ from telegram._inline.inlinequeryresultsbutton import InlineQueryResultsButton
 from telegram._menubutton import MenuButton
 from telegram._message import Message
 from telegram._messageid import MessageId
-from telegram._poll import Poll
+from telegram._poll import InputPollOption, Poll
 from telegram._reaction import ReactionType, ReactionTypeCustomEmoji, ReactionTypeEmoji
 from telegram._reply import ReplyParameters
 from telegram._sentwebappmessage import SentWebAppMessage
@@ -6815,7 +6815,7 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         self,
         chat_id: Union[int, str],
         question: str,
-        options: Sequence[str],
+        options: Sequence[Union[str, InputPollOption]],
         is_anonymous: Optional[bool] = None,
         type: Optional[str] = None,  # pylint: disable=redefined-builtin
         allows_multiple_answers: Optional[bool] = None,
@@ -6848,14 +6848,20 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
             chat_id (:obj:`int` | :obj:`str`): |chat_id_channel|
             question (:obj:`str`): Poll question, :tg-const:`telegram.Poll.MIN_QUESTION_LENGTH`-
                 :tg-const:`telegram.Poll.MAX_QUESTION_LENGTH` characters.
-            options (Sequence[:obj:`str`]): Sequence of answer options,
+            options (Sequence[:obj:`str` | :class:`telegram.InputPollOption]): Sequence of
                 :tg-const:`telegram.Poll.MIN_OPTION_NUMBER`-
-                :tg-const:`telegram.Poll.MAX_OPTION_NUMBER` strings
+                :tg-const:`telegram.Poll.MAX_OPTION_NUMBER` answer options. Each option may either
+                be a string with
                 :tg-const:`telegram.Poll.MIN_OPTION_LENGTH`-
-                :tg-const:`telegram.Poll.MAX_OPTION_LENGTH` characters each.
+                :tg-const:`telegram.Poll.MAX_OPTION_LENGTH` characters or an
+                :class:`~telegram.InputPollOption` object. Strings are converted to
+                :class:`~telegram.InputPollOption` objects automatically.
 
                 .. versionchanged:: 20.0
                     |sequenceargs|
+
+                .. versionchanged:: NEXT.VERSION
+                   Bot API 7.3 adds support for :class:`~telegram.InputPollOption` objects.
             is_anonymous (:obj:`bool`, optional): :obj:`True`, if the poll needs to be anonymous,
                 defaults to :obj:`True`.
             type (:obj:`str`, optional): Poll type, :tg-const:`telegram.Poll.QUIZ` or
@@ -6941,7 +6947,7 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         data: JSONDict = {
             "chat_id": chat_id,
             "question": question,
-            "options": options,
+            "options": [option if isinstance(option, str) else option for option in options],
             "explanation_parse_mode": explanation_parse_mode,
             "is_anonymous": is_anonymous,
             "type": type,

--- a/telegram/_chat.py
+++ b/telegram/_chat.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
         InputMediaDocument,
         InputMediaPhoto,
         InputMediaVideo,
+        InputPollOption,
         LabeledPrice,
         LinkPreviewOptions,
         Location,
@@ -2545,7 +2546,7 @@ class Chat(TelegramObject):
     async def send_poll(
         self,
         question: str,
-        options: Sequence[str],
+        options: Sequence[Union[str, "InputPollOption"]],
         is_anonymous: Optional[bool] = None,
         type: Optional[str] = None,
         allows_multiple_answers: Optional[bool] = None,

--- a/telegram/_message.py
+++ b/telegram/_message.py
@@ -99,6 +99,7 @@ if TYPE_CHECKING:
         InputMediaDocument,
         InputMediaPhoto,
         InputMediaVideo,
+        InputPollOption,
         LabeledPrice,
         MessageId,
         MessageOrigin,
@@ -2890,7 +2891,7 @@ class Message(MaybeInaccessibleMessage):
     async def reply_poll(
         self,
         question: str,
-        options: Sequence[str],
+        options: Sequence[Union[str, "InputPollOption"]],
         is_anonymous: Optional[bool] = None,
         type: Optional[str] = None,  # pylint: disable=redefined-builtin
         allows_multiple_answers: Optional[bool] = None,

--- a/telegram/_poll.py
+++ b/telegram/_poll.py
@@ -51,8 +51,8 @@ class InputPollOption(TelegramObject):
         text_parse_mode (:obj:`str`, optional): |parse_mode|
             Currently, only custom emoji entities are allowed.
         text_entities (Sequence[:class:`telegram.MessageEntity`], optional): Special entities
-            that appear in the option :param:`text`. It can be specified instead of
-            :param:`text_parse_mode`.
+            that appear in the option :paramref:`text`. It can be specified instead of
+            :paramref:`text_parse_mode`.
             Currently, only custom emoji entities are allowed.
             This list is empty if the text does not contain entities.
 
@@ -63,8 +63,8 @@ class InputPollOption(TelegramObject):
         text_parse_mode (:obj:`str`): Optional. |parse_mode|
             Currently, only custom emoji entities are allowed.
         text_entities (Sequence[:class:`telegram.MessageEntity`]): Special entities
-            that appear in the option :param:`text`. It can be specified instead of
-            :param:`text_parse_mode`.
+            that appear in the option :paramref:`text`. It can be specified instead of
+            :paramref:`text_parse_mode`.
             Currently, only custom emoji entities are allowed.
             This list is empty if the text does not contain entities.
     """

--- a/telegram/_poll.py
+++ b/telegram/_poll.py
@@ -28,7 +28,8 @@ from telegram._user import User
 from telegram._utils import enum
 from telegram._utils.argumentparsing import parse_sequence_arg
 from telegram._utils.datetime import extract_tzinfo_from_defaults, from_timestamp
-from telegram._utils.types import JSONDict
+from telegram._utils.defaultvalue import DEFAULT_NONE
+from telegram._utils.types import JSONDict, ODVInput
 
 if TYPE_CHECKING:
     from telegram import Bot
@@ -73,14 +74,14 @@ class InputPollOption(TelegramObject):
     def __init__(
         self,
         text: str,
-        text_parse_mode: Optional[str] = None,
+        text_parse_mode: ODVInput[str] = DEFAULT_NONE,
         text_entities: Optional[Sequence[MessageEntity]] = None,
         *,
         api_kwargs: Optional[JSONDict] = None,
     ):
         super().__init__(api_kwargs=api_kwargs)
         self.text: str = text
-        self.text_parse_mode: Optional[str] = text_parse_mode
+        self.text_parse_mode: ODVInput[str] = text_parse_mode
         self.text_entities: Tuple[MessageEntity, ...] = parse_sequence_arg(text_entities)
 
         self._id_attrs = (self.text,)

--- a/telegram/_poll.py
+++ b/telegram/_poll.py
@@ -34,6 +34,72 @@ if TYPE_CHECKING:
     from telegram import Bot
 
 
+class InputPollOption(TelegramObject):
+    """
+    This object contains information about one answer option in a poll to send.
+
+    Objects of this class are comparable in terms of equality. Two objects of this class are
+    considered equal, if their :attr:`text` is equal.
+
+    .. versionadded:: NEXT.VERSION
+
+    Args:
+        text (:obj:`str`): Option text,
+            :tg-const:`telegram.PollOption.MIN_LENGTH`-:tg-const:`telegram.PollOption.MAX_LENGTH`
+            characters.
+        text_parse_mode (:obj:`str`, optional): |parse_mode|
+            Currently, only custom emoji entities are allowed.
+        text_entities (Sequence[:class:`telegram.MessageEntity`], optional): Special entities
+            that appear in the option :param:`text`. It can be specified instead of
+            :param:`text_parse_mode`.
+            Currently, only custom emoji entities are allowed.
+            This list is empty if the text does not contain entities.
+
+    Attributes:
+        text (:obj:`str`): Option text,
+            :tg-const:`telegram.PollOption.MIN_LENGTH`-:tg-const:`telegram.PollOption.MAX_LENGTH`
+            characters.
+        text_parse_mode (:obj:`str`): Optional. |parse_mode|
+            Currently, only custom emoji entities are allowed.
+        text_entities (Sequence[:class:`telegram.MessageEntity`]): Special entities
+            that appear in the option :param:`text`. It can be specified instead of
+            :param:`text_parse_mode`.
+            Currently, only custom emoji entities are allowed.
+            This list is empty if the text does not contain entities.
+    """
+
+    __slots__ = ("text", "text_entities", "text_parse_mode")
+
+    def __init__(
+        self,
+        text: str,
+        text_parse_mode: Optional[str] = None,
+        text_entities: Optional[Sequence[MessageEntity]] = None,
+        *,
+        api_kwargs: Optional[JSONDict] = None,
+    ):
+        super().__init__(api_kwargs=api_kwargs)
+        self.text: str = text
+        self.text_parse_mode: Optional[str] = text_parse_mode
+        self.text_entities: Tuple[MessageEntity, ...] = parse_sequence_arg(text_entities)
+
+        self._id_attrs = (self.text,)
+
+        self._freeze()
+
+    @classmethod
+    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["InputPollOption"]:
+        """See :meth:`telegram.TelegramObject.de_json`."""
+        data = cls._parse_data(data)
+
+        if not data:
+            return None
+
+        data["text_entities"] = MessageEntity.de_list(data.get("text_entities"), bot)
+
+        return super().de_json(data=data, bot=bot)
+
+
 class PollOption(TelegramObject):
     """
     This object contains information about one answer option in a poll.

--- a/telegram/_user.py
+++ b/telegram/_user.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
         InputMediaDocument,
         InputMediaPhoto,
         InputMediaVideo,
+        InputPollOption,
         LabeledPrice,
         LinkPreviewOptions,
         Location,
@@ -1482,7 +1483,7 @@ class User(TelegramObject):
     async def send_poll(
         self,
         question: str,
-        options: Sequence[str],
+        options: Sequence[Union[str, "InputPollOption"]],
         is_anonymous: Optional[bool] = None,
         type: Optional[str] = None,
         allows_multiple_answers: Optional[bool] = None,

--- a/telegram/ext/_defaults.py
+++ b/telegram/ext/_defaults.py
@@ -265,6 +265,19 @@ class Defaults:
         )
 
     @property
+    def text_parse_mode(self) -> Optional[str]:
+        """:obj:`str`: Optional. Alias for :attr:`parse_mode`, used for
+        the corresponding parameter of :meth:`telegram.InputPollOption`.
+        """
+        return self._parse_mode
+
+    @text_parse_mode.setter
+    def text_parse_mode(self, value: object) -> NoReturn:
+        raise AttributeError(
+            "You can not assign a new value to text_parse_mode after initialization."
+        )
+
+    @property
     def disable_notification(self) -> Optional[bool]:
         """:obj:`bool`: Optional. Sends the message silently. Users will
         receive a notification with no sound.

--- a/telegram/ext/_defaults.py
+++ b/telegram/ext/_defaults.py
@@ -268,6 +268,8 @@ class Defaults:
     def text_parse_mode(self) -> Optional[str]:
         """:obj:`str`: Optional. Alias for :attr:`parse_mode`, used for
         the corresponding parameter of :meth:`telegram.InputPollOption`.
+
+        .. versionadded:: NEXT.VERSION
         """
         return self._parse_mode
 

--- a/telegram/ext/_extbot.py
+++ b/telegram/ext/_extbot.py
@@ -437,6 +437,7 @@ class ExtBot(Bot, Generic[RLARGS]):
         # 3) set the correct parse_mode for all InputMedia objects
         # 4) handle the LinkPreviewOptions case (see below)
         # 5) handle the ReplyParameters case (see below)
+        # 6) handle text_parse_mode in InputPollOption
         for key, val in data.items():
             # 1)
             if isinstance(val, DefaultValue):
@@ -487,6 +488,20 @@ class ExtBot(Bot, Generic[RLARGS]):
                     )
 
                 data[key] = new_value
+
+            elif isinstance(val, Sequence) and all(
+                isinstance(obj, InputPollOption) for obj in val
+            ):
+                new_val = []
+                for option in val:
+                    if not isinstance(option.text_parse_mode, DefaultValue):
+                        new_val.append(option)
+                    else:
+                        new_option = copy(option)
+                        with new_option._unfrozen():
+                            new_option.text_parse_mode = self.defaults.text_parse_mode
+                        new_val.append(new_option)
+                data[key] = new_val
 
     def _replace_keyboard(self, reply_markup: Optional[KT]) -> Optional[KT]:
         # If the reply_markup is an inline keyboard and we allow arbitrary callback data, let the

--- a/telegram/ext/_extbot.py
+++ b/telegram/ext/_extbot.py
@@ -2933,7 +2933,7 @@ class ExtBot(Bot, Generic[RLARGS]):
         self,
         chat_id: Union[int, str],
         question: str,
-        options: Sequence[Union[str, InputPollOption]],
+        options: Sequence[Union[str, "InputPollOption"]],
         is_anonymous: Optional[bool] = None,
         type: Optional[str] = None,  # pylint: disable=redefined-builtin
         allows_multiple_answers: Optional[bool] = None,

--- a/telegram/ext/_extbot.py
+++ b/telegram/ext/_extbot.py
@@ -64,6 +64,7 @@ from telegram import (
     InlineKeyboardMarkup,
     InlineQueryResultsButton,
     InputMedia,
+    InputPollOption,
     LinkPreviewOptions,
     Location,
     MaskPosition,
@@ -2917,7 +2918,7 @@ class ExtBot(Bot, Generic[RLARGS]):
         self,
         chat_id: Union[int, str],
         question: str,
-        options: Sequence[str],
+        options: Sequence[Union[str, InputPollOption]],
         is_anonymous: Optional[bool] = None,
         type: Optional[str] = None,  # pylint: disable=redefined-builtin
         allows_multiple_answers: Optional[bool] = None,

--- a/tests/auxil/bot_method_checks.py
+++ b/tests/auxil/bot_method_checks.py
@@ -314,6 +314,8 @@ def build_kwargs(
             elif name == "ok":
                 kws["ok"] = False
                 kws["error_message"] = "error"
+            elif name == "options":
+                kws[name] = ["option1", "option2"]
             else:
                 kws[name] = True
 

--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -54,6 +54,8 @@ class TestInputPollOptionWithoutRequest(TestInputPollOptionBase):
         ), "duplicate slot"
 
     def test_de_json(self):
+        assert InputPollOption.de_json({}, None) is None
+
         json_dict = {
             "text": self.text,
             "text_parse_mode": self.text_parse_mode,

--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -76,6 +76,11 @@ class TestInputPollOptionWithoutRequest(TestInputPollOptionBase):
             e.to_dict() for e in input_poll_option.text_entities
         ]
 
+        # Test that the default-value parameter is handled correctly
+        input_poll_option = InputPollOption("text")
+        input_poll_option_dict = input_poll_option.to_dict()
+        assert "text_parse_mode" not in input_poll_option_dict
+
     def test_equality(self):
         a = InputPollOption("text")
         b = InputPollOption("text", self.text_parse_mode)


### PR DESCRIPTION
### Checklist

- [x] Added ``.. versionadded:: NEXT.VERSION``, ``.. versionchanged:: NEXT.VERSION`` or ``.. deprecated:: NEXT.VERSION`` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [x] Documented code changes according to the `CSI standard <https://standards.mousepawmedia.com/en/stable/csi.html>`__
- ~[] Added myself alphabetically to ``AUTHORS.rst`` (optional)~
- [x] Added new classes & modules to the docs and all suitable ``__all__`` s
- [x] Checked the `Stability Policy <https://docs.python-telegram-bot.org/stability_policy.html>`_ in case of deprecations or changes to documented behavior

**If the PR contains API changes (otherwise, you can ignore this passage)**

- [x] Checked the Bot API specific sections of the [Stability Policy](https://docs.python-telegram-bot.org/stability_policy.html)

- New classes:

   - [x] Added ``self._id_attrs`` and corresponding documentation
   - [x] ``__init__`` accepts ``api_kwargs`` as kw-only

