### PR TITLE
Fix: Expand successfulpayment test

### DIFF
--- a/tests/_payment/test_successfulpayment.py
+++ b/tests/_payment/test_successfulpayment.py
@@ -68,6 +68,7 @@ class TestSuccessfulPaymentWithoutRequest(TestSuccessfulPaymentBase):
         assert successful_payment.invoice_payload == self.invoice_payload
         assert successful_payment.shipping_option_id == self.shipping_option_id
         assert successful_payment.currency == self.currency
+        assert successful_payment.total_amount == self.total_amount
         assert successful_payment.order_info == self.order_info
         assert successful_payment.telegram_payment_charge_id == self.telegram_payment_charge_id
         assert successful_payment.provider_payment_charge_id == self.provider_payment_charge_id
@@ -81,6 +82,7 @@ class TestSuccessfulPaymentWithoutRequest(TestSuccessfulPaymentBase):
             successful_payment_dict["shipping_option_id"] == successful_payment.shipping_option_id
         )
         assert successful_payment_dict["currency"] == successful_payment.currency
+        assert successful_payment_dict["total_amount"] == successful_payment.total_amount
         assert successful_payment_dict["order_info"] == successful_payment.order_info.to_dict()
         assert (
             successful_payment_dict["telegram_payment_charge_id"]


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

I realized the test doesn't test total_amount. So now it does.