### PR TITLE
Deprecate `python-telegram-bot-raw`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,3 @@
-..
-    Make sure to apply any changes to this file to README_RAW.rst as well!
-
 .. image:: https://raw.githubusercontent.com/python-telegram-bot/logos/master/logo-text/png/ptb-logo-text_768.png
    :align: center
    :target: https://python-telegram-bot.org
@@ -78,13 +75,6 @@ It's compatible with Python versions **3.8+**.
 In addition to the pure API implementation, this library features a number of high-level classes to
 make the development of bots easy and straightforward. These classes are contained in the
 ``telegram.ext`` submodule.
-
-A pure API implementation *without* ``telegram.ext`` is available as the standalone package ``python-telegram-bot-raw``.  `See here for details. <https://github.com/python-telegram-bot/python-telegram-bot/blob/master/README_RAW.rst>`_
-
-Note
-----
-
-Installing both ``python-telegram-bot`` and ``python-telegram-bot-raw`` in conjunction will result in undesired side-effects, so only install *one* of both.
 
 Telegram API support
 ====================

--- a/README_RAW.rst
+++ b/README_RAW.rst
@@ -65,7 +65,7 @@
 The ``python-telegram-bot-raw`` library will no longer be updated after NEXT.VERSION.
 Please instead use the ``python-telegram-bot`` `library <https://pypi.org/python-telegram-bot>`_.
 The change requires no changes in your code and requires no additional dependencies.
-For additional information, please see this `channel post <https://t.me/pythontelegrambotchannel/1>`_.
+For additional information, please see this `channel post <https://t.me/pythontelegrambotchannel/145>`_.
 
 ----
 

--- a/README_RAW.rst
+++ b/README_RAW.rst
@@ -67,7 +67,7 @@ Please instead use the ``python-telegram-bot`` `library <https://pypi.org/python
 The change requires no changes in your code and requires no additional dependencies.
 For additional information, please see this `channel post <https://t.me/pythontelegrambotchannel/1>`_.
 
----
+----
 
 We have made you a wrapper you can't refuse
 

--- a/README_RAW.rst
+++ b/README_RAW.rst
@@ -1,6 +1,3 @@
-..
-    Make sure to apply any changes to this file to README.rst as well!
-
 .. image:: https://github.com/python-telegram-bot/logos/blob/master/logo-text/png/ptb-raw-logo-text_768.png?raw=true
    :align: center
    :target: https://python-telegram-bot.org
@@ -61,6 +58,16 @@
 .. image:: https://img.shields.io/badge/Telegram-Group-blue.svg?logo=telegram
    :target: https://telegram.me/pythontelegrambotgroup
    :alt: Telegram Group
+
+⚠️ Deprecation Notice
+=====================
+
+The ``python-telegram-bot-raw`` library will no longer be updated after NEXT.VERSION.
+Please instead use the ``python-telegram-bot`` `library <https://pypi.org/python-telegram-bot>`_.
+The change requires no changes in your code and requires no additional dependencies.
+For additional information, please see this `channel post <https://t.me/pythontelegrambotchannel/1>`_.
+
+---
 
 We have made you a wrapper you can't refuse
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ filterwarnings = [
     "ignore::DeprecationWarning",
     'ignore:Tasks created via `Application\.create_task` while the application is not running',
     "ignore::ResourceWarning",
-    "ignore:Hey. You seem to be using the `python-telegram-bot-raw` library:UserWarning",
     # TODO: Write so good code that we don't need to ignore ResourceWarnings anymore
     # Unfortunately due to https://github.com/pytest-dev/pytest/issues/8343 we can't have this here
     # and instead do a trick directly in tests/conftest.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ filterwarnings = [
     "ignore::DeprecationWarning",
     'ignore:Tasks created via `Application\.create_task` while the application is not running',
     "ignore::ResourceWarning",
+    "ignore:Hey. You seem to be using the `python-telegram-bot-raw` library:UserWarning",
     # TODO: Write so good code that we don't need to ignore ResourceWarnings anymore
     # Unfortunately due to https://github.com/pytest-dev/pytest/issues/8343 we can't have this here
     # and instead do a trick directly in tests/conftest.py

--- a/telegram/__init__.py
+++ b/telegram/__init__.py
@@ -385,7 +385,7 @@ from ._keyboardbuttonrequest import KeyboardButtonRequestChat, KeyboardButtonReq
 from ._linkpreviewoptions import LinkPreviewOptions
 from ._loginurl import LoginUrl
 from ._menubutton import MenuButton, MenuButtonCommands, MenuButtonDefault, MenuButtonWebApp
-from ._MESSAGE import InaccessibleMessage, MaybeInaccessibleMessage, Message
+from ._message import InaccessibleMessage, MaybeInaccessibleMessage, Message
 from ._messageautodeletetimerchanged import MessageAutoDeleteTimerChanged
 from ._messageentity import MessageEntity
 from ._messageid import MessageId

--- a/telegram/__init__.py
+++ b/telegram/__init__.py
@@ -486,7 +486,7 @@ if not (Path(__file__).parent.resolve().absolute() / "ext").exists():
         "Please instead use the `python-telegram-bot` library. The change requires no "
         "changes in your code and requires no additional dependencies. For additional "
         "information, please see the channel post at "
-        "https://t.me/pythontelegrambotchannel/1."
+        "https://t.me/pythontelegrambotchannel/145."
     )
 
     # DeprecationWarning is ignored by default in Python 3.7 and later by default outside

--- a/telegram/__init__.py
+++ b/telegram/__init__.py
@@ -479,7 +479,7 @@ __bot_api_version__: str = _version.__bot_api_version__
 __bot_api_version_info__: constants._BotAPIVersion = _version.__bot_api_version_info__
 
 
-if not (Path(__file__).resolve().absolute() / "ext").exists():
+if not (Path(__file__).parent.resolve().absolute() / "ext").exists():
     _MESSAGE = (
         "Hey. You seem to be using the `python-telegram-bot-raw` library. "
         "Please note that this libray has been deprecated and will no longer be updated. "

--- a/telegram/__init__.py
+++ b/telegram/__init__.py
@@ -242,6 +242,7 @@ __all__ = (
     "warnings",
 )
 
+from pathlib import Path
 
 from . import _version, constants, error, helpers, request, warnings
 from ._birthdate import Birthdate
@@ -384,7 +385,7 @@ from ._keyboardbuttonrequest import KeyboardButtonRequestChat, KeyboardButtonReq
 from ._linkpreviewoptions import LinkPreviewOptions
 from ._loginurl import LoginUrl
 from ._menubutton import MenuButton, MenuButtonCommands, MenuButtonDefault, MenuButtonWebApp
-from ._message import InaccessibleMessage, MaybeInaccessibleMessage, Message
+from ._MESSAGE import InaccessibleMessage, MaybeInaccessibleMessage, Message
 from ._messageautodeletetimerchanged import MessageAutoDeleteTimerChanged
 from ._messageentity import MessageEntity
 from ._messageid import MessageId
@@ -442,6 +443,7 @@ from ._telegramobject import TelegramObject
 from ._update import Update
 from ._user import User
 from ._userprofilephotos import UserProfilePhotos
+from ._utils.warnings import warn
 from ._videochat import (
     VideoChatEnded,
     VideoChatParticipantsInvited,
@@ -475,3 +477,28 @@ __bot_api_version__: str = _version.__bot_api_version__
 #:
 #: .. versionadded:: 20.0
 __bot_api_version_info__: constants._BotAPIVersion = _version.__bot_api_version_info__
+
+
+if not (Path(__file__).resolve().absolute() / "ext").exists():
+    _MESSAGE = (
+        "Hey. You seem to be using the `python-telegram-bot-raw` library. "
+        "Please note that this libray has been deprecated and will no longer be updated. "
+        "Please instead use the `python-telegram-bot` library. The change requires no "
+        "changes in your code and requires no additional dependencies. For additional "
+        "information, please see the channel post at "
+        "https://t.me/pythontelegrambotchannel/1."
+    )
+
+    # DeprecationWarning is ignored by default in Python 3.7 and later by default outside
+    # __main__ modules. We use both warning categories to increase the chance of the user
+    # seeing the warning.
+
+    warn(
+        warnings.PTBDeprecationWarning(version="NEXT.VERSION", message=_MESSAGE),
+        stacklevel=2,
+    )
+    warn(
+        message=_MESSAGE,
+        category=warnings.PTBUserWarning,
+        stacklevel=2,
+    )

--- a/telegram/_utils/datetime.py
+++ b/telegram/_utils/datetime.py
@@ -194,7 +194,7 @@ def extract_tzinfo_from_defaults(bot: "Bot") -> Union[dtm.tzinfo, None]:
     If the bot has no default values, :obj:`None` is returned.
     """
     # We don't use `ininstance(bot, ExtBot)` here so that this works
-    # in `python-telegram-bot-raw` as well
+    # without the job-queue extra dependencies as well
     if hasattr(bot, "defaults") and bot.defaults:
         return bot.defaults.tzinfo
     return None


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

Adresses first part of #4129 

Manually tested the warnings. Automated testing doesn't seem to be very straight forward at first glance, so I'm willing to skip it …

- [x] Update the link to the channel post before merging

Draft for a channel post:

<details>

Hi all.

*We have decided to deprecate the `python-telegram-bot-raw` library and no longer provide updates for it.*

In [Februrary 2021](https://t.me/pythontelegrambotchannel/95), we introduced the library [`python-telegram-bot-raw`](https://pypi.org/project/python-telegram-bot-raw/) that provides the `telegram` module without `telegram.ext`. Back then, we felt this to be right thing to do since the rather new v13 introduced additional required dependencies for the `JobQueue`.

Since then v20 has seen the light of day however. With v20, `python-telegram-bot` only has a single required dependency, `httpx` for the networking backend. All other dependencies for further functionality of `telegram.ext` are purely optional. Moreover, according to the numbers that we are aware of ([[1]](https://pypistats.org/packages/python-telegram-bot), [[2]](https://pypistats.org/packages/python-telegram-bot-raw), [[3]](https://github.com/python-telegram-bot/python-telegram-bot/network/dependents), [[4]](https://github.com/python-telegram-bot/python-telegram-bot/network/dependents?package_id=UGFja2FnZS0xODU0Mjc2NzE1)), the `python-telegram-bot-raw` library never gained a considerable user base compared to `python-telegram-bot`.

Since maintaining `python-telegram-bot-raw` still consumes some resources and is currently also hindering the modernization of PTBs packaging setup, we have therefore made this decision. The next release of PTB will add a corresponding warning to `python-telegram-bot-raw`. This will be the last update for `python-telegram-bot-raw`.

*What does this mean to you?*

Almost nothing. All you have to do is remove that trailing `-raw` from your requirements file. That's it. No code changes are necessary, since `python-telegram-bot-raw` is a subset of `python-telegram-bot`. No additional dependencies will be installed.

Thank you for your understanding and your continued usage of the `python-telegram-bot` library.
Your PTB Developer Team

</details>