### PR TITLE
Add `adjust_message_entities_to_utf_16` utility

### DIFF
--- a/telegram/_messageentity.py
+++ b/telegram/_messageentity.py
@@ -185,7 +185,7 @@ class MessageEntity(TelegramObject):
 
         Args:
             text (:obj:`str`): The text that the entities belong to
-            entities (List[:class:`telegram.MessageEntity`]): Sequence of entities
+            entities (Sequence[:class:`telegram.MessageEntity`]): Sequence of entities
                 with offset and length calculated in Unicode
 
         Returns:

--- a/telegram/_messageentity.py
+++ b/telegram/_messageentity.py
@@ -20,7 +20,7 @@
 
 import copy
 import itertools
-from typing import TYPE_CHECKING, Final, List, Optional, Sequence
+from typing import TYPE_CHECKING, Dict, Final, List, Optional, Sequence
 
 from telegram import constants
 from telegram._telegramobject import TelegramObject
@@ -147,39 +147,41 @@ class MessageEntity(TelegramObject):
         text: str, entities: Sequence["MessageEntity"]
     ) -> Sequence["MessageEntity"]:
         """Utility functionality for converting the offset and length of entities from
-        Unicode (`str`) to UTF-16 (`utf-16-le` encoded `bytes`).
+        Unicode (:obj:`str`) to UTF-16 (``utf-16-le`` encoded :obj:`bytes`).
 
         Tip:
             Only the offsets and lengths calulated in UTF-16 is acceptable by the Telegram Bot API.
-            If they are calculated using the Unicode string (`str` object), errors may occur
+            If they are calculated using the Unicode string (:obj:`str` object), errors may occur
             when the text contains characters that are not in the Basic Multilingual Plane (BMP).
-            For more information, see `Unicode <https://en.wikipedia.org/wiki/Unicode>` and
-            `Plane (Unicode) <https://en.wikipedia.org/wiki/Plane_(Unicode)>`.
+            For more information, see `Unicode <https://en.wikipedia.org/wiki/Unicode>`_ and
+            `Plane (Unicode) <https://en.wikipedia.org/wiki/Plane_(Unicode)>`_.
+
+        .. versionadded:: NEXT.VERSION
 
         Examples:
             Below is a snippet of code that demonstrates how to use this function to convert
-            entities from Unicode to UTF-16 space. The `unicode_entities` are calculated in
+            entities from Unicode to UTF-16 space. The ``unicode_entities`` are calculated in
             Unicode and the `utf_16_entities` are calculated in UTF-16.
 
-        .. code-block:: python
+            .. code-block:: python
 
-            text = "𠌕 bold 𝄢 italic underlined: 𝛙𝌢𑁍"
-            unicode_entities = [
-                MessageEntity(offset=2, length=4, type=MessageEntity.BOLD),
-                MessageEntity(offset=9, length=6, type=MessageEntity.ITALIC),
-                MessageEntity(offset=28, length=3, type=MessageEntity.UNDERLINE),
-            ]
-            utf_16_entities = MessageEntity.adjust_message_entities_to_utf_16(
-                text, unicode_entities
-            )
-            await bot.send_message(
-                chat_id=123,
-                text=text,
-                entities=utf_16_entities,
-            )
-            # utf_16_entities[0]: offset=3, length=4
-            # utf_16_entities[1]: offset=11, length=6
-            # utf_16_entities[2]: offset=30, length=6
+                text = "𠌕 bold 𝄢 italic underlined: 𝛙𝌢𑁍"
+                unicode_entities = [
+                    MessageEntity(offset=2, length=4, type=MessageEntity.BOLD),
+                    MessageEntity(offset=9, length=6, type=MessageEntity.ITALIC),
+                    MessageEntity(offset=28, length=3, type=MessageEntity.UNDERLINE),
+                ]
+                utf_16_entities = MessageEntity.adjust_message_entities_to_utf_16(
+                    text, unicode_entities
+                )
+                await bot.send_message(
+                    chat_id=123,
+                    text=text,
+                    entities=utf_16_entities,
+                )
+                # utf_16_entities[0]: offset=3, length=4
+                # utf_16_entities[1]: offset=11, length=6
+                # utf_16_entities[2]: offset=30, length=6
 
         Args:
             text (:obj:`str`): The text that the entities belong to
@@ -190,32 +192,27 @@ class MessageEntity(TelegramObject):
             Sequence[:class:`telegram.MessageEntity`]: Sequence of entities
             with offset and length calculated in UTF-16 encoding
         """
-        # get sorted offsets
-        offsets_list = sorted(
-            itertools.chain(*((x.offset, x.offset + x.length) for x in entities))
-        )
+        # get sorted positions
+        positions = sorted(itertools.chain(*((x.offset, x.offset + x.length) for x in entities)))
         accumulated_length = 0
-        according_utf16_lengths: List[int] = []
-        # calculate the length of each slice text[:offset] in utf-16 accordingly,
-        # store them in `according_utf16_lengths`
-        for i, cut_offset in enumerate(offsets_list):
-            last_cut_offset = offsets_list[i - 1] if i > 0 else 0
-            text_slice = text[last_cut_offset:cut_offset]
+        # calculate the length of each slice text[:position] in utf-16 accordingly,
+        # store the position translations
+        position_translation: Dict[int, int] = {}
+        for i, position in enumerate(positions):
+            last_position = positions[i - 1] if i > 0 else 0
+            text_slice = text[last_position:position]
             accumulated_length += len(text_slice.encode("utf-16-le")) // 2
-            according_utf16_lengths.append(accumulated_length)
-        offset_translation = {
-            offset: according_utf16_lengths[i] for i, offset in enumerate(offsets_list)
-        }
+            position_translation[position] = accumulated_length
         # get the final output entites
         out = []
         for entity in entities:
-            translated_offset = offset_translation[entity.offset]
+            translated_positions = position_translation[entity.offset]
             translated_length = (
-                offset_translation[entity.offset + entity.length] - translated_offset
+                position_translation[entity.offset + entity.length] - translated_positions
             )
             new_entity = copy.copy(entity)
             with new_entity._unfrozen():
-                new_entity.offset = translated_offset
+                new_entity.offset = translated_positions
                 new_entity.length = translated_length
             out.append(new_entity)
         return out

--- a/telegram/_messageentity.py
+++ b/telegram/_messageentity.py
@@ -156,33 +156,35 @@ class MessageEntity(TelegramObject):
         Below is a snippet of code that demonstrates how to use this function to convert
         entities from Unicode to UTF-16 space. The `unicode_entities` are calculated in
         Unicode and the `utf_16_entities` are calculated in UTF-16.
-            ```python
-            text = "𠌕 bold 𝄢 italic underlined: 𝛙𝌢𑁍"
-            #         ^^^^   ^^^^^^             ^^^
-            unicode_entities = [
-                MessageEntity(offset=2, length=4, type=MessageEntity.BOLD),
-                MessageEntity(offset=9, length=6, type=MessageEntity.ITALIC),
-                MessageEntity(offset=28, length=3, type=MessageEntity.UNDERLINE),
-            ]
-            utf_16_entities = MessageEntity.adjust_message_entities_for_utf_16(
-                text, unicode_entities
-            )
-            await bot.send_message(
-                chat_id=123,
-                text=text,
-                entities=utf_16_entities,
-            )
-            # utf_16_entities[0]: offset=3, length=4
-            # utf_16_entities[1]: offset=11, length=6
-            # utf_16_entities[2]: offset=30, length=6
-            ```
+
+        ```python
+        text = "𠌕 bold 𝄢 italic underlined: 𝛙𝌢𑁍"
+        #         ^^^^   ^^^^^^             ^^^
+        unicode_entities = [
+            MessageEntity(offset=2, length=4, type=MessageEntity.BOLD),
+            MessageEntity(offset=9, length=6, type=MessageEntity.ITALIC),
+            MessageEntity(offset=28, length=3, type=MessageEntity.UNDERLINE),
+        ]
+        utf_16_entities = MessageEntity.adjust_message_entities_to_utf_16(
+            text, unicode_entities
+        )
+        await bot.send_message(
+            chat_id=123,
+            text=text,
+            entities=utf_16_entities,
+        )
+        # utf_16_entities[0]: offset=3, length=4
+        # utf_16_entities[1]: offset=11, length=6
+        # utf_16_entities[2]: offset=30, length=6
+        ```
 
         Args:
-            text: The text that the entities belong to
-            entities: Sequence of entities with offset and length calculated in Unicode
+            text (:obj:`str`): The text that the entities belong to
+            entities (List[:class:`telegram.MessageEntity`]): Sequence of entities
+                with offset and length calculated in Unicode
 
         Returns:
-            Sequence[MessageEntity]: Sequence of entities with offset and length
+            List[:class:`telegram.MessageEntity`]: Sequence of entities with offset and length
                 calculated in UTF-16 encoding
         """
         offsets_set = set()

--- a/telegram/_messageentity.py
+++ b/telegram/_messageentity.py
@@ -18,6 +18,8 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represents a Telegram MessageEntity."""
 
+import copy
+import itertools
 from typing import TYPE_CHECKING, Final, List, Optional, Sequence
 
 from telegram import constants
@@ -148,35 +150,36 @@ class MessageEntity(TelegramObject):
         Unicode (`str`) to UTF-16 (`utf-16-le` encoded `bytes`).
 
         Tip:
-        Only the offsets and lengths calulated in UTF-16 is acceptable by the Telegram Bot API.
-        If they are calculated using the Unicode string (`str` object), errors may occur
-        when the text contains characters that are not in the Basic Multilingual Plane (BMP).
+            Only the offsets and lengths calulated in UTF-16 is acceptable by the Telegram Bot API.
+            If they are calculated using the Unicode string (`str` object), errors may occur
+            when the text contains characters that are not in the Basic Multilingual Plane (BMP).
+            For more information, see `Unicode <https://en.wikipedia.org/wiki/Unicode>` and
+            `Plane (Unicode) <https://en.wikipedia.org/wiki/Plane_(Unicode)>`.
 
         Examples:
-        Below is a snippet of code that demonstrates how to use this function to convert
-        entities from Unicode to UTF-16 space. The `unicode_entities` are calculated in
-        Unicode and the `utf_16_entities` are calculated in UTF-16.
+            Below is a snippet of code that demonstrates how to use this function to convert
+            entities from Unicode to UTF-16 space. The `unicode_entities` are calculated in
+            Unicode and the `utf_16_entities` are calculated in UTF-16.
 
-        ```python
-        text = "𠌕 bold 𝄢 italic underlined: 𝛙𝌢𑁍"
-        #         ^^^^   ^^^^^^             ^^^
-        unicode_entities = [
-            MessageEntity(offset=2, length=4, type=MessageEntity.BOLD),
-            MessageEntity(offset=9, length=6, type=MessageEntity.ITALIC),
-            MessageEntity(offset=28, length=3, type=MessageEntity.UNDERLINE),
-        ]
-        utf_16_entities = MessageEntity.adjust_message_entities_to_utf_16(
-            text, unicode_entities
-        )
-        await bot.send_message(
-            chat_id=123,
-            text=text,
-            entities=utf_16_entities,
-        )
-        # utf_16_entities[0]: offset=3, length=4
-        # utf_16_entities[1]: offset=11, length=6
-        # utf_16_entities[2]: offset=30, length=6
-        ```
+        .. code-block:: python
+
+            text = "𠌕 bold 𝄢 italic underlined: 𝛙𝌢𑁍"
+            unicode_entities = [
+                MessageEntity(offset=2, length=4, type=MessageEntity.BOLD),
+                MessageEntity(offset=9, length=6, type=MessageEntity.ITALIC),
+                MessageEntity(offset=28, length=3, type=MessageEntity.UNDERLINE),
+            ]
+            utf_16_entities = MessageEntity.adjust_message_entities_to_utf_16(
+                text, unicode_entities
+            )
+            await bot.send_message(
+                chat_id=123,
+                text=text,
+                entities=utf_16_entities,
+            )
+            # utf_16_entities[0]: offset=3, length=4
+            # utf_16_entities[1]: offset=11, length=6
+            # utf_16_entities[2]: offset=30, length=6
 
         Args:
             text (:obj:`str`): The text that the entities belong to
@@ -184,45 +187,36 @@ class MessageEntity(TelegramObject):
                 with offset and length calculated in Unicode
 
         Returns:
-            List[:class:`telegram.MessageEntity`]: Sequence of entities with offset and length
-                calculated in UTF-16 encoding
+            Sequence[:class:`telegram.MessageEntity`]: Sequence of entities
+            with offset and length calculated in UTF-16 encoding
         """
-        offsets_set = set()
-        # collect all offsets occured
-        for entity in entities:
-            offsets_set.add(entity.offset)
-            offsets_set.add(entity.offset + entity.length)
         # get sorted offsets
-        offsets_list = sorted(offsets_set)
-        # indexes_map stores the index of each `cut_offset` in `offsets_list`
-        indexes_map = {cut_offset: i for i, cut_offset in enumerate(offsets_list)}
-        # calculate the length of each slice in utf-16
+        offsets_list = sorted(
+            itertools.chain(*((x.offset, x.offset + x.length) for x in entities))
+        )
         accumulated_length = 0
-        utf16_lengths = []
-        # what utf16_lengths stores:
-        # utf16_lengths[indexes_map[offset]] = len(text[:offset].encode("utf-16-le")) // 2
+        according_utf16_lengths: List[int] = []
+        # calculate the length of each slice text[:offset] in utf-16 accordingly,
+        # store them in `according_utf16_lengths`
         for i, cut_offset in enumerate(offsets_list):
             last_cut_offset = offsets_list[i - 1] if i > 0 else 0
             text_slice = text[last_cut_offset:cut_offset]
             accumulated_length += len(text_slice.encode("utf-16-le")) // 2
-            utf16_lengths.append(accumulated_length)
+            according_utf16_lengths.append(accumulated_length)
+        offset_translation = {
+            offset: according_utf16_lengths[i] for i, offset in enumerate(offsets_list)
+        }
         # get the final output entites
         out = []
         for entity in entities:
-            translated_offset = utf16_lengths[indexes_map[entity.offset]]
+            translated_offset = offset_translation[entity.offset]
             translated_length = (
-                utf16_lengths[indexes_map[entity.offset + entity.length]] - translated_offset
+                offset_translation[entity.offset + entity.length] - translated_offset
             )
-            new_entity = MessageEntity(
-                type=entity.type,
-                offset=translated_offset,
-                length=translated_length,
-                url=entity.url,
-                user=entity.user,
-                language=entity.language,
-                custom_emoji_id=entity.custom_emoji_id,
-                api_kwargs={**entity.api_kwargs},
-            )
+            new_entity = copy.copy(entity)
+            with new_entity._unfrozen():
+                new_entity.offset = translated_offset
+                new_entity.length = translated_length
             out.append(new_entity)
         return out
 

--- a/telegram/_messageentity.py
+++ b/telegram/_messageentity.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represents a Telegram MessageEntity."""
 
-from typing import TYPE_CHECKING, Final, List, Optional
+from typing import TYPE_CHECKING, Final, List, Optional, Sequence
 
 from telegram import constants
 from telegram._telegramobject import TelegramObject
@@ -139,6 +139,90 @@ class MessageEntity(TelegramObject):
         data["user"] = User.de_json(data.get("user"), bot)
 
         return super().de_json(data=data, bot=bot)
+
+    @staticmethod
+    def adjust_message_entities_to_utf_16(
+        text: str, entities: Sequence["MessageEntity"]
+    ) -> Sequence["MessageEntity"]:
+        """Utility functionality for converting the offset and length of entities from
+        Unicode (`str`) to UTF-16 (`utf-16-le` encoded `bytes`).
+
+        Tip:
+        Only the offsets and lengths calulated in UTF-16 is acceptable by the Telegram Bot API.
+        If they are calculated using the Unicode string (`str` object), errors may occur
+        when the text contains characters that are not in the Basic Multilingual Plane (BMP).
+
+        Examples:
+        Below is a snippet of code that demonstrates how to use this function to convert
+        entities from Unicode to UTF-16 space. The `unicode_entities` are calculated in
+        Unicode and the `utf_16_entities` are calculated in UTF-16.
+            ```python
+            text = "𠌕 bold 𝄢 italic underlined: 𝛙𝌢𑁍"
+            #         ^^^^   ^^^^^^             ^^^
+            unicode_entities = [
+                MessageEntity(offset=2, length=4, type=MessageEntity.BOLD),
+                MessageEntity(offset=9, length=6, type=MessageEntity.ITALIC),
+                MessageEntity(offset=28, length=3, type=MessageEntity.UNDERLINE),
+            ]
+            utf_16_entities = MessageEntity.adjust_message_entities_for_utf_16(
+                text, unicode_entities
+            )
+            await bot.send_message(
+                chat_id=123,
+                text=text,
+                entities=utf_16_entities,
+            )
+            # utf_16_entities[0]: offset=3, length=4
+            # utf_16_entities[1]: offset=11, length=6
+            # utf_16_entities[2]: offset=30, length=6
+            ```
+
+        Args:
+            text: The text that the entities belong to
+            entities: Sequence of entities with offset and length calculated in Unicode
+
+        Returns:
+            Sequence[MessageEntity]: Sequence of entities with offset and length
+                calculated in UTF-16 encoding
+        """
+        offsets_set = set()
+        # collect all offsets occured
+        for entity in entities:
+            offsets_set.add(entity.offset)
+            offsets_set.add(entity.offset + entity.length)
+        # get sorted offsets
+        offsets_list = sorted(offsets_set)
+        # indexes_map stores the index of each `cut_offset` in `offsets_list`
+        indexes_map = {cut_offset: i for i, cut_offset in enumerate(offsets_list)}
+        # calculate the length of each slice in utf-16
+        accumulated_length = 0
+        utf16_lengths = []
+        # what utf16_lengths stores:
+        # utf16_lengths[indexes_map[offset]] = len(text[:offset].encode("utf-16-le")) // 2
+        for i, cut_offset in enumerate(offsets_list):
+            last_cut_offset = offsets_list[i - 1] if i > 0 else 0
+            text_slice = text[last_cut_offset:cut_offset]
+            accumulated_length += len(text_slice.encode("utf-16-le")) // 2
+            utf16_lengths.append(accumulated_length)
+        # get the final output entites
+        out = []
+        for entity in entities:
+            translated_offset = utf16_lengths[indexes_map[entity.offset]]
+            translated_length = (
+                utf16_lengths[indexes_map[entity.offset + entity.length]] - translated_offset
+            )
+            new_entity = MessageEntity(
+                type=entity.type,
+                offset=translated_offset,
+                length=translated_length,
+                url=entity.url,
+                user=entity.user,
+                language=entity.language,
+                custom_emoji_id=entity.custom_emoji_id,
+                api_kwargs={**entity.api_kwargs},
+            )
+            out.append(new_entity)
+        return out
 
     ALL_TYPES: Final[List[str]] = list(constants.MessageEntityType)
     """List[:obj:`str`]: A list of all available message entity types."""

--- a/tests/test_messageentity.py
+++ b/tests/test_messageentity.py
@@ -96,3 +96,17 @@ class TestMessageEntityWithoutRequest(TestMessageEntityBase):
 
         assert a != d
         assert hash(a) != hash(d)
+
+    def test_fix_utf16(self):
+        text = "𠌕 bold 𝄢 italic underlined: 𝛙𝌢𑁍"
+        unicode_entities = [
+            MessageEntity(offset=2, length=4, type=MessageEntity.BOLD),
+            MessageEntity(offset=9, length=6, type=MessageEntity.ITALIC),
+            MessageEntity(offset=28, length=3, type=MessageEntity.UNDERLINE),
+        ]
+        utf_16_entities = MessageEntity.adjust_message_entities_for_utf_16(text, unicode_entities)
+        offsets_lengths = [(3, 4), (11, 6), (30, 6)]
+        for entity, offset_length in zip(utf_16_entities, offsets_lengths):
+            offset, length = offset_length
+            assert entity.offset == offset
+            assert entity.length == length

--- a/tests/test_messageentity.py
+++ b/tests/test_messageentity.py
@@ -16,6 +16,7 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
+import random
 from typing import List, Tuple
 
 import pytest
@@ -84,8 +85,6 @@ class TestMessageEntityWithoutRequest(TestMessageEntityBase):
         assert entity.type is MessageEntityType.URL
 
     def test_fix_utf16(self):
-        import random
-
         text = "𠌕 bold 𝄢 italic underlined: 𝛙𝌢𑁍"
         inputs_outputs: List[Tuple[Tuple[int, int, str], Tuple[int, int]]] = [
             ((2, 4, MessageEntity.BOLD), (3, 4)),

--- a/tests/test_messageentity.py
+++ b/tests/test_messageentity.py
@@ -104,7 +104,7 @@ class TestMessageEntityWithoutRequest(TestMessageEntityBase):
             MessageEntity(offset=9, length=6, type=MessageEntity.ITALIC),
             MessageEntity(offset=28, length=3, type=MessageEntity.UNDERLINE),
         ]
-        utf_16_entities = MessageEntity.adjust_message_entities_for_utf_16(text, unicode_entities)
+        utf_16_entities = MessageEntity.adjust_message_entities_to_utf_16(text, unicode_entities)
         offsets_lengths = [(3, 4), (11, 6), (30, 6)]
         for entity, offset_length in zip(utf_16_entities, offsets_lengths):
             offset, length = offset_length


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

add  `adjust_message_entities_to_utf_16` for #4319
