### PR TITLE
Remove surplus logging from updater network loop

### DIFF
--- a/telegram/ext/_updater.py
+++ b/telegram/ext/_updater.py
@@ -763,7 +763,6 @@ class Updater(AsyncContextManager["Updater"]):
                 _LOGGER.exception("Invalid token; aborting")
                 raise
             except TelegramError as telegram_exc:
-                _LOGGER.exception("Error while %s:", description)
                 on_err_cb(telegram_exc)
 
                 # increase waiting times on subsequent errors up to 30secs


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

### Background

When there's an `TelegramError` in the `Updater._network_loop_retry` method, the exception is currently both logged and passed to the `on_err_cb`.

Example log:

```txt
2024-08-18 03:11:51.704 ERROR (MainThread) [telegram.ext.Updater] Error while getting Updates: Bad Gateway
2024-08-18 03:11:51.704 ERROR (MainThread) [telegram.ext.Updater] Exception happened while polling for updates.
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/telegram/ext/_updater.py", line 742, in _network_loop_retry
    if not await do_action():
           ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/telegram/ext/_updater.py", line 736, in do_action
    return action_cb_task.result()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/telegram/ext/_updater.py", line 387, in polling_action_cb
    raise exc
  File "/usr/local/lib/python3.12/site-packages/telegram/ext/_updater.py", line 376, in polling_action_cb
    updates = await self.bot.get_updates(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/telegram/_bot.py", line 541, in decorator
    result = await func(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/telegram/_bot.py", line 4177, in get_updates
    await self._post(
  File "/usr/local/lib/python3.12/site-packages/telegram/_bot.py", line 629, in _post
    return await self._do_post(
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/telegram/_bot.py", line 657, in _do_post
    return await request.post(
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/telegram/request/_baserequest.py", line 200, in post
    result = await self._request_wrapper(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/telegram/request/_baserequest.py", line 383, in _request_wrapper
    raise NetworkError(description or "Bad Gateway")
telegram.error.NetworkError: Bad Gateway
```

### Proposed changes

- I'd like to remove the direct logging of the exception (first log line above), since the error callback also handles the exception. The user of the library is then free to handle the exception as wished, potentially without logging. The default error callback will still log the exception (second log line above) if the user doesn't customizes the error callback.