### PR TITLE
API 7.6 - `PaidMedia*` classes

### DIFF
--- a/docs/source/telegram.at-tree.rst
+++ b/docs/source/telegram.at-tree.rst
@@ -113,6 +113,11 @@ Available Types
     telegram.messageoriginuser
     telegram.messagereactioncountupdated
     telegram.messagereactionupdated
+    telegram.paidmedia
+    telegram.paidmediainfo
+    telegram.paidmediaphoto
+    telegram.paidmediapreview
+    telegram.paidmediavideo
     telegram.photosize
     telegram.poll
     telegram.pollanswer

--- a/docs/source/telegram.paidmedia.rst
+++ b/docs/source/telegram.paidmedia.rst
@@ -1,0 +1,6 @@
+PaidMedia
+=========
+
+.. autoclass:: telegram.PaidMedia
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.paidmediainfo.rst
+++ b/docs/source/telegram.paidmediainfo.rst
@@ -1,0 +1,6 @@
+PaidMediaInfo
+=============
+
+.. autoclass:: telegram.PaidMediaInfo
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.paidmediaphoto.rst
+++ b/docs/source/telegram.paidmediaphoto.rst
@@ -1,0 +1,6 @@
+PaidMediaPhoto
+==============
+
+.. autoclass:: telegram.PaidMediaPhoto
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.paidmediapreview.rst
+++ b/docs/source/telegram.paidmediapreview.rst
@@ -1,0 +1,6 @@
+PaidMediaPreview
+================
+
+.. autoclass:: telegram.PaidMediaPreview
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.paidmediavideo.rst
+++ b/docs/source/telegram.paidmediavideo.rst
@@ -1,0 +1,6 @@
+PaidMediaVideo
+==============
+
+.. autoclass:: telegram.PaidMediaVideo
+    :members:
+    :show-inheritance:

--- a/telegram/__init__.py
+++ b/telegram/__init__.py
@@ -173,6 +173,11 @@ __all__ = (
     "MessageReactionCountUpdated",
     "MessageReactionUpdated",
     "OrderInfo",
+    "PaidMedia",
+    "PaidMediaInfo",
+    "PaidMediaPhoto",
+    "PaidMediaPreview",
+    "PaidMediaVideo",
     "PassportData",
     "PassportElementError",
     "PassportElementErrorDataField",
@@ -405,6 +410,7 @@ from ._messageorigin import (
     MessageOriginUser,
 )
 from ._messagereactionupdated import MessageReactionCountUpdated, MessageReactionUpdated
+from ._paidmedia import PaidMedia, PaidMediaInfo, PaidMediaPhoto, PaidMediaPreview, PaidMediaVideo
 from ._passport.credentials import (
     Credentials,
     DataCredentials,

--- a/telegram/_message.py
+++ b/telegram/_message.py
@@ -52,6 +52,7 @@ from telegram._inline.inlinekeyboardmarkup import InlineKeyboardMarkup
 from telegram._linkpreviewoptions import LinkPreviewOptions
 from telegram._messageautodeletetimerchanged import MessageAutoDeleteTimerChanged
 from telegram._messageentity import MessageEntity
+from telegram._paidmedia import PaidMediaInfo
 from telegram._passport.passportdata import PassportData
 from telegram._payment.invoice import Invoice
 from telegram._payment.successfulpayment import SuccessfulPayment
@@ -571,6 +572,10 @@ class Message(MaybeInaccessibleMessage):
             background set.
 
             .. versionadded:: 21.2
+        paid_media (:obj:`telegram.PaidMediaInfo`, optional): Message contains paid media;
+            information about the paid media.
+
+            .. versionadded:: NEXT.VERSION
 
     Attributes:
         message_id (:obj:`int`): Unique message identifier inside this chat.
@@ -884,6 +889,10 @@ class Message(MaybeInaccessibleMessage):
             background set
 
             .. versionadded:: 21.2
+        paid_media (:obj:`telegram.PaidMediaInfo`): Optional. Message contains paid media;
+            information about the paid media.
+
+            .. versionadded:: NEXT.VERSION
 
     .. |custom_emoji_no_md1_support| replace:: Since custom emoji entities are not supported by
        :attr:`~telegram.constants.ParseMode.MARKDOWN`, this method now raises a
@@ -950,6 +959,7 @@ class Message(MaybeInaccessibleMessage):
         "new_chat_members",
         "new_chat_photo",
         "new_chat_title",
+        "paid_media",
         "passport_data",
         "photo",
         "pinned_message",
@@ -1067,6 +1077,7 @@ class Message(MaybeInaccessibleMessage):
         chat_background_set: Optional[ChatBackground] = None,
         effect_id: Optional[str] = None,
         show_caption_above_media: Optional[bool] = None,
+        paid_media: Optional[PaidMediaInfo] = None,
         *,
         api_kwargs: Optional[JSONDict] = None,
     ):
@@ -1168,6 +1179,7 @@ class Message(MaybeInaccessibleMessage):
             self.chat_background_set: Optional[ChatBackground] = chat_background_set
             self.effect_id: Optional[str] = effect_id
             self.show_caption_above_media: Optional[bool] = show_caption_above_media
+            self.paid_media: Optional[PaidMediaInfo] = paid_media
 
             self._effective_attachment = DEFAULT_NONE
 
@@ -1283,6 +1295,7 @@ class Message(MaybeInaccessibleMessage):
         data["users_shared"] = UsersShared.de_json(data.get("users_shared"), bot)
         data["chat_shared"] = ChatShared.de_json(data.get("chat_shared"), bot)
         data["chat_background_set"] = ChatBackground.de_json(data.get("chat_background_set"), bot)
+        data["paid_media"] = PaidMediaInfo.de_json(data.get("paid_media"), bot)
 
         # Unfortunately, this needs to be here due to cyclic imports
         from telegram._giveaway import (  # pylint: disable=import-outside-toplevel
@@ -1346,6 +1359,7 @@ class Message(MaybeInaccessibleMessage):
         Location,
         PassportData,
         Sequence[PhotoSize],
+        PaidMediaInfo,
         Poll,
         Sticker,
         Story,
@@ -1369,6 +1383,7 @@ class Message(MaybeInaccessibleMessage):
         * :class:`telegram.Location`
         * :class:`telegram.PassportData`
         * List[:class:`telegram.PhotoSize`]
+        * :class:`telegram.PaidMediaInfo`
         * :class:`telegram.Poll`
         * :class:`telegram.Sticker`
         * :class:`telegram.Story`
@@ -1385,6 +1400,9 @@ class Message(MaybeInaccessibleMessage):
         .. versionchanged:: 20.0
             :attr:`dice`, :attr:`passport_data` and :attr:`poll` are now also considered to be an
             attachment.
+
+        .. versionchanged:: NEXT.VERSION
+            :attr:`paid_media` is now also considered to be an attachment.
 
         """
         if not isinstance(self._effective_attachment, DefaultValue):

--- a/telegram/_paidmedia.py
+++ b/telegram/_paidmedia.py
@@ -40,7 +40,7 @@ class PaidMedia(TelegramObject):
     * :class:`telegram.PaidMediaVideo`
 
     Objects of this class are comparable in terms of equality. Two objects of this class are
-    considered equal, if their :attr:`type` are equal.
+    considered equal, if their :attr:`type` is equal.
 
     .. versionadded:: NEXT.VERSION
 

--- a/telegram/_paidmedia.py
+++ b/telegram/_paidmedia.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python
+#
+# A library that provides a Python interface to the Telegram Bot API
+# Copyright (C) 2015-2024
+# Leandro Toledo de Souza <devs@python-telegram-bot.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program. If not, see [http://www.gnu.org/licenses/].
+"""This module contains objects that represent paid media in Telegram."""
+
+from typing import TYPE_CHECKING, Dict, Final, Optional, Sequence, Tuple, Type
+
+from telegram import constants
+from telegram._files.photosize import PhotoSize
+from telegram._files.video import Video
+from telegram._telegramobject import TelegramObject
+from telegram._utils import enum
+from telegram._utils.argumentparsing import parse_sequence_arg
+from telegram._utils.types import JSONDict
+
+if TYPE_CHECKING:
+    from telegram import Bot
+
+
+class PaidMedia(TelegramObject):
+    """Describes the paid media added to a message. Currently, it can be one of:
+
+    * :class:`telegram.PaidMediaPreview`
+    * :class:`telegram.PaidMediaPhoto`
+    * :class:`telegram.PaidMediaVideo`
+
+    Objects of this class are comparable in terms of equality. Two objects of this class are
+    considered equal, if their :attr:`type` are equal.
+
+    .. versionadded:: NEXT.VERSION
+
+    Args:
+        type (:obj:`str`): Type of the paid media.
+
+    Attributes:
+        type (:obj:`str`): Type of the paid media.
+    """
+
+    __slots__ = ("type",)
+
+    PREVIEW: Final[str] = constants.PaidMediaType.PREVIEW
+    """:const:`telegram.constants.PaidMediaType.PREVIEW`"""
+    PHOTO: Final[str] = constants.PaidMediaType.PHOTO
+    """:const:`telegram.constants.PaidMediaType.PHOTO`"""
+    VIDEO: Final[str] = constants.PaidMediaType.VIDEO
+    """:const:`telegram.constants.PaidMediaType.VIDEO`"""
+
+    def __init__(
+        self,
+        type: str,  # pylint: disable=redefined-builtin
+        *,
+        api_kwargs: Optional[JSONDict] = None,
+    ) -> None:
+        super().__init__(api_kwargs=api_kwargs)
+        self.type: str = enum.get_member(constants.PaidMediaType, type, type)
+
+        self._id_attrs = (self.type,)
+        self._freeze()
+
+    @classmethod
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["PaidMedia"]:
+        """Converts JSON data to the appropriate :class:`PaidMedia` object, i.e. takes
+        care of selecting the correct subclass.
+
+        Args:
+            data (Dict[:obj:`str`, ...]): The JSON data.
+            bot (:class:`telegram.Bot`, optional): The bot associated with this object.
+
+        Returns:
+            The Telegram object.
+
+        """
+        data = cls._parse_data(data)
+
+        if data is None:
+            return None
+
+        if not data and cls is PaidMedia:
+            return None
+
+        _class_mapping: Dict[str, Type[PaidMedia]] = {
+            cls.PREVIEW: PaidMediaPreview,
+            cls.PHOTO: PaidMediaPhoto,
+            cls.VIDEO: PaidMediaVideo,
+        }
+
+        if cls is PaidMedia and data.get("type") in _class_mapping:
+            return _class_mapping[data.pop("type")].de_json(data=data, bot=bot)
+
+        return super().de_json(data=data, bot=bot)
+
+
+class PaidMediaPreview(PaidMedia):
+    """The paid media isn't available before the payment.
+
+    Objects of this class are comparable in terms of equality. Two objects of this class are
+    considered equal, if their :attr:`width`, :attr:`height`, and :attr:`duration`
+    are equal.
+
+    .. versionadded:: NEXT.VERSION
+
+    Args:
+        type (:obj:`str`): Type of the paid media, always :tg-const:`telegram.PaidMedia.PREVIEW`.
+        width (:obj:`int`, optional): Media width as defined by the sender.
+        height (:obj:`int`, optional): Media height as defined by the sender.
+        duration (:obj:`int`, optional): Duration of the media in seconds as defined by the sender.
+
+    Attributes:
+        type (:obj:`str`): Type of the paid media, always :tg-const:`telegram.PaidMedia.PREVIEW`.
+        width (:obj:`int`): Optional. Media width as defined by the sender.
+        height (:obj:`int`): Optional. Media height as defined by the sender.
+        duration (:obj:`int`): Optional. Duration of the media in seconds as defined by the sender.
+    """
+
+    __slots__ = ("duration", "height", "width")
+
+    def __init__(
+        self,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+        duration: Optional[int] = None,
+        *,
+        api_kwargs: Optional[JSONDict] = None,
+    ) -> None:
+        super().__init__(type=PaidMedia.PREVIEW, api_kwargs=api_kwargs)
+
+        with self._unfrozen():
+            self.width: Optional[int] = width
+            self.height: Optional[int] = height
+            self.duration: Optional[int] = duration
+
+            self._id_attrs = (self.type, self.width, self.height, self.duration)
+
+
+class PaidMediaPhoto(PaidMedia):
+    """
+    The paid media is a photo.
+
+    Objects of this class are comparable in terms of equality. Two objects of this class are
+    considered equal, if their :attr:`photo` are equal.
+
+    .. versionadded:: NEXT.VERSION
+
+    Args:
+        type (:obj:`str`): Type of the paid media, always :tg-const:`telegram.PaidMedia.PHOTO`.
+        photo (Sequence[:class:`telegram.PhotoSize`]): The photo.
+
+    Attributes:
+        type (:obj:`str`): Type of the paid media, always :tg-const:`telegram.PaidMedia.PHOTO`.
+        photo (Tuple[:class:`telegram.PhotoSize`]): The photo.
+    """
+
+    __slots__ = ("photo",)
+
+    def __init__(
+        self,
+        photo: Sequence["PhotoSize"],
+        *,
+        api_kwargs: Optional[JSONDict] = None,
+    ) -> None:
+        super().__init__(type=PaidMedia.PHOTO, api_kwargs=api_kwargs)
+
+        with self._unfrozen():
+            self.photo: Tuple[PhotoSize, ...] = parse_sequence_arg(photo)
+
+            self._id_attrs = (self.type, self.photo)
+
+    @classmethod
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["PaidMediaPhoto"]:
+        data = cls._parse_data(data)
+
+        if not data:
+            return None
+
+        data["photo"] = PhotoSize.de_list(data.get("photo"), bot=bot)
+        return super().de_json(data=data, bot=bot)  # type: ignore[return-value]
+
+
+class PaidMediaVideo(PaidMedia):
+    """
+    The paid media is a video.
+
+    Objects of this class are comparable in terms of equality. Two objects of this class are
+    considered equal, if their :attr:`video` are equal.
+
+    .. versionadded:: NEXT.VERSION
+
+    Args:
+        type (:obj:`str`): Type of the paid media, always :tg-const:`telegram.PaidMedia.VIDEO`.
+        video (:class:`telegram.Video`): The video.
+
+    Attributes:
+        type (:obj:`str`): Type of the paid media, always :tg-const:`telegram.PaidMedia.VIDEO`.
+        video (:class:`telegram.Video`): The video.
+    """
+
+    __slots__ = ("video",)
+
+    def __init__(
+        self,
+        video: Video,
+        *,
+        api_kwargs: Optional[JSONDict] = None,
+    ) -> None:
+        super().__init__(type=PaidMedia.VIDEO, api_kwargs=api_kwargs)
+
+        with self._unfrozen():
+            self.video: Video = video
+
+            self._id_attrs = (self.type, self.video)
+
+    @classmethod
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["PaidMediaVideo"]:
+        data = cls._parse_data(data)
+
+        if not data:
+            return None
+
+        data["video"] = Video.de_json(data.get("video"), bot=bot)
+        return super().de_json(data=data, bot=bot)  # type: ignore[return-value]
+
+
+class PaidMediaInfo(TelegramObject):
+    """
+    Describes the paid media added to a message.
+
+    Objects of this class are comparable in terms of equality. Two objects of this class are
+    considered equal, if their :attr:`star_count` and :attr:`paid_media` are equal.
+
+    .. versionadded:: NEXT.VERSION
+
+    Args:
+        star_count (:obj:`int`): The number of Telegram Stars that must be paid to buy access to
+            the media.
+        paid_media (Sequence[:class:`telegram.PaidMedia`]): Information about the paid media.
+
+    Attributes:
+        star_count (:obj:`int`): The number of Telegram Stars that must be paid to buy access to
+            the media.
+        paid_media (Tuple[:class:`telegram.PaidMedia`]): Information about the paid media.
+    """
+
+    __slots__ = ("paid_media", "star_count")
+
+    def __init__(
+        self,
+        star_count: int,
+        paid_media: Sequence[PaidMedia],
+        *,
+        api_kwargs: Optional[JSONDict] = None,
+    ) -> None:
+        super().__init__(api_kwargs=api_kwargs)
+        self.star_count: int = star_count
+        self.paid_media: Tuple[PaidMedia, ...] = parse_sequence_arg(paid_media)
+
+        self._id_attrs = (self.star_count, self.paid_media)
+        self._freeze()
+
+    @classmethod
+    def de_json(
+        cls, data: Optional[JSONDict], bot: Optional["Bot"] = None
+    ) -> Optional["PaidMediaInfo"]:
+        data = cls._parse_data(data)
+
+        if not data:
+            return None
+
+        data["paid_media"] = PaidMedia.de_list(data.get("paid_media"), bot=bot)
+        return super().de_json(data=data, bot=bot)

--- a/telegram/_reply.py
+++ b/telegram/_reply.py
@@ -37,6 +37,7 @@ from telegram._giveaway import Giveaway, GiveawayWinners
 from telegram._linkpreviewoptions import LinkPreviewOptions
 from telegram._messageentity import MessageEntity
 from telegram._messageorigin import MessageOrigin
+from telegram._paidmedia import PaidMediaInfo
 from telegram._payment.invoice import Invoice
 from telegram._poll import Poll
 from telegram._story import Story
@@ -101,6 +102,10 @@ class ExternalReplyInfo(TelegramObject):
         poll (:class:`telegram.Poll`, optional): Message is a native poll, information about the
             poll.
         venue (:class:`telegram.Venue`, optional): Message is a venue, information about the venue.
+        paid_media (:class:`telegram.PaidMedia`, optional): Message contains paid media;
+            information about the paid media.
+
+            .. versionadded:: NEXT.VERSION
 
     Attributes:
         origin (:class:`telegram.MessageOrigin`): Origin of the message replied to by the given
@@ -144,6 +149,10 @@ class ExternalReplyInfo(TelegramObject):
         poll (:class:`telegram.Poll`): Optional. Message is a native poll, information about the
             poll.
         venue (:class:`telegram.Venue`): Optional. Message is a venue, information about the venue.
+        paid_media (:class:`telegram.PaidMedia`): Optional. Message contains paid media;
+            information about the paid media.
+
+            .. versionadded:: NEXT.VERSION
     """
 
     __slots__ = (
@@ -162,6 +171,7 @@ class ExternalReplyInfo(TelegramObject):
         "location",
         "message_id",
         "origin",
+        "paid_media",
         "photo",
         "poll",
         "sticker",
@@ -197,6 +207,7 @@ class ExternalReplyInfo(TelegramObject):
         location: Optional[Location] = None,
         poll: Optional[Poll] = None,
         venue: Optional[Venue] = None,
+        paid_media: Optional[PaidMediaInfo] = None,
         *,
         api_kwargs: Optional[JSONDict] = None,
     ):
@@ -225,6 +236,7 @@ class ExternalReplyInfo(TelegramObject):
         self.location: Optional[Location] = location
         self.poll: Optional[Poll] = poll
         self.venue: Optional[Venue] = venue
+        self.paid_media: Optional[PaidMediaInfo] = paid_media
 
         self._id_attrs = (self.origin,)
 
@@ -263,6 +275,7 @@ class ExternalReplyInfo(TelegramObject):
         data["location"] = Location.de_json(data.get("location"), bot)
         data["poll"] = Poll.de_json(data.get("poll"), bot)
         data["venue"] = Venue.de_json(data.get("venue"), bot)
+        data["paid_media"] = PaidMediaInfo.de_json(data.get("paid_media"), bot)
 
         return super().de_json(data=data, bot=bot)
 

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -1603,6 +1603,11 @@ class MessageAttachmentType(StringEnum):
     """:obj:`str`: Messages with :attr:`telegram.Message.invoice`."""
     LOCATION = "location"
     """:obj:`str`: Messages with :attr:`telegram.Message.location`."""
+    PAID_MEDIA = "paid_media"
+    """:obj:`str`: Messages with :attr:`telegram.Message.paid_media`.
+
+    .. versionadded:: NEXT.VERSION
+    """
     PASSPORT_DATA = "passport_data"
     """:obj:`str`: Messages with :attr:`telegram.Message.passport_data`."""
     PHOTO = "photo"
@@ -1884,6 +1889,11 @@ class MessageType(StringEnum):
     """:obj:`str`: Messages with :attr:`telegram.Message.new_chat_title`."""
     NEW_CHAT_PHOTO = "new_chat_photo"
     """:obj:`str`: Messages with :attr:`telegram.Message.new_chat_photo`."""
+    PAID_MEDIA = "paid_media"
+    """:obj:`str`: Messages with :attr:`telegram.Message.paid_media`.
+
+    .. versionadded:: NEXT.VERSION
+    """
     PASSPORT_DATA = "passport_data"
     """:obj:`str`: Messages with :attr:`telegram.Message.passport_data`."""
     PHOTO = "photo"

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -82,6 +82,7 @@ __all__ = [
     "MessageLimit",
     "MessageOriginType",
     "MessageType",
+    "PaidMediaType",
     "ParseMode",
     "PollLimit",
     "PollType",
@@ -1949,6 +1950,24 @@ class MessageType(StringEnum):
 
     .. versionadded:: 20.8
     """
+
+
+class PaidMediaType(StringEnum):
+    """
+    This enum contains the available types of :class:`telegram.PaidMedia`. The enum
+    members of this enumeration are instances of :class:`str` and can be treated as such.
+
+    .. versionadded:: NEXT.VERSION
+    """
+
+    __slots__ = ()
+
+    PREVIEW = "preview"
+    """:obj:`str`: The type of :class:`telegram.PaidMediaPreview`."""
+    VIDEO = "video"
+    """:obj:`str`: The type of :class:`telegram.PaidMediaVideo`."""
+    PHOTO = "photo"
+    """:obj:`str`: The type of :class:`telegram.PaidMediaPhoto`."""
 
 
 class PollingLimit(IntEnum):

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -216,6 +216,8 @@ class TestConstantsWithoutRequest:
             name = to_snake_case(match.group(1))
             if name == "photo_size":
                 name = "photo"
+            if name == "paid_media_info":
+                name = "paid_media"
             try:
                 constants.MessageAttachmentType(name)
             except ValueError:

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -46,6 +46,8 @@ from telegram import (
     MessageAutoDeleteTimerChanged,
     MessageEntity,
     MessageOriginChat,
+    PaidMediaInfo,
+    PaidMediaPreview,
     PassportData,
     PhotoSize,
     Poll,
@@ -275,6 +277,7 @@ def message(bot):
         {"chat_background_set": ChatBackground(type=BackgroundTypeChatTheme("ice"))},
         {"effect_id": "123456789"},
         {"show_caption_above_media": True},
+        {"paid_media": PaidMediaInfo(5, [PaidMediaPreview(10, 10, 10)])},
     ],
     ids=[
         "reply",
@@ -346,6 +349,7 @@ def message(bot):
         "chat_background_set",
         "effect_id",
         "show_caption_above_media",
+        "paid_media",
     ],
 )
 def message_params(bot, request):
@@ -1221,6 +1225,7 @@ class TestMessageWithoutRequest(TestMessageBase):
             "game",
             "invoice",
             "location",
+            "paid_media",
             "passport_data",
             "photo",
             "poll",

--- a/tests/test_paidmedia.py
+++ b/tests/test_paidmedia.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python
+#
+# A library that provides a Python interface to the Telegram Bot API
+# Copyright (C) 2015-2024
+# Leandro Toledo de Souza <devs@python-telegram-bot.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program. If not, see [http://www.gnu.org/licenses/].
+
+from copy import deepcopy
+
+import pytest
+
+from telegram import (
+    Dice,
+    PaidMedia,
+    PaidMediaInfo,
+    PaidMediaPhoto,
+    PaidMediaPreview,
+    PaidMediaVideo,
+    PhotoSize,
+    Video,
+)
+from telegram.constants import PaidMediaType
+from tests.auxil.slots import mro_slots
+
+
+@pytest.fixture(
+    scope="module",
+    params=[
+        PaidMedia.PREVIEW,
+        PaidMedia.PHOTO,
+        PaidMedia.VIDEO,
+    ],
+)
+def pm_scope_type(request):
+    return request.param
+
+
+@pytest.fixture(
+    scope="module",
+    params=[
+        PaidMediaPreview,
+        PaidMediaPhoto,
+        PaidMediaVideo,
+    ],
+    ids=[
+        PaidMedia.PREVIEW,
+        PaidMedia.PHOTO,
+        PaidMedia.VIDEO,
+    ],
+)
+def pm_scope_class(request):
+    return request.param
+
+
+@pytest.fixture(
+    scope="module",
+    params=[
+        (
+            PaidMediaPreview,
+            PaidMedia.PREVIEW,
+        ),
+        (
+            PaidMediaPhoto,
+            PaidMedia.PHOTO,
+        ),
+        (
+            PaidMediaVideo,
+            PaidMedia.VIDEO,
+        ),
+    ],
+    ids=[
+        PaidMedia.PREVIEW,
+        PaidMedia.PHOTO,
+        PaidMedia.VIDEO,
+    ],
+)
+def pm_scope_class_and_type(request):
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def paid_media(pm_scope_class_and_type):
+    # We use de_json here so that we don't have to worry about which class gets which arguments
+    return pm_scope_class_and_type[0].de_json(
+        {
+            "type": pm_scope_class_and_type[1],
+            "width": TestPaidMediaBase.width,
+            "height": TestPaidMediaBase.height,
+            "duration": TestPaidMediaBase.duration,
+            "video": TestPaidMediaBase.video.to_dict(),
+            "photo": [p.to_dict() for p in TestPaidMediaBase.photo],
+        },
+        bot=None,
+    )
+
+
+def paid_media_video():
+    return PaidMediaVideo(video=TestPaidMediaBase.video)
+
+
+def paid_media_photo():
+    return PaidMediaPhoto(photo=TestPaidMediaBase.photo)
+
+
+@pytest.fixture(scope="module")
+def paid_media_info():
+    return PaidMediaInfo(
+        star_count=TestPaidMediaInfoBase.star_count,
+        paid_media=[paid_media_video(), paid_media_photo()],
+    )
+
+
+class TestPaidMediaBase:
+    width = 640
+    height = 480
+    duration = 60
+    video = Video(
+        file_id="video_file_id",
+        width=640,
+        height=480,
+        file_unique_id="file_unique_id",
+        duration=60,
+    )
+    photo = (
+        PhotoSize(
+            file_id="photo_file_id",
+            width=640,
+            height=480,
+            file_unique_id="file_unique_id",
+        ),
+    )
+
+
+class TestPaidMediaWithoutRequest(TestPaidMediaBase):
+    def test_slot_behaviour(self, paid_media):
+        inst = paid_media
+        for attr in inst.__slots__:
+            assert getattr(inst, attr, "err") != "err", f"got extra slot '{attr}'"
+        assert len(mro_slots(inst)) == len(set(mro_slots(inst))), "duplicate slot"
+
+    def test_de_json(self, bot, pm_scope_class_and_type):
+        cls = pm_scope_class_and_type[0]
+        type_ = pm_scope_class_and_type[1]
+
+        json_dict = {
+            "type": type_,
+            "width": self.width,
+            "height": self.height,
+            "duration": self.duration,
+            "video": self.video.to_dict(),
+            "photo": [p.to_dict() for p in self.photo],
+        }
+        pm = PaidMedia.de_json(json_dict, bot)
+        assert set(pm.api_kwargs.keys()) == {
+            "width",
+            "height",
+            "duration",
+            "video",
+            "photo",
+        } - set(cls.__slots__)
+
+        assert isinstance(pm, PaidMedia)
+        assert type(pm) is cls
+        assert pm.type == type_
+        if "width" in cls.__slots__:
+            assert pm.width == self.width
+            assert pm.height == self.height
+            assert pm.duration == self.duration
+        if "video" in cls.__slots__:
+            assert pm.video == self.video
+        if "photo" in cls.__slots__:
+            assert pm.photo == self.photo
+
+        assert cls.de_json(None, bot) is None
+        assert PaidMedia.de_json({}, bot) is None
+
+    def test_de_json_invalid_type(self, bot):
+        json_dict = {
+            "type": "invalid",
+            "width": self.width,
+            "height": self.height,
+            "duration": self.duration,
+            "video": self.video.to_dict(),
+            "photo": [p.to_dict() for p in self.photo],
+        }
+        pm = PaidMedia.de_json(json_dict, bot)
+        assert pm.api_kwargs == {
+            "width": self.width,
+            "height": self.height,
+            "duration": self.duration,
+            "video": self.video.to_dict(),
+            "photo": [p.to_dict() for p in self.photo],
+        }
+
+        assert type(pm) is PaidMedia
+        assert pm.type == "invalid"
+
+    def test_de_json_subclass(self, pm_scope_class, bot):
+        """This makes sure that e.g. PaidMediaPreivew(data) never returns a
+        TransactionPartnerPhoto instance."""
+        json_dict = {
+            "type": "invalid",
+            "width": self.width,
+            "height": self.height,
+            "duration": self.duration,
+            "video": self.video.to_dict(),
+            "photo": [p.to_dict() for p in self.photo],
+        }
+        assert type(pm_scope_class.de_json(json_dict, bot)) is pm_scope_class
+
+    def test_to_dict(self, paid_media):
+        pm_dict = paid_media.to_dict()
+
+        assert isinstance(pm_dict, dict)
+        assert pm_dict["type"] == paid_media.type
+        if hasattr(paid_media_info, "width"):
+            assert pm_dict["width"] == paid_media.width
+            assert pm_dict["height"] == paid_media.height
+            assert pm_dict["duration"] == paid_media.duration
+        if hasattr(paid_media_info, "video"):
+            assert pm_dict["video"] == paid_media.video.to_dict()
+        if hasattr(paid_media_info, "photo"):
+            assert pm_dict["photo"] == [p.to_dict() for p in paid_media.photo]
+
+    def test_type_enum_conversion(self):
+        assert type(PaidMedia("video").type) is PaidMediaType
+        assert PaidMedia("unknown").type == "unknown"
+
+    def test_equality(self, paid_media, bot):
+        a = PaidMedia("base_type")
+        b = PaidMedia("base_type")
+        c = paid_media
+        d = deepcopy(paid_media)
+        e = Dice(4, "emoji")
+
+        assert a == b
+        assert hash(a) == hash(b)
+
+        assert a != c
+        assert hash(a) != hash(c)
+
+        assert a != d
+        assert hash(a) != hash(d)
+
+        assert a != e
+        assert hash(a) != hash(e)
+
+        assert c == d
+        assert hash(c) == hash(d)
+
+        assert c != e
+        assert hash(c) != hash(e)
+
+        if hasattr(c, "video"):
+            json_dict = c.to_dict()
+            json_dict["video"] = Video("different", "d2", 1, 1, 1).to_dict()
+            f = c.__class__.de_json(json_dict, bot)
+
+            assert c != f
+            assert hash(c) != hash(f)
+
+        if hasattr(c, "photo"):
+            json_dict = c.to_dict()
+            json_dict["photo"] = [PhotoSize("different", "d2", 1, 1, 1).to_dict()]
+            f = c.__class__.de_json(json_dict, bot)
+
+            assert c != f
+            assert hash(c) != hash(f)
+
+
+class TestPaidMediaInfoBase:
+    star_count = 200
+    paid_media = [paid_media_video(), paid_media_photo()]
+
+
+class TestPaidMediaInfoWithoutRequest(TestPaidMediaInfoBase):
+    def test_slot_behaviour(self, paid_media_info):
+        inst = paid_media_info
+        for attr in inst.__slots__:
+            assert getattr(inst, attr, "err") != "err", f"got extra slot '{attr}'"
+        assert len(mro_slots(inst)) == len(set(mro_slots(inst))), "duplicate slot"
+
+    def test_de_json(self, bot):
+        json_dict = {
+            "star_count": self.star_count,
+            "paid_media": [t.to_dict() for t in self.paid_media],
+        }
+        pmi = PaidMediaInfo.de_json(json_dict, bot)
+        pmi_none = PaidMediaInfo.de_json(None, bot)
+        assert pmi.paid_media == tuple(self.paid_media)
+        assert pmi.star_count == self.star_count
+        assert pmi_none is None
+
+    def test_to_dict(self, paid_media_info):
+        assert paid_media_info.to_dict() == {
+            "star_count": self.star_count,
+            "paid_media": [t.to_dict() for t in self.paid_media],
+        }
+
+    def test_equality(self):
+        pmi1 = PaidMediaInfo(
+            star_count=self.star_count, paid_media=[paid_media_video(), paid_media_photo()]
+        )
+        pmi2 = PaidMediaInfo(
+            star_count=self.star_count, paid_media=[paid_media_video(), paid_media_photo()]
+        )
+        pmi3 = PaidMediaInfo(star_count=100, paid_media=[paid_media_photo()])
+
+        assert pmi1 == pmi2
+        assert hash(pmi1) == hash(pmi2)
+
+        assert pmi1 != pmi3
+        assert hash(pmi1) != hash(pmi3)

--- a/tests/test_reply.py
+++ b/tests/test_reply.py
@@ -29,6 +29,8 @@ from telegram import (
     LinkPreviewOptions,
     MessageEntity,
     MessageOriginUser,
+    PaidMediaInfo,
+    PaidMediaPreview,
     ReplyParameters,
     TextQuote,
     User,
@@ -44,6 +46,7 @@ def external_reply_info():
         message_id=TestExternalReplyInfoBase.message_id,
         link_preview_options=TestExternalReplyInfoBase.link_preview_options,
         giveaway=TestExternalReplyInfoBase.giveaway,
+        paid_media=TestExternalReplyInfoBase.paid_media,
     )
 
 
@@ -59,6 +62,7 @@ class TestExternalReplyInfoBase:
         dtm.datetime.now(dtm.timezone.utc).replace(microsecond=0),
         1,
     )
+    paid_media = PaidMediaInfo(5, [PaidMediaPreview(10, 10, 10)])
 
 
 class TestExternalReplyInfoWithoutRequest(TestExternalReplyInfoBase):
@@ -76,6 +80,7 @@ class TestExternalReplyInfoWithoutRequest(TestExternalReplyInfoBase):
             "message_id": self.message_id,
             "link_preview_options": self.link_preview_options.to_dict(),
             "giveaway": self.giveaway.to_dict(),
+            "paid_media": self.paid_media.to_dict(),
         }
 
         external_reply_info = ExternalReplyInfo.de_json(json_dict, bot)
@@ -86,6 +91,7 @@ class TestExternalReplyInfoWithoutRequest(TestExternalReplyInfoBase):
         assert external_reply_info.message_id == self.message_id
         assert external_reply_info.link_preview_options == self.link_preview_options
         assert external_reply_info.giveaway == self.giveaway
+        assert external_reply_info.paid_media == self.paid_media
 
         assert ExternalReplyInfo.de_json(None, bot) is None
 
@@ -98,6 +104,7 @@ class TestExternalReplyInfoWithoutRequest(TestExternalReplyInfoBase):
         assert ext_reply_info_dict["message_id"] == self.message_id
         assert ext_reply_info_dict["link_preview_options"] == self.link_preview_options.to_dict()
         assert ext_reply_info_dict["giveaway"] == self.giveaway.to_dict()
+        assert ext_reply_info_dict["paid_media"] == self.paid_media.to_dict()
 
     def test_equality(self, external_reply_info):
         a = external_reply_info

--- a/tests/test_stars.py
+++ b/tests/test_stars.py
@@ -361,7 +361,7 @@ class TestTransactionPartnerBase:
     user = transaction_partner_user().user
 
 
-class TestTransactionPartner(TestTransactionPartnerBase):
+class TestTransactionPartnerWithoutRequest(TestTransactionPartnerBase):
     def test_slot_behaviour(self, transaction_partner):
         inst = transaction_partner
         for attr in inst.__slots__:
@@ -421,7 +421,7 @@ class TestTransactionPartner(TestTransactionPartnerBase):
 
         assert isinstance(tp_dict, dict)
         assert tp_dict["type"] == transaction_partner.type
-        if hasattr(transaction_partner, "web_app"):
+        if hasattr(transaction_partner, "user"):
             assert tp_dict["user"] == transaction_partner.user.to_dict()
         if hasattr(transaction_partner, "withdrawal_state"):
             assert tp_dict["withdrawal_state"] == transaction_partner.withdrawal_state.to_dict()
@@ -469,7 +469,7 @@ class TestRevenueWithdrawalStateBase:
     url = "url"
 
 
-class TestRevenueWithdrawalState(TestRevenueWithdrawalStateBase):
+class TestRevenueWithdrawalStateWithoutRequest(TestRevenueWithdrawalStateBase):
     def test_slot_behaviour(self, revenue_withdrawal_state):
         inst = revenue_withdrawal_state
         for attr in inst.__slots__:

--- a/tests/test_stars.py
+++ b/tests/test_stars.py
@@ -244,6 +244,7 @@ class TestStarTransactionWithoutRequest(TestStarTransactionBase):
         }
         st = StarTransaction.de_json(json_dict, bot)
         st_none = StarTransaction.de_json(None, bot)
+        assert st.api_kwargs == {}
         assert st.id == self.id
         assert st.amount == self.amount
         assert st.date == from_timestamp(self.date)
@@ -329,6 +330,7 @@ class TestStarTransactionsWithoutRequest(TestStarTransactionsBase):
         }
         st = StarTransactions.de_json(json_dict, bot)
         st_none = StarTransactions.de_json(None, bot)
+        assert st.api_kwargs == {}
         assert st.transactions == tuple(self.transactions)
         assert st_none is None
 


### PR DESCRIPTION
### Checklist

- [x] Added ``.. versionadded:: NEXT.VERSION``, ``.. versionchanged:: NEXT.VERSION`` or ``.. deprecated:: NEXT.VERSION`` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x]  Created new or adapted existing unit tests
- [ ] Documented code changes according to the `CSI standard <https://standards.mousepawmedia.com/en/stable/csi.html>`__
- [ ] Added myself alphabetically to ``AUTHORS.rst`` (optional)
- [x] Added new classes & modules to the docs and all suitable ``__all__`` s
- [ ] Checked the `Stability Policy <https://docs.python-telegram-bot.org/stability_policy.html>`_ in case of deprecations or changes to documented behavior

**If the PR contains API changes (otherwise, you can ignore this passage)**

- [x] Checked the Bot API specific sections of the [Stability Policy](https://docs.python-telegram-bot.org/stability_policy.html)

- New classes:

   - [x] Added ``self._id_attrs`` and corresponding documentation
   - [x] ``__init__`` accepts ``api_kwargs`` as kw-only

- Added new shortcuts:

   - [ ]  In :class:`~telegram.Chat` & :class:`~telegram.User` for all methods that accept ``chat/user_id``
   - [ ]  In :class:`~telegram.Message` for all methods that accept ``chat_id`` and ``message_id``
   - [ ]  For new :class:`~telegram.Message` shortcuts: Added ``do_quote`` argument if methods accepts ``reply_to_message_id``
   - [ ] In :class:`~telegram.CallbackQuery` for all methods that accept either ``chat_id`` and ``message_id`` or ``inline_message_id``

-  If relevant:

   - [x] Added new constants at :mod:`telegram.constants` and shortcuts to them as class variables
   - [x] Link new and existing constants in docstrings instead of hard-coded numbers and strings
   - [ ]  Add new message types to :attr:`telegram.Message.effective_attachment`
   - [ ] Added new handlers for new update types
   - [ ] Add the handlers to the warning loop in the :class:`~telegram.ext.ConversationHandler`
   - [ ] Added new filters for new message (sub)types
   - [x]  Added or updated documentation for the changed class(es) and/or method(s)
   - [ ] Added the new method(s) to ``_extbot.py``
   - [ ] Added or updated ``bot_methods.rst``
   - [ ] Updated the Bot API version number in all places: ``README.rst`` and ``README_RAW.rst`` (including the badge), as well as ``telegram.constants.BOT_API_VERSION_INFO``
   - [ ] Added logic for arbitrary callback data in :class:`telegram.ext.ExtBot` for new methods that either accept a ``reply_markup`` in some form or have a return type that is/contains :class:`~telegram.Message`
