### PR TITLE
API 7.6 - `ChatFullInfo.can_send_paid_media`

### DIFF
--- a/telegram/_chatfullinfo.py
+++ b/telegram/_chatfullinfo.py
@@ -195,6 +195,10 @@ class ChatFullInfo(_ChatBase):
             chats.
         location (:class:`telegram.ChatLocation`, optional): For supergroups, the location to which
             the supergroup is connected.
+        can_send_paid_media (:obj:`bool`, optional): :obj:`True`, if paid media messages can be
+            sent or forwarded to the channel chat. The field is available only for channel chats.
+
+            .. versionadded:: NEXT.VERSION
 
     Attributes:
         id (:obj:`int`): Unique identifier for this chat.
@@ -345,6 +349,10 @@ class ChatFullInfo(_ChatBase):
             chats.
         location (:class:`telegram.ChatLocation`): Optional. For supergroups, the location to which
             the supergroup is connected.
+        can_send_paid_media (:obj:`bool`): Optional. :obj:`True`, if paid media messages can be
+            sent or forwarded to the channel chat. The field is available only for channel chats.
+
+            .. versionadded:: NEXT.VERSION
 
     .. _accent colors: https://core.telegram.org/bots/api#accent-colors
     .. _topics: https://telegram.org/blog/topics-in-groups-collectible-usernames#topics-in-groups
@@ -360,6 +368,7 @@ class ChatFullInfo(_ChatBase):
         "business_intro",
         "business_location",
         "business_opening_hours",
+        "can_send_paid_media",
         "can_set_sticker_set",
         "custom_emoji_sticker_set_name",
         "description",
@@ -434,6 +443,7 @@ class ChatFullInfo(_ChatBase):
         custom_emoji_sticker_set_name: Optional[str] = None,
         linked_chat_id: Optional[int] = None,
         location: Optional[ChatLocation] = None,
+        can_send_paid_media: Optional[bool] = None,
         *,
         api_kwargs: Optional[JSONDict] = None,
     ):
@@ -496,6 +506,7 @@ class ChatFullInfo(_ChatBase):
             self.business_intro: Optional[BusinessIntro] = business_intro
             self.business_location: Optional[BusinessLocation] = business_location
             self.business_opening_hours: Optional[BusinessOpeningHours] = business_opening_hours
+            self.can_send_paid_media: Optional[bool] = can_send_paid_media
 
     @classmethod
     def de_json(

--- a/tests/test_chatfullinfo.py
+++ b/tests/test_chatfullinfo.py
@@ -55,13 +55,15 @@ def chat_full_info(bot):
         bio=TestChatFullInfoBase.bio,
         linked_chat_id=TestChatFullInfoBase.linked_chat_id,
         location=TestChatFullInfoBase.location,
-        has_private_forwards=True,
-        has_protected_content=True,
-        has_visible_history=True,
-        join_to_send_messages=True,
-        join_by_request=True,
-        has_restricted_voice_and_video_messages=True,
-        is_forum=True,
+        has_private_forwards=TestChatFullInfoBase.has_private_forwards,
+        has_protected_content=TestChatFullInfoBase.has_protected_content,
+        has_visible_history=TestChatFullInfoBase.has_visible_history,
+        join_to_send_messages=TestChatFullInfoBase.join_to_send_messages,
+        join_by_request=TestChatFullInfoBase.join_by_request,
+        has_restricted_voice_and_video_messages=(
+            TestChatFullInfoBase.has_restricted_voice_and_video_messages
+        ),
+        is_forum=TestChatFullInfoBase.is_forum,
         active_usernames=TestChatFullInfoBase.active_usernames,
         emoji_status_custom_emoji_id=TestChatFullInfoBase.emoji_status_custom_emoji_id,
         emoji_status_expiration_date=TestChatFullInfoBase.emoji_status_expiration_date,
@@ -76,10 +78,11 @@ def chat_full_info(bot):
         business_intro=TestChatFullInfoBase.business_intro,
         business_location=TestChatFullInfoBase.business_location,
         business_opening_hours=TestChatFullInfoBase.business_opening_hours,
-        birthdate=Birthdate(1, 1),
+        birthdate=TestChatFullInfoBase.birthdate,
         personal_chat=TestChatFullInfoBase.personal_chat,
-        first_name="first_name",
-        last_name="last_name",
+        first_name=TestChatFullInfoBase.first_name,
+        last_name=TestChatFullInfoBase.last_name,
+        can_send_paid_media=TestChatFullInfoBase.can_send_paid_media,
     )
     chat.set_bot(bot)
     chat._unfreeze()
@@ -136,6 +139,7 @@ class TestChatFullInfoBase:
     personal_chat = Chat(3, "private", "private")
     first_name = "first_name"
     last_name = "last_name"
+    can_send_paid_media = True
 
 
 class TestChatFullInfoWithoutRequest(TestChatFullInfoBase):
@@ -188,6 +192,7 @@ class TestChatFullInfoWithoutRequest(TestChatFullInfoBase):
             "personal_chat": self.personal_chat.to_dict(),
             "first_name": self.first_name,
             "last_name": self.last_name,
+            "can_send_paid_media": self.can_send_paid_media,
         }
         cfi = ChatFullInfo.de_json(json_dict, bot)
         assert cfi.id == self.id_
@@ -232,6 +237,7 @@ class TestChatFullInfoWithoutRequest(TestChatFullInfoBase):
         assert cfi.first_name == self.first_name
         assert cfi.last_name == self.last_name
         assert cfi.max_reaction_count == self.max_reaction_count
+        assert cfi.can_send_paid_media == self.can_send_paid_media
 
     def test_de_json_localization(self, bot, raw_bot, tz_bot):
         json_dict = {
@@ -305,6 +311,7 @@ class TestChatFullInfoWithoutRequest(TestChatFullInfoBase):
         assert cfi_dict["personal_chat"] == cfi.personal_chat.to_dict()
         assert cfi_dict["first_name"] == cfi.first_name
         assert cfi_dict["last_name"] == cfi.last_name
+        assert cfi_dict["can_send_paid_media"] == cfi.can_send_paid_media
 
         assert cfi_dict["max_reaction_count"] == cfi.max_reaction_count
 


### PR DESCRIPTION
### Checklist

- [x] Added ``.. versionadded:: NEXT.VERSION``, ``.. versionchanged:: NEXT.VERSION`` or ``.. deprecated:: NEXT.VERSION`` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x]  Created new or adapted existing unit tests
- [ ] Documented code changes according to the `CSI standard <https://standards.mousepawmedia.com/en/stable/csi.html>`__
- [ ] Added myself alphabetically to ``AUTHORS.rst`` (optional)
- [ ] Added new classes & modules to the docs and all suitable ``__all__`` s
- [ ] Checked the `Stability Policy <https://docs.python-telegram-bot.org/stability_policy.html>`_ in case of deprecations or changes to documented behavior

**If the PR contains API changes (otherwise, you can ignore this passage)**

- [x] Checked the Bot API specific sections of the [Stability Policy](https://docs.python-telegram-bot.org/stability_policy.html)

- New classes:

   - [ ] Added ``self._id_attrs`` and corresponding documentation
   - [ ] ``__init__`` accepts ``api_kwargs`` as kw-only

- Added new shortcuts:

   - [ ]  In :class:`~telegram.Chat` & :class:`~telegram.User` for all methods that accept ``chat/user_id``
   - [ ]  In :class:`~telegram.Message` for all methods that accept ``chat_id`` and ``message_id``
   - [ ]  For new :class:`~telegram.Message` shortcuts: Added ``do_quote`` argument if methods accepts ``reply_to_message_id``
   - [ ] In :class:`~telegram.CallbackQuery` for all methods that accept either ``chat_id`` and ``message_id`` or ``inline_message_id``

-  If relevant:

   - [ ] Added new constants at :mod:`telegram.constants` and shortcuts to them as class variables
   - [ ] Link new and existing constants in docstrings instead of hard-coded numbers and strings
   - [ ]  Add new message types to :attr:`telegram.Message.effective_attachment`
   - [ ] Added new handlers for new update types
   - [ ] Add the handlers to the warning loop in the :class:`~telegram.ext.ConversationHandler`
   - [ ] Added new filters for new message (sub)types
   - [x]  Added or updated documentation for the changed class(es) and/or method(s)
   - [ ] Added the new method(s) to ``_extbot.py``
   - [ ] Added or updated ``bot_methods.rst``
   - [ ] Updated the Bot API version number in all places: ``README.rst`` and ``README_RAW.rst`` (including the badge), as well as ``telegram.constants.BOT_API_VERSION_INFO``
   - [ ] Added logic for arbitrary callback data in :class:`telegram.ext.ExtBot` for new methods that either accept a ``reply_markup`` in some form or have a return type that is/contains :class:`~telegram.Message`


