### PR TITLE
Adapt to RTD Addons

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,3 +1,4 @@
+import os
 import re
 import sys
 from pathlib import Path
@@ -251,7 +252,14 @@ htmlhelp_basename = "python-telegram-bot-doc"
 
 # The base URL which points to the root of the HTML documentation. It is used to indicate the
 # location of document using The Canonical Link Relation. Default: ''.
-html_baseurl = "https://docs.python-telegram-bot.org"
+# Set canonical URL from the Read the Docs Domain
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+html_context = {}
+if os.environ.get("READTHEDOCS", "") == "True":
+    html_context["READTHEDOCS"] = True
+
 
 # -- Options for LaTeX output ---------------------------------------------
 


### PR DESCRIPTION
I received a mail from RT pointing to https://about.readthedocs.com/blog/2024/07/addons-by-default/ and explaining that ptb currenlty relies on `html_baseurl` and that it should be set via

```python
import os

# Set canonical URL from the Read the Docs Domain
html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")

# Tell Jinja2 templates the build is running on Read the Docs
if os.environ.get("READTHEDOCS", "") == "True":
    html_context["READTHEDOCS"] = True
```

This is also explained somewhat in the [current docs](https://docs.readthedocs.io/en/stable/canonical-urls.html#how-to-specify-the-canonical-url)

Additional changes may be needed to adapt to [RTD addons](https://github.com/readthedocs/addons) - in particular they include a native [search as you type](https://github.com/readthedocs/addons?tab=readme-ov-file#search-as-you-type) addon. I'll create a spearate issue for that and link to the furo theme issue tracking the topic.






