### PR TITLE
Make `Birthdate.to_date` Return a `datetime.date` Object

### DIFF
--- a/telegram/_birthdate.py
+++ b/telegram/_birthdate.py
@@ -73,7 +73,7 @@ class Birthdate(TelegramObject):
     def to_date(self, year: Optional[int] = None) -> date:
         """Return the birthdate as a datetime object.
 
-        .. versionadded:: NEXT.VERSION
+        .. versionchanged:: NEXT.VERSION
            Now returns a :obj:`datetime.date` object instead of a :obj:`datetime.datetime` object,
            as was originally intended.
 

--- a/telegram/_birthdate.py
+++ b/telegram/_birthdate.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represents a Telegram Birthday."""
-from datetime import datetime
+from datetime import date
 from typing import Optional
 
 from telegram._telegramobject import TelegramObject
@@ -70,19 +70,23 @@ class Birthdate(TelegramObject):
 
         self._freeze()
 
-    def to_date(self, year: Optional[int] = None) -> datetime:
+    def to_date(self, year: Optional[int] = None) -> date:
         """Return the birthdate as a datetime object.
+
+        .. versionadded:: NEXT.VERSION
+           Now returns a :obj:`datetime.date` object instead of a :obj:`datetime.datetime` object,
+           as was originally intended.
 
         Args:
             year (:obj:`int`, optional): The year to use. Required, if the :attr:`year` was not
                 present.
 
         Returns:
-            :obj:`datetime.datetime`: The birthdate as a datetime object.
+            :obj:`datetime.date`: The birthdate as a datetime object.
         """
         if self.year is None and year is None:
             raise ValueError(
                 "The `year` argument is required if the `year` attribute was not present."
             )
 
-        return datetime(year or self.year, self.month, self.day)  # type: ignore[arg-type]
+        return date(year or self.year, self.month, self.day)  # type: ignore[arg-type]

--- a/telegram/_birthdate.py
+++ b/telegram/_birthdate.py
@@ -82,7 +82,7 @@ class Birthdate(TelegramObject):
                 present.
 
         Returns:
-            :obj:`datetime.date`: The birthdate as a datetime object.
+            :obj:`datetime.date`: The birthdate as a date object.
         """
         if self.year is None and year is None:
             raise ValueError(

--- a/tests/test_birthdate.py
+++ b/tests/test_birthdate.py
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-from datetime import datetime
+from datetime import date
 
 import pytest
 
@@ -72,10 +72,10 @@ class TestBirthdateWithoutRequest(TestBirthdateBase):
         assert hash(bd1) != hash(bd4)
 
     def test_to_date(self, birthdate):
-        assert isinstance(birthdate.to_date(), datetime)
-        assert birthdate.to_date() == datetime(self.year, self.month, self.day)
+        assert isinstance(birthdate.to_date(), date)
+        assert birthdate.to_date() == date(self.year, self.month, self.day)
         new_bd = birthdate.to_date(2023)
-        assert new_bd == datetime(2023, self.month, self.day)
+        assert new_bd == date(2023, self.month, self.day)
 
     def test_to_date_no_year(self):
         bd = Birthdate(1, 1)


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->
See https://github.com/python-telegram-bot/python-telegram-bot/pull/4250#discussion_r1597153956

Since method name clearly says `date` and there is no meaning in specifying a date without time as datetime, I see this as bug fix and not a breaking change.
