### PR TITLE
API 7.4 - `show_caption_above_media`

### DIFF
--- a/docs/substitutions/global.rst
+++ b/docs/substitutions/global.rst
@@ -83,3 +83,5 @@
 .. |business_id_str| replace:: Unique identifier of the business connection on behalf of which the message will be sent.
 
 .. |message_effect_id| replace:: Unique identifier of the message effect to be added to the message; for private chats only.
+
+.. |show_cap_above_med| replace:: :obj:`True`, if the caption must be shown above the message media.

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -1284,6 +1284,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         reply_parameters: Optional["ReplyParameters"] = None,
         business_connection_id: Optional[str] = None,
         message_effect_id: Optional[str] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
         reply_to_message_id: Optional[int] = None,
@@ -1350,6 +1351,9 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             message_effect_id (:obj:`str`, optional): |message_effect_id|
 
                 .. versionadded:: NEXT.VERSION
+            show_caption_above_media (:obj:`bool`, optional): Pass |show_cap_above_med|
+
+                .. versionadded:: NEXT.VERSION
 
         Keyword Args:
             allow_sending_without_reply (:obj:`bool`, optional): |allow_sending_without_reply|
@@ -1387,6 +1391,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             "chat_id": chat_id,
             "photo": self._parse_file_input(photo, PhotoSize, filename=filename),
             "has_spoiler": has_spoiler,
+            "show_caption_above_media": show_caption_above_media,
         }
 
         return await self._send_message(
@@ -1856,6 +1861,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         reply_parameters: Optional["ReplyParameters"] = None,
         business_connection_id: Optional[str] = None,
         message_effect_id: Optional[str] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
         reply_to_message_id: Optional[int] = None,
@@ -1939,6 +1945,9 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             message_effect_id (:obj:`str`, optional): |message_effect_id|
 
                 .. versionadded:: NEXT.VERSION
+            show_caption_above_media (:obj:`bool`, optional): Pass |show_cap_above_med|
+
+                .. versionadded:: NEXT.VERSION
 
         Keyword Args:
             allow_sending_without_reply (:obj:`bool`, optional): |allow_sending_without_reply|
@@ -1981,6 +1990,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             "supports_streaming": supports_streaming,
             "thumbnail": self._parse_file_input(thumbnail, attach=True) if thumbnail else None,
             "has_spoiler": has_spoiler,
+            "show_caption_above_media": show_caption_above_media,
         }
 
         return await self._send_message(
@@ -2166,6 +2176,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         reply_parameters: Optional["ReplyParameters"] = None,
         business_connection_id: Optional[str] = None,
         message_effect_id: Optional[str] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
         reply_to_message_id: Optional[int] = None,
@@ -2243,6 +2254,9 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             message_effect_id (:obj:`str`, optional): |message_effect_id|
 
                 .. versionadded:: NEXT.VERSION
+            show_caption_above_media (:obj:`bool`, optional): Pass |show_cap_above_med|
+
+                .. versionadded:: NEXT.VERSION
 
         Keyword Args:
             allow_sending_without_reply (:obj:`bool`, optional): |allow_sending_without_reply|
@@ -2284,6 +2298,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             "height": height,
             "thumbnail": self._parse_file_input(thumbnail, attach=True) if thumbnail else None,
             "has_spoiler": has_spoiler,
+            "show_caption_above_media": show_caption_above_media,
         }
 
         return await self._send_message(
@@ -4030,6 +4045,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
         reply_markup: Optional["InlineKeyboardMarkup"] = None,
         parse_mode: ODVInput[str] = DEFAULT_NONE,
         caption_entities: Optional[Sequence["MessageEntity"]] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         read_timeout: ODVInput[float] = DEFAULT_NONE,
         write_timeout: ODVInput[float] = DEFAULT_NONE,
@@ -4061,6 +4077,9 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
                     |sequenceargs|
             reply_markup (:class:`telegram.InlineKeyboardMarkup`, optional): An object for an
                 inline keyboard.
+            show_caption_above_media (:obj:`bool`, optional): Pass |show_cap_above_med|
+
+                .. versionadded:: NEXT.VERSION
 
         Returns:
             :class:`telegram.Message`: On success, if edited message is not an inline message, the
@@ -4074,6 +4093,7 @@ class Bot(TelegramObject, AsyncContextManager["Bot"]):
             "chat_id": chat_id,
             "message_id": message_id,
             "inline_message_id": inline_message_id,
+            "show_caption_above_media": show_caption_above_media,
         }
 
         return await self._send_message(
@@ -7567,6 +7587,7 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         protect_content: ODVInput[bool] = DEFAULT_NONE,
         message_thread_id: Optional[int] = None,
         reply_parameters: Optional["ReplyParameters"] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
         reply_to_message_id: Optional[int] = None,
@@ -7610,6 +7631,9 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
             reply_parameters (:class:`telegram.ReplyParameters`, optional): |reply_parameters|
 
                 .. versionadded:: 20.8
+            show_caption_above_media (:obj:`bool`, optional): Pass |show_cap_above_med|
+
+                .. versionadded:: NEXT.VERSION
 
         Keyword Args:
             allow_sending_without_reply (:obj:`bool`, optional): |allow_sending_without_reply|
@@ -7666,6 +7690,7 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
             "reply_markup": reply_markup,
             "message_thread_id": message_thread_id,
             "reply_parameters": reply_parameters,
+            "show_caption_above_media": show_caption_above_media,
         }
 
         result = await self._post(

--- a/telegram/_callbackquery.py
+++ b/telegram/_callbackquery.py
@@ -281,6 +281,7 @@ class CallbackQuery(TelegramObject):
         reply_markup: Optional["InlineKeyboardMarkup"] = None,
         parse_mode: ODVInput[str] = DEFAULT_NONE,
         caption_entities: Optional[Sequence["MessageEntity"]] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         read_timeout: ODVInput[float] = DEFAULT_NONE,
         write_timeout: ODVInput[float] = DEFAULT_NONE,
@@ -326,6 +327,7 @@ class CallbackQuery(TelegramObject):
                 caption_entities=caption_entities,
                 chat_id=None,
                 message_id=None,
+                show_caption_above_media=show_caption_above_media,
             )
         return await self._get_message().edit_caption(
             caption=caption,
@@ -337,6 +339,7 @@ class CallbackQuery(TelegramObject):
             parse_mode=parse_mode,
             api_kwargs=api_kwargs,
             caption_entities=caption_entities,
+            show_caption_above_media=show_caption_above_media,
         )
 
     async def edit_message_reply_markup(
@@ -815,6 +818,7 @@ class CallbackQuery(TelegramObject):
         protect_content: ODVInput[bool] = DEFAULT_NONE,
         message_thread_id: Optional[int] = None,
         reply_parameters: Optional["ReplyParameters"] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
         reply_to_message_id: Optional[int] = None,
@@ -861,6 +865,7 @@ class CallbackQuery(TelegramObject):
             protect_content=protect_content,
             message_thread_id=message_thread_id,
             reply_parameters=reply_parameters,
+            show_caption_above_media=show_caption_above_media,
         )
 
     MAX_ANSWER_TEXT_LENGTH: Final[int] = (

--- a/telegram/_chat.py
+++ b/telegram/_chat.py
@@ -1219,6 +1219,7 @@ class _ChatBase(TelegramObject):
         reply_parameters: Optional["ReplyParameters"] = None,
         business_connection_id: Optional[str] = None,
         message_effect_id: Optional[str] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         reply_to_message_id: Optional[int] = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
@@ -1261,6 +1262,7 @@ class _ChatBase(TelegramObject):
             has_spoiler=has_spoiler,
             business_connection_id=business_connection_id,
             message_effect_id=message_effect_id,
+            show_caption_above_media=show_caption_above_media,
         )
 
     async def send_contact(
@@ -1713,6 +1715,7 @@ class _ChatBase(TelegramObject):
         reply_parameters: Optional["ReplyParameters"] = None,
         business_connection_id: Optional[str] = None,
         message_effect_id: Optional[str] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         reply_to_message_id: Optional[int] = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
@@ -1759,6 +1762,7 @@ class _ChatBase(TelegramObject):
             thumbnail=thumbnail,
             business_connection_id=business_connection_id,
             message_effect_id=message_effect_id,
+            show_caption_above_media=show_caption_above_media,
         )
 
     async def send_sticker(
@@ -1894,6 +1898,7 @@ class _ChatBase(TelegramObject):
         reply_parameters: Optional["ReplyParameters"] = None,
         business_connection_id: Optional[str] = None,
         message_effect_id: Optional[str] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         reply_to_message_id: Optional[int] = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
@@ -1941,6 +1946,7 @@ class _ChatBase(TelegramObject):
             has_spoiler=has_spoiler,
             business_connection_id=business_connection_id,
             message_effect_id=message_effect_id,
+            show_caption_above_media=show_caption_above_media,
         )
 
     async def send_video_note(
@@ -2143,6 +2149,7 @@ class _ChatBase(TelegramObject):
         protect_content: ODVInput[bool] = DEFAULT_NONE,
         message_thread_id: Optional[int] = None,
         reply_parameters: Optional["ReplyParameters"] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         reply_to_message_id: Optional[int] = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
@@ -2183,6 +2190,7 @@ class _ChatBase(TelegramObject):
             api_kwargs=api_kwargs,
             protect_content=protect_content,
             message_thread_id=message_thread_id,
+            show_caption_above_media=show_caption_above_media,
         )
 
     async def copy_message(
@@ -2197,6 +2205,7 @@ class _ChatBase(TelegramObject):
         protect_content: ODVInput[bool] = DEFAULT_NONE,
         message_thread_id: Optional[int] = None,
         reply_parameters: Optional["ReplyParameters"] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         reply_to_message_id: Optional[int] = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
@@ -2237,6 +2246,7 @@ class _ChatBase(TelegramObject):
             api_kwargs=api_kwargs,
             protect_content=protect_content,
             message_thread_id=message_thread_id,
+            show_caption_above_media=show_caption_above_media,
         )
 
     async def send_copies(

--- a/telegram/_files/inputmedia.py
+++ b/telegram/_files/inputmedia.py
@@ -160,6 +160,9 @@ class InputMediaAnimation(InputMedia):
                 optional): |thumbdocstringnopath|
 
             .. versionadded:: 20.2
+        show_caption_above_media (:obj:`bool`, optional): Pass |show_cap_above_med|
+
+            .. versionadded:: NEXT.VERSION
 
     Attributes:
         type (:obj:`str`): :tg-const:`telegram.constants.InputMediaType.ANIMATION`.
@@ -184,9 +187,19 @@ class InputMediaAnimation(InputMedia):
         thumbnail (:class:`telegram.InputFile`): Optional. |thumbdocstringbase|
 
             .. versionadded:: 20.2
+        show_caption_above_media (:obj:`bool`): Optional. |show_cap_above_med|
+
+            .. versionadded:: NEXT.VERSION
     """
 
-    __slots__ = ("duration", "has_spoiler", "height", "thumbnail", "width")
+    __slots__ = (
+        "duration",
+        "has_spoiler",
+        "height",
+        "show_caption_above_media",
+        "thumbnail",
+        "width",
+    )
 
     def __init__(
         self,
@@ -200,6 +213,7 @@ class InputMediaAnimation(InputMedia):
         filename: Optional[str] = None,
         has_spoiler: Optional[bool] = None,
         thumbnail: Optional[FileInput] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         api_kwargs: Optional[JSONDict] = None,
     ):
@@ -229,6 +243,7 @@ class InputMediaAnimation(InputMedia):
             self.height: Optional[int] = height
             self.duration: Optional[int] = duration
             self.has_spoiler: Optional[bool] = has_spoiler
+            self.show_caption_above_media: Optional[bool] = show_caption_above_media
 
 
 class InputMediaPhoto(InputMedia):
@@ -260,6 +275,9 @@ class InputMediaPhoto(InputMedia):
             with a spoiler animation.
 
             .. versionadded:: 20.0
+        show_caption_above_media (:obj:`bool`, optional): Pass |show_cap_above_med|
+
+            .. versionadded:: NEXT.VERSION
 
     Attributes:
         type (:obj:`str`): :tg-const:`telegram.constants.InputMediaType.PHOTO`.
@@ -278,9 +296,15 @@ class InputMediaPhoto(InputMedia):
             spoiler animation.
 
             .. versionadded:: 20.0
+        show_caption_above_media (:obj:`bool`): Optional. |show_cap_above_med|
+
+            .. versionadded:: NEXT.VERSION
     """
 
-    __slots__ = ("has_spoiler",)
+    __slots__ = (
+        "has_spoiler",
+        "show_caption_above_media",
+    )
 
     def __init__(
         self,
@@ -290,6 +314,7 @@ class InputMediaPhoto(InputMedia):
         caption_entities: Optional[Sequence[MessageEntity]] = None,
         filename: Optional[str] = None,
         has_spoiler: Optional[bool] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         api_kwargs: Optional[JSONDict] = None,
     ):
@@ -307,6 +332,7 @@ class InputMediaPhoto(InputMedia):
 
         with self._unfrozen():
             self.has_spoiler: Optional[bool] = has_spoiler
+            self.show_caption_above_media: Optional[bool] = show_caption_above_media
 
 
 class InputMediaVideo(InputMedia):
@@ -359,6 +385,9 @@ class InputMediaVideo(InputMedia):
                 optional): |thumbdocstringnopath|
 
             .. versionadded:: 20.2
+        show_caption_above_media (:obj:`bool`, optional): Pass |show_cap_above_med|
+
+            .. versionadded:: NEXT.VERSION
 
     Attributes:
         type (:obj:`str`): :tg-const:`telegram.constants.InputMediaType.VIDEO`.
@@ -385,12 +414,16 @@ class InputMediaVideo(InputMedia):
         thumbnail (:class:`telegram.InputFile`): Optional. |thumbdocstringbase|
 
             .. versionadded:: 20.2
+        show_caption_above_media (:obj:`bool`): Optional. |show_cap_above_med|
+
+            .. versionadded:: NEXT.VERSION
     """
 
     __slots__ = (
         "duration",
         "has_spoiler",
         "height",
+        "show_caption_above_media",
         "supports_streaming",
         "thumbnail",
         "width",
@@ -409,6 +442,7 @@ class InputMediaVideo(InputMedia):
         filename: Optional[str] = None,
         has_spoiler: Optional[bool] = None,
         thumbnail: Optional[FileInput] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         api_kwargs: Optional[JSONDict] = None,
     ):
@@ -439,6 +473,7 @@ class InputMediaVideo(InputMedia):
             )
             self.supports_streaming: Optional[bool] = supports_streaming
             self.has_spoiler: Optional[bool] = has_spoiler
+            self.show_caption_above_media: Optional[bool] = show_caption_above_media
 
 
 class InputMediaAudio(InputMedia):

--- a/telegram/_inline/inlinequeryresultcachedgif.py
+++ b/telegram/_inline/inlinequeryresultcachedgif.py
@@ -59,6 +59,9 @@ class InlineQueryResultCachedGif(InlineQueryResult):
             to the message.
         input_message_content (:class:`telegram.InputMessageContent`, optional): Content of the
             message to be sent instead of the gif.
+        show_caption_above_media (:obj:`bool`, optional): Pass |show_cap_above_med|
+
+            .. versionadded:: NEXT.VERSION
 
     Attributes:
         type (:obj:`str`): :tg-const:`telegram.constants.InlineQueryResultType.GIF`.
@@ -81,6 +84,9 @@ class InlineQueryResultCachedGif(InlineQueryResult):
             to the message.
         input_message_content (:class:`telegram.InputMessageContent`): Optional. Content of the
             message to be sent instead of the gif.
+        show_caption_above_media (:obj:`bool`): Optional. |show_cap_above_med|
+
+            .. versionadded:: NEXT.VERSION
 
     """
 
@@ -91,6 +97,7 @@ class InlineQueryResultCachedGif(InlineQueryResult):
         "input_message_content",
         "parse_mode",
         "reply_markup",
+        "show_caption_above_media",
         "title",
     )
 
@@ -104,6 +111,7 @@ class InlineQueryResultCachedGif(InlineQueryResult):
         input_message_content: Optional["InputMessageContent"] = None,
         parse_mode: ODVInput[str] = DEFAULT_NONE,
         caption_entities: Optional[Sequence[MessageEntity]] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         api_kwargs: Optional[JSONDict] = None,
     ):
@@ -119,3 +127,4 @@ class InlineQueryResultCachedGif(InlineQueryResult):
             self.caption_entities: Tuple[MessageEntity, ...] = parse_sequence_arg(caption_entities)
             self.reply_markup: Optional[InlineKeyboardMarkup] = reply_markup
             self.input_message_content: Optional[InputMessageContent] = input_message_content
+            self.show_caption_above_media: Optional[bool] = show_caption_above_media

--- a/telegram/_inline/inlinequeryresultcachedmpeg4gif.py
+++ b/telegram/_inline/inlinequeryresultcachedmpeg4gif.py
@@ -59,6 +59,9 @@ class InlineQueryResultCachedMpeg4Gif(InlineQueryResult):
             to the message.
         input_message_content (:class:`telegram.InputMessageContent`, optional): Content of the
             message to be sent instead of the MPEG-4 file.
+        show_caption_above_media (:obj:`bool`, optional): Pass |show_cap_above_med|
+
+            .. versionadded:: NEXT.VERSION
 
     Attributes:
         type (:obj:`str`): :tg-const:`telegram.constants.InlineQueryResultType.MPEG4GIF`.
@@ -81,6 +84,9 @@ class InlineQueryResultCachedMpeg4Gif(InlineQueryResult):
             to the message.
         input_message_content (:class:`telegram.InputMessageContent`): Optional. Content of the
             message to be sent instead of the MPEG-4 file.
+        show_caption_above_media (:obj:`bool`): Optional. |show_cap_above_med|
+
+            .. versionadded:: NEXT.VERSION
 
     """
 
@@ -91,6 +97,7 @@ class InlineQueryResultCachedMpeg4Gif(InlineQueryResult):
         "mpeg4_file_id",
         "parse_mode",
         "reply_markup",
+        "show_caption_above_media",
         "title",
     )
 
@@ -104,6 +111,7 @@ class InlineQueryResultCachedMpeg4Gif(InlineQueryResult):
         input_message_content: Optional["InputMessageContent"] = None,
         parse_mode: ODVInput[str] = DEFAULT_NONE,
         caption_entities: Optional[Sequence[MessageEntity]] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         api_kwargs: Optional[JSONDict] = None,
     ):
@@ -119,3 +127,4 @@ class InlineQueryResultCachedMpeg4Gif(InlineQueryResult):
             self.caption_entities: Tuple[MessageEntity, ...] = parse_sequence_arg(caption_entities)
             self.reply_markup: Optional[InlineKeyboardMarkup] = reply_markup
             self.input_message_content: Optional[InputMessageContent] = input_message_content
+            self.show_caption_above_media: Optional[bool] = show_caption_above_media

--- a/telegram/_inline/inlinequeryresultcachedphoto.py
+++ b/telegram/_inline/inlinequeryresultcachedphoto.py
@@ -60,6 +60,9 @@ class InlineQueryResultCachedPhoto(InlineQueryResult):
             to the message.
         input_message_content (:class:`telegram.InputMessageContent`, optional): Content of the
             message to be sent instead of the photo.
+        show_caption_above_media (:obj:`bool`, optional): Pass |show_cap_above_med|
+
+            .. versionadded:: NEXT.VERSION
 
     Attributes:
         type (:obj:`str`): :tg-const:`telegram.constants.InlineQueryResultType.PHOTO`.
@@ -83,6 +86,9 @@ class InlineQueryResultCachedPhoto(InlineQueryResult):
             to the message.
         input_message_content (:class:`telegram.InputMessageContent`): Optional. Content of the
             message to be sent instead of the photo.
+        show_caption_above_media (:obj:`bool`): Optional. |show_cap_above_med|
+
+            .. versionadded:: NEXT.VERSION
 
     """
 
@@ -94,6 +100,7 @@ class InlineQueryResultCachedPhoto(InlineQueryResult):
         "parse_mode",
         "photo_file_id",
         "reply_markup",
+        "show_caption_above_media",
         "title",
     )
 
@@ -108,6 +115,7 @@ class InlineQueryResultCachedPhoto(InlineQueryResult):
         input_message_content: Optional["InputMessageContent"] = None,
         parse_mode: ODVInput[str] = DEFAULT_NONE,
         caption_entities: Optional[Sequence[MessageEntity]] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         api_kwargs: Optional[JSONDict] = None,
     ):
@@ -124,3 +132,4 @@ class InlineQueryResultCachedPhoto(InlineQueryResult):
             self.caption_entities: Tuple[MessageEntity, ...] = parse_sequence_arg(caption_entities)
             self.reply_markup: Optional[InlineKeyboardMarkup] = reply_markup
             self.input_message_content: Optional[InputMessageContent] = input_message_content
+            self.show_caption_above_media: Optional[bool] = show_caption_above_media

--- a/telegram/_inline/inlinequeryresultcachedvideo.py
+++ b/telegram/_inline/inlinequeryresultcachedvideo.py
@@ -56,6 +56,9 @@ class InlineQueryResultCachedVideo(InlineQueryResult):
             to the message.
         input_message_content (:class:`telegram.InputMessageContent`, optional): Content of the
             message to be sent instead of the video.
+        show_caption_above_media (:obj:`bool`, optional): Pass |show_cap_above_med|
+
+            .. versionadded:: NEXT.VERSION
 
     Attributes:
         type (:obj:`str`): :tg-const:`telegram.constants.InlineQueryResultType.VIDEO`.
@@ -79,6 +82,9 @@ class InlineQueryResultCachedVideo(InlineQueryResult):
             to the message.
         input_message_content (:class:`telegram.InputMessageContent`): Optional. Content of the
             message to be sent instead of the video.
+        show_caption_above_media (:obj:`bool`): Optional. |show_cap_above_med|
+
+            .. versionadded:: NEXT.VERSION
 
     """
 
@@ -89,6 +95,7 @@ class InlineQueryResultCachedVideo(InlineQueryResult):
         "input_message_content",
         "parse_mode",
         "reply_markup",
+        "show_caption_above_media",
         "title",
         "video_file_id",
     )
@@ -104,6 +111,7 @@ class InlineQueryResultCachedVideo(InlineQueryResult):
         input_message_content: Optional["InputMessageContent"] = None,
         parse_mode: ODVInput[str] = DEFAULT_NONE,
         caption_entities: Optional[Sequence[MessageEntity]] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         api_kwargs: Optional[JSONDict] = None,
     ):
@@ -120,3 +128,4 @@ class InlineQueryResultCachedVideo(InlineQueryResult):
             self.caption_entities: Tuple[MessageEntity, ...] = parse_sequence_arg(caption_entities)
             self.reply_markup: Optional[InlineKeyboardMarkup] = reply_markup
             self.input_message_content: Optional[InputMessageContent] = input_message_content
+            self.show_caption_above_media: Optional[bool] = show_caption_above_media

--- a/telegram/_inline/inlinequeryresultgif.py
+++ b/telegram/_inline/inlinequeryresultgif.py
@@ -78,6 +78,9 @@ class InlineQueryResultGif(InlineQueryResult):
             to the message.
         input_message_content (:class:`telegram.InputMessageContent`, optional): Content of the
             message to be sent instead of the GIF animation.
+        show_caption_above_media (:obj:`bool`, optional): Pass |show_cap_above_med|
+
+            .. versionadded:: NEXT.VERSION
 
     Raises:
         :class:`ValueError`: If neither :paramref:`thumbnail_url` nor :paramref:`thumb_url` is
@@ -115,6 +118,9 @@ class InlineQueryResultGif(InlineQueryResult):
             to the message.
         input_message_content (:class:`telegram.InputMessageContent`): Optional. Content of the
             message to be sent instead of the GIF animation.
+        show_caption_above_media (:obj:`bool`): Optional. |show_cap_above_med|
+
+            .. versionadded:: NEXT.VERSION
 
     """
 
@@ -128,6 +134,7 @@ class InlineQueryResultGif(InlineQueryResult):
         "input_message_content",
         "parse_mode",
         "reply_markup",
+        "show_caption_above_media",
         "thumbnail_mime_type",
         "thumbnail_url",
         "title",
@@ -148,6 +155,7 @@ class InlineQueryResultGif(InlineQueryResult):
         parse_mode: ODVInput[str] = DEFAULT_NONE,
         caption_entities: Optional[Sequence[MessageEntity]] = None,
         thumbnail_mime_type: Optional[str] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         api_kwargs: Optional[JSONDict] = None,
     ):
@@ -168,3 +176,4 @@ class InlineQueryResultGif(InlineQueryResult):
             self.reply_markup: Optional[InlineKeyboardMarkup] = reply_markup
             self.input_message_content: Optional[InputMessageContent] = input_message_content
             self.thumbnail_mime_type: Optional[str] = thumbnail_mime_type
+            self.show_caption_above_media: Optional[bool] = show_caption_above_media

--- a/telegram/_inline/inlinequeryresultmpeg4gif.py
+++ b/telegram/_inline/inlinequeryresultmpeg4gif.py
@@ -80,7 +80,9 @@ class InlineQueryResultMpeg4Gif(InlineQueryResult):
             to the message.
         input_message_content (:class:`telegram.InputMessageContent`, optional): Content of the
             message to be sent instead of the video animation.
+        show_caption_above_media (:obj:`bool`, optional): Pass |show_cap_above_med|
 
+            .. versionadded:: NEXT.VERSION
     Raises:
         :class:`ValueError`: If neither :paramref:`thumbnail_url` nor :paramref:`thumb_url` is
             supplied or if both are supplied and are not equal.
@@ -118,7 +120,9 @@ class InlineQueryResultMpeg4Gif(InlineQueryResult):
             to the message.
         input_message_content (:class:`telegram.InputMessageContent`): Optional. Content of the
             message to be sent instead of the video animation.
+        show_caption_above_media (:obj:`bool`): Optional. |show_cap_above_med|
 
+            .. versionadded:: NEXT.VERSION
     """
 
     __slots__ = (
@@ -131,6 +135,7 @@ class InlineQueryResultMpeg4Gif(InlineQueryResult):
         "mpeg4_width",
         "parse_mode",
         "reply_markup",
+        "show_caption_above_media",
         "thumbnail_mime_type",
         "thumbnail_url",
         "title",
@@ -151,6 +156,7 @@ class InlineQueryResultMpeg4Gif(InlineQueryResult):
         parse_mode: ODVInput[str] = DEFAULT_NONE,
         caption_entities: Optional[Sequence[MessageEntity]] = None,
         thumbnail_mime_type: Optional[str] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         api_kwargs: Optional[JSONDict] = None,
     ):
@@ -171,3 +177,4 @@ class InlineQueryResultMpeg4Gif(InlineQueryResult):
             self.reply_markup: Optional[InlineKeyboardMarkup] = reply_markup
             self.input_message_content: Optional[InputMessageContent] = input_message_content
             self.thumbnail_mime_type: Optional[str] = thumbnail_mime_type
+            self.show_caption_above_media: Optional[bool] = show_caption_above_media

--- a/telegram/_inline/inlinequeryresultphoto.py
+++ b/telegram/_inline/inlinequeryresultphoto.py
@@ -74,6 +74,9 @@ class InlineQueryResultPhoto(InlineQueryResult):
             to the message.
         input_message_content (:class:`telegram.InputMessageContent`, optional): Content of the
             message to be sent instead of the photo.
+        show_caption_above_media (:obj:`bool`, optional): Pass |show_cap_above_med|
+
+            .. versionadded:: NEXT.VERSION
 
     Raises:
         :class:`ValueError`: If neither :paramref:`thumbnail_url` nor :paramref:`thumb_url` is
@@ -105,6 +108,9 @@ class InlineQueryResultPhoto(InlineQueryResult):
             to the message.
         input_message_content (:class:`telegram.InputMessageContent`): Optional. Content of the
             message to be sent instead of the photo.
+        show_caption_above_media (:obj:`bool`): Optional. |show_cap_above_med|
+
+            .. versionadded:: NEXT.VERSION
 
     """
 
@@ -118,6 +124,7 @@ class InlineQueryResultPhoto(InlineQueryResult):
         "photo_url",
         "photo_width",
         "reply_markup",
+        "show_caption_above_media",
         "thumbnail_url",
         "title",
     )
@@ -136,6 +143,7 @@ class InlineQueryResultPhoto(InlineQueryResult):
         input_message_content: Optional["InputMessageContent"] = None,
         parse_mode: ODVInput[str] = DEFAULT_NONE,
         caption_entities: Optional[Sequence[MessageEntity]] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         api_kwargs: Optional[JSONDict] = None,
     ):
@@ -155,3 +163,4 @@ class InlineQueryResultPhoto(InlineQueryResult):
             self.caption_entities: Tuple[MessageEntity, ...] = parse_sequence_arg(caption_entities)
             self.reply_markup: Optional[InlineKeyboardMarkup] = reply_markup
             self.input_message_content: Optional[InputMessageContent] = input_message_content
+            self.show_caption_above_media: Optional[bool] = show_caption_above_media

--- a/telegram/_inline/inlinequeryresultvideo.py
+++ b/telegram/_inline/inlinequeryresultvideo.py
@@ -88,6 +88,9 @@ class InlineQueryResultVideo(InlineQueryResult):
             message to be sent instead of the video. This field is required if
             ``InlineQueryResultVideo`` is used to send an HTML-page as a result
             (e.g., a YouTube video).
+        show_caption_above_media (:obj:`bool`, optional): Pass |show_cap_above_med|
+
+            .. versionadded:: NEXT.VERSION
 
     Raises:
         :class:`ValueError`: If neither :paramref:`thumbnail_url` nor :paramref:`thumb_url` is
@@ -127,6 +130,9 @@ class InlineQueryResultVideo(InlineQueryResult):
             message to be sent instead of the video. This field is required if
             ``InlineQueryResultVideo`` is used to send an HTML-page as a result
             (e.g., a YouTube video).
+        show_caption_above_media (:obj:`bool`): Optional. |show_cap_above_med|
+
+            .. versionadded:: NEXT.VERSION
 
     """
 
@@ -138,6 +144,7 @@ class InlineQueryResultVideo(InlineQueryResult):
         "mime_type",
         "parse_mode",
         "reply_markup",
+        "show_caption_above_media",
         "thumbnail_url",
         "title",
         "video_duration",
@@ -162,6 +169,7 @@ class InlineQueryResultVideo(InlineQueryResult):
         input_message_content: Optional["InputMessageContent"] = None,
         parse_mode: ODVInput[str] = DEFAULT_NONE,
         caption_entities: Optional[Sequence[MessageEntity]] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         api_kwargs: Optional[JSONDict] = None,
     ):
@@ -183,3 +191,4 @@ class InlineQueryResultVideo(InlineQueryResult):
             self.description: Optional[str] = description
             self.reply_markup: Optional[InlineKeyboardMarkup] = reply_markup
             self.input_message_content: Optional[InputMessageContent] = input_message_content
+            self.show_caption_above_media: Optional[bool] = show_caption_above_media

--- a/telegram/_message.py
+++ b/telegram/_message.py
@@ -2060,6 +2060,7 @@ class Message(MaybeInaccessibleMessage):
         has_spoiler: Optional[bool] = None,
         reply_parameters: Optional["ReplyParameters"] = None,
         message_effect_id: Optional[str] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         reply_to_message_id: Optional[int] = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
@@ -2126,6 +2127,7 @@ class Message(MaybeInaccessibleMessage):
             has_spoiler=has_spoiler,
             business_connection_id=self.business_connection_id,
             message_effect_id=message_effect_id,
+            show_caption_above_media=show_caption_above_media,
         )
 
     async def reply_audio(
@@ -2315,6 +2317,7 @@ class Message(MaybeInaccessibleMessage):
         thumbnail: Optional[FileInput] = None,
         reply_parameters: Optional["ReplyParameters"] = None,
         message_effect_id: Optional[str] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         reply_to_message_id: Optional[int] = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
@@ -2385,6 +2388,7 @@ class Message(MaybeInaccessibleMessage):
             thumbnail=thumbnail,
             business_connection_id=self.business_connection_id,
             message_effect_id=message_effect_id,
+            show_caption_above_media=show_caption_above_media,
         )
 
     async def reply_sticker(
@@ -2478,6 +2482,7 @@ class Message(MaybeInaccessibleMessage):
         thumbnail: Optional[FileInput] = None,
         reply_parameters: Optional["ReplyParameters"] = None,
         message_effect_id: Optional[str] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         reply_to_message_id: Optional[int] = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
@@ -2549,6 +2554,7 @@ class Message(MaybeInaccessibleMessage):
             thumbnail=thumbnail,
             business_connection_id=self.business_connection_id,
             message_effect_id=message_effect_id,
+            show_caption_above_media=show_caption_above_media,
         )
 
     async def reply_video_note(
@@ -3427,6 +3433,7 @@ class Message(MaybeInaccessibleMessage):
         protect_content: ODVInput[bool] = DEFAULT_NONE,
         message_thread_id: Optional[int] = None,
         reply_parameters: Optional["ReplyParameters"] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         reply_to_message_id: Optional[int] = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
@@ -3471,6 +3478,7 @@ class Message(MaybeInaccessibleMessage):
             api_kwargs=api_kwargs,
             protect_content=protect_content,
             message_thread_id=message_thread_id,
+            show_caption_above_media=show_caption_above_media,
         )
 
     async def reply_copy(
@@ -3485,6 +3493,7 @@ class Message(MaybeInaccessibleMessage):
         protect_content: ODVInput[bool] = DEFAULT_NONE,
         message_thread_id: ODVInput[int] = DEFAULT_NONE,
         reply_parameters: Optional["ReplyParameters"] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         reply_to_message_id: Optional[int] = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
@@ -3548,6 +3557,7 @@ class Message(MaybeInaccessibleMessage):
             api_kwargs=api_kwargs,
             protect_content=protect_content,
             message_thread_id=message_thread_id,
+            show_caption_above_media=show_caption_above_media,
         )
 
     async def edit_text(
@@ -3606,6 +3616,7 @@ class Message(MaybeInaccessibleMessage):
         reply_markup: Optional["InlineKeyboardMarkup"] = None,
         parse_mode: ODVInput[str] = DEFAULT_NONE,
         caption_entities: Optional[Sequence["MessageEntity"]] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         read_timeout: ODVInput[float] = DEFAULT_NONE,
         write_timeout: ODVInput[float] = DEFAULT_NONE,
@@ -3645,6 +3656,7 @@ class Message(MaybeInaccessibleMessage):
             api_kwargs=api_kwargs,
             caption_entities=caption_entities,
             inline_message_id=None,
+            show_caption_above_media=show_caption_above_media,
         )
 
     async def edit_media(

--- a/telegram/_message.py
+++ b/telegram/_message.py
@@ -342,6 +342,9 @@ class Message(MaybeInaccessibleMessage):
             .. versionchanged:: 20.0
                 |sequenceclassargs|
 
+        show_caption_above_media (:obj:`bool`, optional): |show_cap_above_med|
+
+            .. versionadded:: NEXT.VERSION
         audio (:class:`telegram.Audio`, optional): Message is an audio file, information
             about the file.
         document (:class:`telegram.Document`, optional): Message is a general file, information
@@ -636,6 +639,9 @@ class Message(MaybeInaccessibleMessage):
             .. versionchanged:: 20.0
                 |tupleclassattrs|
 
+        show_caption_above_media (:obj:`bool`): Optional. |show_cap_above_med|
+
+            .. versionadded:: NEXT.VERSION
         audio (:class:`telegram.Audio`): Optional. Message is an audio file, information
             about the file.
 
@@ -953,6 +959,7 @@ class Message(MaybeInaccessibleMessage):
         "sender_boost_count",
         "sender_business_bot",
         "sender_chat",
+        "show_caption_above_media",
         "sticker",
         "story",
         "successful_payment",
@@ -1056,6 +1063,7 @@ class Message(MaybeInaccessibleMessage):
         is_from_offline: Optional[bool] = None,
         chat_background_set: Optional[ChatBackground] = None,
         effect_id: Optional[str] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         api_kwargs: Optional[JSONDict] = None,
     ):
@@ -1156,6 +1164,7 @@ class Message(MaybeInaccessibleMessage):
             self.is_from_offline: Optional[bool] = is_from_offline
             self.chat_background_set: Optional[ChatBackground] = chat_background_set
             self.effect_id: Optional[str] = effect_id
+            self.show_caption_above_media: Optional[bool] = show_caption_above_media
 
             self._effective_attachment = DEFAULT_NONE
 

--- a/telegram/_user.py
+++ b/telegram/_user.py
@@ -534,6 +534,7 @@ class User(TelegramObject):
         reply_parameters: Optional["ReplyParameters"] = None,
         business_connection_id: Optional[str] = None,
         message_effect_id: Optional[str] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         reply_to_message_id: Optional[int] = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
@@ -579,6 +580,7 @@ class User(TelegramObject):
             has_spoiler=has_spoiler,
             business_connection_id=business_connection_id,
             message_effect_id=message_effect_id,
+            show_caption_above_media=show_caption_above_media,
         )
 
     async def send_media_group(
@@ -1150,6 +1152,7 @@ class User(TelegramObject):
         reply_parameters: Optional["ReplyParameters"] = None,
         business_connection_id: Optional[str] = None,
         message_effect_id: Optional[str] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         reply_to_message_id: Optional[int] = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
@@ -1199,6 +1202,7 @@ class User(TelegramObject):
             thumbnail=thumbnail,
             business_connection_id=business_connection_id,
             message_effect_id=message_effect_id,
+            show_caption_above_media=show_caption_above_media,
         )
 
     async def send_sticker(
@@ -1273,6 +1277,7 @@ class User(TelegramObject):
         reply_parameters: Optional["ReplyParameters"] = None,
         business_connection_id: Optional[str] = None,
         message_effect_id: Optional[str] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         reply_to_message_id: Optional[int] = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
@@ -1323,6 +1328,7 @@ class User(TelegramObject):
             has_spoiler=has_spoiler,
             business_connection_id=business_connection_id,
             message_effect_id=message_effect_id,
+            show_caption_above_media=show_caption_above_media,
         )
 
     async def send_venue(
@@ -1601,6 +1607,7 @@ class User(TelegramObject):
         protect_content: ODVInput[bool] = DEFAULT_NONE,
         message_thread_id: Optional[int] = None,
         reply_parameters: Optional["ReplyParameters"] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         reply_to_message_id: Optional[int] = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
@@ -1642,6 +1649,7 @@ class User(TelegramObject):
             api_kwargs=api_kwargs,
             protect_content=protect_content,
             message_thread_id=message_thread_id,
+            show_caption_above_media=show_caption_above_media,
         )
 
     async def copy_message(
@@ -1656,6 +1664,7 @@ class User(TelegramObject):
         protect_content: ODVInput[bool] = DEFAULT_NONE,
         message_thread_id: Optional[int] = None,
         reply_parameters: Optional["ReplyParameters"] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         reply_to_message_id: Optional[int] = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
@@ -1697,6 +1706,7 @@ class User(TelegramObject):
             api_kwargs=api_kwargs,
             protect_content=protect_content,
             message_thread_id=message_thread_id,
+            show_caption_above_media=show_caption_above_media,
         )
 
     async def send_copies(

--- a/telegram/ext/_extbot.py
+++ b/telegram/ext/_extbot.py
@@ -800,6 +800,7 @@ class ExtBot(Bot, Generic[RLARGS]):
         protect_content: ODVInput[bool] = DEFAULT_NONE,
         message_thread_id: Optional[int] = None,
         reply_parameters: Optional["ReplyParameters"] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         reply_to_message_id: Optional[int] = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
@@ -830,6 +831,7 @@ class ExtBot(Bot, Generic[RLARGS]):
             connect_timeout=connect_timeout,
             pool_timeout=pool_timeout,
             api_kwargs=self._merge_api_rl_kwargs(api_kwargs, rate_limit_args),
+            show_caption_above_media=show_caption_above_media,
         )
 
     async def copy_messages(
@@ -1508,6 +1510,7 @@ class ExtBot(Bot, Generic[RLARGS]):
         reply_markup: Optional["InlineKeyboardMarkup"] = None,
         parse_mode: ODVInput[str] = DEFAULT_NONE,
         caption_entities: Optional[Sequence["MessageEntity"]] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         read_timeout: ODVInput[float] = DEFAULT_NONE,
         write_timeout: ODVInput[float] = DEFAULT_NONE,
@@ -1529,6 +1532,7 @@ class ExtBot(Bot, Generic[RLARGS]):
             connect_timeout=connect_timeout,
             pool_timeout=pool_timeout,
             api_kwargs=self._merge_api_rl_kwargs(api_kwargs, rate_limit_args),
+            show_caption_above_media=show_caption_above_media,
         )
 
     async def edit_message_live_location(
@@ -2382,6 +2386,7 @@ class ExtBot(Bot, Generic[RLARGS]):
         reply_parameters: Optional["ReplyParameters"] = None,
         business_connection_id: Optional[str] = None,
         message_effect_id: Optional[str] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         reply_to_message_id: Optional[int] = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
@@ -2419,6 +2424,7 @@ class ExtBot(Bot, Generic[RLARGS]):
             pool_timeout=pool_timeout,
             api_kwargs=self._merge_api_rl_kwargs(api_kwargs, rate_limit_args),
             message_effect_id=message_effect_id,
+            show_caption_above_media=show_caption_above_media,
         )
 
     async def send_audio(
@@ -2922,6 +2928,7 @@ class ExtBot(Bot, Generic[RLARGS]):
         reply_parameters: Optional["ReplyParameters"] = None,
         business_connection_id: Optional[str] = None,
         message_effect_id: Optional[str] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         reply_to_message_id: Optional[int] = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
@@ -2955,6 +2962,7 @@ class ExtBot(Bot, Generic[RLARGS]):
             pool_timeout=pool_timeout,
             api_kwargs=self._merge_api_rl_kwargs(api_kwargs, rate_limit_args),
             message_effect_id=message_effect_id,
+            show_caption_above_media=show_caption_above_media,
         )
 
     async def send_poll(
@@ -3141,6 +3149,7 @@ class ExtBot(Bot, Generic[RLARGS]):
         reply_parameters: Optional["ReplyParameters"] = None,
         business_connection_id: Optional[str] = None,
         message_effect_id: Optional[str] = None,
+        show_caption_above_media: Optional[bool] = None,
         *,
         reply_to_message_id: Optional[int] = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
@@ -3179,6 +3188,7 @@ class ExtBot(Bot, Generic[RLARGS]):
             pool_timeout=pool_timeout,
             api_kwargs=self._merge_api_rl_kwargs(api_kwargs, rate_limit_args),
             message_effect_id=message_effect_id,
+            show_caption_above_media=show_caption_above_media,
         )
 
     async def send_video_note(

--- a/tests/_files/test_animation.py
+++ b/tests/_files/test_animation.py
@@ -233,6 +233,7 @@ class TestAnimationWithRequest(TestAnimationBase):
             protect_content=True,
             thumbnail=thumb_file,
             has_spoiler=True,
+            show_caption_above_media=True,
         )
 
         assert isinstance(message.animation, Animation)
@@ -246,6 +247,7 @@ class TestAnimationWithRequest(TestAnimationBase):
         assert message.animation.thumbnail.width == self.width
         assert message.animation.thumbnail.height == self.height
         assert message.has_protected_content
+        assert message.show_caption_above_media
         try:
             assert message.has_media_spoiler
         except AssertionError:

--- a/tests/_files/test_inputmedia.py
+++ b/tests/_files/test_inputmedia.py
@@ -76,6 +76,7 @@ def input_media_video(class_thumb_file):
         thumbnail=class_thumb_file,
         supports_streaming=TestInputMediaVideoBase.supports_streaming,
         has_spoiler=TestInputMediaVideoBase.has_spoiler,
+        show_caption_above_media=TestInputMediaVideoBase.show_caption_above_media,
     )
 
 
@@ -87,6 +88,7 @@ def input_media_photo():
         parse_mode=TestInputMediaPhotoBase.parse_mode,
         caption_entities=TestInputMediaPhotoBase.caption_entities,
         has_spoiler=TestInputMediaPhotoBase.has_spoiler,
+        show_caption_above_media=TestInputMediaPhotoBase.show_caption_above_media,
     )
 
 
@@ -102,6 +104,7 @@ def input_media_animation(class_thumb_file):
         thumbnail=class_thumb_file,
         duration=TestInputMediaAnimationBase.duration,
         has_spoiler=TestInputMediaAnimationBase.has_spoiler,
+        show_caption_above_media=TestInputMediaAnimationBase.show_caption_above_media,
     )
 
 
@@ -142,6 +145,7 @@ class TestInputMediaVideoBase:
     supports_streaming = True
     caption_entities = [MessageEntity(MessageEntity.BOLD, 0, 2)]
     has_spoiler = True
+    show_caption_above_media = True
 
 
 class TestInputMediaVideoWithoutRequest(TestInputMediaVideoBase):
@@ -163,6 +167,7 @@ class TestInputMediaVideoWithoutRequest(TestInputMediaVideoBase):
         assert input_media_video.supports_streaming == self.supports_streaming
         assert isinstance(input_media_video.thumbnail, InputFile)
         assert input_media_video.has_spoiler == self.has_spoiler
+        assert input_media_video.show_caption_above_media == self.show_caption_above_media
 
     def test_caption_entities_always_tuple(self):
         input_media_video = InputMediaVideo(self.media)
@@ -182,6 +187,10 @@ class TestInputMediaVideoWithoutRequest(TestInputMediaVideoBase):
         ]
         assert input_media_video_dict["supports_streaming"] == input_media_video.supports_streaming
         assert input_media_video_dict["has_spoiler"] == input_media_video.has_spoiler
+        assert (
+            input_media_video_dict["show_caption_above_media"]
+            == input_media_video.show_caption_above_media
+        )
 
     def test_with_video(self, video):  # noqa: F811
         # fixture found in test_video
@@ -235,6 +244,7 @@ class TestInputMediaPhotoBase:
     parse_mode = "Markdown"
     caption_entities = [MessageEntity(MessageEntity.BOLD, 0, 2)]
     has_spoiler = True
+    show_caption_above_media = True
 
 
 class TestInputMediaPhotoWithoutRequest(TestInputMediaPhotoBase):
@@ -251,6 +261,7 @@ class TestInputMediaPhotoWithoutRequest(TestInputMediaPhotoBase):
         assert input_media_photo.parse_mode == self.parse_mode
         assert input_media_photo.caption_entities == tuple(self.caption_entities)
         assert input_media_photo.has_spoiler == self.has_spoiler
+        assert input_media_photo.show_caption_above_media == self.show_caption_above_media
 
     def test_caption_entities_always_tuple(self):
         input_media_photo = InputMediaPhoto(self.media)
@@ -266,6 +277,10 @@ class TestInputMediaPhotoWithoutRequest(TestInputMediaPhotoBase):
             ce.to_dict() for ce in input_media_photo.caption_entities
         ]
         assert input_media_photo_dict["has_spoiler"] == input_media_photo.has_spoiler
+        assert (
+            input_media_photo_dict["show_caption_above_media"]
+            == input_media_photo.show_caption_above_media
+        )
 
     def test_with_photo(self, photo):  # noqa: F811
         # fixture found in test_photo
@@ -296,6 +311,7 @@ class TestInputMediaAnimationBase:
     height = 30
     duration = 1
     has_spoiler = True
+    show_caption_above_media = True
 
 
 class TestInputMediaAnimationWithoutRequest(TestInputMediaAnimationBase):
@@ -313,6 +329,7 @@ class TestInputMediaAnimationWithoutRequest(TestInputMediaAnimationBase):
         assert input_media_animation.caption_entities == tuple(self.caption_entities)
         assert isinstance(input_media_animation.thumbnail, InputFile)
         assert input_media_animation.has_spoiler == self.has_spoiler
+        assert input_media_animation.show_caption_above_media == self.show_caption_above_media
 
     def test_caption_entities_always_tuple(self):
         input_media_animation = InputMediaAnimation(self.media)
@@ -331,6 +348,10 @@ class TestInputMediaAnimationWithoutRequest(TestInputMediaAnimationBase):
         assert input_media_animation_dict["height"] == input_media_animation.height
         assert input_media_animation_dict["duration"] == input_media_animation.duration
         assert input_media_animation_dict["has_spoiler"] == input_media_animation.has_spoiler
+        assert (
+            input_media_animation_dict["show_caption_above_media"]
+            == input_media_animation.show_caption_above_media
+        )
 
     def test_with_animation(self, animation):  # noqa: F811
         # fixture found in test_animation

--- a/tests/_files/test_photo.py
+++ b/tests/_files/test_photo.py
@@ -247,6 +247,7 @@ class TestPhotoWithRequest(TestPhotoBase):
             protect_content=True,
             parse_mode="Markdown",
             has_spoiler=True,
+            show_caption_above_media=True,
         )
 
         assert isinstance(message.photo[-2], PhotoSize)
@@ -264,6 +265,7 @@ class TestPhotoWithRequest(TestPhotoBase):
         assert message.caption == self.caption.replace("*", "")
         assert message.has_protected_content
         assert message.has_media_spoiler
+        assert message.show_caption_above_media
 
     async def test_send_photo_parse_mode_markdown(self, bot, chat_id, photo_file):
         message = await bot.send_photo(

--- a/tests/_files/test_video.py
+++ b/tests/_files/test_video.py
@@ -244,6 +244,7 @@ class TestVideoWithRequest(TestVideoBase):
             parse_mode="Markdown",
             thumbnail=thumb_file,
             has_spoiler=True,
+            show_caption_above_media=True,
         )
 
         assert isinstance(message.video, Video)
@@ -265,6 +266,7 @@ class TestVideoWithRequest(TestVideoBase):
         assert message.video.file_name == self.file_name
         assert message.has_protected_content
         assert message.has_media_spoiler
+        assert message.show_caption_above_media
 
     async def test_get_and_download(self, bot, video, chat_id, tmp_file):
         new_file = await bot.get_file(video.file_id)

--- a/tests/_inline/test_inlinequeryresultcachedgif.py
+++ b/tests/_inline/test_inlinequeryresultcachedgif.py
@@ -40,6 +40,7 @@ def inline_query_result_cached_gif():
         caption_entities=TestInlineQueryResultCachedGifBase.caption_entities,
         input_message_content=TestInlineQueryResultCachedGifBase.input_message_content,
         reply_markup=TestInlineQueryResultCachedGifBase.reply_markup,
+        show_caption_above_media=TestInlineQueryResultCachedGifBase.show_caption_above_media,
     )
 
 
@@ -53,6 +54,7 @@ class TestInlineQueryResultCachedGifBase:
     caption_entities = [MessageEntity(MessageEntity.ITALIC, 0, 7)]
     input_message_content = InputTextMessageContent("input_message_content")
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton("reply_markup")]])
+    show_caption_above_media = True
 
 
 class TestInlineQueryResultCachedGifWithoutRequest(TestInlineQueryResultCachedGifBase):
@@ -75,6 +77,10 @@ class TestInlineQueryResultCachedGifWithoutRequest(TestInlineQueryResultCachedGi
             == self.input_message_content.to_dict()
         )
         assert inline_query_result_cached_gif.reply_markup.to_dict() == self.reply_markup.to_dict()
+        assert (
+            inline_query_result_cached_gif.show_caption_above_media
+            == self.show_caption_above_media
+        )
 
     def test_caption_entities_always_tuple(self):
         result = InlineQueryResultCachedGif(self.id_, self.gif_file_id)
@@ -109,6 +115,10 @@ class TestInlineQueryResultCachedGifWithoutRequest(TestInlineQueryResultCachedGi
         assert (
             inline_query_result_cached_gif_dict["reply_markup"]
             == inline_query_result_cached_gif.reply_markup.to_dict()
+        )
+        assert (
+            inline_query_result_cached_gif_dict["show_caption_above_media"]
+            == inline_query_result_cached_gif.show_caption_above_media
         )
 
     def test_equality(self):

--- a/tests/_inline/test_inlinequeryresultcachedmpeg4gif.py
+++ b/tests/_inline/test_inlinequeryresultcachedmpeg4gif.py
@@ -40,6 +40,7 @@ def inline_query_result_cached_mpeg4_gif():
         caption_entities=TestInlineQueryResultCachedMpeg4GifBase.caption_entities,
         input_message_content=TestInlineQueryResultCachedMpeg4GifBase.input_message_content,
         reply_markup=TestInlineQueryResultCachedMpeg4GifBase.reply_markup,
+        show_caption_above_media=TestInlineQueryResultCachedMpeg4GifBase.show_caption_above_media,
     )
 
 
@@ -53,6 +54,7 @@ class TestInlineQueryResultCachedMpeg4GifBase:
     caption_entities = [MessageEntity(MessageEntity.ITALIC, 0, 7)]
     input_message_content = InputTextMessageContent("input_message_content")
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton("reply_markup")]])
+    show_caption_above_media = True
 
 
 class TestInlineQueryResultCachedMpeg4GifWithoutRequest(TestInlineQueryResultCachedMpeg4GifBase):
@@ -79,6 +81,10 @@ class TestInlineQueryResultCachedMpeg4GifWithoutRequest(TestInlineQueryResultCac
         assert (
             inline_query_result_cached_mpeg4_gif.reply_markup.to_dict()
             == self.reply_markup.to_dict()
+        )
+        assert (
+            inline_query_result_cached_mpeg4_gif.show_caption_above_media
+            == self.show_caption_above_media
         )
 
     def test_caption_entities_always_tuple(self):
@@ -123,6 +129,10 @@ class TestInlineQueryResultCachedMpeg4GifWithoutRequest(TestInlineQueryResultCac
         assert (
             inline_query_result_cached_mpeg4_gif_dict["reply_markup"]
             == inline_query_result_cached_mpeg4_gif.reply_markup.to_dict()
+        )
+        assert (
+            inline_query_result_cached_mpeg4_gif_dict["show_caption_above_media"]
+            == inline_query_result_cached_mpeg4_gif.show_caption_above_media
         )
 
     def test_equality(self):

--- a/tests/_inline/test_inlinequeryresultcachedphoto.py
+++ b/tests/_inline/test_inlinequeryresultcachedphoto.py
@@ -41,6 +41,7 @@ def inline_query_result_cached_photo():
         caption_entities=TestInlineQueryResultCachedPhotoBase.caption_entities,
         input_message_content=TestInlineQueryResultCachedPhotoBase.input_message_content,
         reply_markup=TestInlineQueryResultCachedPhotoBase.reply_markup,
+        show_caption_above_media=TestInlineQueryResultCachedPhotoBase.show_caption_above_media,
     )
 
 
@@ -55,6 +56,7 @@ class TestInlineQueryResultCachedPhotoBase:
     caption_entities = [MessageEntity(MessageEntity.ITALIC, 0, 7)]
     input_message_content = InputTextMessageContent("input_message_content")
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton("reply_markup")]])
+    show_caption_above_media = True
 
 
 class TestInlineQueryResultCachedPhotoWithoutRequest(TestInlineQueryResultCachedPhotoBase):
@@ -79,6 +81,10 @@ class TestInlineQueryResultCachedPhotoWithoutRequest(TestInlineQueryResultCached
         )
         assert (
             inline_query_result_cached_photo.reply_markup.to_dict() == self.reply_markup.to_dict()
+        )
+        assert (
+            inline_query_result_cached_photo.show_caption_above_media
+            == self.show_caption_above_media
         )
 
     def test_caption_entities_always_tuple(self):
@@ -123,6 +129,10 @@ class TestInlineQueryResultCachedPhotoWithoutRequest(TestInlineQueryResultCached
         assert (
             inline_query_result_cached_photo_dict["reply_markup"]
             == inline_query_result_cached_photo.reply_markup.to_dict()
+        )
+        assert (
+            inline_query_result_cached_photo_dict["show_caption_above_media"]
+            == inline_query_result_cached_photo.show_caption_above_media
         )
 
     def test_equality(self):

--- a/tests/_inline/test_inlinequeryresultcachedvideo.py
+++ b/tests/_inline/test_inlinequeryresultcachedvideo.py
@@ -41,6 +41,7 @@ def inline_query_result_cached_video():
         description=TestInlineQueryResultCachedVideoBase.description,
         input_message_content=TestInlineQueryResultCachedVideoBase.input_message_content,
         reply_markup=TestInlineQueryResultCachedVideoBase.reply_markup,
+        show_caption_above_media=TestInlineQueryResultCachedVideoBase.show_caption_above_media,
     )
 
 
@@ -55,6 +56,7 @@ class TestInlineQueryResultCachedVideoBase:
     description = "description"
     input_message_content = InputTextMessageContent("input_message_content")
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton("reply_markup")]])
+    show_caption_above_media = True
 
 
 class TestInlineQueryResultCachedVideoWithoutRequest(TestInlineQueryResultCachedVideoBase):
@@ -79,6 +81,10 @@ class TestInlineQueryResultCachedVideoWithoutRequest(TestInlineQueryResultCached
         )
         assert (
             inline_query_result_cached_video.reply_markup.to_dict() == self.reply_markup.to_dict()
+        )
+        assert (
+            inline_query_result_cached_video.show_caption_above_media
+            == self.show_caption_above_media
         )
 
     def test_caption_entities_always_tuple(self):
@@ -124,6 +130,10 @@ class TestInlineQueryResultCachedVideoWithoutRequest(TestInlineQueryResultCached
         assert (
             inline_query_result_cached_video_dict["reply_markup"]
             == inline_query_result_cached_video.reply_markup.to_dict()
+        )
+        assert (
+            inline_query_result_cached_video_dict["show_caption_above_media"]
+            == inline_query_result_cached_video.show_caption_above_media
         )
 
     def test_equality(self):

--- a/tests/_inline/test_inlinequeryresultgif.py
+++ b/tests/_inline/test_inlinequeryresultgif.py
@@ -45,6 +45,7 @@ def inline_query_result_gif():
         input_message_content=TestInlineQueryResultGifBase.input_message_content,
         reply_markup=TestInlineQueryResultGifBase.reply_markup,
         thumbnail_mime_type=TestInlineQueryResultGifBase.thumbnail_mime_type,
+        show_caption_above_media=TestInlineQueryResultGifBase.show_caption_above_media,
     )
 
 
@@ -63,6 +64,7 @@ class TestInlineQueryResultGifBase:
     caption_entities = [MessageEntity(MessageEntity.ITALIC, 0, 7)]
     input_message_content = InputTextMessageContent("input_message_content")
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton("reply_markup")]])
+    show_caption_above_media = True
 
 
 class TestInlineQueryResultGifWithoutRequest(TestInlineQueryResultGifBase):
@@ -94,6 +96,7 @@ class TestInlineQueryResultGifWithoutRequest(TestInlineQueryResultGifBase):
             == self.input_message_content.to_dict()
         )
         assert inline_query_result_gif.reply_markup.to_dict() == self.reply_markup.to_dict()
+        assert inline_query_result_gif.show_caption_above_media == self.show_caption_above_media
 
     def test_to_dict(self, inline_query_result_gif):
         inline_query_result_gif_dict = inline_query_result_gif.to_dict()
@@ -125,6 +128,10 @@ class TestInlineQueryResultGifWithoutRequest(TestInlineQueryResultGifBase):
         assert (
             inline_query_result_gif_dict["reply_markup"]
             == inline_query_result_gif.reply_markup.to_dict()
+        )
+        assert (
+            inline_query_result_gif_dict["show_caption_above_media"]
+            == inline_query_result_gif.show_caption_above_media
         )
 
     def test_equality(self):

--- a/tests/_inline/test_inlinequeryresultmpeg4gif.py
+++ b/tests/_inline/test_inlinequeryresultmpeg4gif.py
@@ -45,6 +45,7 @@ def inline_query_result_mpeg4_gif():
         input_message_content=TestInlineQueryResultMpeg4GifBase.input_message_content,
         reply_markup=TestInlineQueryResultMpeg4GifBase.reply_markup,
         thumbnail_mime_type=TestInlineQueryResultMpeg4GifBase.thumbnail_mime_type,
+        show_caption_above_media=TestInlineQueryResultMpeg4GifBase.show_caption_above_media,
     )
 
 
@@ -63,6 +64,7 @@ class TestInlineQueryResultMpeg4GifBase:
     caption_entities = [MessageEntity(MessageEntity.ITALIC, 0, 7)]
     input_message_content = InputTextMessageContent("input_message_content")
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton("reply_markup")]])
+    show_caption_above_media = True
 
 
 class TestInlineQueryResultMpeg4GifWithoutRequest(TestInlineQueryResultMpeg4GifBase):
@@ -90,6 +92,9 @@ class TestInlineQueryResultMpeg4GifWithoutRequest(TestInlineQueryResultMpeg4GifB
             == self.input_message_content.to_dict()
         )
         assert inline_query_result_mpeg4_gif.reply_markup.to_dict() == self.reply_markup.to_dict()
+        assert (
+            inline_query_result_mpeg4_gif.show_caption_above_media == self.show_caption_above_media
+        )
 
     def test_caption_entities_always_tuple(self):
         result = InlineQueryResultMpeg4Gif(self.id_, self.mpeg4_url, self.thumbnail_url)
@@ -143,6 +148,10 @@ class TestInlineQueryResultMpeg4GifWithoutRequest(TestInlineQueryResultMpeg4GifB
         assert (
             inline_query_result_mpeg4_gif_dict["reply_markup"]
             == inline_query_result_mpeg4_gif.reply_markup.to_dict()
+        )
+        assert (
+            inline_query_result_mpeg4_gif_dict["show_caption_above_media"]
+            == inline_query_result_mpeg4_gif.show_caption_above_media
         )
 
     def test_equality(self):

--- a/tests/_inline/test_inlinequeryresultphoto.py
+++ b/tests/_inline/test_inlinequeryresultphoto.py
@@ -44,6 +44,7 @@ def inline_query_result_photo():
         caption_entities=TestInlineQueryResultPhotoBase.caption_entities,
         input_message_content=TestInlineQueryResultPhotoBase.input_message_content,
         reply_markup=TestInlineQueryResultPhotoBase.reply_markup,
+        show_caption_above_media=TestInlineQueryResultPhotoBase.show_caption_above_media,
     )
 
 
@@ -62,6 +63,7 @@ class TestInlineQueryResultPhotoBase:
 
     input_message_content = InputTextMessageContent("input_message_content")
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton("reply_markup")]])
+    show_caption_above_media = True
 
 
 class TestInlineQueryResultPhotoWithoutRequest(TestInlineQueryResultPhotoBase):
@@ -88,6 +90,7 @@ class TestInlineQueryResultPhotoWithoutRequest(TestInlineQueryResultPhotoBase):
             == self.input_message_content.to_dict()
         )
         assert inline_query_result_photo.reply_markup.to_dict() == self.reply_markup.to_dict()
+        assert inline_query_result_photo.show_caption_above_media == self.show_caption_above_media
 
     def test_caption_entities_always_tuple(self):
         result = InlineQueryResultPhoto(self.id_, self.photo_url, self.thumbnail_url)
@@ -127,6 +130,10 @@ class TestInlineQueryResultPhotoWithoutRequest(TestInlineQueryResultPhotoBase):
         assert (
             inline_query_result_photo_dict["reply_markup"]
             == inline_query_result_photo.reply_markup.to_dict()
+        )
+        assert (
+            inline_query_result_photo_dict["show_caption_above_media"]
+            == inline_query_result_photo.show_caption_above_media
         )
 
     def test_equality(self):

--- a/tests/_inline/test_inlinequeryresultvideo.py
+++ b/tests/_inline/test_inlinequeryresultvideo.py
@@ -46,6 +46,7 @@ def inline_query_result_video():
         description=TestInlineQueryResultVideoBase.description,
         input_message_content=TestInlineQueryResultVideoBase.input_message_content,
         reply_markup=TestInlineQueryResultVideoBase.reply_markup,
+        show_caption_above_media=TestInlineQueryResultVideoBase.show_caption_above_media,
     )
 
 
@@ -65,6 +66,7 @@ class TestInlineQueryResultVideoBase:
     description = "description"
     input_message_content = InputTextMessageContent("input_message_content")
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton("reply_markup")]])
+    show_caption_above_media = True
 
 
 class TestInlineQueryResultVideoWithoutRequest(TestInlineQueryResultVideoBase):
@@ -93,6 +95,7 @@ class TestInlineQueryResultVideoWithoutRequest(TestInlineQueryResultVideoBase):
             == self.input_message_content.to_dict()
         )
         assert inline_query_result_video.reply_markup.to_dict() == self.reply_markup.to_dict()
+        assert inline_query_result_video.show_caption_above_media == self.show_caption_above_media
 
     def test_caption_entities_always_tuple(self):
         video = InlineQueryResultVideo(
@@ -139,6 +142,10 @@ class TestInlineQueryResultVideoWithoutRequest(TestInlineQueryResultVideoBase):
         assert (
             inline_query_result_video_dict["reply_markup"]
             == inline_query_result_video.reply_markup.to_dict()
+        )
+        assert (
+            inline_query_result_video_dict["show_caption_above_media"]
+            == inline_query_result_video.show_caption_above_media
         )
 
     def test_equality(self):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2814,9 +2814,11 @@ class TestBotWithRequest:
             caption="new_caption",
             chat_id=media_message.chat_id,
             message_id=media_message.message_id,
+            show_caption_above_media=False,
         )
 
         assert message.caption == "new_caption"
+        assert not message.show_caption_above_media
 
     async def test_edit_message_caption_entities(self, bot, media_message):
         test_string = "Italic Bold Code"
@@ -3799,6 +3801,7 @@ class TestBotWithRequest:
             parse_mode=ParseMode.HTML,
             reply_to_message_id=media_message.message_id,
             reply_markup=keyboard,
+            show_caption_above_media=False,
         )
         # we send a temp message which replies to the returned message id in order to get a
         # message object

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -711,8 +711,8 @@ class TestChatWithoutRequest(TestChatBase):
             return from_chat_id and message_id and chat_id
 
         assert check_shortcut_signature(Chat.send_copy, Bot.copy_message, ["chat_id"], [])
-        assert await check_shortcut_call(chat.copy_message, chat.get_bot(), "copy_message")
-        assert await check_defaults_handling(chat.copy_message, chat.get_bot())
+        assert await check_shortcut_call(chat.send_copy, chat.get_bot(), "copy_message")
+        assert await check_defaults_handling(chat.send_copy, chat.get_bot())
 
         monkeypatch.setattr(chat.get_bot(), "copy_message", make_assertion)
         assert await chat.send_copy(from_chat_id="test_copy", message_id=42)

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -173,10 +173,9 @@ class TestConstantsWithoutRequest:
             "is_accessible",
             "quote",
             "external_reply",
-            # attribute is deprecated, no need to add it to MessageType
-            "user_shared",
             "via_bot",
             "is_from_offline",
+            "show_caption_above_media",
         }
 
     @pytest.mark.parametrize(

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -274,6 +274,7 @@ def message(bot):
         {"business_connection_id": "123456789"},
         {"chat_background_set": ChatBackground(type=BackgroundTypeChatTheme("ice"))},
         {"effect_id": "123456789"},
+        {"show_caption_above_media": True},
     ],
     ids=[
         "reply",
@@ -344,6 +345,7 @@ def message(bot):
         "is_from_offline",
         "chat_background_set",
         "effect_id",
+        "show_caption_above_media",
     ],
 )
 def message_params(bot, request):

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -439,8 +439,8 @@ class TestUserWithoutRequest(TestUserBase):
             return from_chat_id and message_id and user_id
 
         assert check_shortcut_signature(User.send_copy, Bot.copy_message, ["chat_id"], [])
-        assert await check_shortcut_call(user.copy_message, user.get_bot(), "copy_message")
-        assert await check_defaults_handling(user.copy_message, user.get_bot())
+        assert await check_shortcut_call(user.send_copy, user.get_bot(), "copy_message")
+        assert await check_defaults_handling(user.send_copy, user.get_bot())
 
         monkeypatch.setattr(user.get_bot(), "copy_message", make_assertion)
         assert await user.send_copy(from_chat_id="from_chat_id", message_id="message_id")


### PR DESCRIPTION
### Checklist

- [x] Added ``.. versionadded:: NEXT.VERSION``, ``.. versionchanged:: NEXT.VERSION`` or ``.. deprecated:: NEXT.VERSION`` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [ ] Documented code changes according to the `CSI standard <https://standards.mousepawmedia.com/en/stable/csi.html>`__
- [ ] Added myself alphabetically to ``AUTHORS.rst`` (optional)
- [ ] Added new classes & modules to the docs and all suitable ``__all__`` s
- [ ] Checked the `Stability Policy <https://docs.python-telegram-bot.org/stability_policy.html>`_ in case of deprecations or changes to documented behavior

**If the PR contains API changes (otherwise, you can ignore this passage)**

- [x] Checked the Bot API specific sections of the [Stability Policy](https://docs.python-telegram-bot.org/stability_policy.html)

- New classes:

   - [ ] Added ``self._id_attrs`` and corresponding documentation
   - [ ] ``__init__`` accepts ``api_kwargs`` as kw-only

- Added new shortcuts:

   - [ ]  In :class:`~telegram.Chat` & :class:`~telegram.User` for all methods that accept ``chat/user_id``
   - [ ]  In :class:`~telegram.Message` for all methods that accept ``chat_id`` and ``message_id``
   - [ ]  For new :class:`~telegram.Message` shortcuts: Added ``do_quote`` argument if methods accepts ``reply_to_message_id``
   - [ ] In :class:`~telegram.CallbackQuery` for all methods that accept either ``chat_id`` and ``message_id`` or ``inline_message_id``

-  If relevant:

   - [ ] Added new constants at :mod:`telegram.constants` and shortcuts to them as class variables
   - [ ] Link new and existing constants in docstrings instead of hard-coded numbers and strings
   - [ ]  Add new message types to :attr:`telegram.Message.effective_attachment`
   - [ ] Added new handlers for new update types
   - [ ] Add the handlers to the warning loop in the :class:`~telegram.ext.ConversationHandler`
   - [ ] Added new filters for new message (sub)types
   - [x]  Added or updated documentation for the changed class(es) and/or method(s)
   - [ ] Added the new method(s) to ``_extbot.py``
   - [ ] Added or updated ``bot_methods.rst``
   - [ ] Updated the Bot API version number in all places: ``README.rst`` and ``README_RAW.rst`` (including the badge), as well as ``telegram.constants.BOT_API_VERSION_INFO``
   - [ ] Added logic for arbitrary callback data in :class:`telegram.ext.ExtBot` for new methods that either accept a ``reply_markup`` in some form or have a return type that is/contains :class:`~telegram.Message`
