### PR TITLE
Update Settings for pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,8 @@
 
 ci:
     autofix_prs: false
-    autoupdate_schedule: monthly
+    autoupdate_schedule: quarterly
+    autoupdate_commit_msg: 'Bump `pre-commit` Hooks to Latest Versions'
 
 repos:
 -   repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

This does two things:

* Makes the updates run quarterly instead of weekly. IMO the monthly updates have been a bit too much in the past, especially since these are "just" code quality dependencies
* Instead of using the default commit message `[pre-commit.ci] pre-commit autoupdate` it sets a commit message that is roughly in the same style as the dependabot commit messages. Probably mostly personal preference but at least the `[pre-commit.ci]` part is unnecessary IMO and so far I've always removed it.

See https://pre-commit.ci/#configuration for reference.