### PR TITLE
API 7.6 - `paid_media` for `Message` and `ExternalReplyInfo`

### DIFF
--- a/telegram/_message.py
+++ b/telegram/_message.py
@@ -52,6 +52,7 @@ from telegram._inline.inlinekeyboardmarkup import InlineKeyboardMarkup
 from telegram._linkpreviewoptions import LinkPreviewOptions
 from telegram._messageautodeletetimerchanged import MessageAutoDeleteTimerChanged
 from telegram._messageentity import MessageEntity
+from telegram._paidmedia import PaidMediaInfo
 from telegram._passport.passportdata import PassportData
 from telegram._payment.invoice import Invoice
 from telegram._payment.successfulpayment import SuccessfulPayment
@@ -571,6 +572,10 @@ class Message(MaybeInaccessibleMessage):
             background set.
 
             .. versionadded:: 21.2
+        paid_media (:obj:`telegram.PaidMediaInfo`, optional): Message contains paid media;
+            information about the paid media.
+
+            .. versionadded:: NEXT.VERSION
 
     Attributes:
         message_id (:obj:`int`): Unique message identifier inside this chat.
@@ -884,6 +889,10 @@ class Message(MaybeInaccessibleMessage):
             background set
 
             .. versionadded:: 21.2
+        paid_media (:obj:`telegram.PaidMediaInfo`): Optional. Message contains paid media;
+            information about the paid media.
+
+            .. versionadded:: NEXT.VERSION
 
     .. |custom_emoji_no_md1_support| replace:: Since custom emoji entities are not supported by
        :attr:`~telegram.constants.ParseMode.MARKDOWN`, this method now raises a
@@ -950,6 +959,7 @@ class Message(MaybeInaccessibleMessage):
         "new_chat_members",
         "new_chat_photo",
         "new_chat_title",
+        "paid_media",
         "passport_data",
         "photo",
         "pinned_message",
@@ -1067,6 +1077,7 @@ class Message(MaybeInaccessibleMessage):
         chat_background_set: Optional[ChatBackground] = None,
         effect_id: Optional[str] = None,
         show_caption_above_media: Optional[bool] = None,
+        paid_media: Optional[PaidMediaInfo] = None,
         *,
         api_kwargs: Optional[JSONDict] = None,
     ):
@@ -1168,6 +1179,7 @@ class Message(MaybeInaccessibleMessage):
             self.chat_background_set: Optional[ChatBackground] = chat_background_set
             self.effect_id: Optional[str] = effect_id
             self.show_caption_above_media: Optional[bool] = show_caption_above_media
+            self.paid_media: Optional[PaidMediaInfo] = paid_media
 
             self._effective_attachment = DEFAULT_NONE
 
@@ -1283,6 +1295,7 @@ class Message(MaybeInaccessibleMessage):
         data["users_shared"] = UsersShared.de_json(data.get("users_shared"), bot)
         data["chat_shared"] = ChatShared.de_json(data.get("chat_shared"), bot)
         data["chat_background_set"] = ChatBackground.de_json(data.get("chat_background_set"), bot)
+        data["paid_media"] = PaidMediaInfo.de_json(data.get("paid_media"), bot)
 
         # Unfortunately, this needs to be here due to cyclic imports
         from telegram._giveaway import (  # pylint: disable=import-outside-toplevel
@@ -1346,6 +1359,7 @@ class Message(MaybeInaccessibleMessage):
         Location,
         PassportData,
         Sequence[PhotoSize],
+        PaidMediaInfo,
         Poll,
         Sticker,
         Story,
@@ -1369,6 +1383,7 @@ class Message(MaybeInaccessibleMessage):
         * :class:`telegram.Location`
         * :class:`telegram.PassportData`
         * List[:class:`telegram.PhotoSize`]
+        * :class:`telegram.PaidMediaInfo`
         * :class:`telegram.Poll`
         * :class:`telegram.Sticker`
         * :class:`telegram.Story`
@@ -1385,6 +1400,9 @@ class Message(MaybeInaccessibleMessage):
         .. versionchanged:: 20.0
             :attr:`dice`, :attr:`passport_data` and :attr:`poll` are now also considered to be an
             attachment.
+
+        .. versionchanged:: NEXT.VERSION
+            :attr:`paid_media` is now also considered to be an attachment.
 
         """
         if not isinstance(self._effective_attachment, DefaultValue):

--- a/telegram/_reply.py
+++ b/telegram/_reply.py
@@ -37,6 +37,7 @@ from telegram._giveaway import Giveaway, GiveawayWinners
 from telegram._linkpreviewoptions import LinkPreviewOptions
 from telegram._messageentity import MessageEntity
 from telegram._messageorigin import MessageOrigin
+from telegram._paidmedia import PaidMediaInfo
 from telegram._payment.invoice import Invoice
 from telegram._poll import Poll
 from telegram._story import Story
@@ -101,6 +102,10 @@ class ExternalReplyInfo(TelegramObject):
         poll (:class:`telegram.Poll`, optional): Message is a native poll, information about the
             poll.
         venue (:class:`telegram.Venue`, optional): Message is a venue, information about the venue.
+        paid_media (:class:`telegram.PaidMedia`, optional): Message contains paid media;
+            information about the paid media.
+
+            .. versionadded:: NEXT.VERSION
 
     Attributes:
         origin (:class:`telegram.MessageOrigin`): Origin of the message replied to by the given
@@ -144,6 +149,10 @@ class ExternalReplyInfo(TelegramObject):
         poll (:class:`telegram.Poll`): Optional. Message is a native poll, information about the
             poll.
         venue (:class:`telegram.Venue`): Optional. Message is a venue, information about the venue.
+        paid_media (:class:`telegram.PaidMedia`): Optional. Message contains paid media;
+            information about the paid media.
+
+            .. versionadded:: NEXT.VERSION
     """
 
     __slots__ = (
@@ -162,6 +171,7 @@ class ExternalReplyInfo(TelegramObject):
         "location",
         "message_id",
         "origin",
+        "paid_media",
         "photo",
         "poll",
         "sticker",
@@ -197,6 +207,7 @@ class ExternalReplyInfo(TelegramObject):
         location: Optional[Location] = None,
         poll: Optional[Poll] = None,
         venue: Optional[Venue] = None,
+        paid_media: Optional[PaidMediaInfo] = None,
         *,
         api_kwargs: Optional[JSONDict] = None,
     ):
@@ -225,6 +236,7 @@ class ExternalReplyInfo(TelegramObject):
         self.location: Optional[Location] = location
         self.poll: Optional[Poll] = poll
         self.venue: Optional[Venue] = venue
+        self.paid_media: Optional[PaidMediaInfo] = paid_media
 
         self._id_attrs = (self.origin,)
 
@@ -263,6 +275,7 @@ class ExternalReplyInfo(TelegramObject):
         data["location"] = Location.de_json(data.get("location"), bot)
         data["poll"] = Poll.de_json(data.get("poll"), bot)
         data["venue"] = Venue.de_json(data.get("venue"), bot)
+        data["paid_media"] = PaidMediaInfo.de_json(data.get("paid_media"), bot)
 
         return super().de_json(data=data, bot=bot)
 

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -1603,6 +1603,11 @@ class MessageAttachmentType(StringEnum):
     """:obj:`str`: Messages with :attr:`telegram.Message.invoice`."""
     LOCATION = "location"
     """:obj:`str`: Messages with :attr:`telegram.Message.location`."""
+    PAID_MEDIA = "paid_media"
+    """:obj:`str`: Messages with :attr:`telegram.Message.paid_media`.
+
+    .. versionadded:: NEXT.VERSION
+    """
     PASSPORT_DATA = "passport_data"
     """:obj:`str`: Messages with :attr:`telegram.Message.passport_data`."""
     PHOTO = "photo"
@@ -1884,6 +1889,11 @@ class MessageType(StringEnum):
     """:obj:`str`: Messages with :attr:`telegram.Message.new_chat_title`."""
     NEW_CHAT_PHOTO = "new_chat_photo"
     """:obj:`str`: Messages with :attr:`telegram.Message.new_chat_photo`."""
+    PAID_MEDIA = "paid_media"
+    """:obj:`str`: Messages with :attr:`telegram.Message.paid_media`.
+
+    .. versionadded:: NEXT.VERSION
+    """
     PASSPORT_DATA = "passport_data"
     """:obj:`str`: Messages with :attr:`telegram.Message.passport_data`."""
     PHOTO = "photo"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -216,6 +216,8 @@ class TestConstantsWithoutRequest:
             name = to_snake_case(match.group(1))
             if name == "photo_size":
                 name = "photo"
+            if name == "paid_media_info":
+                name = "paid_media"
             try:
                 constants.MessageAttachmentType(name)
             except ValueError:

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -46,6 +46,8 @@ from telegram import (
     MessageAutoDeleteTimerChanged,
     MessageEntity,
     MessageOriginChat,
+    PaidMediaInfo,
+    PaidMediaPreview,
     PassportData,
     PhotoSize,
     Poll,
@@ -275,6 +277,7 @@ def message(bot):
         {"chat_background_set": ChatBackground(type=BackgroundTypeChatTheme("ice"))},
         {"effect_id": "123456789"},
         {"show_caption_above_media": True},
+        {"paid_media": PaidMediaInfo(5, [PaidMediaPreview(10, 10, 10)])},
     ],
     ids=[
         "reply",
@@ -346,6 +349,7 @@ def message(bot):
         "chat_background_set",
         "effect_id",
         "show_caption_above_media",
+        "paid_media",
     ],
 )
 def message_params(bot, request):
@@ -1221,6 +1225,7 @@ class TestMessageWithoutRequest(TestMessageBase):
             "game",
             "invoice",
             "location",
+            "paid_media",
             "passport_data",
             "photo",
             "poll",

--- a/tests/test_reply.py
+++ b/tests/test_reply.py
@@ -29,6 +29,8 @@ from telegram import (
     LinkPreviewOptions,
     MessageEntity,
     MessageOriginUser,
+    PaidMediaInfo,
+    PaidMediaPreview,
     ReplyParameters,
     TextQuote,
     User,
@@ -44,6 +46,7 @@ def external_reply_info():
         message_id=TestExternalReplyInfoBase.message_id,
         link_preview_options=TestExternalReplyInfoBase.link_preview_options,
         giveaway=TestExternalReplyInfoBase.giveaway,
+        paid_media=TestExternalReplyInfoBase.paid_media,
     )
 
 
@@ -59,6 +62,7 @@ class TestExternalReplyInfoBase:
         dtm.datetime.now(dtm.timezone.utc).replace(microsecond=0),
         1,
     )
+    paid_media = PaidMediaInfo(5, [PaidMediaPreview(10, 10, 10)])
 
 
 class TestExternalReplyInfoWithoutRequest(TestExternalReplyInfoBase):
@@ -76,6 +80,7 @@ class TestExternalReplyInfoWithoutRequest(TestExternalReplyInfoBase):
             "message_id": self.message_id,
             "link_preview_options": self.link_preview_options.to_dict(),
             "giveaway": self.giveaway.to_dict(),
+            "paid_media": self.paid_media.to_dict(),
         }
 
         external_reply_info = ExternalReplyInfo.de_json(json_dict, bot)
@@ -86,6 +91,7 @@ class TestExternalReplyInfoWithoutRequest(TestExternalReplyInfoBase):
         assert external_reply_info.message_id == self.message_id
         assert external_reply_info.link_preview_options == self.link_preview_options
         assert external_reply_info.giveaway == self.giveaway
+        assert external_reply_info.paid_media == self.paid_media
 
         assert ExternalReplyInfo.de_json(None, bot) is None
 
@@ -98,6 +104,7 @@ class TestExternalReplyInfoWithoutRequest(TestExternalReplyInfoBase):
         assert ext_reply_info_dict["message_id"] == self.message_id
         assert ext_reply_info_dict["link_preview_options"] == self.link_preview_options.to_dict()
         assert ext_reply_info_dict["giveaway"] == self.giveaway.to_dict()
+        assert ext_reply_info_dict["paid_media"] == self.paid_media.to_dict()
 
     def test_equality(self, external_reply_info):
         a = external_reply_info

--- a/tests/test_stars.py
+++ b/tests/test_stars.py
@@ -244,6 +244,7 @@ class TestStarTransactionWithoutRequest(TestStarTransactionBase):
         }
         st = StarTransaction.de_json(json_dict, bot)
         st_none = StarTransaction.de_json(None, bot)
+        assert st.api_kwargs == {}
         assert st.id == self.id
         assert st.amount == self.amount
         assert st.date == from_timestamp(self.date)
@@ -329,6 +330,7 @@ class TestStarTransactionsWithoutRequest(TestStarTransactionsBase):
         }
         st = StarTransactions.de_json(json_dict, bot)
         st_none = StarTransactions.de_json(None, bot)
+        assert st.api_kwargs == {}
         assert st.transactions == tuple(self.transactions)
         assert st_none is None
 


### PR DESCRIPTION
### Checklist

- [x] Added ``.. versionadded:: NEXT.VERSION``, ``.. versionchanged:: NEXT.VERSION`` or ``.. deprecated:: NEXT.VERSION`` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x]  Created new or adapted existing unit tests
- [ ] Documented code changes according to the `CSI standard <https://standards.mousepawmedia.com/en/stable/csi.html>`__
- [ ] Added myself alphabetically to ``AUTHORS.rst`` (optional)
- [ ] Added new classes & modules to the docs and all suitable ``__all__`` s
- [ ] Checked the `Stability Policy <https://docs.python-telegram-bot.org/stability_policy.html>`_ in case of deprecations or changes to documented behavior

**If the PR contains API changes (otherwise, you can ignore this passage)**

- [x] Checked the Bot API specific sections of the [Stability Policy](https://docs.python-telegram-bot.org/stability_policy.html)

- New classes:

   - [ ] Added ``self._id_attrs`` and corresponding documentation
   - [ ] ``__init__`` accepts ``api_kwargs`` as kw-only

- Added new shortcuts:

   - [ ]  In :class:`~telegram.Chat` & :class:`~telegram.User` for all methods that accept ``chat/user_id``
   - [ ]  In :class:`~telegram.Message` for all methods that accept ``chat_id`` and ``message_id``
   - [ ]  For new :class:`~telegram.Message` shortcuts: Added ``do_quote`` argument if methods accepts ``reply_to_message_id``
   - [ ] In :class:`~telegram.CallbackQuery` for all methods that accept either ``chat_id`` and ``message_id`` or ``inline_message_id``

-  If relevant:

   - [x] Added new constants at :mod:`telegram.constants` and shortcuts to them as class variables
   - [x] Link new and existing constants in docstrings instead of hard-coded numbers and strings
   - [x]  Add new message types to :attr:`telegram.Message.effective_attachment`
   - [ ] Added new handlers for new update types
   - [ ] Add the handlers to the warning loop in the :class:`~telegram.ext.ConversationHandler`
   - [ ] Added new filters for new message (sub)types
   - [x]  Added or updated documentation for the changed class(es) and/or method(s)
   - [ ] Added the new method(s) to ``_extbot.py``
   - [ ] Added or updated ``bot_methods.rst``
   - [ ] Updated the Bot API version number in all places: ``README.rst`` and ``README_RAW.rst`` (including the badge), as well as ``telegram.constants.BOT_API_VERSION_INFO``
   - [ ] Added logic for arbitrary callback data in :class:`telegram.ext.ExtBot` for new methods that either accept a ``reply_markup`` in some form or have a return type that is/contains :class:`~telegram.Message`


