### PR TITLE
API 7.6 - `TransactionPartnerUser.invoice_payload`

### DIFF
--- a/telegram/_stars.py
+++ b/telegram/_stars.py
@@ -305,20 +305,29 @@ class TransactionPartnerUser(TransactionPartner):
 
     Args:
         user (:class:`telegram.User`): Information about the user.
+        invoice_payload (:obj:`str`, optional): Bot-specified invoice payload.
 
     Attributes:
         type (:obj:`str`): The type of the transaction partner,
             always :tg-const:`telegram.TransactionPartner.USER`.
         user (:class:`telegram.User`): Information about the user.
+        invoice_payload (:obj:`str`): Optional. Bot-specified invoice payload.
     """
 
-    __slots__ = ("user",)
+    __slots__ = ("invoice_payload", "user")
 
-    def __init__(self, user: "User", *, api_kwargs: Optional[JSONDict] = None) -> None:
+    def __init__(
+        self,
+        user: "User",
+        invoice_payload: Optional[str] = None,
+        *,
+        api_kwargs: Optional[JSONDict] = None,
+    ) -> None:
         super().__init__(type=TransactionPartner.USER, api_kwargs=api_kwargs)
 
         with self._unfrozen():
             self.user: User = user
+            self.invoice_payload: Optional[str] = invoice_payload
             self._id_attrs = (
                 self.type,
                 self.user,

--- a/tests/test_stars.py
+++ b/tests/test_stars.py
@@ -147,6 +147,7 @@ def transaction_partner(tp_scope_class_and_type):
     return tp_scope_class_and_type[0].de_json(
         {
             "type": tp_scope_class_and_type[1],
+            "invoice_payload": TestTransactionPartnerBase.invoice_payload,
             "withdrawal_state": TestTransactionPartnerBase.withdrawal_state.to_dict(),
             "user": TestTransactionPartnerBase.user.to_dict(),
         },
@@ -359,6 +360,7 @@ class TestStarTransactionsWithoutRequest(TestStarTransactionsBase):
 class TestTransactionPartnerBase:
     withdrawal_state = withdrawal_state_succeeded()
     user = transaction_partner_user().user
+    invoice_payload = "payload"
 
 
 class TestTransactionPartner(TestTransactionPartnerBase):
@@ -374,11 +376,14 @@ class TestTransactionPartner(TestTransactionPartnerBase):
 
         json_dict = {
             "type": type_,
+            "invoice_payload": self.invoice_payload,
             "withdrawal_state": self.withdrawal_state.to_dict(),
             "user": self.user.to_dict(),
         }
         tp = TransactionPartner.de_json(json_dict, bot)
-        assert set(tp.api_kwargs.keys()) == {"user", "withdrawal_state"} - set(cls.__slots__)
+        assert set(tp.api_kwargs.keys()) == {"user", "withdrawal_state", "invoice_payload"} - set(
+            cls.__slots__
+        )
 
         assert isinstance(tp, TransactionPartner)
         assert type(tp) is cls
@@ -387,6 +392,7 @@ class TestTransactionPartner(TestTransactionPartnerBase):
             assert tp.withdrawal_state == self.withdrawal_state
         if "user" in cls.__slots__:
             assert tp.user == self.user
+            assert tp.invoice_payload == self.invoice_payload
 
         assert cls.de_json(None, bot) is None
         assert TransactionPartner.de_json({}, bot) is None
@@ -394,6 +400,7 @@ class TestTransactionPartner(TestTransactionPartnerBase):
     def test_de_json_invalid_type(self, bot):
         json_dict = {
             "type": "invalid",
+            "invoice_payload": self.invoice_payload,
             "withdrawal_state": self.withdrawal_state.to_dict(),
             "user": self.user.to_dict(),
         }
@@ -401,6 +408,7 @@ class TestTransactionPartner(TestTransactionPartnerBase):
         assert tp.api_kwargs == {
             "withdrawal_state": self.withdrawal_state.to_dict(),
             "user": self.user.to_dict(),
+            "invoice_payload": self.invoice_payload,
         }
 
         assert type(tp) is TransactionPartner
@@ -411,6 +419,7 @@ class TestTransactionPartner(TestTransactionPartnerBase):
         TransactionPartnerFragment instance."""
         json_dict = {
             "type": "invalid",
+            "invoice_payload": self.invoice_payload,
             "withdrawal_state": self.withdrawal_state.to_dict(),
             "user": self.user.to_dict(),
         }
@@ -421,8 +430,9 @@ class TestTransactionPartner(TestTransactionPartnerBase):
 
         assert isinstance(tp_dict, dict)
         assert tp_dict["type"] == transaction_partner.type
-        if hasattr(transaction_partner, "web_app"):
+        if hasattr(transaction_partner, "user"):
             assert tp_dict["user"] == transaction_partner.user.to_dict()
+            assert tp_dict["invoice_payload"] == transaction_partner.invoice_payload
         if hasattr(transaction_partner, "withdrawal_state"):
             assert tp_dict["withdrawal_state"] == transaction_partner.withdrawal_state.to_dict()
 


### PR DESCRIPTION
### Checklist

- [x] Added ``.. versionadded:: NEXT.VERSION``, ``.. versionchanged:: NEXT.VERSION`` or ``.. deprecated:: NEXT.VERSION`` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x]  Created new or adapted existing unit tests
- [ ] Documented code changes according to the `CSI standard <https://standards.mousepawmedia.com/en/stable/csi.html>`__
- [ ] Added myself alphabetically to ``AUTHORS.rst`` (optional)
- [ ] Added new classes & modules to the docs and all suitable ``__all__`` s
- [ ] Checked the `Stability Policy <https://docs.python-telegram-bot.org/stability_policy.html>`_ in case of deprecations or changes to documented behavior

**If the PR contains API changes (otherwise, you can ignore this passage)**

- [x] Checked the Bot API specific sections of the [Stability Policy](https://docs.python-telegram-bot.org/stability_policy.html)

- New classes:

   - [ ] Added ``self._id_attrs`` and corresponding documentation
   - [ ] ``__init__`` accepts ``api_kwargs`` as kw-only

- Added new shortcuts:

   - [ ]  In :class:`~telegram.Chat` & :class:`~telegram.User` for all methods that accept ``chat/user_id``
   - [ ]  In :class:`~telegram.Message` for all methods that accept ``chat_id`` and ``message_id``
   - [ ]  For new :class:`~telegram.Message` shortcuts: Added ``do_quote`` argument if methods accepts ``reply_to_message_id``
   - [ ] In :class:`~telegram.CallbackQuery` for all methods that accept either ``chat_id`` and ``message_id`` or ``inline_message_id``

-  If relevant:

   - [ ] Added new constants at :mod:`telegram.constants` and shortcuts to them as class variables
   - [ ] Link new and existing constants in docstrings instead of hard-coded numbers and strings
   - [ ]  Add new message types to :attr:`telegram.Message.effective_attachment`
   - [ ] Added new handlers for new update types
   - [ ] Add the handlers to the warning loop in the :class:`~telegram.ext.ConversationHandler`
   - [ ] Added new filters for new message (sub)types
   - [x]  Added or updated documentation for the changed class(es) and/or method(s)
   - [ ] Added the new method(s) to ``_extbot.py``
   - [ ] Added or updated ``bot_methods.rst``
   - [ ] Updated the Bot API version number in all places: ``README.rst`` and ``README_RAW.rst`` (including the badge), as well as ``telegram.constants.BOT_API_VERSION_INFO``
   - [ ] Added logic for arbitrary callback data in :class:`telegram.ext.ExtBot` for new methods that either accept a ``reply_markup`` in some form or have a return type that is/contains :class:`~telegram.Message`


