### PR TITLE
Make Argument `bot` of `TelegramObject.de_json` Optional

### DIFF
--- a/telegram/_botcommandscope.py
+++ b/telegram/_botcommandscope.py
@@ -96,7 +96,7 @@ class BotCommandScope(TelegramObject):
                 :obj:`None`, in which case shortcut methods will not be available.
 
                 .. versionchanged:: NEXT.VERSION
-                   :paramref:`bot` now is optional and defaults to :obj:`None`
+                   :paramref:`bot` is now optional and defaults to :obj:`None`
 
         Returns:
             The Telegram object.

--- a/telegram/_botcommandscope.py
+++ b/telegram/_botcommandscope.py
@@ -84,13 +84,19 @@ class BotCommandScope(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["BotCommandScope"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["BotCommandScope"]:
         """Converts JSON data to the appropriate :class:`BotCommandScope` object, i.e. takes
         care of selecting the correct subclass.
 
         Args:
             data (Dict[:obj:`str`, ...]): The JSON data.
-            bot (:class:`telegram.Bot`): The bot associated with this object.
+            bot (:class:`telegram.Bot`, optional): The bot associated with this object. Defaults to
+                :obj:`None`, in which case shortcut methods will not be available.
+
+                .. versionchanged:: NEXT.VERSION
+                   :paramref:`bot` now is optional and defaults to :obj:`None`
 
         Returns:
             The Telegram object.

--- a/telegram/_business.py
+++ b/telegram/_business.py
@@ -106,7 +106,9 @@ class BusinessConnection(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["BusinessConnection"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["BusinessConnection"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 
@@ -175,7 +177,9 @@ class BusinessMessagesDeleted(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["BusinessMessagesDeleted"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["BusinessMessagesDeleted"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 
@@ -232,7 +236,9 @@ class BusinessIntro(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["BusinessIntro"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["BusinessIntro"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 
@@ -284,7 +290,9 @@ class BusinessLocation(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["BusinessLocation"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["BusinessLocation"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 
@@ -431,7 +439,9 @@ class BusinessOpeningHours(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["BusinessOpeningHours"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["BusinessOpeningHours"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_callbackquery.py
+++ b/telegram/_callbackquery.py
@@ -148,7 +148,9 @@ class CallbackQuery(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["CallbackQuery"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["CallbackQuery"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_chatbackground.py
+++ b/telegram/_chatbackground.py
@@ -78,7 +78,9 @@ class BackgroundFill(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["BackgroundFill"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["BackgroundFill"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 
@@ -267,7 +269,9 @@ class BackgroundType(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["BackgroundType"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["BackgroundType"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 
@@ -528,7 +532,9 @@ class ChatBackground(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["ChatBackground"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["ChatBackground"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_chatboost.py
+++ b/telegram/_chatboost.py
@@ -110,7 +110,9 @@ class ChatBoostSource(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["ChatBoostSource"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["ChatBoostSource"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 
@@ -275,7 +277,9 @@ class ChatBoost(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["ChatBoost"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["ChatBoost"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 
@@ -325,7 +329,9 @@ class ChatBoostUpdated(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["ChatBoostUpdated"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["ChatBoostUpdated"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 
@@ -382,7 +388,9 @@ class ChatBoostRemoved(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["ChatBoostRemoved"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["ChatBoostRemoved"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 
@@ -429,7 +437,9 @@ class UserChatBoosts(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["UserChatBoosts"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["UserChatBoosts"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_chatfullinfo.py
+++ b/telegram/_chatfullinfo.py
@@ -496,7 +496,9 @@ class ChatFullInfo(_ChatBase):
             self.business_opening_hours: Optional[BusinessOpeningHours] = business_opening_hours
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["ChatFullInfo"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["ChatFullInfo"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_chatinvitelink.py
+++ b/telegram/_chatinvitelink.py
@@ -151,7 +151,9 @@ class ChatInviteLink(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["ChatInviteLink"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["ChatInviteLink"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_chatjoinrequest.py
+++ b/telegram/_chatjoinrequest.py
@@ -129,7 +129,9 @@ class ChatJoinRequest(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["ChatJoinRequest"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["ChatJoinRequest"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_chatlocation.py
+++ b/telegram/_chatlocation.py
@@ -68,7 +68,9 @@ class ChatLocation(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["ChatLocation"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["ChatLocation"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_chatmember.py
+++ b/telegram/_chatmember.py
@@ -104,7 +104,9 @@ class ChatMember(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["ChatMember"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["ChatMember"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_chatmemberupdated.py
+++ b/telegram/_chatmemberupdated.py
@@ -141,7 +141,9 @@ class ChatMemberUpdated(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["ChatMemberUpdated"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["ChatMemberUpdated"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_chatpermissions.py
+++ b/telegram/_chatpermissions.py
@@ -231,7 +231,9 @@ class ChatPermissions(TelegramObject):
         return cls(*(14 * (False,)))
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["ChatPermissions"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["ChatPermissions"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_choseninlineresult.py
+++ b/telegram/_choseninlineresult.py
@@ -92,7 +92,9 @@ class ChosenInlineResult(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["ChosenInlineResult"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["ChosenInlineResult"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_files/_basethumbedmedium.py
+++ b/telegram/_files/_basethumbedmedium.py
@@ -82,7 +82,7 @@ class _BaseThumbedMedium(_BaseMedium):
 
     @classmethod
     def de_json(
-        cls: Type[ThumbedMT_co], data: Optional[JSONDict], bot: "Bot"
+        cls: Type[ThumbedMT_co], data: Optional[JSONDict], bot: Optional["Bot"] = None
     ) -> Optional[ThumbedMT_co]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)

--- a/telegram/_files/sticker.py
+++ b/telegram/_files/sticker.py
@@ -193,7 +193,7 @@ class Sticker(_BaseThumbedMedium):
     """:const:`telegram.constants.StickerType.CUSTOM_EMOJI`"""
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["Sticker"]:
+    def de_json(cls, data: Optional[JSONDict], bot: Optional["Bot"] = None) -> Optional["Sticker"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 
@@ -305,7 +305,9 @@ class StickerSet(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["StickerSet"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["StickerSet"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         if not data:
             return None

--- a/telegram/_files/venue.py
+++ b/telegram/_files/venue.py
@@ -103,7 +103,7 @@ class Venue(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["Venue"]:
+    def de_json(cls, data: Optional[JSONDict], bot: Optional["Bot"] = None) -> Optional["Venue"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_games/game.py
+++ b/telegram/_games/game.py
@@ -122,7 +122,7 @@ class Game(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["Game"]:
+    def de_json(cls, data: Optional[JSONDict], bot: Optional["Bot"] = None) -> Optional["Game"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_games/gamehighscore.py
+++ b/telegram/_games/gamehighscore.py
@@ -61,7 +61,9 @@ class GameHighScore(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["GameHighScore"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["GameHighScore"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_giveaway.py
+++ b/telegram/_giveaway.py
@@ -123,7 +123,9 @@ class Giveaway(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["Giveaway"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["Giveaway"]:
         """See :obj:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 
@@ -257,7 +259,9 @@ class GiveawayWinners(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["GiveawayWinners"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["GiveawayWinners"]:
         """See :obj:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 
@@ -323,7 +327,9 @@ class GiveawayCompleted(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["GiveawayCompleted"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["GiveawayCompleted"]:
         """See :obj:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_inline/inlinekeyboardbutton.py
+++ b/telegram/_inline/inlinekeyboardbutton.py
@@ -284,7 +284,9 @@ class InlineKeyboardButton(TelegramObject):
         )
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["InlineKeyboardButton"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["InlineKeyboardButton"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_inline/inlinekeyboardmarkup.py
+++ b/telegram/_inline/inlinekeyboardmarkup.py
@@ -90,7 +90,9 @@ class InlineKeyboardMarkup(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["InlineKeyboardMarkup"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["InlineKeyboardMarkup"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         if not data:
             return None

--- a/telegram/_inline/inlinequery.py
+++ b/telegram/_inline/inlinequery.py
@@ -125,7 +125,9 @@ class InlineQuery(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["InlineQuery"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["InlineQuery"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_inline/inlinequeryresultsbutton.py
+++ b/telegram/_inline/inlinequeryresultsbutton.py
@@ -97,7 +97,9 @@ class InlineQueryResultsButton(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["InlineQueryResultsButton"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["InlineQueryResultsButton"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         if not data:
             return None

--- a/telegram/_inline/inputinvoicemessagecontent.py
+++ b/telegram/_inline/inputinvoicemessagecontent.py
@@ -255,7 +255,7 @@ class InputInvoiceMessageContent(InputMessageContent):
 
     @classmethod
     def de_json(
-        cls, data: Optional[JSONDict], bot: "Bot"
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
     ) -> Optional["InputInvoiceMessageContent"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)

--- a/telegram/_keyboardbutton.py
+++ b/telegram/_keyboardbutton.py
@@ -168,7 +168,9 @@ class KeyboardButton(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["KeyboardButton"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["KeyboardButton"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_keyboardbuttonrequest.py
+++ b/telegram/_keyboardbuttonrequest.py
@@ -264,7 +264,7 @@ class KeyboardButtonRequestChat(TelegramObject):
 
     @classmethod
     def de_json(
-        cls, data: Optional[JSONDict], bot: "Bot"
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
     ) -> Optional["KeyboardButtonRequestChat"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)

--- a/telegram/_menubutton.py
+++ b/telegram/_menubutton.py
@@ -69,13 +69,19 @@ class MenuButton(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["MenuButton"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["MenuButton"]:
         """Converts JSON data to the appropriate :class:`MenuButton` object, i.e. takes
         care of selecting the correct subclass.
 
         Args:
             data (Dict[:obj:`str`, ...]): The JSON data.
-            bot (:class:`telegram.Bot`): The bot associated with this object.
+            bot (:class:`telegram.Bot`, optional): The bot associated with this object. Defaults to
+                :obj:`None`, in which case shortcut methods will not be available.
+
+                .. versionchanged:: NEXT.VERSION
+                   :paramref:`bot` now is optional and defaults to :obj:`None`
 
         Returns:
             The Telegram object.
@@ -161,7 +167,9 @@ class MenuButtonWebApp(MenuButton):
             self._id_attrs = (self.type, self.text, self.web_app)
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["MenuButtonWebApp"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["MenuButtonWebApp"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_menubutton.py
+++ b/telegram/_menubutton.py
@@ -81,7 +81,7 @@ class MenuButton(TelegramObject):
                 :obj:`None`, in which case shortcut methods will not be available.
 
                 .. versionchanged:: NEXT.VERSION
-                   :paramref:`bot` now is optional and defaults to :obj:`None`
+                   :paramref:`bot` is now optional and defaults to :obj:`None`
 
         Returns:
             The Telegram object.

--- a/telegram/_message.py
+++ b/telegram/_message.py
@@ -178,7 +178,10 @@ class MaybeInaccessibleMessage(TelegramObject):
 
     @classmethod
     def _de_json(
-        cls, data: Optional[JSONDict], bot: "Bot", api_kwargs: Optional[JSONDict] = None
+        cls,
+        data: Optional[JSONDict],
+        bot: Optional["Bot"] = None,
+        api_kwargs: Optional[JSONDict] = None,
     ) -> Optional["MaybeInaccessibleMessage"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
@@ -1205,7 +1208,7 @@ class Message(MaybeInaccessibleMessage):
         return None
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["Message"]:
+    def de_json(cls, data: Optional[JSONDict], bot: Optional["Bot"] = None) -> Optional["Message"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_messageentity.py
+++ b/telegram/_messageentity.py
@@ -129,7 +129,9 @@ class MessageEntity(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["MessageEntity"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["MessageEntity"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_messageorigin.py
+++ b/telegram/_messageorigin.py
@@ -94,7 +94,9 @@ class MessageOrigin(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["MessageOrigin"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["MessageOrigin"]:
         """Converts JSON data to the appropriate :class:`MessageOrigin` object, i.e. takes
         care of selecting the correct subclass.
         """

--- a/telegram/_messagereactionupdated.py
+++ b/telegram/_messagereactionupdated.py
@@ -86,7 +86,7 @@ class MessageReactionCountUpdated(TelegramObject):
 
     @classmethod
     def de_json(
-        cls, data: Optional[JSONDict], bot: "Bot"
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
     ) -> Optional["MessageReactionCountUpdated"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
@@ -186,7 +186,9 @@ class MessageReactionUpdated(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["MessageReactionUpdated"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["MessageReactionUpdated"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_passport/credentials.py
+++ b/telegram/_passport/credentials.py
@@ -232,7 +232,9 @@ class Credentials(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["Credentials"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["Credentials"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 
@@ -342,7 +344,9 @@ class SecureData(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["SecureData"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["SecureData"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 
@@ -448,7 +452,9 @@ class SecureValue(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["SecureValue"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["SecureValue"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_passport/encryptedpassportelement.py
+++ b/telegram/_passport/encryptedpassportelement.py
@@ -225,7 +225,7 @@ class EncryptedPassportElement(TelegramObject):
                 .. versionchanged:: NEXT.VERSION
                    :paramref:`bot` now is optional and defaults to :obj:`None`
 
-                .. versiondeprecated:: NEXT.VERSION
+                .. deprecated:: NEXT.VERSION
                    This argument will be converted to an optional argument in future versions.
             credentials (:class:`telegram.FileCredentials`): The credentials
 

--- a/telegram/_passport/encryptedpassportelement.py
+++ b/telegram/_passport/encryptedpassportelement.py
@@ -193,7 +193,9 @@ class EncryptedPassportElement(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["EncryptedPassportElement"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["EncryptedPassportElement"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 
@@ -210,14 +212,21 @@ class EncryptedPassportElement(TelegramObject):
 
     @classmethod
     def de_json_decrypted(
-        cls, data: Optional[JSONDict], bot: "Bot", credentials: "Credentials"
+        cls, data: Optional[JSONDict], bot: Optional["Bot"], credentials: "Credentials"
     ) -> Optional["EncryptedPassportElement"]:
         """Variant of :meth:`telegram.TelegramObject.de_json` that also takes into account
         passport credentials.
 
         Args:
             data (Dict[:obj:`str`, ...]): The JSON data.
-            bot (:class:`telegram.Bot`): The bot associated with this object.
+            bot (:class:`telegram.Bot` | :obj:`None`): The bot associated with these object.
+                Maybe be :obj:`None`, in which case shortcut methods will not be available.
+
+                .. versionchanged:: NEXT.VERSION
+                   :paramref:`bot` now is optional and defaults to :obj:`None`
+
+                .. versiondeprecated:: NEXT.VERSION
+                   This argument will be converted to an optional argument in future versions.
             credentials (:class:`telegram.FileCredentials`): The credentials
 
         Returns:

--- a/telegram/_passport/encryptedpassportelement.py
+++ b/telegram/_passport/encryptedpassportelement.py
@@ -220,10 +220,10 @@ class EncryptedPassportElement(TelegramObject):
         Args:
             data (Dict[:obj:`str`, ...]): The JSON data.
             bot (:class:`telegram.Bot` | :obj:`None`): The bot associated with these object.
-                Maybe be :obj:`None`, in which case shortcut methods will not be available.
+                May be :obj:`None`, in which case shortcut methods will not be available.
 
                 .. versionchanged:: NEXT.VERSION
-                   :paramref:`bot` now is optional and defaults to :obj:`None`
+                   :paramref:`bot` is now optional and defaults to :obj:`None`
 
                 .. deprecated:: NEXT.VERSION
                    This argument will be converted to an optional argument in future versions.

--- a/telegram/_passport/passportdata.py
+++ b/telegram/_passport/passportdata.py
@@ -81,7 +81,9 @@ class PassportData(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["PassportData"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["PassportData"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_passport/passportfile.py
+++ b/telegram/_passport/passportfile.py
@@ -126,10 +126,10 @@ class PassportFile(TelegramObject):
         Args:
             data (Dict[:obj:`str`, ...]): The JSON data.
             bot (:class:`telegram.Bot` | :obj:`None`): The bot associated with these object.
-                Maybe be :obj:`None`, in which case shortcut methods will not be available.
+                May be :obj:`None`, in which case shortcut methods will not be available.
 
                 .. versionchanged:: NEXT.VERSION
-                   :paramref:`bot` now is optional and defaults to :obj:`None`
+                   :paramref:`bot` is now optional and defaults to :obj:`None`
 
                 .. deprecated:: NEXT.VERSION
                    This argument will be converted to an optional argument in future versions.
@@ -166,10 +166,10 @@ class PassportFile(TelegramObject):
         Args:
             data (List[Dict[:obj:`str`, ...]]): The JSON data.
             bot (:class:`telegram.Bot` | :obj:`None`): The bot associated with these object.
-                Maybe be :obj:`None`, in which case shortcut methods will not be available.
+                May be :obj:`None`, in which case shortcut methods will not be available.
 
                 .. versionchanged:: NEXT.VERSION
-                   :paramref:`bot` now is optional and defaults to :obj:`None`
+                   :paramref:`bot` is now optional and defaults to :obj:`None`
 
                 .. deprecated:: NEXT.VERSION
                    This argument will be converted to an optional argument in future versions.

--- a/telegram/_passport/passportfile.py
+++ b/telegram/_passport/passportfile.py
@@ -118,14 +118,21 @@ class PassportFile(TelegramObject):
 
     @classmethod
     def de_json_decrypted(
-        cls, data: Optional[JSONDict], bot: "Bot", credentials: "FileCredentials"
+        cls, data: Optional[JSONDict], bot: Optional["Bot"], credentials: "FileCredentials"
     ) -> Optional["PassportFile"]:
         """Variant of :meth:`telegram.TelegramObject.de_json` that also takes into account
         passport credentials.
 
         Args:
             data (Dict[:obj:`str`, ...]): The JSON data.
-            bot (:class:`telegram.Bot`): The bot associated with this object.
+            bot (:class:`telegram.Bot` | :obj:`None`): The bot associated with these object.
+                Maybe be :obj:`None`, in which case shortcut methods will not be available.
+
+                .. versionchanged:: NEXT.VERSION
+                   :paramref:`bot` now is optional and defaults to :obj:`None`
+
+                .. versiondeprecated:: NEXT.VERSION
+                   This argument will be converted to an optional argument in future versions.
             credentials (:class:`telegram.FileCredentials`): The credentials
 
         Returns:
@@ -143,7 +150,10 @@ class PassportFile(TelegramObject):
 
     @classmethod
     def de_list_decrypted(
-        cls, data: Optional[List[JSONDict]], bot: "Bot", credentials: List["FileCredentials"]
+        cls,
+        data: Optional[List[JSONDict]],
+        bot: Optional["Bot"],
+        credentials: List["FileCredentials"],
     ) -> Tuple[Optional["PassportFile"], ...]:
         """Variant of :meth:`telegram.TelegramObject.de_list` that also takes into account
         passport credentials.
@@ -155,7 +165,14 @@ class PassportFile(TelegramObject):
 
         Args:
             data (List[Dict[:obj:`str`, ...]]): The JSON data.
-            bot (:class:`telegram.Bot`): The bot associated with these objects.
+            bot (:class:`telegram.Bot` | :obj:`None`): The bot associated with these object.
+                Maybe be :obj:`None`, in which case shortcut methods will not be available.
+
+                .. versionchanged:: NEXT.VERSION
+                   :paramref:`bot` now is optional and defaults to :obj:`None`
+
+                .. versiondeprecated:: NEXT.VERSION
+                   This argument will be converted to an optional argument in future versions.
             credentials (:class:`telegram.FileCredentials`): The credentials
 
         Returns:

--- a/telegram/_passport/passportfile.py
+++ b/telegram/_passport/passportfile.py
@@ -131,7 +131,7 @@ class PassportFile(TelegramObject):
                 .. versionchanged:: NEXT.VERSION
                    :paramref:`bot` now is optional and defaults to :obj:`None`
 
-                .. versiondeprecated:: NEXT.VERSION
+                .. deprecated:: NEXT.VERSION
                    This argument will be converted to an optional argument in future versions.
             credentials (:class:`telegram.FileCredentials`): The credentials
 
@@ -171,7 +171,7 @@ class PassportFile(TelegramObject):
                 .. versionchanged:: NEXT.VERSION
                    :paramref:`bot` now is optional and defaults to :obj:`None`
 
-                .. versiondeprecated:: NEXT.VERSION
+                .. deprecated:: NEXT.VERSION
                    This argument will be converted to an optional argument in future versions.
             credentials (:class:`telegram.FileCredentials`): The credentials
 

--- a/telegram/_payment/orderinfo.py
+++ b/telegram/_payment/orderinfo.py
@@ -71,7 +71,9 @@ class OrderInfo(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["OrderInfo"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["OrderInfo"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_payment/precheckoutquery.py
+++ b/telegram/_payment/precheckoutquery.py
@@ -110,7 +110,9 @@ class PreCheckoutQuery(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["PreCheckoutQuery"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["PreCheckoutQuery"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_payment/shippingquery.py
+++ b/telegram/_payment/shippingquery.py
@@ -77,7 +77,9 @@ class ShippingQuery(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["ShippingQuery"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["ShippingQuery"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_payment/successfulpayment.py
+++ b/telegram/_payment/successfulpayment.py
@@ -105,7 +105,9 @@ class SuccessfulPayment(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["SuccessfulPayment"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["SuccessfulPayment"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_poll.py
+++ b/telegram/_poll.py
@@ -90,7 +90,9 @@ class InputPollOption(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["InputPollOption"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["InputPollOption"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 
@@ -154,7 +156,9 @@ class PollOption(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["PollOption"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["PollOption"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 
@@ -301,7 +305,9 @@ class PollAnswer(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["PollAnswer"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["PollAnswer"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 
@@ -467,7 +473,7 @@ class Poll(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["Poll"]:
+    def de_json(cls, data: Optional[JSONDict], bot: Optional["Bot"] = None) -> Optional["Poll"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_proximityalerttriggered.py
+++ b/telegram/_proximityalerttriggered.py
@@ -67,7 +67,9 @@ class ProximityAlertTriggered(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["ProximityAlertTriggered"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["ProximityAlertTriggered"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_reaction.py
+++ b/telegram/_reaction.py
@@ -65,7 +65,9 @@ class ReactionType(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["ReactionType"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["ReactionType"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 
@@ -192,7 +194,9 @@ class ReactionCount(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["ReactionCount"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["ReactionCount"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_reply.py
+++ b/telegram/_reply.py
@@ -231,7 +231,9 @@ class ExternalReplyInfo(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["ExternalReplyInfo"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["ExternalReplyInfo"]:
         """See :obj:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 
@@ -329,7 +331,9 @@ class TextQuote(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["TextQuote"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["TextQuote"]:
         """See :obj:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 
@@ -434,7 +438,9 @@ class ReplyParameters(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["ReplyParameters"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["ReplyParameters"]:
         """See :obj:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_shared.py
+++ b/telegram/_shared.py
@@ -83,7 +83,9 @@ class UsersShared(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["UsersShared"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["UsersShared"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 
@@ -172,7 +174,9 @@ class ChatShared(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["ChatShared"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["ChatShared"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 
@@ -250,7 +254,9 @@ class SharedUser(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["SharedUser"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["SharedUser"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_story.py
+++ b/telegram/_story.py
@@ -71,7 +71,7 @@ class Story(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["Story"]:
+    def de_json(cls, data: Optional[JSONDict], bot: Optional["Bot"] = None) -> Optional["Story"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_telegramobject.py
+++ b/telegram/_telegramobject.py
@@ -443,7 +443,7 @@ class TelegramObject:
                 :obj:`None`, in which case shortcut methods will not be available.
 
                 .. versionchanged:: NEXT.VERSION
-                   :paramref:`bot` now is optional and defaults to :obj:`None`
+                   :paramref:`bot` is now optional and defaults to :obj:`None`
 
         Returns:
             The Telegram object.
@@ -468,7 +468,7 @@ class TelegramObject:
                 to :obj:`None`, in which case shortcut methods will not be available.
 
                 .. versionchanged:: NEXT.VERSION
-                   :paramref:`bot` now is optional and defaults to :obj:`None`
+                   :paramref:`bot` is now optional and defaults to :obj:`None`
 
         Returns:
             A tuple of Telegram objects.

--- a/telegram/_telegramobject.py
+++ b/telegram/_telegramobject.py
@@ -403,7 +403,7 @@ class TelegramObject:
     def _de_json(
         cls: Type[Tele_co],
         data: Optional[JSONDict],
-        bot: "Bot",
+        bot: Optional["Bot"],
         api_kwargs: Optional[JSONDict] = None,
     ) -> Optional[Tele_co]:
         if data is None:
@@ -432,12 +432,18 @@ class TelegramObject:
         return obj
 
     @classmethod
-    def de_json(cls: Type[Tele_co], data: Optional[JSONDict], bot: "Bot") -> Optional[Tele_co]:
+    def de_json(
+        cls: Type[Tele_co], data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional[Tele_co]:
         """Converts JSON data to a Telegram object.
 
         Args:
             data (Dict[:obj:`str`, ...]): The JSON data.
-            bot (:class:`telegram.Bot`): The bot associated with this object.
+            bot (:class:`telegram.Bot`, optional): The bot associated with this object. Defaults to
+                :obj:`None`, in which case shortcut methods will not be available.
+
+                .. versionchanged:: NEXT.VERSION
+                   :paramref:`bot` now is optional and defaults to :obj:`None`
 
         Returns:
             The Telegram object.
@@ -447,7 +453,7 @@ class TelegramObject:
 
     @classmethod
     def de_list(
-        cls: Type[Tele_co], data: Optional[List[JSONDict]], bot: "Bot"
+        cls: Type[Tele_co], data: Optional[List[JSONDict]], bot: Optional["Bot"] = None
     ) -> Tuple[Tele_co, ...]:
         """Converts a list of JSON objects to a tuple of Telegram objects.
 
@@ -458,7 +464,11 @@ class TelegramObject:
 
         Args:
             data (List[Dict[:obj:`str`, ...]]): The JSON data.
-            bot (:class:`telegram.Bot`): The bot associated with these objects.
+            bot (:class:`telegram.Bot`, optional): The bot associated with these object. Defaults
+                to :obj:`None`, in which case shortcut methods will not be available.
+
+                .. versionchanged:: NEXT.VERSION
+                   :paramref:`bot` now is optional and defaults to :obj:`None`
 
         Returns:
             A tuple of Telegram objects.

--- a/telegram/_update.py
+++ b/telegram/_update.py
@@ -729,7 +729,7 @@ class Update(TelegramObject):
         return message
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["Update"]:
+    def de_json(cls, data: Optional[JSONDict], bot: Optional["Bot"] = None) -> Optional["Update"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_userprofilephotos.py
+++ b/telegram/_userprofilephotos.py
@@ -70,7 +70,9 @@ class UserProfilePhotos(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["UserProfilePhotos"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["UserProfilePhotos"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_utils/datetime.py
+++ b/telegram/_utils/datetime.py
@@ -188,13 +188,16 @@ def from_timestamp(
     return dtm.datetime.fromtimestamp(unixtime, tz=UTC if tzinfo is None else tzinfo)
 
 
-def extract_tzinfo_from_defaults(bot: "Bot") -> Union[dtm.tzinfo, None]:
+def extract_tzinfo_from_defaults(bot: Optional["Bot"]) -> Union[dtm.tzinfo, None]:
     """
     Extracts the timezone info from the default values of the bot.
     If the bot has no default values, :obj:`None` is returned.
     """
     # We don't use `ininstance(bot, ExtBot)` here so that this works
     # without the job-queue extra dependencies as well
+    if bot is None:
+        return None
+
     if hasattr(bot, "defaults") and bot.defaults:
         return bot.defaults.tzinfo
     return None

--- a/telegram/_videochat.py
+++ b/telegram/_videochat.py
@@ -125,7 +125,7 @@ class VideoChatParticipantsInvited(TelegramObject):
 
     @classmethod
     def de_json(
-        cls, data: Optional[JSONDict], bot: "Bot"
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
     ) -> Optional["VideoChatParticipantsInvited"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
@@ -177,7 +177,9 @@ class VideoChatScheduled(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["VideoChatScheduled"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["VideoChatScheduled"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/telegram/_webhookinfo.py
+++ b/telegram/_webhookinfo.py
@@ -162,7 +162,9 @@ class WebhookInfo(TelegramObject):
         self._freeze()
 
     @classmethod
-    def de_json(cls, data: Optional[JSONDict], bot: "Bot") -> Optional["WebhookInfo"]:
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["WebhookInfo"]:
         """See :meth:`telegram.TelegramObject.de_json`."""
         data = cls._parse_data(data)
 

--- a/tests/test_telegramobject.py
+++ b/tests/test_telegramobject.py
@@ -90,6 +90,11 @@ class TestTelegramObject:
         assert to.api_kwargs == {"foo": "bar"}
         assert to.get_bot() is bot
 
+    def test_de_json_optional_bot(self):
+        to = TelegramObject.de_json(data={})
+        with pytest.raises(RuntimeError, match="no bot associated with it"):
+            to.get_bot()
+
     def test_de_list(self, bot):
         class SubClass(TelegramObject):
             def __init__(self, arg: int, **kwargs):


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

Adresses a part of #4289

- [x] Added `.. versionadded:: NEXT.VERSION`, `.. versionchanged:: NEXT.VERSION`, `.. deprecated:: NEXT.VERSION` or `.. versionremoved:: NEXT.VERSION`` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [x] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html>)
- ~Added myself alphabetically to ``AUTHORS.rst`` (optional)~
- ~Added new classes & modules to the docs and all suitable ``__all__`` s~
- [x] Checked the [Stability Policy](https://docs.python-telegram-bot.org/stability_policy.html) in case of deprecations or changes to documented behavior