### PR TITLE
API 7.6 - `TransactionPartnerTelegramAds`

### DIFF
--- a/docs/source/telegram.at-tree.rst
+++ b/docs/source/telegram.at-tree.rst
@@ -140,6 +140,7 @@ Available Types
     telegram.transactionpartner
     telegram.transactionpartnerfragment
     telegram.transactionpartnerother
+    telegram.transactionpartnertelegramads
     telegram.transactionpartneruser
     telegram.update
     telegram.user

--- a/docs/source/telegram.transactionpartnertelegramads.rst
+++ b/docs/source/telegram.transactionpartnertelegramads.rst
@@ -1,0 +1,7 @@
+TransactionPartnerTelegramAds
+=============================
+
+.. autoclass:: telegram.TransactionPartnerTelegramAds
+    :members:
+    :show-inheritance:
+    :inherited-members: TelegramObject

--- a/telegram/__init__.py
+++ b/telegram/__init__.py
@@ -223,6 +223,7 @@ __all__ = (
     "TransactionPartner",
     "TransactionPartnerFragment",
     "TransactionPartnerOther",
+    "TransactionPartnerTelegramAds",
     "TransactionPartnerUser",
     "Update",
     "User",
@@ -455,6 +456,7 @@ from ._stars import (
     TransactionPartner,
     TransactionPartnerFragment,
     TransactionPartnerOther,
+    TransactionPartnerTelegramAds,
     TransactionPartnerUser,
 )
 from ._story import Story

--- a/telegram/_stars.py
+++ b/telegram/_stars.py
@@ -183,8 +183,9 @@ class TransactionPartner(TelegramObject):
     """This object describes the source of a transaction, or its recipient for outgoing
     transactions. Currently, it can be one of:
 
-    * :class:`TransactionPartnerFragment`
     * :class:`TransactionPartnerUser`
+    * :class:`TransactionPartnerFragment`
+    * :class:`TransactionPartnerTelegramAds`
     * :class:`TransactionPartnerOther`
 
     Objects of this class are comparable in terms of equality. Two objects of this class are
@@ -207,6 +208,8 @@ class TransactionPartner(TelegramObject):
     """:const:`telegram.constants.TransactionPartnerType.USER`"""
     OTHER: Final[str] = constants.TransactionPartnerType.OTHER
     """:const:`telegram.constants.TransactionPartnerType.OTHER`"""
+    TELEGRAM_ADS: Final[str] = constants.TransactionPartnerType.TELEGRAM_ADS
+    """:const:`telegram.constants.TransactionPartnerType.TELEGRAM_ADS`"""
 
     def __init__(self, type: str, *, api_kwargs: Optional[JSONDict] = None) -> None:
         super().__init__(api_kwargs=api_kwargs)
@@ -242,6 +245,7 @@ class TransactionPartner(TelegramObject):
             cls.FRAGMENT: TransactionPartnerFragment,
             cls.USER: TransactionPartnerUser,
             cls.OTHER: TransactionPartnerOther,
+            cls.TELEGRAM_ADS: TransactionPartnerTelegramAds,
         }
 
         if cls is TransactionPartner and data.get("type") in _class_mapping:
@@ -352,6 +356,23 @@ class TransactionPartnerOther(TransactionPartner):
 
     def __init__(self, *, api_kwargs: Optional[JSONDict] = None) -> None:
         super().__init__(type=TransactionPartner.OTHER, api_kwargs=api_kwargs)
+        self._freeze()
+
+
+class TransactionPartnerTelegramAds(TransactionPartner):
+    """Describes a withdrawal transaction to the Telegram Ads platform.
+
+    .. versionadded:: NEXT.VERSION
+
+    Attributes:
+        type (:obj:`str`): The type of the transaction partner,
+            always :tg-const:`telegram.TransactionPartner.TELEGRAM_ADS`.
+    """
+
+    __slots__ = ()
+
+    def __init__(self, *, api_kwargs: Optional[JSONDict] = None) -> None:
+        super().__init__(type=TransactionPartner.TELEGRAM_ADS, api_kwargs=api_kwargs)
         self._freeze()
 
 

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -2490,6 +2490,8 @@ class TransactionPartnerType(StringEnum):
     """:obj:`str`: Transaction with a user."""
     OTHER = "other"
     """:obj:`str`: Transaction with unknown source or recipient."""
+    TELEGRAM_ADS = "telegram_ads"
+    """:obj:`str`: Transaction with Telegram Ads."""
 
 
 class ParseMode(StringEnum):

--- a/tests/test_stars.py
+++ b/tests/test_stars.py
@@ -33,6 +33,7 @@ from telegram import (
     TransactionPartner,
     TransactionPartnerFragment,
     TransactionPartnerOther,
+    TransactionPartnerTelegramAds,
     TransactionPartnerUser,
     User,
 )
@@ -101,6 +102,7 @@ def star_transactions():
         TransactionPartner.FRAGMENT,
         TransactionPartner.OTHER,
         TransactionPartner.USER,
+        TransactionPartner.TELEGRAM_ADS,
     ],
 )
 def tp_scope_type(request):
@@ -113,11 +115,13 @@ def tp_scope_type(request):
         TransactionPartnerFragment,
         TransactionPartnerOther,
         TransactionPartnerUser,
+        TransactionPartnerTelegramAds,
     ],
     ids=[
         TransactionPartner.FRAGMENT,
         TransactionPartner.OTHER,
         TransactionPartner.USER,
+        TransactionPartner.TELEGRAM_ADS,
     ],
 )
 def tp_scope_class(request):
@@ -130,11 +134,13 @@ def tp_scope_class(request):
         (TransactionPartnerFragment, TransactionPartner.FRAGMENT),
         (TransactionPartnerOther, TransactionPartner.OTHER),
         (TransactionPartnerUser, TransactionPartner.USER),
+        (TransactionPartnerTelegramAds, TransactionPartner.TELEGRAM_ADS),
     ],
     ids=[
         TransactionPartner.FRAGMENT,
         TransactionPartner.OTHER,
         TransactionPartner.USER,
+        TransactionPartner.TELEGRAM_ADS,
     ],
 )
 def tp_scope_class_and_type(request):


### PR DESCRIPTION
### Checklist

- [x] Added ``.. versionadded:: NEXT.VERSION``, ``.. versionchanged:: NEXT.VERSION`` or ``.. deprecated:: NEXT.VERSION`` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x]  Created new or adapted existing unit tests
- [ ] Documented code changes according to the `CSI standard <https://standards.mousepawmedia.com/en/stable/csi.html>`__
- [ ] Added myself alphabetically to ``AUTHORS.rst`` (optional)
- [x] Added new classes & modules to the docs and all suitable ``__all__`` s
- [ ] Checked the `Stability Policy <https://docs.python-telegram-bot.org/stability_policy.html>`_ in case of deprecations or changes to documented behavior

**If the PR contains API changes (otherwise, you can ignore this passage)**

- [x] Checked the Bot API specific sections of the [Stability Policy](https://docs.python-telegram-bot.org/stability_policy.html)

- New classes:

   - [x] Added ``self._id_attrs`` and corresponding documentation
   - [x] ``__init__`` accepts ``api_kwargs`` as kw-only

- Added new shortcuts:

   - [ ]  In :class:`~telegram.Chat` & :class:`~telegram.User` for all methods that accept ``chat/user_id``
   - [ ]  In :class:`~telegram.Message` for all methods that accept ``chat_id`` and ``message_id``
   - [ ]  For new :class:`~telegram.Message` shortcuts: Added ``do_quote`` argument if methods accepts ``reply_to_message_id``
   - [ ] In :class:`~telegram.CallbackQuery` for all methods that accept either ``chat_id`` and ``message_id`` or ``inline_message_id``

-  If relevant:

   - [x] Added new constants at :mod:`telegram.constants` and shortcuts to them as class variables
   - [x] Link new and existing constants in docstrings instead of hard-coded numbers and strings
   - [ ]  Add new message types to :attr:`telegram.Message.effective_attachment`
   - [ ] Added new handlers for new update types
   - [ ] Add the handlers to the warning loop in the :class:`~telegram.ext.ConversationHandler`
   - [ ] Added new filters for new message (sub)types
   - [x]  Added or updated documentation for the changed class(es) and/or method(s)
   - [ ] Added the new method(s) to ``_extbot.py``
   - [ ] Added or updated ``bot_methods.rst``
   - [ ] Updated the Bot API version number in all places: ``README.rst`` and ``README_RAW.rst`` (including the badge), as well as ``telegram.constants.BOT_API_VERSION_INFO``
   - [ ] Added logic for arbitrary callback data in :class:`telegram.ext.ExtBot` for new methods that either accept a ``reply_markup`` in some form or have a return type that is/contains :class:`~telegram.Message`
