### PR TITLE
Improve PyPI Automation

### DIFF
--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -105,10 +105,6 @@ jobs:
         with:
           name: python-package-distributions-and-signatures
           path: dist/
-      - name: Get Tag Name
-        run: |
-          TAG=$(python -c "from telegram import __version__; print(f'v{__version__}')")
-          echo "TAG=$TAG" >> $GITHUB_ENV
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -27,6 +27,12 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
+      - name: Get Tag Name
+        id: get_tag
+        run: |
+          pip install .
+          TAG=$(python -c "from telegram import __version__; print(f'v{__version__}')")
+          echo "TAG=$TAG" >> $GITHUB_OUTPUT
 
   publish-to-pypi:
     name: Publish to PyPI
@@ -81,11 +87,6 @@ jobs:
         with:
           name: python-package-distributions-and-signatures
           path: dist/
-      - name: Get Tag Name
-        id: get_tag
-        run: |
-          TAG=$(python -c "from telegram import __version__; print(f'v{__version__}')")
-          echo "TAG=$TAG" >> $GITHUB_OUTPUT
 
   github-release:
     name: Upload to GitHub Release

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -26,14 +26,14 @@ jobs:
           name: python-package-distributions
           path: dist/
 
-  publish-to-test-pypi:
-    name: Publish to Test PyPI
+  publish-to-pypi:
+    name: Publish to PyPI
     needs:
       - build
     runs-on: ubuntu-latest
     environment:
-      name: release_test_pypi
-      url: https://test.pypi.org/p/python-telegram-bot
+      name: release_pypi
+      url: https://pypi.org/p/python-telegram-bot
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
@@ -43,16 +43,14 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
-      - name: Publish to Test PyPI
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
 
   compute-signatures:
     name: Compute SHA1 Sums and Sign with Sigstore
     runs-on: ubuntu-latest
     needs:
-      - publish-to-test-pypi
+      - publish-to-pypi
 
     permissions:
       id-token: write  # IMPORTANT: mandatory for sigstore
@@ -82,8 +80,8 @@ jobs:
           name: python-package-distributions-and-signatures
           path: dist/
 
-  github-test-release:
-    name: Upload to GitHub Release Draft
+  github-release:
+    name: Upload to GitHub Release
     needs:
       - compute-signatures
 
@@ -101,14 +99,13 @@ jobs:
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        # Create a GitHub Release *draft*. The description can be changed later, as for now
+        # Create a tag and a GitHub Release. The description can be changed later, as for now
         # we don't define it through this workflow.
         run: >-
           gh release create
           '${{ github.ref_name }}'
           --repo '${{ github.repository }}'
           --generate-notes
-          --draft
       - name: Upload artifact signatures to GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -26,14 +26,14 @@ jobs:
           name: python-package-distributions
           path: dist/
 
-  publish-to-pypi:
-    name: Publish to PyPI
+  publish-to-test-pypi:
+    name: Publish to Test PyPI
     needs:
       - build
     runs-on: ubuntu-latest
     environment:
-      name: release_pypi
-      url: https://pypi.org/p/python-telegram-bot
+      name: release_test_pypi
+      url: https://test.pypi.org/p/python-telegram-bot
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
@@ -43,14 +43,16 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
-      - name: Publish to PyPI
+      - name: Publish to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
 
   compute-signatures:
     name: Compute SHA1 Sums and Sign with Sigstore
     runs-on: ubuntu-latest
     needs:
-      - publish-to-pypi
+      - publish-to-test-pypi
 
     permissions:
       id-token: write  # IMPORTANT: mandatory for sigstore
@@ -80,8 +82,8 @@ jobs:
           name: python-package-distributions-and-signatures
           path: dist/
 
-  github-release:
-    name: Upload to GitHub Release
+  github-test-release:
+    name: Upload to GitHub Release Draft
     needs:
       - compute-signatures
 
@@ -99,13 +101,14 @@ jobs:
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        # Create a tag and a GitHub Release. The description can be changed later, as for now
+        # Create a GitHub Release *draft*. The description can be changed later, as for now
         # we don't define it through this workflow.
         run: >-
           gh release create
           '${{ github.ref_name }}'
           --repo '${{ github.repository }}'
           --generate-notes
+          --draft
       - name: Upload artifact signatures to GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -77,7 +77,7 @@ jobs:
               sha1sum $file > $file.sha1
           done
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v2.1.1
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -112,11 +112,12 @@ jobs:
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.build.outputs.TAG }}
         # Create a tag and a GitHub Release. The description can be changed later, as for now
         # we don't define it through this workflow.
         run: >-
           gh release create
-          '$TAG'
+          '${{ env.TAG }}'
           --repo '${{ github.repository }}'
           --generate-notes
       - name: Upload artifact signatures to GitHub Release
@@ -128,5 +129,5 @@ jobs:
         # sigstore-produced signatures and certificates.
         run: >-
           gh release upload
-          '$TAG' dist/**
+          '${{ env.TAG }}' dist/**
           --repo '${{ github.repository }}'

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -96,6 +96,10 @@ jobs:
         with:
           name: python-package-distributions-and-signatures
           path: dist/
+      - name: Get Tag Name
+        run: |
+          TAG=$(python -c "from telegram import __version__; print(f'v{__version__}')")
+          echo "TAG=$TAG" >> $GITHUB_ENV
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -103,7 +107,7 @@ jobs:
         # we don't define it through this workflow.
         run: >-
           gh release create
-          '${{ github.ref_name }}'
+          '$TAG'
           --repo '${{ github.repository }}'
           --generate-notes
       - name: Upload artifact signatures to GitHub Release
@@ -114,5 +118,5 @@ jobs:
         # sigstore-produced signatures and certificates.
         run: >-
           gh release upload
-          '${{ github.ref_name }}' dist/**
+          '$TAG' dist/**
           --repo '${{ github.repository }}'

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -8,6 +8,8 @@ jobs:
   build:
     name: Build Distribution
     runs-on: ubuntu-latest
+    outputs:
+      TAG: ${{ steps.get_tag.outputs.TAG }}
 
     steps:
       - uses: actions/checkout@v4
@@ -79,10 +81,16 @@ jobs:
         with:
           name: python-package-distributions-and-signatures
           path: dist/
+      - name: Get Tag Name
+        id: get_tag
+        run: |
+          TAG=$(python -c "from telegram import __version__; print(f'v{__version__}')")
+          echo "TAG=$TAG" >> $GITHUB_OUTPUT
 
   github-release:
     name: Upload to GitHub Release
     needs:
+      - build
       - compute-signatures
 
     runs-on: ubuntu-latest
@@ -113,6 +121,7 @@ jobs:
       - name: Upload artifact signatures to GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.build.outputs.TAG }}
         # Upload to GitHub Release using the `gh` CLI.
         # `dist/` contains the built packages, and the
         # sigstore-produced signatures and certificates.

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -28,8 +28,6 @@ jobs:
 
   publish-to-pypi:
     name: Publish to PyPI
-    # only publish to PyPI on tag pushes
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     needs:
       - build
     runs-on: ubuntu-latest
@@ -101,7 +99,7 @@ jobs:
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        # Create a GitHub Release for this tag. The description can be changed later, as for now
+        # Create a tag and a GitHub Release. The description can be changed later, as for now
         # we don't define it through this workflow.
         run: >-
           gh release create

--- a/.github/workflows/release_test_pypi.yml
+++ b/.github/workflows/release_test_pypi.yml
@@ -3,6 +3,9 @@ name: Publish to Test PyPI
 on:
   # manually trigger the workflow
   workflow_dispatch:
+  push:
+    branches:
+      - improve-pypi-automation
 
 jobs:
   build:

--- a/.github/workflows/release_test_pypi.yml
+++ b/.github/workflows/release_test_pypi.yml
@@ -86,6 +86,7 @@ jobs:
     name: Upload to GitHub Release Draft
     needs:
       - compute-signatures
+
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/release_test_pypi.yml
+++ b/.github/workflows/release_test_pypi.yml
@@ -113,11 +113,12 @@ jobs:
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.build.outputs.TAG }}
         # Create a GitHub Release *draft*. The description can be changed later, as for now
         # we don't define it through this workflow.
         run: >-
           gh release create
-          '$TAG'
+          '${{ env.TAG }}'
           --repo '${{ github.repository }}'
           --generate-notes
           --draft
@@ -130,5 +131,5 @@ jobs:
         # sigstore-produced signatures and certificates.
         run: >-
           gh release upload
-          '$TAG' dist/**
+          '${{ env.TAG }}' dist/**
           --repo '${{ github.repository }}'

--- a/.github/workflows/release_test_pypi.yml
+++ b/.github/workflows/release_test_pypi.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Get Tag Name
         id: get_tag
         run: |
+          pip install .
           TAG=$(python -c "from telegram import __version__; print(f'v{__version__}')")
           echo "TAG=$TAG" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release_test_pypi.yml
+++ b/.github/workflows/release_test_pypi.yml
@@ -98,6 +98,10 @@ jobs:
         with:
           name: python-package-distributions-and-signatures
           path: dist/
+      - name: Get Tag Name
+        run: |
+          TAG=$(python -c "from telegram import __version__; print(f'v{__version__}')")
+          echo "TAG=$TAG" >> $GITHUB_ENV
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -105,7 +109,7 @@ jobs:
         # we don't define it through this workflow.
         run: >-
           gh release create
-          '${{ github.ref_name }}'
+          '$TAG'
           --repo '${{ github.repository }}'
           --generate-notes
           --draft
@@ -117,5 +121,5 @@ jobs:
         # sigstore-produced signatures and certificates.
         run: >-
           gh release upload
-          '${{ github.ref_name }}' dist/**
+          '$TAG' dist/**
           --repo '${{ github.repository }}'

--- a/.github/workflows/release_test_pypi.yml
+++ b/.github/workflows/release_test_pypi.yml
@@ -79,7 +79,7 @@ jobs:
               sha1sum $file > $file.sha1
           done
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v2.1.1
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/.github/workflows/release_test_pypi.yml
+++ b/.github/workflows/release_test_pypi.yml
@@ -3,9 +3,6 @@ name: Publish to Test PyPI
 on:
   # manually trigger the workflow
   workflow_dispatch:
-  push:
-    branches:
-      - improve-pypi-automation
 
 jobs:
   build:

--- a/.github/workflows/release_test_pypi.yml
+++ b/.github/workflows/release_test_pypi.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPI
+name: Publish to Test PyPI
 
 on:
   # manually trigger the workflow

--- a/.github/workflows/release_test_pypi.yml
+++ b/.github/workflows/release_test_pypi.yml
@@ -11,6 +11,8 @@ jobs:
   build:
     name: Build Distribution
     runs-on: ubuntu-latest
+    outputs:
+      TAG: ${{ steps.get_tag.outputs.TAG }}
 
     steps:
       - uses: actions/checkout@v4
@@ -28,6 +30,11 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
+      - name: Get Tag Name
+        id: get_tag
+        run: |
+          TAG=$(python -c "from telegram import __version__; print(f'v{__version__}')")
+          echo "TAG=$TAG" >> $GITHUB_OUTPUT
 
   publish-to-test-pypi:
     name: Publish to Test PyPI
@@ -88,6 +95,7 @@ jobs:
   github-test-release:
     name: Upload to GitHub Release Draft
     needs:
+      - build
       - compute-signatures
 
     runs-on: ubuntu-latest
@@ -101,10 +109,6 @@ jobs:
         with:
           name: python-package-distributions-and-signatures
           path: dist/
-      - name: Get Tag Name
-        run: |
-          TAG=$(python -c "from telegram import __version__; print(f'v{__version__}')")
-          echo "TAG=$TAG" >> $GITHUB_ENV
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -119,6 +123,7 @@ jobs:
       - name: Upload artifact signatures to GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.build.outputs.TAG }}
         # Upload to GitHub Release using the `gh` CLI.
         # `dist/` contains the built packages, and the
         # sigstore-produced signatures and certificates.

--- a/.github/workflows/release_test_pypi.yml
+++ b/.github/workflows/release_test_pypi.yml
@@ -26,16 +26,14 @@ jobs:
           name: python-package-distributions
           path: dist/
 
-  publish-to-pypi:
-    name: Publish to PyPI
-    # only publish to PyPI on tag pushes
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+  publish-to-test-pypi:
+    name: Publish to Test PyPI
     needs:
       - build
     runs-on: ubuntu-latest
     environment:
-      name: release_pypi
-      url: https://pypi.org/p/python-telegram-bot
+      name: release_test_pypi
+      url: https://test.pypi.org/p/python-telegram-bot
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
@@ -45,14 +43,16 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
-      - name: Publish to PyPI
+      - name: Publish to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
 
   compute-signatures:
     name: Compute SHA1 Sums and Sign with Sigstore
     runs-on: ubuntu-latest
     needs:
-      - publish-to-pypi
+      - publish-to-test-pypi
 
     permissions:
       id-token: write  # IMPORTANT: mandatory for sigstore
@@ -82,11 +82,10 @@ jobs:
           name: python-package-distributions-and-signatures
           path: dist/
 
-  github-release:
-    name: Upload to GitHub Release
+  github-test-release:
+    name: Upload to GitHub Release Draft
     needs:
       - compute-signatures
-
     runs-on: ubuntu-latest
 
     permissions:
@@ -101,13 +100,14 @@ jobs:
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        # Create a GitHub Release for this tag. The description can be changed later, as for now
+        # Create a GitHub Release *draft*. The description can be changed later, as for now
         # we don't define it through this workflow.
         run: >-
           gh release create
           '${{ github.ref_name }}'
           --repo '${{ github.repository }}'
           --generate-notes
+          --draft
       - name: Upload artifact signatures to GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/telegram/_version.py
+++ b/telegram/_version.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 # pylint: disable=missing-module-docstring
+import random
 from typing import Final, NamedTuple
 
 __all__ = ("__version__", "__version_info__")
@@ -51,6 +52,6 @@ class Version(NamedTuple):
 
 
 __version_info__: Final[Version] = Version(
-    major=21, minor=4, micro=0, releaselevel="final", serial=0
+    major=21, minor=4, micro=0, releaselevel="final", serial=random.randint(0, 9999)
 )
 __version__: Final[str] = str(__version_info__)

--- a/telegram/_version.py
+++ b/telegram/_version.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 # pylint: disable=missing-module-docstring
-import random
 from typing import Final, NamedTuple
 
 __all__ = ("__version__", "__version_info__")
@@ -52,6 +51,6 @@ class Version(NamedTuple):
 
 
 __version_info__: Final[Version] = Version(
-    major=21, minor=5, micro=0, releaselevel="alpha", serial=random.randint(0, 9999)
+    major=21, minor=4, micro=0, releaselevel="final", serial=0
 )
 __version__: Final[str] = str(__version_info__)

--- a/telegram/_version.py
+++ b/telegram/_version.py
@@ -52,6 +52,6 @@ class Version(NamedTuple):
 
 
 __version_info__: Final[Version] = Version(
-    major=21, minor=4, micro=0, releaselevel="final", serial=random.randint(0, 9999)
+    major=21, minor=5, micro=0, releaselevel="alpha", serial=random.randint(0, 9999)
 )
 __version__: Final[str] = str(__version_info__)


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->
closes #4373.
workflow triggers based on commit message regex do not seem to be easily possible.

To verify that both workflows are basically the same now, see https://github.com/python-telegram-bot/python-telegram-bot/commit/cbee05dc1d35ccc118fc4cd37373c211aca0a3c5

Todo when merged:

- [ ] update the how-to-release wiki page a bit more
- [x] update the test-pypi project to use the new workflow file name
- [ ] update repo settings to forbid pushes to master also for admins (will no longer be necessary even for tags)
- [x] revert the temporary version and workflow trigger changes
- [x] include #4409
