### PR TITLE
Rename Testing Base Classes

### DIFF
--- a/tests/_files/test_animation.py
+++ b/tests/_files/test_animation.py
@@ -51,7 +51,7 @@ async def animation(bot, chat_id):
         ).animation
 
 
-class TestAnimationBase:
+class AnimationTestBase:
     animation_file_id = "CgADAQADngIAAuyVeEez0xRovKi9VAI"
     animation_file_unique_id = "adc3145fd2e84d95b64d68eaa22aa33e"
     width = 320
@@ -66,7 +66,7 @@ class TestAnimationBase:
     caption = "Test *animation*"
 
 
-class TestAnimationWithoutRequest(TestAnimationBase):
+class TestAnimationWithoutRequest(AnimationTestBase):
     def test_slot_behaviour(self, animation):
         for attr in animation.__slots__:
             assert getattr(animation, attr, "err") != "err", f"got extra slot '{attr}'"
@@ -219,7 +219,7 @@ class TestAnimationWithoutRequest(TestAnimationBase):
         )
 
 
-class TestAnimationWithRequest(TestAnimationBase):
+class TestAnimationWithRequest(AnimationTestBase):
     async def test_send_all_args(self, bot, chat_id, animation_file, animation, thumb_file):
         message = await bot.send_animation(
             chat_id,

--- a/tests/_files/test_audio.py
+++ b/tests/_files/test_audio.py
@@ -49,7 +49,7 @@ async def audio(bot, chat_id):
         return (await bot.send_audio(chat_id, audio=f, read_timeout=50, thumbnail=thumb)).audio
 
 
-class TestAudioBase:
+class AudioTestBase:
     caption = "Test *audio*"
     performer = "Leandro Toledo"
     title = "Teste"
@@ -67,7 +67,7 @@ class TestAudioBase:
     audio_file_unique_id = "adc3145fd2e84d95b64d68eaa22aa33e"
 
 
-class TestAudioWithoutRequest(TestAudioBase):
+class TestAudioWithoutRequest(AudioTestBase):
     def test_slot_behaviour(self, audio):
         for attr in audio.__slots__:
             assert getattr(audio, attr, "err") != "err", f"got extra slot '{attr}'"
@@ -222,7 +222,7 @@ class TestAudioWithoutRequest(TestAudioBase):
         await default_bot.send_audio(chat_id, audio, reply_parameters=ReplyParameters(**kwargs))
 
 
-class TestAudioWithRequest(TestAudioBase):
+class TestAudioWithRequest(AudioTestBase):
     async def test_send_all_args(self, bot, chat_id, audio_file, thumb_file):
         message = await bot.send_audio(
             chat_id,

--- a/tests/_files/test_chatphoto.py
+++ b/tests/_files/test_chatphoto.py
@@ -52,7 +52,7 @@ async def chat_photo(bot, super_group_id):
     )
 
 
-class TestChatPhotoBase:
+class ChatPhotoTestBase:
     chatphoto_small_file_id = "smallCgADAQADngIAAuyVeEez0xRovKi9VAI"
     chatphoto_big_file_id = "bigCgADAQADngIAAuyVeEez0xRovKi9VAI"
     chatphoto_small_file_unique_id = "smalladc3145fd2e84d95b64d68eaa22aa33e"
@@ -60,7 +60,7 @@ class TestChatPhotoBase:
     chatphoto_file_url = "https://python-telegram-bot.org/static/testfiles/telegram.jpg"
 
 
-class TestChatPhotoWithoutRequest(TestChatPhotoBase):
+class TestChatPhotoWithoutRequest(ChatPhotoTestBase):
     def test_slot_behaviour(self, chat_photo):
         for attr in chat_photo.__slots__:
             assert getattr(chat_photo, attr, "err") != "err", f"got extra slot '{attr}'"

--- a/tests/_files/test_contact.py
+++ b/tests/_files/test_contact.py
@@ -32,21 +32,21 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def contact():
     return Contact(
-        TestContactBase.phone_number,
-        TestContactBase.first_name,
-        TestContactBase.last_name,
-        TestContactBase.user_id,
+        ContactTestBase.phone_number,
+        ContactTestBase.first_name,
+        ContactTestBase.last_name,
+        ContactTestBase.user_id,
     )
 
 
-class TestContactBase:
+class ContactTestBase:
     phone_number = "+11234567890"
     first_name = "Leandro"
     last_name = "Toledo"
     user_id = 23
 
 
-class TestContactWithoutRequest(TestContactBase):
+class TestContactWithoutRequest(ContactTestBase):
     def test_slot_behaviour(self, contact):
         for attr in contact.__slots__:
             assert getattr(contact, attr, "err") != "err", f"got extra slot '{attr}'"
@@ -156,7 +156,7 @@ class TestContactWithoutRequest(TestContactBase):
         )
 
 
-class TestContactWithRequest(TestContactBase):
+class TestContactWithRequest(ContactTestBase):
     @pytest.mark.parametrize(
         ("default_bot", "custom"),
         [

--- a/tests/_files/test_document.py
+++ b/tests/_files/test_document.py
@@ -49,7 +49,7 @@ async def document(bot, chat_id):
         return (await bot.send_document(chat_id, document=f, read_timeout=50)).document
 
 
-class TestDocumentBase:
+class DocumentTestBase:
     caption = "DocumentTest - *Caption*"
     document_file_url = "https://python-telegram-bot.org/static/testfiles/telegram.gif"
     file_size = 12948
@@ -62,7 +62,7 @@ class TestDocumentBase:
     document_file_unique_id = "adc3145fd2e84d95b64d68eaa22aa33e"
 
 
-class TestDocumentWithoutRequest(TestDocumentBase):
+class TestDocumentWithoutRequest(DocumentTestBase):
     def test_slot_behaviour(self, document):
         for attr in document.__slots__:
             assert getattr(document, attr, "err") != "err", f"got extra slot '{attr}'"
@@ -218,7 +218,7 @@ class TestDocumentWithoutRequest(TestDocumentBase):
         assert await document.get_file()
 
 
-class TestDocumentWithRequest(TestDocumentBase):
+class TestDocumentWithRequest(DocumentTestBase):
     async def test_error_send_empty_file(self, bot, chat_id):
         with Path(os.devnull).open("rb") as f, pytest.raises(TelegramError):
             await bot.send_document(chat_id=chat_id, document=f)

--- a/tests/_files/test_file.py
+++ b/tests/_files/test_file.py
@@ -31,10 +31,10 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def file(bot):
     file = File(
-        TestFileBase.file_id,
-        TestFileBase.file_unique_id,
-        file_path=TestFileBase.file_path,
-        file_size=TestFileBase.file_size,
+        FileTestBase.file_id,
+        FileTestBase.file_unique_id,
+        file_path=FileTestBase.file_path,
+        file_size=FileTestBase.file_size,
     )
     file.set_bot(bot)
     file._unfreeze()
@@ -51,10 +51,10 @@ def encrypted_file(bot):
         "Pt7fKPgYWKA/7a8E64Ea1X8C+Wf7Ky1tF4ANBl63vl4=",
     )
     ef = File(
-        TestFileBase.file_id,
-        TestFileBase.file_unique_id,
-        TestFileBase.file_size,
-        TestFileBase.file_path,
+        FileTestBase.file_id,
+        FileTestBase.file_unique_id,
+        FileTestBase.file_size,
+        FileTestBase.file_path,
     )
     ef.set_bot(bot)
     ef.set_credentials(fc)
@@ -69,9 +69,9 @@ def encrypted_local_file(bot):
         "Pt7fKPgYWKA/7a8E64Ea1X8C+Wf7Ky1tF4ANBl63vl4=",
     )
     ef = File(
-        TestFileBase.file_id,
-        TestFileBase.file_unique_id,
-        TestFileBase.file_size,
+        FileTestBase.file_id,
+        FileTestBase.file_unique_id,
+        FileTestBase.file_size,
         file_path=str(data_file("image_encrypted.jpg")),
     )
     ef.set_bot(bot)
@@ -82,16 +82,16 @@ def encrypted_local_file(bot):
 @pytest.fixture(scope="module")
 def local_file(bot):
     file = File(
-        TestFileBase.file_id,
-        TestFileBase.file_unique_id,
+        FileTestBase.file_id,
+        FileTestBase.file_unique_id,
         file_path=str(data_file("local_file.txt")),
-        file_size=TestFileBase.file_size,
+        file_size=FileTestBase.file_size,
     )
     file.set_bot(bot)
     return file
 
 
-class TestFileBase:
+class FileTestBase:
     file_id = "NOTVALIDDOESNOTMATTER"
     file_unique_id = "adc3145fd2e84d95b64d68eaa22aa33e"
     file_path = (
@@ -101,7 +101,7 @@ class TestFileBase:
     file_content = "Saint-Saëns".encode()  # Intentionally contains unicode chars.
 
 
-class TestFileWithoutRequest(TestFileBase):
+class TestFileWithoutRequest(FileTestBase):
     def test_slot_behaviour(self, file):
         for attr in file.__slots__:
             assert getattr(file, attr, "err") != "err", f"got extra slot '{attr}'"
@@ -273,7 +273,7 @@ class TestFileWithoutRequest(TestFileBase):
         assert buf2[: len(buf)] == buf
 
 
-class TestFileWithRequest(TestFileBase):
+class TestFileWithRequest(FileTestBase):
     async def test_error_get_empty_file_id(self, bot):
         with pytest.raises(TelegramError):
             await bot.get_file(file_id="")

--- a/tests/_files/test_inputmedia.py
+++ b/tests/_files/test_inputmedia.py
@@ -68,94 +68,94 @@ from .test_video import video, video_file  # noqa: F401
 @pytest.fixture(scope="module")
 def input_media_video(class_thumb_file):
     return InputMediaVideo(
-        media=TestInputMediaVideoBase.media,
-        caption=TestInputMediaVideoBase.caption,
-        width=TestInputMediaVideoBase.width,
-        height=TestInputMediaVideoBase.height,
-        duration=TestInputMediaVideoBase.duration,
-        parse_mode=TestInputMediaVideoBase.parse_mode,
-        caption_entities=TestInputMediaVideoBase.caption_entities,
+        media=InputMediaVideoTestBase.media,
+        caption=InputMediaVideoTestBase.caption,
+        width=InputMediaVideoTestBase.width,
+        height=InputMediaVideoTestBase.height,
+        duration=InputMediaVideoTestBase.duration,
+        parse_mode=InputMediaVideoTestBase.parse_mode,
+        caption_entities=InputMediaVideoTestBase.caption_entities,
         thumbnail=class_thumb_file,
-        supports_streaming=TestInputMediaVideoBase.supports_streaming,
-        has_spoiler=TestInputMediaVideoBase.has_spoiler,
-        show_caption_above_media=TestInputMediaVideoBase.show_caption_above_media,
+        supports_streaming=InputMediaVideoTestBase.supports_streaming,
+        has_spoiler=InputMediaVideoTestBase.has_spoiler,
+        show_caption_above_media=InputMediaVideoTestBase.show_caption_above_media,
     )
 
 
 @pytest.fixture(scope="module")
 def input_media_photo():
     return InputMediaPhoto(
-        media=TestInputMediaPhotoBase.media,
-        caption=TestInputMediaPhotoBase.caption,
-        parse_mode=TestInputMediaPhotoBase.parse_mode,
-        caption_entities=TestInputMediaPhotoBase.caption_entities,
-        has_spoiler=TestInputMediaPhotoBase.has_spoiler,
-        show_caption_above_media=TestInputMediaPhotoBase.show_caption_above_media,
+        media=InputMediaPhotoTestBase.media,
+        caption=InputMediaPhotoTestBase.caption,
+        parse_mode=InputMediaPhotoTestBase.parse_mode,
+        caption_entities=InputMediaPhotoTestBase.caption_entities,
+        has_spoiler=InputMediaPhotoTestBase.has_spoiler,
+        show_caption_above_media=InputMediaPhotoTestBase.show_caption_above_media,
     )
 
 
 @pytest.fixture(scope="module")
 def input_media_animation(class_thumb_file):
     return InputMediaAnimation(
-        media=TestInputMediaAnimationBase.media,
-        caption=TestInputMediaAnimationBase.caption,
-        parse_mode=TestInputMediaAnimationBase.parse_mode,
-        caption_entities=TestInputMediaAnimationBase.caption_entities,
-        width=TestInputMediaAnimationBase.width,
-        height=TestInputMediaAnimationBase.height,
+        media=InputMediaAnimationTestBase.media,
+        caption=InputMediaAnimationTestBase.caption,
+        parse_mode=InputMediaAnimationTestBase.parse_mode,
+        caption_entities=InputMediaAnimationTestBase.caption_entities,
+        width=InputMediaAnimationTestBase.width,
+        height=InputMediaAnimationTestBase.height,
         thumbnail=class_thumb_file,
-        duration=TestInputMediaAnimationBase.duration,
-        has_spoiler=TestInputMediaAnimationBase.has_spoiler,
-        show_caption_above_media=TestInputMediaAnimationBase.show_caption_above_media,
+        duration=InputMediaAnimationTestBase.duration,
+        has_spoiler=InputMediaAnimationTestBase.has_spoiler,
+        show_caption_above_media=InputMediaAnimationTestBase.show_caption_above_media,
     )
 
 
 @pytest.fixture(scope="module")
 def input_media_audio(class_thumb_file):
     return InputMediaAudio(
-        media=TestInputMediaAudioBase.media,
-        caption=TestInputMediaAudioBase.caption,
-        duration=TestInputMediaAudioBase.duration,
-        performer=TestInputMediaAudioBase.performer,
-        title=TestInputMediaAudioBase.title,
+        media=InputMediaAudioTestBase.media,
+        caption=InputMediaAudioTestBase.caption,
+        duration=InputMediaAudioTestBase.duration,
+        performer=InputMediaAudioTestBase.performer,
+        title=InputMediaAudioTestBase.title,
         thumbnail=class_thumb_file,
-        parse_mode=TestInputMediaAudioBase.parse_mode,
-        caption_entities=TestInputMediaAudioBase.caption_entities,
+        parse_mode=InputMediaAudioTestBase.parse_mode,
+        caption_entities=InputMediaAudioTestBase.caption_entities,
     )
 
 
 @pytest.fixture(scope="module")
 def input_media_document(class_thumb_file):
     return InputMediaDocument(
-        media=TestInputMediaDocumentBase.media,
-        caption=TestInputMediaDocumentBase.caption,
+        media=InputMediaDocumentTestBase.media,
+        caption=InputMediaDocumentTestBase.caption,
         thumbnail=class_thumb_file,
-        parse_mode=TestInputMediaDocumentBase.parse_mode,
-        caption_entities=TestInputMediaDocumentBase.caption_entities,
-        disable_content_type_detection=TestInputMediaDocumentBase.disable_content_type_detection,
+        parse_mode=InputMediaDocumentTestBase.parse_mode,
+        caption_entities=InputMediaDocumentTestBase.caption_entities,
+        disable_content_type_detection=InputMediaDocumentTestBase.disable_content_type_detection,
     )
 
 
 @pytest.fixture(scope="module")
 def input_paid_media_photo():
     return InputPaidMediaPhoto(
-        media=TestInputMediaPhotoBase.media,
+        media=InputMediaPhotoTestBase.media,
     )
 
 
 @pytest.fixture(scope="module")
 def input_paid_media_video(class_thumb_file):
     return InputPaidMediaVideo(
-        media=TestInputMediaVideoBase.media,
+        media=InputMediaVideoTestBase.media,
         thumbnail=class_thumb_file,
-        width=TestInputMediaVideoBase.width,
-        height=TestInputMediaVideoBase.height,
-        duration=TestInputMediaVideoBase.duration,
-        supports_streaming=TestInputMediaVideoBase.supports_streaming,
+        width=InputMediaVideoTestBase.width,
+        height=InputMediaVideoTestBase.height,
+        duration=InputMediaVideoTestBase.duration,
+        supports_streaming=InputMediaVideoTestBase.supports_streaming,
     )
 
 
-class TestInputMediaVideoBase:
+class InputMediaVideoTestBase:
     type_ = "video"
     media = "NOTAREALFILEID"
     caption = "My Caption"
@@ -169,7 +169,7 @@ class TestInputMediaVideoBase:
     show_caption_above_media = True
 
 
-class TestInputMediaVideoWithoutRequest(TestInputMediaVideoBase):
+class TestInputMediaVideoWithoutRequest(InputMediaVideoTestBase):
     def test_slot_behaviour(self, input_media_video):
         inst = input_media_video
         for attr in inst.__slots__:
@@ -258,7 +258,7 @@ class TestInputMediaVideoWithoutRequest(TestInputMediaVideoBase):
         )
 
 
-class TestInputMediaPhotoBase:
+class InputMediaPhotoTestBase:
     type_ = "photo"
     media = "NOTAREALFILEID"
     caption = "My Caption"
@@ -268,7 +268,7 @@ class TestInputMediaPhotoBase:
     show_caption_above_media = True
 
 
-class TestInputMediaPhotoWithoutRequest(TestInputMediaPhotoBase):
+class TestInputMediaPhotoWithoutRequest(InputMediaPhotoTestBase):
     def test_slot_behaviour(self, input_media_photo):
         inst = input_media_photo
         for attr in inst.__slots__:
@@ -322,7 +322,7 @@ class TestInputMediaPhotoWithoutRequest(TestInputMediaPhotoBase):
         assert input_media_photo.media == data_file("telegram.mp4").as_uri()
 
 
-class TestInputMediaAnimationBase:
+class InputMediaAnimationTestBase:
     type_ = "animation"
     media = "NOTAREALFILEID"
     caption = "My Caption"
@@ -335,7 +335,7 @@ class TestInputMediaAnimationBase:
     show_caption_above_media = True
 
 
-class TestInputMediaAnimationWithoutRequest(TestInputMediaAnimationBase):
+class TestInputMediaAnimationWithoutRequest(InputMediaAnimationTestBase):
     def test_slot_behaviour(self, input_media_animation):
         inst = input_media_animation
         for attr in inst.__slots__:
@@ -396,7 +396,7 @@ class TestInputMediaAnimationWithoutRequest(TestInputMediaAnimationBase):
         assert input_media_animation.thumbnail == data_file("telegram.jpg").as_uri()
 
 
-class TestInputMediaAudioBase:
+class InputMediaAudioTestBase:
     type_ = "audio"
     media = "NOTAREALFILEID"
     caption = "My Caption"
@@ -407,7 +407,7 @@ class TestInputMediaAudioBase:
     caption_entities = [MessageEntity(MessageEntity.BOLD, 0, 2)]
 
 
-class TestInputMediaAudioWithoutRequest(TestInputMediaAudioBase):
+class TestInputMediaAudioWithoutRequest(InputMediaAudioTestBase):
     def test_slot_behaviour(self, input_media_audio):
         inst = input_media_audio
         for attr in inst.__slots__:
@@ -467,7 +467,7 @@ class TestInputMediaAudioWithoutRequest(TestInputMediaAudioBase):
         assert input_media_audio.thumbnail == data_file("telegram.jpg").as_uri()
 
 
-class TestInputMediaDocumentBase:
+class InputMediaDocumentTestBase:
     type_ = "document"
     media = "NOTAREALFILEID"
     caption = "My Caption"
@@ -476,7 +476,7 @@ class TestInputMediaDocumentBase:
     disable_content_type_detection = True
 
 
-class TestInputMediaDocumentWithoutRequest(TestInputMediaDocumentBase):
+class TestInputMediaDocumentWithoutRequest(InputMediaDocumentTestBase):
     def test_slot_behaviour(self, input_media_document):
         inst = input_media_document
         for attr in inst.__slots__:
@@ -535,7 +535,7 @@ class TestInputMediaDocumentWithoutRequest(TestInputMediaDocumentBase):
         assert input_media_document.thumbnail == data_file("telegram.jpg").as_uri()
 
 
-class TestInputPaidMediaPhotoWithoutRequest(TestInputMediaPhotoBase):
+class TestInputPaidMediaPhotoWithoutRequest(InputMediaPhotoTestBase):
     def test_slot_behaviour(self, input_paid_media_photo):
         inst = input_paid_media_photo
         for attr in inst.__slots__:
@@ -568,7 +568,7 @@ class TestInputPaidMediaPhotoWithoutRequest(TestInputMediaPhotoBase):
         assert input_paid_media_photo.media == data_file("telegram.jpg").as_uri()
 
 
-class TestInputPaidMediaVideoWithoutRequest(TestInputMediaVideoBase):
+class TestInputPaidMediaVideoWithoutRequest(InputMediaVideoTestBase):
     def test_slot_behaviour(self, input_paid_media_video):
         inst = input_paid_media_video
         for attr in inst.__slots__:

--- a/tests/_files/test_inputsticker.py
+++ b/tests/_files/test_inputsticker.py
@@ -29,15 +29,15 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def input_sticker():
     return InputSticker(
-        sticker=TestInputStickerBase.sticker,
-        emoji_list=TestInputStickerBase.emoji_list,
-        mask_position=TestInputStickerBase.mask_position,
-        keywords=TestInputStickerBase.keywords,
-        format=TestInputStickerBase.format,
+        sticker=InputStickerTestBase.sticker,
+        emoji_list=InputStickerTestBase.emoji_list,
+        mask_position=InputStickerTestBase.mask_position,
+        keywords=InputStickerTestBase.keywords,
+        format=InputStickerTestBase.format,
     )
 
 
-class TestInputStickerBase:
+class InputStickerTestBase:
     sticker = "fake_file_id"
     emoji_list = ("👍", "👎")
     mask_position = MaskPosition("forehead", 0.5, 0.5, 0.5)
@@ -45,7 +45,7 @@ class TestInputStickerBase:
     format = "static"
 
 
-class TestInputStickerWithoutRequest(TestInputStickerBase):
+class TestInputStickerWithoutRequest(InputStickerTestBase):
     def test_slot_behaviour(self, input_sticker):
         inst = input_sticker
         for attr in inst.__slots__:

--- a/tests/_files/test_location.py
+++ b/tests/_files/test_location.py
@@ -31,16 +31,16 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def location():
     return Location(
-        latitude=TestLocationBase.latitude,
-        longitude=TestLocationBase.longitude,
-        horizontal_accuracy=TestLocationBase.horizontal_accuracy,
-        live_period=TestLocationBase.live_period,
-        heading=TestLocationBase.live_period,
-        proximity_alert_radius=TestLocationBase.proximity_alert_radius,
+        latitude=LocationTestBase.latitude,
+        longitude=LocationTestBase.longitude,
+        horizontal_accuracy=LocationTestBase.horizontal_accuracy,
+        live_period=LocationTestBase.live_period,
+        heading=LocationTestBase.live_period,
+        proximity_alert_radius=LocationTestBase.proximity_alert_radius,
     )
 
 
-class TestLocationBase:
+class LocationTestBase:
     latitude = -23.691288
     longitude = -46.788279
     horizontal_accuracy = 999
@@ -49,7 +49,7 @@ class TestLocationBase:
     proximity_alert_radius = 50
 
 
-class TestLocationWithoutRequest(TestLocationBase):
+class TestLocationWithoutRequest(LocationTestBase):
     def test_slot_behaviour(self, location):
         for attr in location.__slots__:
             assert getattr(location, attr, "err") != "err", f"got extra slot '{attr}'"

--- a/tests/_files/test_photo.py
+++ b/tests/_files/test_photo.py
@@ -65,7 +65,7 @@ def photo(photolist):
     return photolist[-1]
 
 
-class TestPhotoBase:
+class PhotoTestBase:
     width = 800
     height = 800
     caption = "<b>PhotoTest</b> - *Caption*"
@@ -75,7 +75,7 @@ class TestPhotoBase:
     file_size = [29176, 27662]
 
 
-class TestPhotoWithoutRequest(TestPhotoBase):
+class TestPhotoWithoutRequest(PhotoTestBase):
     def test_slot_behaviour(self, photo):
         for attr in photo.__slots__:
             assert getattr(photo, attr, "err") != "err", f"got extra slot '{attr}'"
@@ -237,7 +237,7 @@ class TestPhotoWithoutRequest(TestPhotoBase):
         await default_bot.send_photo(chat_id, photo, reply_parameters=ReplyParameters(**kwargs))
 
 
-class TestPhotoWithRequest(TestPhotoBase):
+class TestPhotoWithRequest(PhotoTestBase):
     async def test_send_photo_all_args(self, bot, chat_id, photo_file):
         message = await bot.send_photo(
             chat_id,

--- a/tests/_files/test_sticker.py
+++ b/tests/_files/test_sticker.py
@@ -61,7 +61,7 @@ async def sticker(bot, chat_id):
         sticker = (await bot.send_sticker(chat_id, sticker=f, read_timeout=50)).sticker
         # necessary to properly test needs_repainting
         with sticker._unfrozen():
-            sticker.needs_repainting = TestStickerBase.needs_repainting
+            sticker.needs_repainting = StickerTestBase.needs_repainting
         return sticker
 
 
@@ -89,7 +89,7 @@ def video_sticker(bot, chat_id):
         return bot.send_sticker(chat_id, sticker=f, timeout=50).sticker
 
 
-class TestStickerBase:
+class StickerTestBase:
     # sticker_file_url = 'https://python-telegram-bot.org/static/testfiles/telegram.webp'
     # Serving sticker from gh since our server sends wrong content_type
     sticker_file_url = (
@@ -116,7 +116,7 @@ class TestStickerBase:
     premium_animation = File("this_is_an_id", "this_is_an_unique_id")
 
 
-class TestStickerWithoutRequest(TestStickerBase):
+class TestStickerWithoutRequest(StickerTestBase):
     def test_slot_behaviour(self, sticker):
         for attr in sticker.__slots__:
             assert getattr(sticker, attr, "err") != "err", f"got extra slot '{attr}'"
@@ -345,7 +345,7 @@ class TestStickerWithoutRequest(TestStickerBase):
         )
 
 
-class TestStickerWithRequest(TestStickerBase):
+class TestStickerWithRequest(StickerTestBase):
     async def test_send_all_args(self, bot, chat_id, sticker_file, sticker):
         message = await bot.send_sticker(
             chat_id, sticker=sticker_file, disable_notification=False, protect_content=True
@@ -572,7 +572,7 @@ def sticker_set_thumb_file():
         yield file
 
 
-class TestStickerSetBase:
+class StickerSetTestBase:
     title = "Test stickers"
     stickers = [Sticker("file_id", "file_un_id", 512, 512, True, True, Sticker.REGULAR)]
     name = "NOTAREALNAME"
@@ -580,7 +580,7 @@ class TestStickerSetBase:
     contains_masks = True
 
 
-class TestStickerSetWithoutRequest(TestStickerSetBase):
+class TestStickerSetWithoutRequest(StickerSetTestBase):
     def test_slot_behaviour(self):
         inst = StickerSet("this", "is", self.stickers, "not")
         for attr in inst.__slots__:
@@ -1064,21 +1064,21 @@ class TestStickerSetWithRequest:
 @pytest.fixture(scope="module")
 def mask_position():
     return MaskPosition(
-        TestMaskPositionBase.point,
-        TestMaskPositionBase.x_shift,
-        TestMaskPositionBase.y_shift,
-        TestMaskPositionBase.scale,
+        MaskPositionTestBase.point,
+        MaskPositionTestBase.x_shift,
+        MaskPositionTestBase.y_shift,
+        MaskPositionTestBase.scale,
     )
 
 
-class TestMaskPositionBase:
+class MaskPositionTestBase:
     point = MaskPosition.EYES
     x_shift = -1
     y_shift = 1
     scale = 2
 
 
-class TestMaskPositionWithoutRequest(TestMaskPositionBase):
+class TestMaskPositionWithoutRequest(MaskPositionTestBase):
     def test_slot_behaviour(self, mask_position):
         inst = mask_position
         for attr in inst.__slots__:
@@ -1130,7 +1130,7 @@ class TestMaskPositionWithoutRequest(TestMaskPositionBase):
         assert hash(a) != hash(e)
 
 
-class TestMaskPositionWithRequest(TestMaskPositionBase):
+class TestMaskPositionWithRequest(MaskPositionTestBase):
     async def test_create_new_mask_sticker_set(self, bot, chat_id, sticker_file, mask_position):
         name = f"masks_by_{bot.username}"
         try:

--- a/tests/_files/test_venue.py
+++ b/tests/_files/test_venue.py
@@ -31,17 +31,17 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def venue():
     return Venue(
-        TestVenueBase.location,
-        TestVenueBase.title,
-        TestVenueBase.address,
-        foursquare_id=TestVenueBase.foursquare_id,
-        foursquare_type=TestVenueBase.foursquare_type,
-        google_place_id=TestVenueBase.google_place_id,
-        google_place_type=TestVenueBase.google_place_type,
+        VenueTestBase.location,
+        VenueTestBase.title,
+        VenueTestBase.address,
+        foursquare_id=VenueTestBase.foursquare_id,
+        foursquare_type=VenueTestBase.foursquare_type,
+        google_place_id=VenueTestBase.google_place_id,
+        google_place_type=VenueTestBase.google_place_type,
     )
 
 
-class TestVenueBase:
+class VenueTestBase:
     location = Location(longitude=-46.788279, latitude=-23.691288)
     title = "title"
     address = "address"
@@ -51,7 +51,7 @@ class TestVenueBase:
     google_place_type = "google place type"
 
 
-class TestVenueWithoutRequest(TestVenueBase):
+class TestVenueWithoutRequest(VenueTestBase):
     def test_slot_behaviour(self, venue):
         for attr in venue.__slots__:
             assert getattr(venue, attr, "err") != "err", f"got extra slot '{attr}'"
@@ -171,7 +171,7 @@ class TestVenueWithoutRequest(TestVenueBase):
         )
 
 
-class TestVenueWithRequest(TestVenueBase):
+class TestVenueWithRequest(VenueTestBase):
     @pytest.mark.parametrize(
         ("default_bot", "custom"),
         [

--- a/tests/_files/test_video.py
+++ b/tests/_files/test_video.py
@@ -49,7 +49,7 @@ async def video(bot, chat_id):
         return (await bot.send_video(chat_id, video=f, read_timeout=50)).video
 
 
-class TestVideoBase:
+class VideoTestBase:
     width = 360
     height = 640
     duration = 5
@@ -66,7 +66,7 @@ class TestVideoBase:
     video_file_unique_id = "adc3145fd2e84d95b64d68eaa22aa33e"
 
 
-class TestVideoWithoutRequest(TestVideoBase):
+class TestVideoWithoutRequest(VideoTestBase):
     def test_slot_behaviour(self, video):
         for attr in video.__slots__:
             assert getattr(video, attr, "err") != "err", f"got extra slot '{attr}'"
@@ -229,7 +229,7 @@ class TestVideoWithoutRequest(TestVideoBase):
         await default_bot.send_video(chat_id, video, reply_parameters=ReplyParameters(**kwargs))
 
 
-class TestVideoWithRequest(TestVideoBase):
+class TestVideoWithRequest(VideoTestBase):
     async def test_send_all_args(self, bot, chat_id, video_file, video, thumb_file):
         message = await bot.send_video(
             chat_id,

--- a/tests/_files/test_videonote.py
+++ b/tests/_files/test_videonote.py
@@ -48,7 +48,7 @@ async def video_note(bot, chat_id):
         return (await bot.send_video_note(chat_id, video_note=f, read_timeout=50)).video_note
 
 
-class TestVideoNoteBase:
+class VideoNoteTestBase:
     length = 240
     duration = 3
     file_size = 132084
@@ -60,7 +60,7 @@ class TestVideoNoteBase:
     videonote_file_unique_id = "adc3145fd2e84d95b64d68eaa22aa33e"
 
 
-class TestVideoNoteWithoutRequest(TestVideoNoteBase):
+class TestVideoNoteWithoutRequest(VideoNoteTestBase):
     def test_slot_behaviour(self, video_note):
         for attr in video_note.__slots__:
             assert getattr(video_note, attr, "err") != "err", f"got extra slot '{attr}'"
@@ -218,7 +218,7 @@ class TestVideoNoteWithoutRequest(TestVideoNoteBase):
         )
 
 
-class TestVideoNoteWithRequest(TestVideoNoteBase):
+class TestVideoNoteWithRequest(VideoNoteTestBase):
     async def test_send_all_args(self, bot, chat_id, video_note_file, video_note, thumb_file):
         message = await bot.send_video_note(
             chat_id,

--- a/tests/_files/test_voice.py
+++ b/tests/_files/test_voice.py
@@ -49,7 +49,7 @@ async def voice(bot, chat_id):
         return (await bot.send_voice(chat_id, voice=f, read_timeout=50)).voice
 
 
-class TestVoiceBase:
+class VoiceTestBase:
     duration = 3
     mime_type = "audio/ogg"
     file_size = 9199
@@ -59,7 +59,7 @@ class TestVoiceBase:
     voice_file_unique_id = "adc3145fd2e84d95b64d68eaa22aa33e"
 
 
-class TestVoiceWithoutRequest(TestVoiceBase):
+class TestVoiceWithoutRequest(VoiceTestBase):
     def test_slot_behaviour(self, voice):
         for attr in voice.__slots__:
             assert getattr(voice, attr, "err") != "err", f"got extra slot '{attr}'"
@@ -203,7 +203,7 @@ class TestVoiceWithoutRequest(TestVoiceBase):
         await default_bot.send_voice(chat_id, voice, reply_parameters=ReplyParameters(**kwargs))
 
 
-class TestVoiceWithRequest(TestVoiceBase):
+class TestVoiceWithRequest(VoiceTestBase):
     async def test_send_all_args(self, bot, chat_id, voice_file, voice):
         message = await bot.send_voice(
             chat_id,

--- a/tests/_games/test_game.py
+++ b/tests/_games/test_game.py
@@ -26,18 +26,18 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def game():
     game = Game(
-        TestGameBase.title,
-        TestGameBase.description,
-        TestGameBase.photo,
-        text=TestGameBase.text,
-        text_entities=TestGameBase.text_entities,
-        animation=TestGameBase.animation,
+        GameTestBase.title,
+        GameTestBase.description,
+        GameTestBase.photo,
+        text=GameTestBase.text,
+        text_entities=GameTestBase.text_entities,
+        animation=GameTestBase.animation,
     )
     game._unfreeze()
     return game
 
 
-class TestGameBase:
+class GameTestBase:
     title = "Python-telegram-bot Test Game"
     description = "description"
     photo = [PhotoSize("Blah", "ElseBlah", 640, 360, file_size=0)]
@@ -49,7 +49,7 @@ class TestGameBase:
     animation = Animation("blah", "unique_id", 320, 180, 1)
 
 
-class TestGameWithoutRequest(TestGameBase):
+class TestGameWithoutRequest(GameTestBase):
     def test_slot_behaviour(self, game):
         for attr in game.__slots__:
             assert getattr(game, attr, "err") != "err", f"got extra slot '{attr}'"

--- a/tests/_games/test_gamehighscore.py
+++ b/tests/_games/test_gamehighscore.py
@@ -26,17 +26,17 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def game_highscore():
     return GameHighScore(
-        TestGameHighScoreBase.position, TestGameHighScoreBase.user, TestGameHighScoreBase.score
+        GameHighScoreTestBase.position, GameHighScoreTestBase.user, GameHighScoreTestBase.score
     )
 
 
-class TestGameHighScoreBase:
+class GameHighScoreTestBase:
     position = 12
     user = User(2, "test user", False)
     score = 42
 
 
-class TestGameHighScoreWithoutRequest(TestGameHighScoreBase):
+class TestGameHighScoreWithoutRequest(GameHighScoreTestBase):
     def test_slot_behaviour(self, game_highscore):
         for attr in game_highscore.__slots__:
             assert getattr(game_highscore, attr, "err") != "err", f"got extra slot '{attr}'"

--- a/tests/_inline/test_inlinekeyboardbutton.py
+++ b/tests/_inline/test_inlinekeyboardbutton.py
@@ -32,24 +32,24 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def inline_keyboard_button():
     return InlineKeyboardButton(
-        TestInlineKeyboardButtonBase.text,
-        url=TestInlineKeyboardButtonBase.url,
-        callback_data=TestInlineKeyboardButtonBase.callback_data,
-        switch_inline_query=TestInlineKeyboardButtonBase.switch_inline_query,
+        InlineKeyboardButtonTestBase.text,
+        url=InlineKeyboardButtonTestBase.url,
+        callback_data=InlineKeyboardButtonTestBase.callback_data,
+        switch_inline_query=InlineKeyboardButtonTestBase.switch_inline_query,
         switch_inline_query_current_chat=(
-            TestInlineKeyboardButtonBase.switch_inline_query_current_chat
+            InlineKeyboardButtonTestBase.switch_inline_query_current_chat
         ),
-        callback_game=TestInlineKeyboardButtonBase.callback_game,
-        pay=TestInlineKeyboardButtonBase.pay,
-        login_url=TestInlineKeyboardButtonBase.login_url,
-        web_app=TestInlineKeyboardButtonBase.web_app,
+        callback_game=InlineKeyboardButtonTestBase.callback_game,
+        pay=InlineKeyboardButtonTestBase.pay,
+        login_url=InlineKeyboardButtonTestBase.login_url,
+        web_app=InlineKeyboardButtonTestBase.web_app,
         switch_inline_query_chosen_chat=(
-            TestInlineKeyboardButtonBase.switch_inline_query_chosen_chat
+            InlineKeyboardButtonTestBase.switch_inline_query_chosen_chat
         ),
     )
 
 
-class TestInlineKeyboardButtonBase:
+class InlineKeyboardButtonTestBase:
     text = "text"
     url = "url"
     callback_data = "callback data"
@@ -62,7 +62,7 @@ class TestInlineKeyboardButtonBase:
     switch_inline_query_chosen_chat = SwitchInlineQueryChosenChat("a_bot", True, False, True, True)
 
 
-class TestInlineKeyboardButtonWithoutRequest(TestInlineKeyboardButtonBase):
+class TestInlineKeyboardButtonWithoutRequest(InlineKeyboardButtonTestBase):
     def test_slot_behaviour(self, inline_keyboard_button):
         inst = inline_keyboard_button
         for attr in inst.__slots__:

--- a/tests/_inline/test_inlinekeyboardmarkup.py
+++ b/tests/_inline/test_inlinekeyboardmarkup.py
@@ -31,10 +31,10 @@ from tests.auxil.slots import mro_slots
 
 @pytest.fixture(scope="module")
 def inline_keyboard_markup():
-    return InlineKeyboardMarkup(TestInlineKeyboardMarkupBase.inline_keyboard)
+    return InlineKeyboardMarkup(InlineKeyboardMarkupTestBase.inline_keyboard)
 
 
-class TestInlineKeyboardMarkupBase:
+class InlineKeyboardMarkupTestBase:
     inline_keyboard = [
         [
             InlineKeyboardButton(text="button1", callback_data="data1"),
@@ -43,7 +43,7 @@ class TestInlineKeyboardMarkupBase:
     ]
 
 
-class TestInlineKeyboardMarkupWithoutRequest(TestInlineKeyboardMarkupBase):
+class TestInlineKeyboardMarkupWithoutRequest(InlineKeyboardMarkupTestBase):
     def test_slot_behaviour(self, inline_keyboard_markup):
         inst = inline_keyboard_markup
         for attr in inst.__slots__:
@@ -228,7 +228,7 @@ class TestInlineKeyboardMarkupWithoutRequest(TestInlineKeyboardMarkupBase):
         await bot.send_message(123, "test", reply_markup=inline_keyboard_markup)
 
 
-class TestInlineKeyborardMarkupWithRequest(TestInlineKeyboardMarkupBase):
+class TestInlineKeyborardMarkupWithRequest(InlineKeyboardMarkupTestBase):
     async def test_send_message_with_inline_keyboard_markup(
         self, bot, chat_id, inline_keyboard_markup
     ):

--- a/tests/_inline/test_inlinequery.py
+++ b/tests/_inline/test_inlinequery.py
@@ -31,17 +31,17 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def inline_query(bot):
     ilq = InlineQuery(
-        TestInlineQueryBase.id_,
-        TestInlineQueryBase.from_user,
-        TestInlineQueryBase.query,
-        TestInlineQueryBase.offset,
-        location=TestInlineQueryBase.location,
+        InlineQueryTestBase.id_,
+        InlineQueryTestBase.from_user,
+        InlineQueryTestBase.query,
+        InlineQueryTestBase.offset,
+        location=InlineQueryTestBase.location,
     )
     ilq.set_bot(bot)
     return ilq
 
 
-class TestInlineQueryBase:
+class InlineQueryTestBase:
     id_ = 1234
     from_user = User(1, "First name", False)
     query = "query text"
@@ -49,7 +49,7 @@ class TestInlineQueryBase:
     location = Location(8.8, 53.1)
 
 
-class TestInlineQueryWithoutRequest(TestInlineQueryBase):
+class TestInlineQueryWithoutRequest(InlineQueryTestBase):
     def test_slot_behaviour(self, inline_query):
         for attr in inline_query.__slots__:
             assert getattr(inline_query, attr, "err") != "err", f"got extra slot '{attr}'"

--- a/tests/_inline/test_inlinequeryresultarticle.py
+++ b/tests/_inline/test_inlinequeryresultarticle.py
@@ -34,20 +34,20 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def inline_query_result_article():
     return InlineQueryResultArticle(
-        TestInlineQueryResultArticleBase.id_,
-        TestInlineQueryResultArticleBase.title,
-        input_message_content=TestInlineQueryResultArticleBase.input_message_content,
-        reply_markup=TestInlineQueryResultArticleBase.reply_markup,
-        url=TestInlineQueryResultArticleBase.url,
-        hide_url=TestInlineQueryResultArticleBase.hide_url,
-        description=TestInlineQueryResultArticleBase.description,
-        thumbnail_url=TestInlineQueryResultArticleBase.thumbnail_url,
-        thumbnail_height=TestInlineQueryResultArticleBase.thumbnail_height,
-        thumbnail_width=TestInlineQueryResultArticleBase.thumbnail_width,
+        InlineQueryResultArticleTestBase.id_,
+        InlineQueryResultArticleTestBase.title,
+        input_message_content=InlineQueryResultArticleTestBase.input_message_content,
+        reply_markup=InlineQueryResultArticleTestBase.reply_markup,
+        url=InlineQueryResultArticleTestBase.url,
+        hide_url=InlineQueryResultArticleTestBase.hide_url,
+        description=InlineQueryResultArticleTestBase.description,
+        thumbnail_url=InlineQueryResultArticleTestBase.thumbnail_url,
+        thumbnail_height=InlineQueryResultArticleTestBase.thumbnail_height,
+        thumbnail_width=InlineQueryResultArticleTestBase.thumbnail_width,
     )
 
 
-class TestInlineQueryResultArticleBase:
+class InlineQueryResultArticleTestBase:
     id_ = "id"
     type_ = "article"
     title = "title"
@@ -61,7 +61,7 @@ class TestInlineQueryResultArticleBase:
     thumbnail_width = 15
 
 
-class TestInlineQueryResultArticleWithoutRequest(TestInlineQueryResultArticleBase):
+class TestInlineQueryResultArticleWithoutRequest(InlineQueryResultArticleTestBase):
     def test_slot_behaviour(self, inline_query_result_article):
         inst = inline_query_result_article
         for attr in inst.__slots__:

--- a/tests/_inline/test_inlinequeryresultaudio.py
+++ b/tests/_inline/test_inlinequeryresultaudio.py
@@ -33,20 +33,20 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def inline_query_result_audio():
     return InlineQueryResultAudio(
-        TestInlineQueryResultAudioBase.id_,
-        TestInlineQueryResultAudioBase.audio_url,
-        TestInlineQueryResultAudioBase.title,
-        performer=TestInlineQueryResultAudioBase.performer,
-        audio_duration=TestInlineQueryResultAudioBase.audio_duration,
-        caption=TestInlineQueryResultAudioBase.caption,
-        parse_mode=TestInlineQueryResultAudioBase.parse_mode,
-        caption_entities=TestInlineQueryResultAudioBase.caption_entities,
-        input_message_content=TestInlineQueryResultAudioBase.input_message_content,
-        reply_markup=TestInlineQueryResultAudioBase.reply_markup,
+        InlineQueryResultAudioTestBase.id_,
+        InlineQueryResultAudioTestBase.audio_url,
+        InlineQueryResultAudioTestBase.title,
+        performer=InlineQueryResultAudioTestBase.performer,
+        audio_duration=InlineQueryResultAudioTestBase.audio_duration,
+        caption=InlineQueryResultAudioTestBase.caption,
+        parse_mode=InlineQueryResultAudioTestBase.parse_mode,
+        caption_entities=InlineQueryResultAudioTestBase.caption_entities,
+        input_message_content=InlineQueryResultAudioTestBase.input_message_content,
+        reply_markup=InlineQueryResultAudioTestBase.reply_markup,
     )
 
 
-class TestInlineQueryResultAudioBase:
+class InlineQueryResultAudioTestBase:
     id_ = "id"
     type_ = "audio"
     audio_url = "audio url"
@@ -60,7 +60,7 @@ class TestInlineQueryResultAudioBase:
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton("reply_markup")]])
 
 
-class TestInlineQueryResultAudioWithoutRequest(TestInlineQueryResultAudioBase):
+class TestInlineQueryResultAudioWithoutRequest(InlineQueryResultAudioTestBase):
     def test_slot_behaviour(self, inline_query_result_audio):
         inst = inline_query_result_audio
         for attr in inst.__slots__:

--- a/tests/_inline/test_inlinequeryresultcachedaudio.py
+++ b/tests/_inline/test_inlinequeryresultcachedaudio.py
@@ -33,17 +33,17 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def inline_query_result_cached_audio():
     return InlineQueryResultCachedAudio(
-        TestInlineQueryResultCachedAudioBase.id_,
-        TestInlineQueryResultCachedAudioBase.audio_file_id,
-        caption=TestInlineQueryResultCachedAudioBase.caption,
-        parse_mode=TestInlineQueryResultCachedAudioBase.parse_mode,
-        caption_entities=TestInlineQueryResultCachedAudioBase.caption_entities,
-        input_message_content=TestInlineQueryResultCachedAudioBase.input_message_content,
-        reply_markup=TestInlineQueryResultCachedAudioBase.reply_markup,
+        InlineQueryResultCachedAudioTestBase.id_,
+        InlineQueryResultCachedAudioTestBase.audio_file_id,
+        caption=InlineQueryResultCachedAudioTestBase.caption,
+        parse_mode=InlineQueryResultCachedAudioTestBase.parse_mode,
+        caption_entities=InlineQueryResultCachedAudioTestBase.caption_entities,
+        input_message_content=InlineQueryResultCachedAudioTestBase.input_message_content,
+        reply_markup=InlineQueryResultCachedAudioTestBase.reply_markup,
     )
 
 
-class TestInlineQueryResultCachedAudioBase:
+class InlineQueryResultCachedAudioTestBase:
     id_ = "id"
     type_ = "audio"
     audio_file_id = "audio file id"
@@ -54,7 +54,7 @@ class TestInlineQueryResultCachedAudioBase:
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton("reply_markup")]])
 
 
-class TestInlineQueryResultCachedAudioWithoutRequest(TestInlineQueryResultCachedAudioBase):
+class TestInlineQueryResultCachedAudioWithoutRequest(InlineQueryResultCachedAudioTestBase):
     def test_slot_behaviour(self, inline_query_result_cached_audio):
         inst = inline_query_result_cached_audio
         for attr in inst.__slots__:

--- a/tests/_inline/test_inlinequeryresultcacheddocument.py
+++ b/tests/_inline/test_inlinequeryresultcacheddocument.py
@@ -33,19 +33,19 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def inline_query_result_cached_document():
     return InlineQueryResultCachedDocument(
-        TestInlineQueryResultCachedDocumentBase.id_,
-        TestInlineQueryResultCachedDocumentBase.title,
-        TestInlineQueryResultCachedDocumentBase.document_file_id,
-        caption=TestInlineQueryResultCachedDocumentBase.caption,
-        parse_mode=TestInlineQueryResultCachedDocumentBase.parse_mode,
-        caption_entities=TestInlineQueryResultCachedDocumentBase.caption_entities,
-        description=TestInlineQueryResultCachedDocumentBase.description,
-        input_message_content=TestInlineQueryResultCachedDocumentBase.input_message_content,
-        reply_markup=TestInlineQueryResultCachedDocumentBase.reply_markup,
+        InlineQueryResultCachedDocumentTestBase.id_,
+        InlineQueryResultCachedDocumentTestBase.title,
+        InlineQueryResultCachedDocumentTestBase.document_file_id,
+        caption=InlineQueryResultCachedDocumentTestBase.caption,
+        parse_mode=InlineQueryResultCachedDocumentTestBase.parse_mode,
+        caption_entities=InlineQueryResultCachedDocumentTestBase.caption_entities,
+        description=InlineQueryResultCachedDocumentTestBase.description,
+        input_message_content=InlineQueryResultCachedDocumentTestBase.input_message_content,
+        reply_markup=InlineQueryResultCachedDocumentTestBase.reply_markup,
     )
 
 
-class TestInlineQueryResultCachedDocumentBase:
+class InlineQueryResultCachedDocumentTestBase:
     id_ = "id"
     type_ = "document"
     document_file_id = "document file id"
@@ -58,7 +58,7 @@ class TestInlineQueryResultCachedDocumentBase:
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton("reply_markup")]])
 
 
-class TestInlineQueryResultCachedDocumentWithoutRequest(TestInlineQueryResultCachedDocumentBase):
+class TestInlineQueryResultCachedDocumentWithoutRequest(InlineQueryResultCachedDocumentTestBase):
     def test_slot_behaviour(self, inline_query_result_cached_document):
         inst = inline_query_result_cached_document
         for attr in inst.__slots__:

--- a/tests/_inline/test_inlinequeryresultcachedgif.py
+++ b/tests/_inline/test_inlinequeryresultcachedgif.py
@@ -32,19 +32,19 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def inline_query_result_cached_gif():
     return InlineQueryResultCachedGif(
-        TestInlineQueryResultCachedGifBase.id_,
-        TestInlineQueryResultCachedGifBase.gif_file_id,
-        title=TestInlineQueryResultCachedGifBase.title,
-        caption=TestInlineQueryResultCachedGifBase.caption,
-        parse_mode=TestInlineQueryResultCachedGifBase.parse_mode,
-        caption_entities=TestInlineQueryResultCachedGifBase.caption_entities,
-        input_message_content=TestInlineQueryResultCachedGifBase.input_message_content,
-        reply_markup=TestInlineQueryResultCachedGifBase.reply_markup,
-        show_caption_above_media=TestInlineQueryResultCachedGifBase.show_caption_above_media,
+        InlineQueryResultCachedGifTestBase.id_,
+        InlineQueryResultCachedGifTestBase.gif_file_id,
+        title=InlineQueryResultCachedGifTestBase.title,
+        caption=InlineQueryResultCachedGifTestBase.caption,
+        parse_mode=InlineQueryResultCachedGifTestBase.parse_mode,
+        caption_entities=InlineQueryResultCachedGifTestBase.caption_entities,
+        input_message_content=InlineQueryResultCachedGifTestBase.input_message_content,
+        reply_markup=InlineQueryResultCachedGifTestBase.reply_markup,
+        show_caption_above_media=InlineQueryResultCachedGifTestBase.show_caption_above_media,
     )
 
 
-class TestInlineQueryResultCachedGifBase:
+class InlineQueryResultCachedGifTestBase:
     id_ = "id"
     type_ = "gif"
     gif_file_id = "gif file id"
@@ -57,7 +57,7 @@ class TestInlineQueryResultCachedGifBase:
     show_caption_above_media = True
 
 
-class TestInlineQueryResultCachedGifWithoutRequest(TestInlineQueryResultCachedGifBase):
+class TestInlineQueryResultCachedGifWithoutRequest(InlineQueryResultCachedGifTestBase):
     def test_slot_behaviour(self, inline_query_result_cached_gif):
         inst = inline_query_result_cached_gif
         for attr in inst.__slots__:

--- a/tests/_inline/test_inlinequeryresultcachedmpeg4gif.py
+++ b/tests/_inline/test_inlinequeryresultcachedmpeg4gif.py
@@ -32,19 +32,19 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def inline_query_result_cached_mpeg4_gif():
     return InlineQueryResultCachedMpeg4Gif(
-        TestInlineQueryResultCachedMpeg4GifBase.id_,
-        TestInlineQueryResultCachedMpeg4GifBase.mpeg4_file_id,
-        title=TestInlineQueryResultCachedMpeg4GifBase.title,
-        caption=TestInlineQueryResultCachedMpeg4GifBase.caption,
-        parse_mode=TestInlineQueryResultCachedMpeg4GifBase.parse_mode,
-        caption_entities=TestInlineQueryResultCachedMpeg4GifBase.caption_entities,
-        input_message_content=TestInlineQueryResultCachedMpeg4GifBase.input_message_content,
-        reply_markup=TestInlineQueryResultCachedMpeg4GifBase.reply_markup,
-        show_caption_above_media=TestInlineQueryResultCachedMpeg4GifBase.show_caption_above_media,
+        InlineQueryResultCachedMpeg4GifTestBase.id_,
+        InlineQueryResultCachedMpeg4GifTestBase.mpeg4_file_id,
+        title=InlineQueryResultCachedMpeg4GifTestBase.title,
+        caption=InlineQueryResultCachedMpeg4GifTestBase.caption,
+        parse_mode=InlineQueryResultCachedMpeg4GifTestBase.parse_mode,
+        caption_entities=InlineQueryResultCachedMpeg4GifTestBase.caption_entities,
+        input_message_content=InlineQueryResultCachedMpeg4GifTestBase.input_message_content,
+        reply_markup=InlineQueryResultCachedMpeg4GifTestBase.reply_markup,
+        show_caption_above_media=InlineQueryResultCachedMpeg4GifTestBase.show_caption_above_media,
     )
 
 
-class TestInlineQueryResultCachedMpeg4GifBase:
+class InlineQueryResultCachedMpeg4GifTestBase:
     id_ = "id"
     type_ = "mpeg4_gif"
     mpeg4_file_id = "mpeg4 file id"
@@ -57,7 +57,7 @@ class TestInlineQueryResultCachedMpeg4GifBase:
     show_caption_above_media = True
 
 
-class TestInlineQueryResultCachedMpeg4GifWithoutRequest(TestInlineQueryResultCachedMpeg4GifBase):
+class TestInlineQueryResultCachedMpeg4GifWithoutRequest(InlineQueryResultCachedMpeg4GifTestBase):
     def test_slot_behaviour(self, inline_query_result_cached_mpeg4_gif):
         inst = inline_query_result_cached_mpeg4_gif
         for attr in inst.__slots__:

--- a/tests/_inline/test_inlinequeryresultcachedphoto.py
+++ b/tests/_inline/test_inlinequeryresultcachedphoto.py
@@ -32,20 +32,20 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def inline_query_result_cached_photo():
     return InlineQueryResultCachedPhoto(
-        TestInlineQueryResultCachedPhotoBase.id_,
-        TestInlineQueryResultCachedPhotoBase.photo_file_id,
-        title=TestInlineQueryResultCachedPhotoBase.title,
-        description=TestInlineQueryResultCachedPhotoBase.description,
-        caption=TestInlineQueryResultCachedPhotoBase.caption,
-        parse_mode=TestInlineQueryResultCachedPhotoBase.parse_mode,
-        caption_entities=TestInlineQueryResultCachedPhotoBase.caption_entities,
-        input_message_content=TestInlineQueryResultCachedPhotoBase.input_message_content,
-        reply_markup=TestInlineQueryResultCachedPhotoBase.reply_markup,
-        show_caption_above_media=TestInlineQueryResultCachedPhotoBase.show_caption_above_media,
+        InlineQueryResultCachedPhotoTestBase.id_,
+        InlineQueryResultCachedPhotoTestBase.photo_file_id,
+        title=InlineQueryResultCachedPhotoTestBase.title,
+        description=InlineQueryResultCachedPhotoTestBase.description,
+        caption=InlineQueryResultCachedPhotoTestBase.caption,
+        parse_mode=InlineQueryResultCachedPhotoTestBase.parse_mode,
+        caption_entities=InlineQueryResultCachedPhotoTestBase.caption_entities,
+        input_message_content=InlineQueryResultCachedPhotoTestBase.input_message_content,
+        reply_markup=InlineQueryResultCachedPhotoTestBase.reply_markup,
+        show_caption_above_media=InlineQueryResultCachedPhotoTestBase.show_caption_above_media,
     )
 
 
-class TestInlineQueryResultCachedPhotoBase:
+class InlineQueryResultCachedPhotoTestBase:
     id_ = "id"
     type_ = "photo"
     photo_file_id = "photo file id"
@@ -59,7 +59,7 @@ class TestInlineQueryResultCachedPhotoBase:
     show_caption_above_media = True
 
 
-class TestInlineQueryResultCachedPhotoWithoutRequest(TestInlineQueryResultCachedPhotoBase):
+class TestInlineQueryResultCachedPhotoWithoutRequest(InlineQueryResultCachedPhotoTestBase):
     def test_slot_behaviour(self, inline_query_result_cached_photo):
         inst = inline_query_result_cached_photo
         for attr in inst.__slots__:

--- a/tests/_inline/test_inlinequeryresultcachedsticker.py
+++ b/tests/_inline/test_inlinequeryresultcachedsticker.py
@@ -31,14 +31,14 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def inline_query_result_cached_sticker():
     return InlineQueryResultCachedSticker(
-        TestInlineQueryResultCachedStickerBase.id_,
-        TestInlineQueryResultCachedStickerBase.sticker_file_id,
-        input_message_content=TestInlineQueryResultCachedStickerBase.input_message_content,
-        reply_markup=TestInlineQueryResultCachedStickerBase.reply_markup,
+        InlineQueryResultCachedStickerTestBase.id_,
+        InlineQueryResultCachedStickerTestBase.sticker_file_id,
+        input_message_content=InlineQueryResultCachedStickerTestBase.input_message_content,
+        reply_markup=InlineQueryResultCachedStickerTestBase.reply_markup,
     )
 
 
-class TestInlineQueryResultCachedStickerBase:
+class InlineQueryResultCachedStickerTestBase:
     id_ = "id"
     type_ = "sticker"
     sticker_file_id = "sticker file id"
@@ -46,7 +46,7 @@ class TestInlineQueryResultCachedStickerBase:
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton("reply_markup")]])
 
 
-class TestInlineQueryResultCachedStickerWithoutRequest(TestInlineQueryResultCachedStickerBase):
+class TestInlineQueryResultCachedStickerWithoutRequest(InlineQueryResultCachedStickerTestBase):
     def test_slot_behaviour(self, inline_query_result_cached_sticker):
         inst = inline_query_result_cached_sticker
         for attr in inst.__slots__:

--- a/tests/_inline/test_inlinequeryresultcachedvideo.py
+++ b/tests/_inline/test_inlinequeryresultcachedvideo.py
@@ -32,20 +32,20 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def inline_query_result_cached_video():
     return InlineQueryResultCachedVideo(
-        TestInlineQueryResultCachedVideoBase.id_,
-        TestInlineQueryResultCachedVideoBase.video_file_id,
-        TestInlineQueryResultCachedVideoBase.title,
-        caption=TestInlineQueryResultCachedVideoBase.caption,
-        parse_mode=TestInlineQueryResultCachedVideoBase.parse_mode,
-        caption_entities=TestInlineQueryResultCachedVideoBase.caption_entities,
-        description=TestInlineQueryResultCachedVideoBase.description,
-        input_message_content=TestInlineQueryResultCachedVideoBase.input_message_content,
-        reply_markup=TestInlineQueryResultCachedVideoBase.reply_markup,
-        show_caption_above_media=TestInlineQueryResultCachedVideoBase.show_caption_above_media,
+        InlineQueryResultCachedVideoTestBase.id_,
+        InlineQueryResultCachedVideoTestBase.video_file_id,
+        InlineQueryResultCachedVideoTestBase.title,
+        caption=InlineQueryResultCachedVideoTestBase.caption,
+        parse_mode=InlineQueryResultCachedVideoTestBase.parse_mode,
+        caption_entities=InlineQueryResultCachedVideoTestBase.caption_entities,
+        description=InlineQueryResultCachedVideoTestBase.description,
+        input_message_content=InlineQueryResultCachedVideoTestBase.input_message_content,
+        reply_markup=InlineQueryResultCachedVideoTestBase.reply_markup,
+        show_caption_above_media=InlineQueryResultCachedVideoTestBase.show_caption_above_media,
     )
 
 
-class TestInlineQueryResultCachedVideoBase:
+class InlineQueryResultCachedVideoTestBase:
     id_ = "id"
     type_ = "video"
     video_file_id = "video file id"
@@ -59,7 +59,7 @@ class TestInlineQueryResultCachedVideoBase:
     show_caption_above_media = True
 
 
-class TestInlineQueryResultCachedVideoWithoutRequest(TestInlineQueryResultCachedVideoBase):
+class TestInlineQueryResultCachedVideoWithoutRequest(InlineQueryResultCachedVideoTestBase):
     def test_slot_behaviour(self, inline_query_result_cached_video):
         inst = inline_query_result_cached_video
         for attr in inst.__slots__:

--- a/tests/_inline/test_inlinequeryresultcachedvoice.py
+++ b/tests/_inline/test_inlinequeryresultcachedvoice.py
@@ -32,18 +32,18 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def inline_query_result_cached_voice():
     return InlineQueryResultCachedVoice(
-        TestInlineQueryResultCachedVoiceBase.id_,
-        TestInlineQueryResultCachedVoiceBase.voice_file_id,
-        TestInlineQueryResultCachedVoiceBase.title,
-        caption=TestInlineQueryResultCachedVoiceBase.caption,
-        parse_mode=TestInlineQueryResultCachedVoiceBase.parse_mode,
-        caption_entities=TestInlineQueryResultCachedVoiceBase.caption_entities,
-        input_message_content=TestInlineQueryResultCachedVoiceBase.input_message_content,
-        reply_markup=TestInlineQueryResultCachedVoiceBase.reply_markup,
+        InlineQueryResultCachedVoiceTestBase.id_,
+        InlineQueryResultCachedVoiceTestBase.voice_file_id,
+        InlineQueryResultCachedVoiceTestBase.title,
+        caption=InlineQueryResultCachedVoiceTestBase.caption,
+        parse_mode=InlineQueryResultCachedVoiceTestBase.parse_mode,
+        caption_entities=InlineQueryResultCachedVoiceTestBase.caption_entities,
+        input_message_content=InlineQueryResultCachedVoiceTestBase.input_message_content,
+        reply_markup=InlineQueryResultCachedVoiceTestBase.reply_markup,
     )
 
 
-class TestInlineQueryResultCachedVoiceBase:
+class InlineQueryResultCachedVoiceTestBase:
     id_ = "id"
     type_ = "voice"
     voice_file_id = "voice file id"
@@ -55,7 +55,7 @@ class TestInlineQueryResultCachedVoiceBase:
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton("reply_markup")]])
 
 
-class TestInlineQueryResultCachedVoiceWithoutRequest(TestInlineQueryResultCachedVoiceBase):
+class TestInlineQueryResultCachedVoiceWithoutRequest(InlineQueryResultCachedVoiceTestBase):
     def test_slot_behaviour(self, inline_query_result_cached_voice):
         inst = inline_query_result_cached_voice
         for attr in inst.__slots__:

--- a/tests/_inline/test_inlinequeryresultcontact.py
+++ b/tests/_inline/test_inlinequeryresultcontact.py
@@ -31,19 +31,19 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def inline_query_result_contact():
     return InlineQueryResultContact(
-        TestInlineQueryResultContactBase.id_,
-        TestInlineQueryResultContactBase.phone_number,
-        TestInlineQueryResultContactBase.first_name,
-        last_name=TestInlineQueryResultContactBase.last_name,
-        thumbnail_url=TestInlineQueryResultContactBase.thumbnail_url,
-        thumbnail_width=TestInlineQueryResultContactBase.thumbnail_width,
-        thumbnail_height=TestInlineQueryResultContactBase.thumbnail_height,
-        input_message_content=TestInlineQueryResultContactBase.input_message_content,
-        reply_markup=TestInlineQueryResultContactBase.reply_markup,
+        InlineQueryResultContactTestBase.id_,
+        InlineQueryResultContactTestBase.phone_number,
+        InlineQueryResultContactTestBase.first_name,
+        last_name=InlineQueryResultContactTestBase.last_name,
+        thumbnail_url=InlineQueryResultContactTestBase.thumbnail_url,
+        thumbnail_width=InlineQueryResultContactTestBase.thumbnail_width,
+        thumbnail_height=InlineQueryResultContactTestBase.thumbnail_height,
+        input_message_content=InlineQueryResultContactTestBase.input_message_content,
+        reply_markup=InlineQueryResultContactTestBase.reply_markup,
     )
 
 
-class TestInlineQueryResultContactBase:
+class InlineQueryResultContactTestBase:
     id_ = "id"
     type_ = "contact"
     phone_number = "phone_number"
@@ -56,7 +56,7 @@ class TestInlineQueryResultContactBase:
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton("reply_markup")]])
 
 
-class TestInlineQueryResultContactWithoutRequest(TestInlineQueryResultContactBase):
+class TestInlineQueryResultContactWithoutRequest(InlineQueryResultContactTestBase):
     def test_slot_behaviour(self, inline_query_result_contact):
         inst = inline_query_result_contact
         for attr in inst.__slots__:

--- a/tests/_inline/test_inlinequeryresultdocument.py
+++ b/tests/_inline/test_inlinequeryresultdocument.py
@@ -32,23 +32,23 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def inline_query_result_document():
     return InlineQueryResultDocument(
-        TestInlineQueryResultDocumentBase.id_,
-        TestInlineQueryResultDocumentBase.document_url,
-        TestInlineQueryResultDocumentBase.title,
-        TestInlineQueryResultDocumentBase.mime_type,
-        caption=TestInlineQueryResultDocumentBase.caption,
-        parse_mode=TestInlineQueryResultDocumentBase.parse_mode,
-        caption_entities=TestInlineQueryResultDocumentBase.caption_entities,
-        description=TestInlineQueryResultDocumentBase.description,
-        thumbnail_url=TestInlineQueryResultDocumentBase.thumbnail_url,
-        thumbnail_width=TestInlineQueryResultDocumentBase.thumbnail_width,
-        thumbnail_height=TestInlineQueryResultDocumentBase.thumbnail_height,
-        input_message_content=TestInlineQueryResultDocumentBase.input_message_content,
-        reply_markup=TestInlineQueryResultDocumentBase.reply_markup,
+        InlineQueryResultDocumentTestBase.id_,
+        InlineQueryResultDocumentTestBase.document_url,
+        InlineQueryResultDocumentTestBase.title,
+        InlineQueryResultDocumentTestBase.mime_type,
+        caption=InlineQueryResultDocumentTestBase.caption,
+        parse_mode=InlineQueryResultDocumentTestBase.parse_mode,
+        caption_entities=InlineQueryResultDocumentTestBase.caption_entities,
+        description=InlineQueryResultDocumentTestBase.description,
+        thumbnail_url=InlineQueryResultDocumentTestBase.thumbnail_url,
+        thumbnail_width=InlineQueryResultDocumentTestBase.thumbnail_width,
+        thumbnail_height=InlineQueryResultDocumentTestBase.thumbnail_height,
+        input_message_content=InlineQueryResultDocumentTestBase.input_message_content,
+        reply_markup=InlineQueryResultDocumentTestBase.reply_markup,
     )
 
 
-class TestInlineQueryResultDocumentBase:
+class InlineQueryResultDocumentTestBase:
     id_ = "id"
     type_ = "document"
     document_url = "document url"
@@ -65,7 +65,7 @@ class TestInlineQueryResultDocumentBase:
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton("reply_markup")]])
 
 
-class TestInlineQueryResultDocumentWithoutRequest(TestInlineQueryResultDocumentBase):
+class TestInlineQueryResultDocumentWithoutRequest(InlineQueryResultDocumentTestBase):
     def test_slot_behaviour(self, inline_query_result_document):
         inst = inline_query_result_document
         for attr in inst.__slots__:

--- a/tests/_inline/test_inlinequeryresultgame.py
+++ b/tests/_inline/test_inlinequeryresultgame.py
@@ -30,20 +30,20 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def inline_query_result_game():
     return InlineQueryResultGame(
-        TestInlineQueryResultGameBase.id_,
-        TestInlineQueryResultGameBase.game_short_name,
-        reply_markup=TestInlineQueryResultGameBase.reply_markup,
+        InlineQueryResultGameTestBase.id_,
+        InlineQueryResultGameTestBase.game_short_name,
+        reply_markup=InlineQueryResultGameTestBase.reply_markup,
     )
 
 
-class TestInlineQueryResultGameBase:
+class InlineQueryResultGameTestBase:
     id_ = "id"
     type_ = "game"
     game_short_name = "game short name"
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton("reply_markup")]])
 
 
-class TestInlineQueryResultGameWithoutRequest(TestInlineQueryResultGameBase):
+class TestInlineQueryResultGameWithoutRequest(InlineQueryResultGameTestBase):
     def test_slot_behaviour(self, inline_query_result_game):
         inst = inline_query_result_game
         for attr in inst.__slots__:

--- a/tests/_inline/test_inlinequeryresultgif.py
+++ b/tests/_inline/test_inlinequeryresultgif.py
@@ -32,24 +32,24 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def inline_query_result_gif():
     return InlineQueryResultGif(
-        TestInlineQueryResultGifBase.id_,
-        TestInlineQueryResultGifBase.gif_url,
-        TestInlineQueryResultGifBase.thumbnail_url,
-        gif_width=TestInlineQueryResultGifBase.gif_width,
-        gif_height=TestInlineQueryResultGifBase.gif_height,
-        gif_duration=TestInlineQueryResultGifBase.gif_duration,
-        title=TestInlineQueryResultGifBase.title,
-        caption=TestInlineQueryResultGifBase.caption,
-        parse_mode=TestInlineQueryResultGifBase.parse_mode,
-        caption_entities=TestInlineQueryResultGifBase.caption_entities,
-        input_message_content=TestInlineQueryResultGifBase.input_message_content,
-        reply_markup=TestInlineQueryResultGifBase.reply_markup,
-        thumbnail_mime_type=TestInlineQueryResultGifBase.thumbnail_mime_type,
-        show_caption_above_media=TestInlineQueryResultGifBase.show_caption_above_media,
+        InlineQueryResultGifTestBase.id_,
+        InlineQueryResultGifTestBase.gif_url,
+        InlineQueryResultGifTestBase.thumbnail_url,
+        gif_width=InlineQueryResultGifTestBase.gif_width,
+        gif_height=InlineQueryResultGifTestBase.gif_height,
+        gif_duration=InlineQueryResultGifTestBase.gif_duration,
+        title=InlineQueryResultGifTestBase.title,
+        caption=InlineQueryResultGifTestBase.caption,
+        parse_mode=InlineQueryResultGifTestBase.parse_mode,
+        caption_entities=InlineQueryResultGifTestBase.caption_entities,
+        input_message_content=InlineQueryResultGifTestBase.input_message_content,
+        reply_markup=InlineQueryResultGifTestBase.reply_markup,
+        thumbnail_mime_type=InlineQueryResultGifTestBase.thumbnail_mime_type,
+        show_caption_above_media=InlineQueryResultGifTestBase.show_caption_above_media,
     )
 
 
-class TestInlineQueryResultGifBase:
+class InlineQueryResultGifTestBase:
     id_ = "id"
     type_ = "gif"
     gif_url = "gif url"
@@ -67,7 +67,7 @@ class TestInlineQueryResultGifBase:
     show_caption_above_media = True
 
 
-class TestInlineQueryResultGifWithoutRequest(TestInlineQueryResultGifBase):
+class TestInlineQueryResultGifWithoutRequest(InlineQueryResultGifTestBase):
     def test_slot_behaviour(self, inline_query_result_gif):
         inst = inline_query_result_gif
         for attr in inst.__slots__:

--- a/tests/_inline/test_inlinequeryresultlocation.py
+++ b/tests/_inline/test_inlinequeryresultlocation.py
@@ -31,23 +31,23 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def inline_query_result_location():
     return InlineQueryResultLocation(
-        TestInlineQueryResultLocationBase.id_,
-        TestInlineQueryResultLocationBase.latitude,
-        TestInlineQueryResultLocationBase.longitude,
-        TestInlineQueryResultLocationBase.title,
-        live_period=TestInlineQueryResultLocationBase.live_period,
-        thumbnail_url=TestInlineQueryResultLocationBase.thumbnail_url,
-        thumbnail_width=TestInlineQueryResultLocationBase.thumbnail_width,
-        thumbnail_height=TestInlineQueryResultLocationBase.thumbnail_height,
-        input_message_content=TestInlineQueryResultLocationBase.input_message_content,
-        reply_markup=TestInlineQueryResultLocationBase.reply_markup,
-        horizontal_accuracy=TestInlineQueryResultLocationBase.horizontal_accuracy,
-        heading=TestInlineQueryResultLocationBase.heading,
-        proximity_alert_radius=TestInlineQueryResultLocationBase.proximity_alert_radius,
+        InlineQueryResultLocationTestBase.id_,
+        InlineQueryResultLocationTestBase.latitude,
+        InlineQueryResultLocationTestBase.longitude,
+        InlineQueryResultLocationTestBase.title,
+        live_period=InlineQueryResultLocationTestBase.live_period,
+        thumbnail_url=InlineQueryResultLocationTestBase.thumbnail_url,
+        thumbnail_width=InlineQueryResultLocationTestBase.thumbnail_width,
+        thumbnail_height=InlineQueryResultLocationTestBase.thumbnail_height,
+        input_message_content=InlineQueryResultLocationTestBase.input_message_content,
+        reply_markup=InlineQueryResultLocationTestBase.reply_markup,
+        horizontal_accuracy=InlineQueryResultLocationTestBase.horizontal_accuracy,
+        heading=InlineQueryResultLocationTestBase.heading,
+        proximity_alert_radius=InlineQueryResultLocationTestBase.proximity_alert_radius,
     )
 
 
-class TestInlineQueryResultLocationBase:
+class InlineQueryResultLocationTestBase:
     id_ = "id"
     type_ = "location"
     latitude = 0.0
@@ -64,7 +64,7 @@ class TestInlineQueryResultLocationBase:
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton("reply_markup")]])
 
 
-class TestInlineQueryResultLocationWithoutRequest(TestInlineQueryResultLocationBase):
+class TestInlineQueryResultLocationWithoutRequest(InlineQueryResultLocationTestBase):
     def test_slot_behaviour(self, inline_query_result_location):
         inst = inline_query_result_location
         for attr in inst.__slots__:

--- a/tests/_inline/test_inlinequeryresultmpeg4gif.py
+++ b/tests/_inline/test_inlinequeryresultmpeg4gif.py
@@ -32,24 +32,24 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def inline_query_result_mpeg4_gif():
     return InlineQueryResultMpeg4Gif(
-        TestInlineQueryResultMpeg4GifBase.id_,
-        TestInlineQueryResultMpeg4GifBase.mpeg4_url,
-        TestInlineQueryResultMpeg4GifBase.thumbnail_url,
-        mpeg4_width=TestInlineQueryResultMpeg4GifBase.mpeg4_width,
-        mpeg4_height=TestInlineQueryResultMpeg4GifBase.mpeg4_height,
-        mpeg4_duration=TestInlineQueryResultMpeg4GifBase.mpeg4_duration,
-        title=TestInlineQueryResultMpeg4GifBase.title,
-        caption=TestInlineQueryResultMpeg4GifBase.caption,
-        parse_mode=TestInlineQueryResultMpeg4GifBase.parse_mode,
-        caption_entities=TestInlineQueryResultMpeg4GifBase.caption_entities,
-        input_message_content=TestInlineQueryResultMpeg4GifBase.input_message_content,
-        reply_markup=TestInlineQueryResultMpeg4GifBase.reply_markup,
-        thumbnail_mime_type=TestInlineQueryResultMpeg4GifBase.thumbnail_mime_type,
-        show_caption_above_media=TestInlineQueryResultMpeg4GifBase.show_caption_above_media,
+        InlineQueryResultMpeg4GifTestBase.id_,
+        InlineQueryResultMpeg4GifTestBase.mpeg4_url,
+        InlineQueryResultMpeg4GifTestBase.thumbnail_url,
+        mpeg4_width=InlineQueryResultMpeg4GifTestBase.mpeg4_width,
+        mpeg4_height=InlineQueryResultMpeg4GifTestBase.mpeg4_height,
+        mpeg4_duration=InlineQueryResultMpeg4GifTestBase.mpeg4_duration,
+        title=InlineQueryResultMpeg4GifTestBase.title,
+        caption=InlineQueryResultMpeg4GifTestBase.caption,
+        parse_mode=InlineQueryResultMpeg4GifTestBase.parse_mode,
+        caption_entities=InlineQueryResultMpeg4GifTestBase.caption_entities,
+        input_message_content=InlineQueryResultMpeg4GifTestBase.input_message_content,
+        reply_markup=InlineQueryResultMpeg4GifTestBase.reply_markup,
+        thumbnail_mime_type=InlineQueryResultMpeg4GifTestBase.thumbnail_mime_type,
+        show_caption_above_media=InlineQueryResultMpeg4GifTestBase.show_caption_above_media,
     )
 
 
-class TestInlineQueryResultMpeg4GifBase:
+class InlineQueryResultMpeg4GifTestBase:
     id_ = "id"
     type_ = "mpeg4_gif"
     mpeg4_url = "mpeg4 url"
@@ -67,7 +67,7 @@ class TestInlineQueryResultMpeg4GifBase:
     show_caption_above_media = True
 
 
-class TestInlineQueryResultMpeg4GifWithoutRequest(TestInlineQueryResultMpeg4GifBase):
+class TestInlineQueryResultMpeg4GifWithoutRequest(InlineQueryResultMpeg4GifTestBase):
     def test_slot_behaviour(self, inline_query_result_mpeg4_gif):
         inst = inline_query_result_mpeg4_gif
         for attr in inst.__slots__:

--- a/tests/_inline/test_inlinequeryresultphoto.py
+++ b/tests/_inline/test_inlinequeryresultphoto.py
@@ -32,23 +32,23 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def inline_query_result_photo():
     return InlineQueryResultPhoto(
-        TestInlineQueryResultPhotoBase.id_,
-        TestInlineQueryResultPhotoBase.photo_url,
-        TestInlineQueryResultPhotoBase.thumbnail_url,
-        photo_width=TestInlineQueryResultPhotoBase.photo_width,
-        photo_height=TestInlineQueryResultPhotoBase.photo_height,
-        title=TestInlineQueryResultPhotoBase.title,
-        description=TestInlineQueryResultPhotoBase.description,
-        caption=TestInlineQueryResultPhotoBase.caption,
-        parse_mode=TestInlineQueryResultPhotoBase.parse_mode,
-        caption_entities=TestInlineQueryResultPhotoBase.caption_entities,
-        input_message_content=TestInlineQueryResultPhotoBase.input_message_content,
-        reply_markup=TestInlineQueryResultPhotoBase.reply_markup,
-        show_caption_above_media=TestInlineQueryResultPhotoBase.show_caption_above_media,
+        InlineQueryResultPhotoTestBase.id_,
+        InlineQueryResultPhotoTestBase.photo_url,
+        InlineQueryResultPhotoTestBase.thumbnail_url,
+        photo_width=InlineQueryResultPhotoTestBase.photo_width,
+        photo_height=InlineQueryResultPhotoTestBase.photo_height,
+        title=InlineQueryResultPhotoTestBase.title,
+        description=InlineQueryResultPhotoTestBase.description,
+        caption=InlineQueryResultPhotoTestBase.caption,
+        parse_mode=InlineQueryResultPhotoTestBase.parse_mode,
+        caption_entities=InlineQueryResultPhotoTestBase.caption_entities,
+        input_message_content=InlineQueryResultPhotoTestBase.input_message_content,
+        reply_markup=InlineQueryResultPhotoTestBase.reply_markup,
+        show_caption_above_media=InlineQueryResultPhotoTestBase.show_caption_above_media,
     )
 
 
-class TestInlineQueryResultPhotoBase:
+class InlineQueryResultPhotoTestBase:
     id_ = "id"
     type_ = "photo"
     photo_url = "photo url"
@@ -66,7 +66,7 @@ class TestInlineQueryResultPhotoBase:
     show_caption_above_media = True
 
 
-class TestInlineQueryResultPhotoWithoutRequest(TestInlineQueryResultPhotoBase):
+class TestInlineQueryResultPhotoWithoutRequest(InlineQueryResultPhotoTestBase):
     def test_slot_behaviour(self, inline_query_result_photo):
         inst = inline_query_result_photo
         for attr in inst.__slots__:

--- a/tests/_inline/test_inlinequeryresultvenue.py
+++ b/tests/_inline/test_inlinequeryresultvenue.py
@@ -31,24 +31,24 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def inline_query_result_venue():
     return InlineQueryResultVenue(
-        TestInlineQueryResultVenueBase.id_,
-        TestInlineQueryResultVenueBase.latitude,
-        TestInlineQueryResultVenueBase.longitude,
-        TestInlineQueryResultVenueBase.title,
-        TestInlineQueryResultVenueBase.address,
-        foursquare_id=TestInlineQueryResultVenueBase.foursquare_id,
-        foursquare_type=TestInlineQueryResultVenueBase.foursquare_type,
-        thumbnail_url=TestInlineQueryResultVenueBase.thumbnail_url,
-        thumbnail_width=TestInlineQueryResultVenueBase.thumbnail_width,
-        thumbnail_height=TestInlineQueryResultVenueBase.thumbnail_height,
-        input_message_content=TestInlineQueryResultVenueBase.input_message_content,
-        reply_markup=TestInlineQueryResultVenueBase.reply_markup,
-        google_place_id=TestInlineQueryResultVenueBase.google_place_id,
-        google_place_type=TestInlineQueryResultVenueBase.google_place_type,
+        InlineQueryResultVenueTestBase.id_,
+        InlineQueryResultVenueTestBase.latitude,
+        InlineQueryResultVenueTestBase.longitude,
+        InlineQueryResultVenueTestBase.title,
+        InlineQueryResultVenueTestBase.address,
+        foursquare_id=InlineQueryResultVenueTestBase.foursquare_id,
+        foursquare_type=InlineQueryResultVenueTestBase.foursquare_type,
+        thumbnail_url=InlineQueryResultVenueTestBase.thumbnail_url,
+        thumbnail_width=InlineQueryResultVenueTestBase.thumbnail_width,
+        thumbnail_height=InlineQueryResultVenueTestBase.thumbnail_height,
+        input_message_content=InlineQueryResultVenueTestBase.input_message_content,
+        reply_markup=InlineQueryResultVenueTestBase.reply_markup,
+        google_place_id=InlineQueryResultVenueTestBase.google_place_id,
+        google_place_type=InlineQueryResultVenueTestBase.google_place_type,
     )
 
 
-class TestInlineQueryResultVenueBase:
+class InlineQueryResultVenueTestBase:
     id_ = "id"
     type_ = "venue"
     latitude = "latitude"
@@ -66,7 +66,7 @@ class TestInlineQueryResultVenueBase:
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton("reply_markup")]])
 
 
-class TestInlineQueryResultVenueWithoutRequest(TestInlineQueryResultVenueBase):
+class TestInlineQueryResultVenueWithoutRequest(InlineQueryResultVenueTestBase):
     def test_slot_behaviour(self, inline_query_result_venue):
         inst = inline_query_result_venue
         for attr in inst.__slots__:

--- a/tests/_inline/test_inlinequeryresultvideo.py
+++ b/tests/_inline/test_inlinequeryresultvideo.py
@@ -32,25 +32,25 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def inline_query_result_video():
     return InlineQueryResultVideo(
-        TestInlineQueryResultVideoBase.id_,
-        TestInlineQueryResultVideoBase.video_url,
-        TestInlineQueryResultVideoBase.mime_type,
-        TestInlineQueryResultVideoBase.thumbnail_url,
-        TestInlineQueryResultVideoBase.title,
-        video_width=TestInlineQueryResultVideoBase.video_width,
-        video_height=TestInlineQueryResultVideoBase.video_height,
-        video_duration=TestInlineQueryResultVideoBase.video_duration,
-        caption=TestInlineQueryResultVideoBase.caption,
-        parse_mode=TestInlineQueryResultVideoBase.parse_mode,
-        caption_entities=TestInlineQueryResultVideoBase.caption_entities,
-        description=TestInlineQueryResultVideoBase.description,
-        input_message_content=TestInlineQueryResultVideoBase.input_message_content,
-        reply_markup=TestInlineQueryResultVideoBase.reply_markup,
-        show_caption_above_media=TestInlineQueryResultVideoBase.show_caption_above_media,
+        InlineQueryResultVideoTestBase.id_,
+        InlineQueryResultVideoTestBase.video_url,
+        InlineQueryResultVideoTestBase.mime_type,
+        InlineQueryResultVideoTestBase.thumbnail_url,
+        InlineQueryResultVideoTestBase.title,
+        video_width=InlineQueryResultVideoTestBase.video_width,
+        video_height=InlineQueryResultVideoTestBase.video_height,
+        video_duration=InlineQueryResultVideoTestBase.video_duration,
+        caption=InlineQueryResultVideoTestBase.caption,
+        parse_mode=InlineQueryResultVideoTestBase.parse_mode,
+        caption_entities=InlineQueryResultVideoTestBase.caption_entities,
+        description=InlineQueryResultVideoTestBase.description,
+        input_message_content=InlineQueryResultVideoTestBase.input_message_content,
+        reply_markup=InlineQueryResultVideoTestBase.reply_markup,
+        show_caption_above_media=InlineQueryResultVideoTestBase.show_caption_above_media,
     )
 
 
-class TestInlineQueryResultVideoBase:
+class InlineQueryResultVideoTestBase:
     id_ = "id"
     type_ = "video"
     video_url = "video url"
@@ -69,7 +69,7 @@ class TestInlineQueryResultVideoBase:
     show_caption_above_media = True
 
 
-class TestInlineQueryResultVideoWithoutRequest(TestInlineQueryResultVideoBase):
+class TestInlineQueryResultVideoWithoutRequest(InlineQueryResultVideoTestBase):
     def test_slot_behaviour(self, inline_query_result_video):
         inst = inline_query_result_video
         for attr in inst.__slots__:

--- a/tests/_inline/test_inlinequeryresultvoice.py
+++ b/tests/_inline/test_inlinequeryresultvoice.py
@@ -32,19 +32,19 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def inline_query_result_voice():
     return InlineQueryResultVoice(
-        id=TestInlineQueryResultVoiceBase.id_,
-        voice_url=TestInlineQueryResultVoiceBase.voice_url,
-        title=TestInlineQueryResultVoiceBase.title,
-        voice_duration=TestInlineQueryResultVoiceBase.voice_duration,
-        caption=TestInlineQueryResultVoiceBase.caption,
-        parse_mode=TestInlineQueryResultVoiceBase.parse_mode,
-        caption_entities=TestInlineQueryResultVoiceBase.caption_entities,
-        input_message_content=TestInlineQueryResultVoiceBase.input_message_content,
-        reply_markup=TestInlineQueryResultVoiceBase.reply_markup,
+        id=InlineQueryResultVoiceTestBase.id_,
+        voice_url=InlineQueryResultVoiceTestBase.voice_url,
+        title=InlineQueryResultVoiceTestBase.title,
+        voice_duration=InlineQueryResultVoiceTestBase.voice_duration,
+        caption=InlineQueryResultVoiceTestBase.caption,
+        parse_mode=InlineQueryResultVoiceTestBase.parse_mode,
+        caption_entities=InlineQueryResultVoiceTestBase.caption_entities,
+        input_message_content=InlineQueryResultVoiceTestBase.input_message_content,
+        reply_markup=InlineQueryResultVoiceTestBase.reply_markup,
     )
 
 
-class TestInlineQueryResultVoiceBase:
+class InlineQueryResultVoiceTestBase:
     id_ = "id"
     type_ = "voice"
     voice_url = "voice url"
@@ -57,7 +57,7 @@ class TestInlineQueryResultVoiceBase:
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton("reply_markup")]])
 
 
-class TestInlineQueryResultVoiceWithoutRequest(TestInlineQueryResultVoiceBase):
+class TestInlineQueryResultVoiceWithoutRequest(InlineQueryResultVoiceTestBase):
     def test_slot_behaviour(self, inline_query_result_voice):
         inst = inline_query_result_voice
         for attr in inst.__slots__:

--- a/tests/_inline/test_inputcontactmessagecontent.py
+++ b/tests/_inline/test_inputcontactmessagecontent.py
@@ -25,19 +25,19 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def input_contact_message_content():
     return InputContactMessageContent(
-        TestInputContactMessageContentBase.phone_number,
-        TestInputContactMessageContentBase.first_name,
-        TestInputContactMessageContentBase.last_name,
+        InputContactMessageContentTestBase.phone_number,
+        InputContactMessageContentTestBase.first_name,
+        InputContactMessageContentTestBase.last_name,
     )
 
 
-class TestInputContactMessageContentBase:
+class InputContactMessageContentTestBase:
     phone_number = "phone number"
     first_name = "first name"
     last_name = "last name"
 
 
-class TestInputContactMessageContentWithoutRequest(TestInputContactMessageContentBase):
+class TestInputContactMessageContentWithoutRequest(InputContactMessageContentTestBase):
     def test_slot_behaviour(self, input_contact_message_content):
         inst = input_contact_message_content
         for attr in inst.__slots__:

--- a/tests/_inline/test_inputinvoicemessagecontent.py
+++ b/tests/_inline/test_inputinvoicemessagecontent.py
@@ -26,32 +26,32 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def input_invoice_message_content():
     return InputInvoiceMessageContent(
-        title=TestInputInvoiceMessageContentBase.title,
-        description=TestInputInvoiceMessageContentBase.description,
-        payload=TestInputInvoiceMessageContentBase.payload,
-        provider_token=TestInputInvoiceMessageContentBase.provider_token,
-        currency=TestInputInvoiceMessageContentBase.currency,
-        prices=TestInputInvoiceMessageContentBase.prices,
-        max_tip_amount=TestInputInvoiceMessageContentBase.max_tip_amount,
-        suggested_tip_amounts=TestInputInvoiceMessageContentBase.suggested_tip_amounts,
-        provider_data=TestInputInvoiceMessageContentBase.provider_data,
-        photo_url=TestInputInvoiceMessageContentBase.photo_url,
-        photo_size=TestInputInvoiceMessageContentBase.photo_size,
-        photo_width=TestInputInvoiceMessageContentBase.photo_width,
-        photo_height=TestInputInvoiceMessageContentBase.photo_height,
-        need_name=TestInputInvoiceMessageContentBase.need_name,
-        need_phone_number=TestInputInvoiceMessageContentBase.need_phone_number,
-        need_email=TestInputInvoiceMessageContentBase.need_email,
-        need_shipping_address=TestInputInvoiceMessageContentBase.need_shipping_address,
+        title=InputInvoiceMessageContentTestBase.title,
+        description=InputInvoiceMessageContentTestBase.description,
+        payload=InputInvoiceMessageContentTestBase.payload,
+        provider_token=InputInvoiceMessageContentTestBase.provider_token,
+        currency=InputInvoiceMessageContentTestBase.currency,
+        prices=InputInvoiceMessageContentTestBase.prices,
+        max_tip_amount=InputInvoiceMessageContentTestBase.max_tip_amount,
+        suggested_tip_amounts=InputInvoiceMessageContentTestBase.suggested_tip_amounts,
+        provider_data=InputInvoiceMessageContentTestBase.provider_data,
+        photo_url=InputInvoiceMessageContentTestBase.photo_url,
+        photo_size=InputInvoiceMessageContentTestBase.photo_size,
+        photo_width=InputInvoiceMessageContentTestBase.photo_width,
+        photo_height=InputInvoiceMessageContentTestBase.photo_height,
+        need_name=InputInvoiceMessageContentTestBase.need_name,
+        need_phone_number=InputInvoiceMessageContentTestBase.need_phone_number,
+        need_email=InputInvoiceMessageContentTestBase.need_email,
+        need_shipping_address=InputInvoiceMessageContentTestBase.need_shipping_address,
         send_phone_number_to_provider=(
-            TestInputInvoiceMessageContentBase.send_phone_number_to_provider
+            InputInvoiceMessageContentTestBase.send_phone_number_to_provider
         ),
-        send_email_to_provider=TestInputInvoiceMessageContentBase.send_email_to_provider,
-        is_flexible=TestInputInvoiceMessageContentBase.is_flexible,
+        send_email_to_provider=InputInvoiceMessageContentTestBase.send_email_to_provider,
+        is_flexible=InputInvoiceMessageContentTestBase.is_flexible,
     )
 
 
-class TestInputInvoiceMessageContentBase:
+class InputInvoiceMessageContentTestBase:
     title = "invoice title"
     description = "invoice description"
     payload = "invoice payload"
@@ -74,7 +74,7 @@ class TestInputInvoiceMessageContentBase:
     is_flexible = True
 
 
-class TestInputInvoiceMessageContentWithoutRequest(TestInputInvoiceMessageContentBase):
+class TestInputInvoiceMessageContentWithoutRequest(InputInvoiceMessageContentTestBase):
     def test_slot_behaviour(self, input_invoice_message_content):
         inst = input_invoice_message_content
         for attr in inst.__slots__:

--- a/tests/_inline/test_inputlocationmessagecontent.py
+++ b/tests/_inline/test_inputlocationmessagecontent.py
@@ -25,16 +25,16 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def input_location_message_content():
     return InputLocationMessageContent(
-        TestInputLocationMessageContentBase.latitude,
-        TestInputLocationMessageContentBase.longitude,
-        live_period=TestInputLocationMessageContentBase.live_period,
-        horizontal_accuracy=TestInputLocationMessageContentBase.horizontal_accuracy,
-        heading=TestInputLocationMessageContentBase.heading,
-        proximity_alert_radius=TestInputLocationMessageContentBase.proximity_alert_radius,
+        InputLocationMessageContentTestBase.latitude,
+        InputLocationMessageContentTestBase.longitude,
+        live_period=InputLocationMessageContentTestBase.live_period,
+        horizontal_accuracy=InputLocationMessageContentTestBase.horizontal_accuracy,
+        heading=InputLocationMessageContentTestBase.heading,
+        proximity_alert_radius=InputLocationMessageContentTestBase.proximity_alert_radius,
     )
 
 
-class TestInputLocationMessageContentBase:
+class InputLocationMessageContentTestBase:
     latitude = -23.691288
     longitude = -46.788279
     live_period = 80
@@ -43,7 +43,7 @@ class TestInputLocationMessageContentBase:
     proximity_alert_radius = 999
 
 
-class TestInputLocationMessageContentWithoutRequest(TestInputLocationMessageContentBase):
+class TestInputLocationMessageContentWithoutRequest(InputLocationMessageContentTestBase):
     def test_slot_behaviour(self, input_location_message_content):
         inst = input_location_message_content
         for attr in inst.__slots__:

--- a/tests/_inline/test_inputtextmessagecontent.py
+++ b/tests/_inline/test_inputtextmessagecontent.py
@@ -26,14 +26,14 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def input_text_message_content():
     return InputTextMessageContent(
-        TestInputTextMessageContentBase.message_text,
-        parse_mode=TestInputTextMessageContentBase.parse_mode,
-        entities=TestInputTextMessageContentBase.entities,
-        link_preview_options=TestInputTextMessageContentBase.link_preview_options,
+        InputTextMessageContentTestBase.message_text,
+        parse_mode=InputTextMessageContentTestBase.parse_mode,
+        entities=InputTextMessageContentTestBase.entities,
+        link_preview_options=InputTextMessageContentTestBase.link_preview_options,
     )
 
 
-class TestInputTextMessageContentBase:
+class InputTextMessageContentTestBase:
     message_text = "*message text*"
     parse_mode = ParseMode.MARKDOWN
     entities = [MessageEntity(MessageEntity.ITALIC, 0, 7)]
@@ -41,7 +41,7 @@ class TestInputTextMessageContentBase:
     link_preview_options = LinkPreviewOptions(False, url="https://python-telegram-bot.org")
 
 
-class TestInputTextMessageContentWithoutRequest(TestInputTextMessageContentBase):
+class TestInputTextMessageContentWithoutRequest(InputTextMessageContentTestBase):
     def test_slot_behaviour(self, input_text_message_content):
         inst = input_text_message_content
         for attr in inst.__slots__:

--- a/tests/_inline/test_inputvenuemessagecontent.py
+++ b/tests/_inline/test_inputvenuemessagecontent.py
@@ -25,18 +25,18 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def input_venue_message_content():
     return InputVenueMessageContent(
-        TestInputVenueMessageContentBase.latitude,
-        TestInputVenueMessageContentBase.longitude,
-        TestInputVenueMessageContentBase.title,
-        TestInputVenueMessageContentBase.address,
-        foursquare_id=TestInputVenueMessageContentBase.foursquare_id,
-        foursquare_type=TestInputVenueMessageContentBase.foursquare_type,
-        google_place_id=TestInputVenueMessageContentBase.google_place_id,
-        google_place_type=TestInputVenueMessageContentBase.google_place_type,
+        InputVenueMessageContentTestBase.latitude,
+        InputVenueMessageContentTestBase.longitude,
+        InputVenueMessageContentTestBase.title,
+        InputVenueMessageContentTestBase.address,
+        foursquare_id=InputVenueMessageContentTestBase.foursquare_id,
+        foursquare_type=InputVenueMessageContentTestBase.foursquare_type,
+        google_place_id=InputVenueMessageContentTestBase.google_place_id,
+        google_place_type=InputVenueMessageContentTestBase.google_place_type,
     )
 
 
-class TestInputVenueMessageContentBase:
+class InputVenueMessageContentTestBase:
     latitude = 1.0
     longitude = 2.0
     title = "title"
@@ -47,7 +47,7 @@ class TestInputVenueMessageContentBase:
     google_place_type = "google place type"
 
 
-class TestInputVenueMessageContentWithoutRequest(TestInputVenueMessageContentBase):
+class TestInputVenueMessageContentWithoutRequest(InputVenueMessageContentTestBase):
     def test_slot_behaviour(self, input_venue_message_content):
         inst = input_venue_message_content
         for attr in inst.__slots__:

--- a/tests/_passport/test_encryptedcredentials.py
+++ b/tests/_passport/test_encryptedcredentials.py
@@ -26,19 +26,19 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def encrypted_credentials():
     return EncryptedCredentials(
-        TestEncryptedCredentialsBase.data,
-        TestEncryptedCredentialsBase.hash,
-        TestEncryptedCredentialsBase.secret,
+        EncryptedCredentialsTestBase.data,
+        EncryptedCredentialsTestBase.hash,
+        EncryptedCredentialsTestBase.secret,
     )
 
 
-class TestEncryptedCredentialsBase:
+class EncryptedCredentialsTestBase:
     data = "data"
     hash = "hash"
     secret = "secret"
 
 
-class TestEncryptedCredentialsWithoutRequest(TestEncryptedCredentialsBase):
+class TestEncryptedCredentialsWithoutRequest(EncryptedCredentialsTestBase):
     def test_slot_behaviour(self, encrypted_credentials):
         inst = encrypted_credentials
         for attr in inst.__slots__:

--- a/tests/_passport/test_encryptedpassportelement.py
+++ b/tests/_passport/test_encryptedpassportelement.py
@@ -26,19 +26,19 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def encrypted_passport_element():
     return EncryptedPassportElement(
-        TestEncryptedPassportElementBase.type_,
+        EncryptedPassportElementTestBase.type_,
         "this is a hash",
-        data=TestEncryptedPassportElementBase.data,
-        phone_number=TestEncryptedPassportElementBase.phone_number,
-        email=TestEncryptedPassportElementBase.email,
-        files=TestEncryptedPassportElementBase.files,
-        front_side=TestEncryptedPassportElementBase.front_side,
-        reverse_side=TestEncryptedPassportElementBase.reverse_side,
-        selfie=TestEncryptedPassportElementBase.selfie,
+        data=EncryptedPassportElementTestBase.data,
+        phone_number=EncryptedPassportElementTestBase.phone_number,
+        email=EncryptedPassportElementTestBase.email,
+        files=EncryptedPassportElementTestBase.files,
+        front_side=EncryptedPassportElementTestBase.front_side,
+        reverse_side=EncryptedPassportElementTestBase.reverse_side,
+        selfie=EncryptedPassportElementTestBase.selfie,
     )
 
 
-class TestEncryptedPassportElementBase:
+class EncryptedPassportElementTestBase:
     type_ = "type"
     hash = "this is a hash"
     data = "data"
@@ -50,7 +50,7 @@ class TestEncryptedPassportElementBase:
     selfie = PassportFile("file_id", 50, 0, 25)
 
 
-class TestEncryptedPassportElementWithoutRequest(TestEncryptedPassportElementBase):
+class TestEncryptedPassportElementWithoutRequest(EncryptedPassportElementTestBase):
     def test_slot_behaviour(self, encrypted_passport_element):
         inst = encrypted_passport_element
         for attr in inst.__slots__:

--- a/tests/_passport/test_passport.py
+++ b/tests/_passport/test_passport.py
@@ -220,7 +220,7 @@ def passport_data(bot):
     return PassportData.de_json(RAW_PASSPORT_DATA, bot=bot)
 
 
-class TestPassportBase:
+class PassportTestBase:
     driver_license_selfie_file_id = "DgADBAADEQQAAkopgFNr6oi-wISRtAI"
     driver_license_selfie_file_unique_id = "d4e390cca57b4da5a65322b304762a12"
     driver_license_front_side_file_id = "DgADBAADxwMAApnQgVPK2-ckL2eXVAI"
@@ -243,7 +243,7 @@ class TestPassportBase:
     driver_license_selfie_credentials_secret = "tivdId6RNYNsvXYPppdzrbxOBuBOr9wXRPDcCvnXU7E="
 
 
-class TestPassportWithoutRequest(TestPassportBase):
+class TestPassportWithoutRequest(PassportTestBase):
     def test_slot_behaviour(self, passport_data):
         inst = passport_data
         for attr in inst.__slots__:

--- a/tests/_passport/test_passportelementerrordatafield.py
+++ b/tests/_passport/test_passportelementerrordatafield.py
@@ -25,14 +25,14 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def passport_element_error_data_field():
     return PassportElementErrorDataField(
-        TestPassportElementErrorDataFieldBase.type_,
-        TestPassportElementErrorDataFieldBase.field_name,
-        TestPassportElementErrorDataFieldBase.data_hash,
-        TestPassportElementErrorDataFieldBase.message,
+        PassportElementErrorDataFieldTestBase.type_,
+        PassportElementErrorDataFieldTestBase.field_name,
+        PassportElementErrorDataFieldTestBase.data_hash,
+        PassportElementErrorDataFieldTestBase.message,
     )
 
 
-class TestPassportElementErrorDataFieldBase:
+class PassportElementErrorDataFieldTestBase:
     source = "data"
     type_ = "test_type"
     field_name = "test_field"
@@ -40,7 +40,7 @@ class TestPassportElementErrorDataFieldBase:
     message = "Error message"
 
 
-class TestPassportElementErrorDataFieldWithoutRequest(TestPassportElementErrorDataFieldBase):
+class TestPassportElementErrorDataFieldWithoutRequest(PassportElementErrorDataFieldTestBase):
     def test_slot_behaviour(self, passport_element_error_data_field):
         inst = passport_element_error_data_field
         for attr in inst.__slots__:

--- a/tests/_passport/test_passportelementerrorfile.py
+++ b/tests/_passport/test_passportelementerrorfile.py
@@ -25,20 +25,20 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def passport_element_error_file():
     return PassportElementErrorFile(
-        TestPassportElementErrorFileBase.type_,
-        TestPassportElementErrorFileBase.file_hash,
-        TestPassportElementErrorFileBase.message,
+        PassportElementErrorFileTestBase.type_,
+        PassportElementErrorFileTestBase.file_hash,
+        PassportElementErrorFileTestBase.message,
     )
 
 
-class TestPassportElementErrorFileBase:
+class PassportElementErrorFileTestBase:
     source = "file"
     type_ = "test_type"
     file_hash = "file_hash"
     message = "Error message"
 
 
-class TestPassportElementErrorFileWithoutRequest(TestPassportElementErrorFileBase):
+class TestPassportElementErrorFileWithoutRequest(PassportElementErrorFileTestBase):
     def test_slot_behaviour(self, passport_element_error_file):
         inst = passport_element_error_file
         for attr in inst.__slots__:

--- a/tests/_passport/test_passportelementerrorfiles.py
+++ b/tests/_passport/test_passportelementerrorfiles.py
@@ -26,20 +26,20 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def passport_element_error_files():
     return PassportElementErrorFiles(
-        TestPassportElementErrorFilesBase.type_,
-        TestPassportElementErrorFilesBase.file_hashes,
-        TestPassportElementErrorFilesBase.message,
+        PassportElementErrorFilesTestBase.type_,
+        PassportElementErrorFilesTestBase.file_hashes,
+        PassportElementErrorFilesTestBase.message,
     )
 
 
-class TestPassportElementErrorFilesBase:
+class PassportElementErrorFilesTestBase:
     source = "files"
     type_ = "test_type"
     file_hashes = ["hash1", "hash2"]
     message = "Error message"
 
 
-class TestPassportElementErrorFilesWithoutRequest(TestPassportElementErrorFilesBase):
+class TestPassportElementErrorFilesWithoutRequest(PassportElementErrorFilesTestBase):
     def test_slot_behaviour(self, passport_element_error_files):
         inst = passport_element_error_files
         for attr in inst.__slots__:

--- a/tests/_passport/test_passportelementerrorfrontside.py
+++ b/tests/_passport/test_passportelementerrorfrontside.py
@@ -25,20 +25,20 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def passport_element_error_front_side():
     return PassportElementErrorFrontSide(
-        TestPassportElementErrorFrontSideBase.type_,
-        TestPassportElementErrorFrontSideBase.file_hash,
-        TestPassportElementErrorFrontSideBase.message,
+        PassportElementErrorFrontSideTestBase.type_,
+        PassportElementErrorFrontSideTestBase.file_hash,
+        PassportElementErrorFrontSideTestBase.message,
     )
 
 
-class TestPassportElementErrorFrontSideBase:
+class PassportElementErrorFrontSideTestBase:
     source = "front_side"
     type_ = "test_type"
     file_hash = "file_hash"
     message = "Error message"
 
 
-class TestPassportElementErrorFrontSideWithoutRequest(TestPassportElementErrorFrontSideBase):
+class TestPassportElementErrorFrontSideWithoutRequest(PassportElementErrorFrontSideTestBase):
     def test_slot_behaviour(self, passport_element_error_front_side):
         inst = passport_element_error_front_side
         for attr in inst.__slots__:

--- a/tests/_passport/test_passportelementerrorreverseside.py
+++ b/tests/_passport/test_passportelementerrorreverseside.py
@@ -25,20 +25,20 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def passport_element_error_reverse_side():
     return PassportElementErrorReverseSide(
-        TestPassportElementErrorReverseSideBase.type_,
-        TestPassportElementErrorReverseSideBase.file_hash,
-        TestPassportElementErrorReverseSideBase.message,
+        PassportElementErrorReverseSideTestBase.type_,
+        PassportElementErrorReverseSideTestBase.file_hash,
+        PassportElementErrorReverseSideTestBase.message,
     )
 
 
-class TestPassportElementErrorReverseSideBase:
+class PassportElementErrorReverseSideTestBase:
     source = "reverse_side"
     type_ = "test_type"
     file_hash = "file_hash"
     message = "Error message"
 
 
-class TestPassportElementErrorReverseSideWithoutRequest(TestPassportElementErrorReverseSideBase):
+class TestPassportElementErrorReverseSideWithoutRequest(PassportElementErrorReverseSideTestBase):
     def test_slot_behaviour(self, passport_element_error_reverse_side):
         inst = passport_element_error_reverse_side
         for attr in inst.__slots__:

--- a/tests/_passport/test_passportelementerrorselfie.py
+++ b/tests/_passport/test_passportelementerrorselfie.py
@@ -25,20 +25,20 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def passport_element_error_selfie():
     return PassportElementErrorSelfie(
-        TestPassportElementErrorSelfieBase.type_,
-        TestPassportElementErrorSelfieBase.file_hash,
-        TestPassportElementErrorSelfieBase.message,
+        PassportElementErrorSelfieTestBase.type_,
+        PassportElementErrorSelfieTestBase.file_hash,
+        PassportElementErrorSelfieTestBase.message,
     )
 
 
-class TestPassportElementErrorSelfieBase:
+class PassportElementErrorSelfieTestBase:
     source = "selfie"
     type_ = "test_type"
     file_hash = "file_hash"
     message = "Error message"
 
 
-class TestPassportElementErrorSelfieWithoutRequest(TestPassportElementErrorSelfieBase):
+class TestPassportElementErrorSelfieWithoutRequest(PassportElementErrorSelfieTestBase):
     def test_slot_behaviour(self, passport_element_error_selfie):
         inst = passport_element_error_selfie
         for attr in inst.__slots__:

--- a/tests/_passport/test_passportelementerrortranslationfile.py
+++ b/tests/_passport/test_passportelementerrortranslationfile.py
@@ -25,13 +25,13 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def passport_element_error_translation_file():
     return PassportElementErrorTranslationFile(
-        TestPassportElementErrorTranslationFileBase.type_,
-        TestPassportElementErrorTranslationFileBase.file_hash,
-        TestPassportElementErrorTranslationFileBase.message,
+        PassportElementErrorTranslationFileTestBase.type_,
+        PassportElementErrorTranslationFileTestBase.file_hash,
+        PassportElementErrorTranslationFileTestBase.message,
     )
 
 
-class TestPassportElementErrorTranslationFileBase:
+class PassportElementErrorTranslationFileTestBase:
     source = "translation_file"
     type_ = "test_type"
     file_hash = "file_hash"
@@ -39,7 +39,7 @@ class TestPassportElementErrorTranslationFileBase:
 
 
 class TestPassportElementErrorTranslationFileWithoutRequest(
-    TestPassportElementErrorTranslationFileBase
+    PassportElementErrorTranslationFileTestBase
 ):
     def test_slot_behaviour(self, passport_element_error_translation_file):
         inst = passport_element_error_translation_file

--- a/tests/_passport/test_passportelementerrortranslationfiles.py
+++ b/tests/_passport/test_passportelementerrortranslationfiles.py
@@ -26,13 +26,13 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def passport_element_error_translation_files():
     return PassportElementErrorTranslationFiles(
-        TestPassportElementErrorTranslationFilesBase.type_,
-        TestPassportElementErrorTranslationFilesBase.file_hashes,
-        TestPassportElementErrorTranslationFilesBase.message,
+        PassportElementErrorTranslationFilesTestBase.type_,
+        PassportElementErrorTranslationFilesTestBase.file_hashes,
+        PassportElementErrorTranslationFilesTestBase.message,
     )
 
 
-class TestPassportElementErrorTranslationFilesBase:
+class PassportElementErrorTranslationFilesTestBase:
     source = "translation_files"
     type_ = "test_type"
     file_hashes = ["hash1", "hash2"]
@@ -40,7 +40,7 @@ class TestPassportElementErrorTranslationFilesBase:
 
 
 class TestPassportElementErrorTranslationFilesWithoutRequest(
-    TestPassportElementErrorTranslationFilesBase
+    PassportElementErrorTranslationFilesTestBase
 ):
     def test_slot_behaviour(self, passport_element_error_translation_files):
         inst = passport_element_error_translation_files

--- a/tests/_passport/test_passportelementerrorunspecified.py
+++ b/tests/_passport/test_passportelementerrorunspecified.py
@@ -25,20 +25,20 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def passport_element_error_unspecified():
     return PassportElementErrorUnspecified(
-        TestPassportElementErrorUnspecifiedBase.type_,
-        TestPassportElementErrorUnspecifiedBase.element_hash,
-        TestPassportElementErrorUnspecifiedBase.message,
+        PassportElementErrorUnspecifiedTestBase.type_,
+        PassportElementErrorUnspecifiedTestBase.element_hash,
+        PassportElementErrorUnspecifiedTestBase.message,
     )
 
 
-class TestPassportElementErrorUnspecifiedBase:
+class PassportElementErrorUnspecifiedTestBase:
     source = "unspecified"
     type_ = "test_type"
     element_hash = "element_hash"
     message = "Error message"
 
 
-class TestPassportElementErrorUnspecifiedWithoutRequest(TestPassportElementErrorUnspecifiedBase):
+class TestPassportElementErrorUnspecifiedWithoutRequest(PassportElementErrorUnspecifiedTestBase):
     def test_slot_behaviour(self, passport_element_error_unspecified):
         inst = passport_element_error_unspecified
         for attr in inst.__slots__:

--- a/tests/_passport/test_passportfile.py
+++ b/tests/_passport/test_passportfile.py
@@ -31,23 +31,23 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="class")
 def passport_file(bot):
     pf = PassportFile(
-        file_id=TestPassportFileBase.file_id,
-        file_unique_id=TestPassportFileBase.file_unique_id,
-        file_size=TestPassportFileBase.file_size,
-        file_date=TestPassportFileBase.file_date,
+        file_id=PassportFileTestBase.file_id,
+        file_unique_id=PassportFileTestBase.file_unique_id,
+        file_size=PassportFileTestBase.file_size,
+        file_date=PassportFileTestBase.file_date,
     )
     pf.set_bot(bot)
     return pf
 
 
-class TestPassportFileBase:
+class PassportFileTestBase:
     file_id = "data"
     file_unique_id = "adc3145fd2e84d95b64d68eaa22aa33e"
     file_size = 50
     file_date = 1532879128
 
 
-class TestPassportFileWithoutRequest(TestPassportFileBase):
+class TestPassportFileWithoutRequest(PassportFileTestBase):
     def test_slot_behaviour(self, passport_file):
         inst = passport_file
         for attr in inst.__slots__:

--- a/tests/_payment/test_invoice.py
+++ b/tests/_payment/test_invoice.py
@@ -31,15 +31,15 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def invoice():
     return Invoice(
-        TestInvoiceBase.title,
-        TestInvoiceBase.description,
-        TestInvoiceBase.start_parameter,
-        TestInvoiceBase.currency,
-        TestInvoiceBase.total_amount,
+        InvoiceTestBase.title,
+        InvoiceTestBase.description,
+        InvoiceTestBase.start_parameter,
+        InvoiceTestBase.currency,
+        InvoiceTestBase.total_amount,
     )
 
 
-class TestInvoiceBase:
+class InvoiceTestBase:
     payload = "payload"
     prices = [LabeledPrice("Fish", 100), LabeledPrice("Fish Tax", 1000)]
     provider_data = """{"test":"test"}"""
@@ -52,7 +52,7 @@ class TestInvoiceBase:
     suggested_tip_amounts = [13, 42]
 
 
-class TestInvoiceWithoutRequest(TestInvoiceBase):
+class TestInvoiceWithoutRequest(InvoiceTestBase):
     def test_slot_behaviour(self, invoice):
         for attr in invoice.__slots__:
             assert getattr(invoice, attr, "err") != "err", f"got extra slot '{attr}'"
@@ -219,7 +219,7 @@ class TestInvoiceWithoutRequest(TestInvoiceBase):
         assert hash(a) != hash(d)
 
 
-class TestInvoiceWithRequest(TestInvoiceBase):
+class TestInvoiceWithRequest(InvoiceTestBase):
     async def test_send_required_args_only(self, bot, chat_id, provider_token):
         message = await bot.send_invoice(
             chat_id=chat_id,

--- a/tests/_payment/test_labeledprice.py
+++ b/tests/_payment/test_labeledprice.py
@@ -24,15 +24,15 @@ from tests.auxil.slots import mro_slots
 
 @pytest.fixture(scope="module")
 def labeled_price():
-    return LabeledPrice(TestLabeledPriceBase.label, TestLabeledPriceBase.amount)
+    return LabeledPrice(LabeledPriceTestBase.label, LabeledPriceTestBase.amount)
 
 
-class TestLabeledPriceBase:
+class LabeledPriceTestBase:
     label = "label"
     amount = 100
 
 
-class TestLabeledPriceWithoutRequest(TestLabeledPriceBase):
+class TestLabeledPriceWithoutRequest(LabeledPriceTestBase):
     def test_slot_behaviour(self, labeled_price):
         inst = labeled_price
         for attr in inst.__slots__:

--- a/tests/_payment/test_orderinfo.py
+++ b/tests/_payment/test_orderinfo.py
@@ -25,21 +25,21 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def order_info():
     return OrderInfo(
-        TestOrderInfoBase.name,
-        TestOrderInfoBase.phone_number,
-        TestOrderInfoBase.email,
-        TestOrderInfoBase.shipping_address,
+        OrderInfoTestBase.name,
+        OrderInfoTestBase.phone_number,
+        OrderInfoTestBase.email,
+        OrderInfoTestBase.shipping_address,
     )
 
 
-class TestOrderInfoBase:
+class OrderInfoTestBase:
     name = "name"
     phone_number = "phone_number"
     email = "email"
     shipping_address = ShippingAddress("GB", "", "London", "12 Grimmauld Place", "", "WC1")
 
 
-class TestOrderInfoWithoutRequest(TestOrderInfoBase):
+class TestOrderInfoWithoutRequest(OrderInfoTestBase):
     def test_slot_behaviour(self, order_info):
         for attr in order_info.__slots__:
             assert getattr(order_info, attr, "err") != "err", f"got extra slot '{attr}'"

--- a/tests/_payment/test_precheckoutquery.py
+++ b/tests/_payment/test_precheckoutquery.py
@@ -31,19 +31,19 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def pre_checkout_query(bot):
     pcq = PreCheckoutQuery(
-        TestPreCheckoutQueryBase.id_,
-        TestPreCheckoutQueryBase.from_user,
-        TestPreCheckoutQueryBase.currency,
-        TestPreCheckoutQueryBase.total_amount,
-        TestPreCheckoutQueryBase.invoice_payload,
-        shipping_option_id=TestPreCheckoutQueryBase.shipping_option_id,
-        order_info=TestPreCheckoutQueryBase.order_info,
+        PreCheckoutQueryTestBase.id_,
+        PreCheckoutQueryTestBase.from_user,
+        PreCheckoutQueryTestBase.currency,
+        PreCheckoutQueryTestBase.total_amount,
+        PreCheckoutQueryTestBase.invoice_payload,
+        shipping_option_id=PreCheckoutQueryTestBase.shipping_option_id,
+        order_info=PreCheckoutQueryTestBase.order_info,
     )
     pcq.set_bot(bot)
     return pcq
 
 
-class TestPreCheckoutQueryBase:
+class PreCheckoutQueryTestBase:
     id_ = 5
     invoice_payload = "invoice_payload"
     shipping_option_id = "shipping_option_id"
@@ -53,7 +53,7 @@ class TestPreCheckoutQueryBase:
     order_info = OrderInfo()
 
 
-class TestPreCheckoutQueryWithoutRequest(TestPreCheckoutQueryBase):
+class TestPreCheckoutQueryWithoutRequest(PreCheckoutQueryTestBase):
     def test_slot_behaviour(self, pre_checkout_query):
         inst = pre_checkout_query
         for attr in inst.__slots__:

--- a/tests/_payment/test_refundedpayment.py
+++ b/tests/_payment/test_refundedpayment.py
@@ -25,15 +25,15 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def refunded_payment():
     return RefundedPayment(
-        TestRefundedPaymentBase.currency,
-        TestRefundedPaymentBase.total_amount,
-        TestRefundedPaymentBase.invoice_payload,
-        TestRefundedPaymentBase.telegram_payment_charge_id,
-        TestRefundedPaymentBase.provider_payment_charge_id,
+        RefundedPaymentTestBase.currency,
+        RefundedPaymentTestBase.total_amount,
+        RefundedPaymentTestBase.invoice_payload,
+        RefundedPaymentTestBase.telegram_payment_charge_id,
+        RefundedPaymentTestBase.provider_payment_charge_id,
     )
 
 
-class TestRefundedPaymentBase:
+class RefundedPaymentTestBase:
     invoice_payload = "invoice_payload"
     currency = "EUR"
     total_amount = 100
@@ -41,7 +41,7 @@ class TestRefundedPaymentBase:
     provider_payment_charge_id = "provider_payment_charge_id"
 
 
-class TestRefundedPaymentWithoutRequest(TestRefundedPaymentBase):
+class TestRefundedPaymentWithoutRequest(RefundedPaymentTestBase):
     def test_slot_behaviour(self, refunded_payment):
         inst = refunded_payment
         for attr in inst.__slots__:

--- a/tests/_payment/test_shippingaddress.py
+++ b/tests/_payment/test_shippingaddress.py
@@ -25,16 +25,16 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def shipping_address():
     return ShippingAddress(
-        TestShippingAddressBase.country_code,
-        TestShippingAddressBase.state,
-        TestShippingAddressBase.city,
-        TestShippingAddressBase.street_line1,
-        TestShippingAddressBase.street_line2,
-        TestShippingAddressBase.post_code,
+        ShippingAddressTestBase.country_code,
+        ShippingAddressTestBase.state,
+        ShippingAddressTestBase.city,
+        ShippingAddressTestBase.street_line1,
+        ShippingAddressTestBase.street_line2,
+        ShippingAddressTestBase.post_code,
     )
 
 
-class TestShippingAddressBase:
+class ShippingAddressTestBase:
     country_code = "GB"
     state = "state"
     city = "London"
@@ -43,7 +43,7 @@ class TestShippingAddressBase:
     post_code = "WC1"
 
 
-class TestShippingAddressWithoutRequest(TestShippingAddressBase):
+class TestShippingAddressWithoutRequest(ShippingAddressTestBase):
     def test_slot_behaviour(self, shipping_address):
         inst = shipping_address
         for attr in inst.__slots__:

--- a/tests/_payment/test_shippingoption.py
+++ b/tests/_payment/test_shippingoption.py
@@ -25,17 +25,17 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def shipping_option():
     return ShippingOption(
-        TestShippingOptionBase.id_, TestShippingOptionBase.title, TestShippingOptionBase.prices
+        ShippingOptionTestBase.id_, ShippingOptionTestBase.title, ShippingOptionTestBase.prices
     )
 
 
-class TestShippingOptionBase:
+class ShippingOptionTestBase:
     id_ = "id"
     title = "title"
     prices = [LabeledPrice("Fish Container", 100), LabeledPrice("Premium Fish Container", 1000)]
 
 
-class TestShippingOptionWithoutRequest(TestShippingOptionBase):
+class TestShippingOptionWithoutRequest(ShippingOptionTestBase):
     def test_slot_behaviour(self, shipping_option):
         inst = shipping_option
         for attr in inst.__slots__:

--- a/tests/_payment/test_shippingquery.py
+++ b/tests/_payment/test_shippingquery.py
@@ -31,23 +31,23 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def shipping_query(bot):
     sq = ShippingQuery(
-        TestShippingQueryBase.id_,
-        TestShippingQueryBase.from_user,
-        TestShippingQueryBase.invoice_payload,
-        TestShippingQueryBase.shipping_address,
+        ShippingQueryTestBase.id_,
+        ShippingQueryTestBase.from_user,
+        ShippingQueryTestBase.invoice_payload,
+        ShippingQueryTestBase.shipping_address,
     )
     sq.set_bot(bot)
     return sq
 
 
-class TestShippingQueryBase:
+class ShippingQueryTestBase:
     id_ = "5"
     invoice_payload = "invoice_payload"
     from_user = User(0, "", False)
     shipping_address = ShippingAddress("GB", "", "London", "12 Grimmauld Place", "", "WC1")
 
 
-class TestShippingQueryWithoutRequest(TestShippingQueryBase):
+class TestShippingQueryWithoutRequest(ShippingQueryTestBase):
     def test_slot_behaviour(self, shipping_query):
         inst = shipping_query
         for attr in inst.__slots__:

--- a/tests/_payment/test_successfulpayment.py
+++ b/tests/_payment/test_successfulpayment.py
@@ -25,17 +25,17 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def successful_payment():
     return SuccessfulPayment(
-        TestSuccessfulPaymentBase.currency,
-        TestSuccessfulPaymentBase.total_amount,
-        TestSuccessfulPaymentBase.invoice_payload,
-        TestSuccessfulPaymentBase.telegram_payment_charge_id,
-        TestSuccessfulPaymentBase.provider_payment_charge_id,
-        shipping_option_id=TestSuccessfulPaymentBase.shipping_option_id,
-        order_info=TestSuccessfulPaymentBase.order_info,
+        SuccessfulPaymentTestBase.currency,
+        SuccessfulPaymentTestBase.total_amount,
+        SuccessfulPaymentTestBase.invoice_payload,
+        SuccessfulPaymentTestBase.telegram_payment_charge_id,
+        SuccessfulPaymentTestBase.provider_payment_charge_id,
+        shipping_option_id=SuccessfulPaymentTestBase.shipping_option_id,
+        order_info=SuccessfulPaymentTestBase.order_info,
     )
 
 
-class TestSuccessfulPaymentBase:
+class SuccessfulPaymentTestBase:
     invoice_payload = "invoice_payload"
     shipping_option_id = "shipping_option_id"
     currency = "EUR"
@@ -45,7 +45,7 @@ class TestSuccessfulPaymentBase:
     provider_payment_charge_id = "provider_payment_charge_id"
 
 
-class TestSuccessfulPaymentWithoutRequest(TestSuccessfulPaymentBase):
+class TestSuccessfulPaymentWithoutRequest(SuccessfulPaymentTestBase):
     def test_slot_behaviour(self, successful_payment):
         inst = successful_payment
         for attr in inst.__slots__:

--- a/tests/test_birthdate.py
+++ b/tests/test_birthdate.py
@@ -24,7 +24,7 @@ from telegram import Birthdate
 from tests.auxil.slots import mro_slots
 
 
-class TestBirthdateBase:
+class BirthdateTestBase:
     day = 1
     month = 1
     year = 2022
@@ -32,10 +32,10 @@ class TestBirthdateBase:
 
 @pytest.fixture(scope="module")
 def birthdate():
-    return Birthdate(TestBirthdateBase.day, TestBirthdateBase.month, TestBirthdateBase.year)
+    return Birthdate(BirthdateTestBase.day, BirthdateTestBase.month, BirthdateTestBase.year)
 
 
-class TestBirthdateWithoutRequest(TestBirthdateBase):
+class TestBirthdateWithoutRequest(BirthdateTestBase):
     def test_slot_behaviour(self, birthdate):
         for attr in birthdate.__slots__:
             assert getattr(birthdate, attr, "err") != "err", f"got extra slot '{attr}'"

--- a/tests/test_botdescription.py
+++ b/tests/test_botdescription.py
@@ -24,20 +24,20 @@ from tests.auxil.slots import mro_slots
 
 @pytest.fixture(scope="module")
 def bot_description(bot):
-    return BotDescription(TestBotDescriptionBase.description)
+    return BotDescription(BotDescriptionTestBase.description)
 
 
 @pytest.fixture(scope="module")
 def bot_short_description(bot):
-    return BotShortDescription(TestBotDescriptionBase.short_description)
+    return BotShortDescription(BotDescriptionTestBase.short_description)
 
 
-class TestBotDescriptionBase:
+class BotDescriptionTestBase:
     description = "This is a test description"
     short_description = "This is a test short description"
 
 
-class TestBotDescriptionWithoutRequest(TestBotDescriptionBase):
+class TestBotDescriptionWithoutRequest(BotDescriptionTestBase):
     def test_slot_behaviour(self, bot_description):
         for attr in bot_description.__slots__:
             assert getattr(bot_description, attr, "err") != "err", f"got extra slot '{attr}'"
@@ -64,7 +64,7 @@ class TestBotDescriptionWithoutRequest(TestBotDescriptionBase):
         assert hash(a) != hash(c)
 
 
-class TestBotShortDescriptionWithoutRequest(TestBotDescriptionBase):
+class TestBotShortDescriptionWithoutRequest(BotDescriptionTestBase):
     def test_slot_behaviour(self, bot_short_description):
         for attr in bot_short_description.__slots__:
             assert getattr(bot_short_description, attr, "err") != "err", f"got extra slot '{attr}'"

--- a/tests/test_botname.py
+++ b/tests/test_botname.py
@@ -24,14 +24,14 @@ from tests.auxil.slots import mro_slots
 
 @pytest.fixture(scope="module")
 def bot_name(bot):
-    return BotName(TestBotNameBase.name)
+    return BotName(BotNameTestBase.name)
 
 
-class TestBotNameBase:
+class BotNameTestBase:
     name = "This is a test name"
 
 
-class TestBotNameWithoutRequest(TestBotNameBase):
+class TestBotNameWithoutRequest(BotNameTestBase):
     def test_slot_behaviour(self, bot_name):
         for attr in bot_name.__slots__:
             assert getattr(bot_name, attr, "err") != "err", f"got extra slot '{attr}'"

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -36,7 +36,7 @@ from telegram._utils.datetime import UTC, to_timestamp
 from tests.auxil.slots import mro_slots
 
 
-class TestBusinessBase:
+class BusinessTestBase:
     id_ = "123"
     user = User(123, "test_user", False)
     user_chat_id = 123
@@ -62,58 +62,58 @@ class TestBusinessBase:
 @pytest.fixture(scope="module")
 def business_connection():
     return BusinessConnection(
-        TestBusinessBase.id_,
-        TestBusinessBase.user,
-        TestBusinessBase.user_chat_id,
-        TestBusinessBase.date,
-        TestBusinessBase.can_reply,
-        TestBusinessBase.is_enabled,
+        BusinessTestBase.id_,
+        BusinessTestBase.user,
+        BusinessTestBase.user_chat_id,
+        BusinessTestBase.date,
+        BusinessTestBase.can_reply,
+        BusinessTestBase.is_enabled,
     )
 
 
 @pytest.fixture(scope="module")
 def business_messages_deleted():
     return BusinessMessagesDeleted(
-        TestBusinessBase.business_connection_id,
-        TestBusinessBase.chat,
-        TestBusinessBase.message_ids,
+        BusinessTestBase.business_connection_id,
+        BusinessTestBase.chat,
+        BusinessTestBase.message_ids,
     )
 
 
 @pytest.fixture(scope="module")
 def business_intro():
     return BusinessIntro(
-        TestBusinessBase.title,
-        TestBusinessBase.message,
-        TestBusinessBase.sticker,
+        BusinessTestBase.title,
+        BusinessTestBase.message,
+        BusinessTestBase.sticker,
     )
 
 
 @pytest.fixture(scope="module")
 def business_location():
     return BusinessLocation(
-        TestBusinessBase.address,
-        TestBusinessBase.location,
+        BusinessTestBase.address,
+        BusinessTestBase.location,
     )
 
 
 @pytest.fixture(scope="module")
 def business_opening_hours_interval():
     return BusinessOpeningHoursInterval(
-        TestBusinessBase.opening_minute,
-        TestBusinessBase.closing_minute,
+        BusinessTestBase.opening_minute,
+        BusinessTestBase.closing_minute,
     )
 
 
 @pytest.fixture(scope="module")
 def business_opening_hours():
     return BusinessOpeningHours(
-        TestBusinessBase.time_zone_name,
-        TestBusinessBase.opening_hours,
+        BusinessTestBase.time_zone_name,
+        BusinessTestBase.opening_hours,
     )
 
 
-class TestBusinessConnectionWithoutRequest(TestBusinessBase):
+class TestBusinessConnectionWithoutRequest(BusinessTestBase):
     def test_slots(self, business_connection):
         bc = business_connection
         for attr in bc.__slots__:
@@ -188,7 +188,7 @@ class TestBusinessConnectionWithoutRequest(TestBusinessBase):
         assert hash(bc1) != hash(bc3)
 
 
-class TestBusinessMessagesDeleted(TestBusinessBase):
+class TestBusinessMessagesDeleted(BusinessTestBase):
     def test_slots(self, business_messages_deleted):
         bmd = business_messages_deleted
         for attr in bmd.__slots__:
@@ -227,7 +227,7 @@ class TestBusinessMessagesDeleted(TestBusinessBase):
         assert hash(bmd1) != hash(bmd3)
 
 
-class TestBusinessIntroWithoutRequest(TestBusinessBase):
+class TestBusinessIntroWithoutRequest(BusinessTestBase):
     def test_slot_behaviour(self, business_intro):
         intro = business_intro
         for attr in intro.__slots__:
@@ -267,7 +267,7 @@ class TestBusinessIntroWithoutRequest(TestBusinessBase):
         assert hash(intro1) != hash(intro3)
 
 
-class TestBusinessLocationWithoutRequest(TestBusinessBase):
+class TestBusinessLocationWithoutRequest(BusinessTestBase):
     def test_slot_behaviour(self, business_location):
         inst = business_location
         for attr in inst.__slots__:
@@ -304,7 +304,7 @@ class TestBusinessLocationWithoutRequest(TestBusinessBase):
         assert hash(blc1) != hash(blc3)
 
 
-class TestBusinessOpeningHoursIntervalWithoutRequest(TestBusinessBase):
+class TestBusinessOpeningHoursIntervalWithoutRequest(BusinessTestBase):
     def test_slot_behaviour(self, business_opening_hours_interval):
         inst = business_opening_hours_interval
         for attr in inst.__slots__:
@@ -375,7 +375,7 @@ class TestBusinessOpeningHoursIntervalWithoutRequest(TestBusinessBase):
         assert cached is closing_time
 
 
-class TestBusinessOpeningHoursWithoutRequest(TestBusinessBase):
+class TestBusinessOpeningHoursWithoutRequest(BusinessTestBase):
     def test_slot_behaviour(self, business_opening_hours):
         inst = business_opening_hours
         for attr in inst.__slots__:

--- a/tests/test_callbackquery.py
+++ b/tests/test_callbackquery.py
@@ -33,28 +33,28 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(params=["message", "inline", "inaccessible_message"])
 def callback_query(bot, request):
     cbq = CallbackQuery(
-        TestCallbackQueryBase.id_,
-        TestCallbackQueryBase.from_user,
-        TestCallbackQueryBase.chat_instance,
-        data=TestCallbackQueryBase.data,
-        game_short_name=TestCallbackQueryBase.game_short_name,
+        CallbackQueryTestBase.id_,
+        CallbackQueryTestBase.from_user,
+        CallbackQueryTestBase.chat_instance,
+        data=CallbackQueryTestBase.data,
+        game_short_name=CallbackQueryTestBase.game_short_name,
     )
     cbq.set_bot(bot)
     cbq._unfreeze()
     if request.param == "message":
-        cbq.message = TestCallbackQueryBase.message
+        cbq.message = CallbackQueryTestBase.message
         cbq.message.set_bot(bot)
     elif request.param == "inline":
-        cbq.inline_message_id = TestCallbackQueryBase.inline_message_id
+        cbq.inline_message_id = CallbackQueryTestBase.inline_message_id
     elif request.param == "inaccessible_message":
         cbq.message = InaccessibleMessage(
-            chat=TestCallbackQueryBase.message.chat,
-            message_id=TestCallbackQueryBase.message.message_id,
+            chat=CallbackQueryTestBase.message.chat,
+            message_id=CallbackQueryTestBase.message.message_id,
         )
     return cbq
 
 
-class TestCallbackQueryBase:
+class CallbackQueryTestBase:
     id_ = "id"
     from_user = User(1, "test_user", False)
     chat_instance = "chat_instance"
@@ -64,7 +64,7 @@ class TestCallbackQueryBase:
     game_short_name = "the_game"
 
 
-class TestCallbackQueryWithoutRequest(TestCallbackQueryBase):
+class TestCallbackQueryWithoutRequest(CallbackQueryTestBase):
     @staticmethod
     def skip_params(callback_query: CallbackQuery):
         if callback_query.inline_message_id:

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -34,20 +34,20 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def chat(bot):
     chat = Chat(
-        TestChatBase.id_,
-        title=TestChatBase.title,
-        type=TestChatBase.type_,
-        username=TestChatBase.username,
+        ChatTestBase.id_,
+        title=ChatTestBase.title,
+        type=ChatTestBase.type_,
+        username=ChatTestBase.username,
         is_forum=True,
-        first_name=TestChatBase.first_name,
-        last_name=TestChatBase.last_name,
+        first_name=ChatTestBase.first_name,
+        last_name=ChatTestBase.last_name,
     )
     chat.set_bot(bot)
     chat._unfreeze()
     return chat
 
 
-class TestChatBase:
+class ChatTestBase:
     id_ = -28767330
     title = "ToledosPalaceBot - Group"
     type_ = "group"
@@ -57,7 +57,7 @@ class TestChatBase:
     last_name = "last"
 
 
-class TestChatWithoutRequest(TestChatBase):
+class TestChatWithoutRequest(ChatTestBase):
     def test_slot_behaviour(self, chat):
         for attr in chat.__slots__:
             assert getattr(chat, attr, "err") != "err", f"got extra slot '{attr}'"

--- a/tests/test_chatfullinfo.py
+++ b/tests/test_chatfullinfo.py
@@ -42,47 +42,47 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def chat_full_info(bot):
     chat = ChatFullInfo(
-        TestChatFullInfoBase.id_,
-        type=TestChatFullInfoBase.type_,
-        accent_color_id=TestChatFullInfoBase.accent_color_id,
-        max_reaction_count=TestChatFullInfoBase.max_reaction_count,
-        title=TestChatFullInfoBase.title,
-        username=TestChatFullInfoBase.username,
-        sticker_set_name=TestChatFullInfoBase.sticker_set_name,
-        can_set_sticker_set=TestChatFullInfoBase.can_set_sticker_set,
-        permissions=TestChatFullInfoBase.permissions,
-        slow_mode_delay=TestChatFullInfoBase.slow_mode_delay,
-        bio=TestChatFullInfoBase.bio,
-        linked_chat_id=TestChatFullInfoBase.linked_chat_id,
-        location=TestChatFullInfoBase.location,
-        has_private_forwards=TestChatFullInfoBase.has_private_forwards,
-        has_protected_content=TestChatFullInfoBase.has_protected_content,
-        has_visible_history=TestChatFullInfoBase.has_visible_history,
-        join_to_send_messages=TestChatFullInfoBase.join_to_send_messages,
-        join_by_request=TestChatFullInfoBase.join_by_request,
+        ChatFullInfoTestBase.id_,
+        type=ChatFullInfoTestBase.type_,
+        accent_color_id=ChatFullInfoTestBase.accent_color_id,
+        max_reaction_count=ChatFullInfoTestBase.max_reaction_count,
+        title=ChatFullInfoTestBase.title,
+        username=ChatFullInfoTestBase.username,
+        sticker_set_name=ChatFullInfoTestBase.sticker_set_name,
+        can_set_sticker_set=ChatFullInfoTestBase.can_set_sticker_set,
+        permissions=ChatFullInfoTestBase.permissions,
+        slow_mode_delay=ChatFullInfoTestBase.slow_mode_delay,
+        bio=ChatFullInfoTestBase.bio,
+        linked_chat_id=ChatFullInfoTestBase.linked_chat_id,
+        location=ChatFullInfoTestBase.location,
+        has_private_forwards=ChatFullInfoTestBase.has_private_forwards,
+        has_protected_content=ChatFullInfoTestBase.has_protected_content,
+        has_visible_history=ChatFullInfoTestBase.has_visible_history,
+        join_to_send_messages=ChatFullInfoTestBase.join_to_send_messages,
+        join_by_request=ChatFullInfoTestBase.join_by_request,
         has_restricted_voice_and_video_messages=(
-            TestChatFullInfoBase.has_restricted_voice_and_video_messages
+            ChatFullInfoTestBase.has_restricted_voice_and_video_messages
         ),
-        is_forum=TestChatFullInfoBase.is_forum,
-        active_usernames=TestChatFullInfoBase.active_usernames,
-        emoji_status_custom_emoji_id=TestChatFullInfoBase.emoji_status_custom_emoji_id,
-        emoji_status_expiration_date=TestChatFullInfoBase.emoji_status_expiration_date,
-        has_aggressive_anti_spam_enabled=TestChatFullInfoBase.has_aggressive_anti_spam_enabled,
-        has_hidden_members=TestChatFullInfoBase.has_hidden_members,
-        available_reactions=TestChatFullInfoBase.available_reactions,
-        background_custom_emoji_id=TestChatFullInfoBase.background_custom_emoji_id,
-        profile_accent_color_id=TestChatFullInfoBase.profile_accent_color_id,
-        profile_background_custom_emoji_id=TestChatFullInfoBase.profile_background_custom_emoji_id,
-        unrestrict_boost_count=TestChatFullInfoBase.unrestrict_boost_count,
-        custom_emoji_sticker_set_name=TestChatFullInfoBase.custom_emoji_sticker_set_name,
-        business_intro=TestChatFullInfoBase.business_intro,
-        business_location=TestChatFullInfoBase.business_location,
-        business_opening_hours=TestChatFullInfoBase.business_opening_hours,
-        birthdate=TestChatFullInfoBase.birthdate,
-        personal_chat=TestChatFullInfoBase.personal_chat,
-        first_name=TestChatFullInfoBase.first_name,
-        last_name=TestChatFullInfoBase.last_name,
-        can_send_paid_media=TestChatFullInfoBase.can_send_paid_media,
+        is_forum=ChatFullInfoTestBase.is_forum,
+        active_usernames=ChatFullInfoTestBase.active_usernames,
+        emoji_status_custom_emoji_id=ChatFullInfoTestBase.emoji_status_custom_emoji_id,
+        emoji_status_expiration_date=ChatFullInfoTestBase.emoji_status_expiration_date,
+        has_aggressive_anti_spam_enabled=ChatFullInfoTestBase.has_aggressive_anti_spam_enabled,
+        has_hidden_members=ChatFullInfoTestBase.has_hidden_members,
+        available_reactions=ChatFullInfoTestBase.available_reactions,
+        background_custom_emoji_id=ChatFullInfoTestBase.background_custom_emoji_id,
+        profile_accent_color_id=ChatFullInfoTestBase.profile_accent_color_id,
+        profile_background_custom_emoji_id=ChatFullInfoTestBase.profile_background_custom_emoji_id,
+        unrestrict_boost_count=ChatFullInfoTestBase.unrestrict_boost_count,
+        custom_emoji_sticker_set_name=ChatFullInfoTestBase.custom_emoji_sticker_set_name,
+        business_intro=ChatFullInfoTestBase.business_intro,
+        business_location=ChatFullInfoTestBase.business_location,
+        business_opening_hours=ChatFullInfoTestBase.business_opening_hours,
+        birthdate=ChatFullInfoTestBase.birthdate,
+        personal_chat=ChatFullInfoTestBase.personal_chat,
+        first_name=ChatFullInfoTestBase.first_name,
+        last_name=ChatFullInfoTestBase.last_name,
+        can_send_paid_media=ChatFullInfoTestBase.can_send_paid_media,
     )
     chat.set_bot(bot)
     chat._unfreeze()
@@ -90,7 +90,7 @@ def chat_full_info(bot):
 
 
 # Shortcut methods are tested in test_chat.py.
-class TestChatFullInfoBase:
+class ChatFullInfoTestBase:
     id_ = -28767330
     max_reaction_count = 2
     title = "ToledosPalaceBot - Group"
@@ -142,7 +142,7 @@ class TestChatFullInfoBase:
     can_send_paid_media = True
 
 
-class TestChatFullInfoWithoutRequest(TestChatFullInfoBase):
+class TestChatFullInfoWithoutRequest(ChatFullInfoTestBase):
     def test_slot_behaviour(self, chat_full_info):
         cfi = chat_full_info
         for attr in cfi.__slots__:

--- a/tests/test_chatinvitelink.py
+++ b/tests/test_chatinvitelink.py
@@ -33,21 +33,21 @@ def creator():
 @pytest.fixture(scope="module")
 def invite_link(creator):
     return ChatInviteLink(
-        TestChatInviteLinkBase.link,
+        ChatInviteLinkTestBase.link,
         creator,
-        TestChatInviteLinkBase.creates_join_request,
-        TestChatInviteLinkBase.primary,
-        TestChatInviteLinkBase.revoked,
-        expire_date=TestChatInviteLinkBase.expire_date,
-        member_limit=TestChatInviteLinkBase.member_limit,
-        name=TestChatInviteLinkBase.name,
-        pending_join_request_count=TestChatInviteLinkBase.pending_join_request_count,
-        subscription_period=TestChatInviteLinkBase.subscription_period,
-        subscription_price=TestChatInviteLinkBase.subscription_price,
+        ChatInviteLinkTestBase.creates_join_request,
+        ChatInviteLinkTestBase.primary,
+        ChatInviteLinkTestBase.revoked,
+        expire_date=ChatInviteLinkTestBase.expire_date,
+        member_limit=ChatInviteLinkTestBase.member_limit,
+        name=ChatInviteLinkTestBase.name,
+        pending_join_request_count=ChatInviteLinkTestBase.pending_join_request_count,
+        subscription_period=ChatInviteLinkTestBase.subscription_period,
+        subscription_price=ChatInviteLinkTestBase.subscription_price,
     )
 
 
-class TestChatInviteLinkBase:
+class ChatInviteLinkTestBase:
     link = "thisialink"
     creates_join_request = False
     primary = True
@@ -60,7 +60,7 @@ class TestChatInviteLinkBase:
     subscription_price = 44
 
 
-class TestChatInviteLinkWithoutRequest(TestChatInviteLinkBase):
+class TestChatInviteLinkWithoutRequest(ChatInviteLinkTestBase):
     def test_slot_behaviour(self, invite_link):
         for attr in invite_link.__slots__:
             assert getattr(invite_link, attr, "err") != "err", f"got extra slot '{attr}'"

--- a/tests/test_chatjoinrequest.py
+++ b/tests/test_chatjoinrequest.py
@@ -38,18 +38,18 @@ def time():
 @pytest.fixture(scope="module")
 def chat_join_request(bot, time):
     cjr = ChatJoinRequest(
-        chat=TestChatJoinRequestBase.chat,
-        from_user=TestChatJoinRequestBase.from_user,
+        chat=ChatJoinRequestTestBase.chat,
+        from_user=ChatJoinRequestTestBase.from_user,
         date=time,
-        bio=TestChatJoinRequestBase.bio,
-        invite_link=TestChatJoinRequestBase.invite_link,
-        user_chat_id=TestChatJoinRequestBase.from_user.id,
+        bio=ChatJoinRequestTestBase.bio,
+        invite_link=ChatJoinRequestTestBase.invite_link,
+        user_chat_id=ChatJoinRequestTestBase.from_user.id,
     )
     cjr.set_bot(bot)
     return cjr
 
 
-class TestChatJoinRequestBase:
+class ChatJoinRequestTestBase:
     chat = Chat(1, Chat.SUPERGROUP)
     from_user = User(2, "first_name", False)
     bio = "bio"
@@ -63,7 +63,7 @@ class TestChatJoinRequestBase:
     )
 
 
-class TestChatJoinRequestWithoutRequest(TestChatJoinRequestBase):
+class TestChatJoinRequestWithoutRequest(ChatJoinRequestTestBase):
     def test_slot_behaviour(self, chat_join_request):
         inst = chat_join_request
         for attr in inst.__slots__:

--- a/tests/test_chatlocation.py
+++ b/tests/test_chatlocation.py
@@ -25,15 +25,15 @@ from tests.auxil.slots import mro_slots
 
 @pytest.fixture(scope="module")
 def chat_location():
-    return ChatLocation(TestChatLocationBase.location, TestChatLocationBase.address)
+    return ChatLocation(ChatLocationTestBase.location, ChatLocationTestBase.address)
 
 
-class TestChatLocationBase:
+class ChatLocationTestBase:
     location = Location(123, 456)
     address = "The Shire"
 
 
-class TestChatLocationWithoutRequest(TestChatLocationBase):
+class TestChatLocationWithoutRequest(ChatLocationTestBase):
     def test_slot_behaviour(self, chat_location):
         inst = chat_location
         for attr in inst.__slots__:

--- a/tests/test_chatmemberupdated.py
+++ b/tests/test_chatmemberupdated.py
@@ -47,7 +47,7 @@ def chat():
 
 @pytest.fixture(scope="module")
 def old_chat_member(user):
-    return ChatMember(user, TestChatMemberUpdatedBase.old_status)
+    return ChatMember(user, ChatMemberUpdatedTestBase.old_status)
 
 
 @pytest.fixture(scope="module")
@@ -66,7 +66,7 @@ def new_chat_member(user):
         True,
         True,
         True,
-        custom_title=TestChatMemberUpdatedBase.new_status,
+        custom_title=ChatMemberUpdatedTestBase.new_status,
     )
 
 
@@ -87,12 +87,12 @@ def chat_member_updated(user, chat, old_chat_member, new_chat_member, invite_lin
     )
 
 
-class TestChatMemberUpdatedBase:
+class ChatMemberUpdatedTestBase:
     old_status = ChatMember.MEMBER
     new_status = ChatMember.ADMINISTRATOR
 
 
-class TestChatMemberUpdatedWithoutRequest(TestChatMemberUpdatedBase):
+class TestChatMemberUpdatedWithoutRequest(ChatMemberUpdatedTestBase):
     def test_slot_behaviour(self, chat_member_updated):
         action = chat_member_updated
         for attr in action.__slots__:

--- a/tests/test_chatpermissions.py
+++ b/tests/test_chatpermissions.py
@@ -43,7 +43,7 @@ def chat_permissions():
     )
 
 
-class TestChatPermissionsBase:
+class ChatPermissionsTestBase:
     can_send_messages = True
     can_send_polls = True
     can_send_other_messages = False
@@ -60,7 +60,7 @@ class TestChatPermissionsBase:
     can_send_voice_notes = None
 
 
-class TestChatPermissionsWithoutRequest(TestChatPermissionsBase):
+class TestChatPermissionsWithoutRequest(ChatPermissionsTestBase):
     def test_slot_behaviour(self, chat_permissions):
         inst = chat_permissions
         for attr in inst.__slots__:

--- a/tests/test_choseninlineresult.py
+++ b/tests/test_choseninlineresult.py
@@ -33,16 +33,16 @@ def user():
 @pytest.fixture(scope="module")
 def chosen_inline_result(user):
     return ChosenInlineResult(
-        TestChosenInlineResultBase.result_id, user, TestChosenInlineResultBase.query
+        ChosenInlineResultTestBase.result_id, user, ChosenInlineResultTestBase.query
     )
 
 
-class TestChosenInlineResultBase:
+class ChosenInlineResultTestBase:
     result_id = "result id"
     query = "query text"
 
 
-class TestChosenInlineResultWithoutRequest(TestChosenInlineResultBase):
+class TestChosenInlineResultWithoutRequest(ChosenInlineResultTestBase):
     def test_slot_behaviour(self, chosen_inline_result):
         inst = chosen_inline_result
         for attr in inst.__slots__:

--- a/tests/test_dice.py
+++ b/tests/test_dice.py
@@ -28,11 +28,11 @@ def dice(request):
     return Dice(value=5, emoji=request.param)
 
 
-class TestDiceBase:
+class DiceTestBase:
     value = 4
 
 
-class TestDiceWithoutRequest(TestDiceBase):
+class TestDiceWithoutRequest(DiceTestBase):
     def test_slot_behaviour(self, dice):
         for attr in dice.__slots__:
             assert getattr(dice, attr, "err") != "err", f"got extra slot '{attr}'"

--- a/tests/test_forcereply.py
+++ b/tests/test_forcereply.py
@@ -25,16 +25,16 @@ from tests.auxil.slots import mro_slots
 
 @pytest.fixture(scope="module")
 def force_reply():
-    return ForceReply(TestForceReplyBase.selective, TestForceReplyBase.input_field_placeholder)
+    return ForceReply(ForceReplyTestBase.selective, ForceReplyTestBase.input_field_placeholder)
 
 
-class TestForceReplyBase:
+class ForceReplyTestBase:
     force_reply = True
     selective = True
     input_field_placeholder = "force replies can be annoying if not used properly"
 
 
-class TestForceReplyWithoutRequest(TestForceReplyBase):
+class TestForceReplyWithoutRequest(ForceReplyTestBase):
     def test_slot_behaviour(self, force_reply):
         for attr in force_reply.__slots__:
             assert getattr(force_reply, attr, "err") != "err", f"got extra slot '{attr}'"
@@ -69,7 +69,7 @@ class TestForceReplyWithoutRequest(TestForceReplyBase):
         assert hash(a) != hash(d)
 
 
-class TestForceReplyWithRequest(TestForceReplyBase):
+class TestForceReplyWithRequest(ForceReplyTestBase):
     async def test_send_message_with_force_reply(self, bot, chat_id, force_reply):
         message = await bot.send_message(chat_id, "text", reply_markup=force_reply)
         assert message.text == "text"

--- a/tests/test_inlinequeryresultsbutton.py
+++ b/tests/test_inlinequeryresultsbutton.py
@@ -25,19 +25,19 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def inline_query_results_button():
     return InlineQueryResultsButton(
-        text=TestInlineQueryResultsButtonBase.text,
-        start_parameter=TestInlineQueryResultsButtonBase.start_parameter,
-        web_app=TestInlineQueryResultsButtonBase.web_app,
+        text=InlineQueryResultsButtonTestBase.text,
+        start_parameter=InlineQueryResultsButtonTestBase.start_parameter,
+        web_app=InlineQueryResultsButtonTestBase.web_app,
     )
 
 
-class TestInlineQueryResultsButtonBase:
+class InlineQueryResultsButtonTestBase:
     text = "text"
     start_parameter = "start_parameter"
     web_app = WebAppInfo(url="https://python-telegram-bot.org")
 
 
-class TestInlineQueryResultsButtonWithoutRequest(TestInlineQueryResultsButtonBase):
+class TestInlineQueryResultsButtonWithoutRequest(InlineQueryResultsButtonTestBase):
     def test_slot_behaviour(self, inline_query_results_button):
         inst = inline_query_results_button
         for attr in inst.__slots__:

--- a/tests/test_keyboardbutton.py
+++ b/tests/test_keyboardbutton.py
@@ -32,17 +32,17 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def keyboard_button():
     return KeyboardButton(
-        TestKeyboardButtonBase.text,
-        request_location=TestKeyboardButtonBase.request_location,
-        request_contact=TestKeyboardButtonBase.request_contact,
-        request_poll=TestKeyboardButtonBase.request_poll,
-        web_app=TestKeyboardButtonBase.web_app,
-        request_chat=TestKeyboardButtonBase.request_chat,
-        request_users=TestKeyboardButtonBase.request_users,
+        KeyboardButtonTestBase.text,
+        request_location=KeyboardButtonTestBase.request_location,
+        request_contact=KeyboardButtonTestBase.request_contact,
+        request_poll=KeyboardButtonTestBase.request_poll,
+        web_app=KeyboardButtonTestBase.web_app,
+        request_chat=KeyboardButtonTestBase.request_chat,
+        request_users=KeyboardButtonTestBase.request_users,
     )
 
 
-class TestKeyboardButtonBase:
+class KeyboardButtonTestBase:
     text = "text"
     request_location = True
     request_contact = True
@@ -52,7 +52,7 @@ class TestKeyboardButtonBase:
     request_users = KeyboardButtonRequestUsers(2)
 
 
-class TestKeyboardButtonWithoutRequest(TestKeyboardButtonBase):
+class TestKeyboardButtonWithoutRequest(KeyboardButtonTestBase):
     def test_slot_behaviour(self, keyboard_button):
         inst = keyboard_button
         for attr in inst.__slots__:

--- a/tests/test_keyboardbuttonpolltype.py
+++ b/tests/test_keyboardbuttonpolltype.py
@@ -25,14 +25,14 @@ from tests.auxil.slots import mro_slots
 
 @pytest.fixture(scope="module")
 def keyboard_button_poll_type():
-    return KeyboardButtonPollType(TestKeyboardButtonPollTypeBase.type)
+    return KeyboardButtonPollType(KeyboardButtonPollTypeTestBase.type)
 
 
-class TestKeyboardButtonPollTypeBase:
+class KeyboardButtonPollTypeTestBase:
     type = Poll.QUIZ
 
 
-class TestKeyboardButtonPollTypeWithoutRequest(TestKeyboardButtonPollTypeBase):
+class TestKeyboardButtonPollTypeWithoutRequest(KeyboardButtonPollTypeTestBase):
     def test_slot_behaviour(self, keyboard_button_poll_type):
         inst = keyboard_button_poll_type
         for attr in inst.__slots__:

--- a/tests/test_keyboardbuttonrequest.py
+++ b/tests/test_keyboardbuttonrequest.py
@@ -26,21 +26,21 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="class")
 def request_users():
     return KeyboardButtonRequestUsers(
-        TestKeyboardButtonRequestUsersBase.request_id,
-        TestKeyboardButtonRequestUsersBase.user_is_bot,
-        TestKeyboardButtonRequestUsersBase.user_is_premium,
-        TestKeyboardButtonRequestUsersBase.max_quantity,
+        KeyboardButtonRequestUsersTestBase.request_id,
+        KeyboardButtonRequestUsersTestBase.user_is_bot,
+        KeyboardButtonRequestUsersTestBase.user_is_premium,
+        KeyboardButtonRequestUsersTestBase.max_quantity,
     )
 
 
-class TestKeyboardButtonRequestUsersBase:
+class KeyboardButtonRequestUsersTestBase:
     request_id = 123
     user_is_bot = True
     user_is_premium = False
     max_quantity = 10
 
 
-class TestKeyboardButtonRequestUsersWithoutRequest(TestKeyboardButtonRequestUsersBase):
+class TestKeyboardButtonRequestUsersWithoutRequest(KeyboardButtonRequestUsersTestBase):
     def test_slot_behaviour(self, request_users):
         for attr in request_users.__slots__:
             assert getattr(request_users, attr, "err") != "err", f"got extra slot '{attr}'"
@@ -88,18 +88,18 @@ class TestKeyboardButtonRequestUsersWithoutRequest(TestKeyboardButtonRequestUser
 @pytest.fixture(scope="class")
 def request_chat():
     return KeyboardButtonRequestChat(
-        TestKeyboardButtonRequestChatBase.request_id,
-        TestKeyboardButtonRequestChatBase.chat_is_channel,
-        TestKeyboardButtonRequestChatBase.chat_is_forum,
-        TestKeyboardButtonRequestChatBase.chat_has_username,
-        TestKeyboardButtonRequestChatBase.chat_is_created,
-        TestKeyboardButtonRequestChatBase.user_administrator_rights,
-        TestKeyboardButtonRequestChatBase.bot_administrator_rights,
-        TestKeyboardButtonRequestChatBase.bot_is_member,
+        KeyboardButtonRequestChatTestBase.request_id,
+        KeyboardButtonRequestChatTestBase.chat_is_channel,
+        KeyboardButtonRequestChatTestBase.chat_is_forum,
+        KeyboardButtonRequestChatTestBase.chat_has_username,
+        KeyboardButtonRequestChatTestBase.chat_is_created,
+        KeyboardButtonRequestChatTestBase.user_administrator_rights,
+        KeyboardButtonRequestChatTestBase.bot_administrator_rights,
+        KeyboardButtonRequestChatTestBase.bot_is_member,
     )
 
 
-class TestKeyboardButtonRequestChatBase:
+class KeyboardButtonRequestChatTestBase:
     request_id = 456
     chat_is_channel = True
     chat_is_forum = False
@@ -134,7 +134,7 @@ class TestKeyboardButtonRequestChatBase:
     bot_is_member = True
 
 
-class TestKeyboardButtonRequestChatWithoutRequest(TestKeyboardButtonRequestChatBase):
+class TestKeyboardButtonRequestChatWithoutRequest(KeyboardButtonRequestChatTestBase):
     def test_slot_behaviour(self, request_chat):
         for attr in request_chat.__slots__:
             assert getattr(request_chat, attr, "err") != "err", f"got extra slot '{attr}'"

--- a/tests/test_linkpreviewoptions.py
+++ b/tests/test_linkpreviewoptions.py
@@ -25,15 +25,15 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def link_preview_options():
     return LinkPreviewOptions(
-        is_disabled=TestLinkPreviewOptionsBase.is_disabled,
-        url=TestLinkPreviewOptionsBase.url,
-        prefer_small_media=TestLinkPreviewOptionsBase.prefer_small_media,
-        prefer_large_media=TestLinkPreviewOptionsBase.prefer_large_media,
-        show_above_text=TestLinkPreviewOptionsBase.show_above_text,
+        is_disabled=LinkPreviewOptionsTestBase.is_disabled,
+        url=LinkPreviewOptionsTestBase.url,
+        prefer_small_media=LinkPreviewOptionsTestBase.prefer_small_media,
+        prefer_large_media=LinkPreviewOptionsTestBase.prefer_large_media,
+        show_above_text=LinkPreviewOptionsTestBase.show_above_text,
     )
 
 
-class TestLinkPreviewOptionsBase:
+class LinkPreviewOptionsTestBase:
     is_disabled = True
     url = "https://www.example.com"
     prefer_small_media = True
@@ -41,7 +41,7 @@ class TestLinkPreviewOptionsBase:
     show_above_text = True
 
 
-class TestLinkPreviewOptionsWithoutRequest(TestLinkPreviewOptionsBase):
+class TestLinkPreviewOptionsWithoutRequest(LinkPreviewOptionsTestBase):
     def test_slot_behaviour(self, link_preview_options):
         a = link_preview_options
         for attr in a.__slots__:

--- a/tests/test_loginurl.py
+++ b/tests/test_loginurl.py
@@ -25,21 +25,21 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def login_url():
     return LoginUrl(
-        url=TestLoginUrlBase.url,
-        forward_text=TestLoginUrlBase.forward_text,
-        bot_username=TestLoginUrlBase.bot_username,
-        request_write_access=TestLoginUrlBase.request_write_access,
+        url=LoginUrlTestBase.url,
+        forward_text=LoginUrlTestBase.forward_text,
+        bot_username=LoginUrlTestBase.bot_username,
+        request_write_access=LoginUrlTestBase.request_write_access,
     )
 
 
-class TestLoginUrlBase:
+class LoginUrlTestBase:
     url = "http://www.google.com"
     forward_text = "Send me forward!"
     bot_username = "botname"
     request_write_access = True
 
 
-class TestLoginUrlWithoutRequest(TestLoginUrlBase):
+class TestLoginUrlWithoutRequest(LoginUrlTestBase):
     def test_slot_behaviour(self, login_url):
         for attr in login_url.__slots__:
             assert getattr(login_url, attr, "err") != "err", f"got extra slot '{attr}'"

--- a/tests/test_maybeinaccessiblemessage.py
+++ b/tests/test_maybeinaccessiblemessage.py
@@ -29,19 +29,19 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="class")
 def maybe_inaccessible_message():
     return MaybeInaccessibleMessage(
-        TestMaybeInaccessibleMessageBase.chat,
-        TestMaybeInaccessibleMessageBase.message_id,
-        TestMaybeInaccessibleMessageBase.date,
+        MaybeInaccessibleMessageTestBase.chat,
+        MaybeInaccessibleMessageTestBase.message_id,
+        MaybeInaccessibleMessageTestBase.date,
     )
 
 
-class TestMaybeInaccessibleMessageBase:
+class MaybeInaccessibleMessageTestBase:
     chat = Chat(1, "title")
     message_id = 123
     date = dtm.datetime.now(dtm.timezone.utc).replace(microsecond=0)
 
 
-class TestMaybeInaccessibleMessageWithoutRequest(TestMaybeInaccessibleMessageBase):
+class TestMaybeInaccessibleMessageWithoutRequest(MaybeInaccessibleMessageTestBase):
     def test_slot_behaviour(self, maybe_inaccessible_message):
         for attr in maybe_inaccessible_message.__slots__:
             assert (

--- a/tests/test_menubutton.py
+++ b/tests/test_menubutton.py
@@ -84,20 +84,20 @@ def menu_button(scope_class_and_type):
     return scope_class_and_type[0].de_json(
         {
             "type": scope_class_and_type[1],
-            "text": TestMenuButtonselfBase.text,
-            "web_app": TestMenuButtonselfBase.web_app.to_dict(),
+            "text": MenuButtonTestBase.text,
+            "web_app": MenuButtonTestBase.web_app.to_dict(),
         },
         bot=None,
     )
 
 
-class TestMenuButtonselfBase:
+class MenuButtonTestBase:
     text = "button_text"
     web_app = WebAppInfo(url="https://python-telegram-bot.org/web_app")
 
 
 # All the scope types are very similar, so we test everything via parametrization
-class TestMenuButtonWithoutRequest(TestMenuButtonselfBase):
+class TestMenuButtonWithoutRequest(MenuButtonTestBase):
     def test_slot_behaviour(self, menu_button):
         for attr in menu_button.__slots__:
             assert getattr(menu_button, attr, "err") != "err", f"got extra slot '{attr}'"

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -93,10 +93,10 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture
 def message(bot):
     message = PytestMessage(
-        message_id=TestMessageBase.id_,
-        date=TestMessageBase.date,
-        chat=copy(TestMessageBase.chat),
-        from_user=copy(TestMessageBase.from_user),
+        message_id=MessageTestBase.id_,
+        date=MessageTestBase.date,
+        chat=copy(MessageTestBase.chat),
+        from_user=copy(MessageTestBase.from_user),
         business_connection_id="123456789",
     )
     message.set_bot(bot)
@@ -357,17 +357,17 @@ def message(bot):
 )
 def message_params(bot, request):
     message = Message(
-        message_id=TestMessageBase.id_,
-        from_user=TestMessageBase.from_user,
-        date=TestMessageBase.date,
-        chat=TestMessageBase.chat,
+        message_id=MessageTestBase.id_,
+        from_user=MessageTestBase.from_user,
+        date=MessageTestBase.date,
+        chat=MessageTestBase.chat,
         **request.param,
     )
     message.set_bot(bot)
     return message
 
 
-class TestMessageBase:
+class MessageTestBase:
     id_ = 1
     from_user = User(2, "testuser", False)
     date = datetime.utcnow()
@@ -439,7 +439,7 @@ class TestMessageBase:
     )
 
 
-class TestMessageWithoutRequest(TestMessageBase):
+class TestMessageWithoutRequest(MessageTestBase):
     @staticmethod
     async def check_quote_parsing(
         message: Message, method, bot_method_name: str, args, monkeypatch
@@ -559,10 +559,10 @@ class TestMessageWithoutRequest(TestMessageBase):
 
     def test_slot_behaviour(self):
         message = Message(
-            message_id=TestMessageBase.id_,
-            date=TestMessageBase.date,
-            chat=copy(TestMessageBase.chat),
-            from_user=copy(TestMessageBase.from_user),
+            message_id=MessageTestBase.id_,
+            date=MessageTestBase.date,
+            chat=copy(MessageTestBase.chat),
+            from_user=copy(MessageTestBase.from_user),
         )
         for attr in message.__slots__:
             assert getattr(message, attr, "err") != "err", f"got extra slot '{attr}'"

--- a/tests/test_messageentity.py
+++ b/tests/test_messageentity.py
@@ -41,14 +41,14 @@ def message_entity(request):
     return MessageEntity(type_, 1, 3, url=url, user=user, language=language)
 
 
-class TestMessageEntityBase:
+class MessageEntityTestBase:
     type_ = "url"
     offset = 1
     length = 2
     url = "url"
 
 
-class TestMessageEntityWithoutRequest(TestMessageEntityBase):
+class TestMessageEntityWithoutRequest(MessageEntityTestBase):
     def test_slot_behaviour(self, message_entity):
         inst = message_entity
         for attr in inst.__slots__:

--- a/tests/test_paidmedia.py
+++ b/tests/test_paidmedia.py
@@ -96,33 +96,33 @@ def paid_media(pm_scope_class_and_type):
     return pm_scope_class_and_type[0].de_json(
         {
             "type": pm_scope_class_and_type[1],
-            "width": TestPaidMediaBase.width,
-            "height": TestPaidMediaBase.height,
-            "duration": TestPaidMediaBase.duration,
-            "video": TestPaidMediaBase.video.to_dict(),
-            "photo": [p.to_dict() for p in TestPaidMediaBase.photo],
+            "width": PaidMediaTestBase.width,
+            "height": PaidMediaTestBase.height,
+            "duration": PaidMediaTestBase.duration,
+            "video": PaidMediaTestBase.video.to_dict(),
+            "photo": [p.to_dict() for p in PaidMediaTestBase.photo],
         },
         bot=None,
     )
 
 
 def paid_media_video():
-    return PaidMediaVideo(video=TestPaidMediaBase.video)
+    return PaidMediaVideo(video=PaidMediaTestBase.video)
 
 
 def paid_media_photo():
-    return PaidMediaPhoto(photo=TestPaidMediaBase.photo)
+    return PaidMediaPhoto(photo=PaidMediaTestBase.photo)
 
 
 @pytest.fixture(scope="module")
 def paid_media_info():
     return PaidMediaInfo(
-        star_count=TestPaidMediaInfoBase.star_count,
+        star_count=PaidMediaInfoTestBase.star_count,
         paid_media=[paid_media_video(), paid_media_photo()],
     )
 
 
-class TestPaidMediaBase:
+class PaidMediaTestBase:
     width = 640
     height = 480
     duration = 60
@@ -143,7 +143,7 @@ class TestPaidMediaBase:
     )
 
 
-class TestPaidMediaWithoutRequest(TestPaidMediaBase):
+class TestPaidMediaWithoutRequest(PaidMediaTestBase):
     def test_slot_behaviour(self, paid_media):
         inst = paid_media
         for attr in inst.__slots__:
@@ -280,12 +280,12 @@ class TestPaidMediaWithoutRequest(TestPaidMediaBase):
             assert hash(c) != hash(f)
 
 
-class TestPaidMediaInfoBase:
+class PaidMediaInfoTestBase:
     star_count = 200
     paid_media = [paid_media_video(), paid_media_photo()]
 
 
-class TestPaidMediaInfoWithoutRequest(TestPaidMediaInfoBase):
+class TestPaidMediaInfoWithoutRequest(PaidMediaInfoTestBase):
     def test_slot_behaviour(self, paid_media_info):
         inst = paid_media_info
         for attr in inst.__slots__:

--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -28,15 +28,15 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def input_poll_option():
     out = InputPollOption(
-        text=TestInputPollOptionBase.text,
-        text_parse_mode=TestInputPollOptionBase.text_parse_mode,
-        text_entities=TestInputPollOptionBase.text_entities,
+        text=InputPollOptionTestBase.text,
+        text_parse_mode=InputPollOptionTestBase.text_parse_mode,
+        text_entities=InputPollOptionTestBase.text_entities,
     )
     out._unfreeze()
     return out
 
 
-class TestInputPollOptionBase:
+class InputPollOptionTestBase:
     text = "test option"
     text_parse_mode = "MarkdownV2"
     text_entities = [
@@ -45,7 +45,7 @@ class TestInputPollOptionBase:
     ]
 
 
-class TestInputPollOptionWithoutRequest(TestInputPollOptionBase):
+class TestInputPollOptionWithoutRequest(InputPollOptionTestBase):
     def test_slot_behaviour(self, input_poll_option):
         for attr in input_poll_option.__slots__:
             assert getattr(input_poll_option, attr, "err") != "err", f"got extra slot '{attr}'"
@@ -106,15 +106,15 @@ class TestInputPollOptionWithoutRequest(TestInputPollOptionBase):
 @pytest.fixture(scope="module")
 def poll_option():
     out = PollOption(
-        text=TestPollOptionBase.text,
-        voter_count=TestPollOptionBase.voter_count,
-        text_entities=TestPollOptionBase.text_entities,
+        text=PollOptionTestBase.text,
+        voter_count=PollOptionTestBase.voter_count,
+        text_entities=PollOptionTestBase.text_entities,
     )
     out._unfreeze()
     return out
 
 
-class TestPollOptionBase:
+class PollOptionTestBase:
     text = "test option"
     voter_count = 3
     text_entities = [
@@ -123,7 +123,7 @@ class TestPollOptionBase:
     ]
 
 
-class TestPollOptionWithoutRequest(TestPollOptionBase):
+class TestPollOptionWithoutRequest(PollOptionTestBase):
     def test_slot_behaviour(self, poll_option):
         for attr in poll_option.__slots__:
             assert getattr(poll_option, attr, "err") != "err", f"got extra slot '{attr}'"
@@ -198,21 +198,21 @@ class TestPollOptionWithoutRequest(TestPollOptionBase):
 @pytest.fixture(scope="module")
 def poll_answer():
     return PollAnswer(
-        TestPollAnswerBase.poll_id,
-        TestPollAnswerBase.option_ids,
-        TestPollAnswerBase.user,
-        TestPollAnswerBase.voter_chat,
+        PollAnswerTestBase.poll_id,
+        PollAnswerTestBase.option_ids,
+        PollAnswerTestBase.user,
+        PollAnswerTestBase.voter_chat,
     )
 
 
-class TestPollAnswerBase:
+class PollAnswerTestBase:
     poll_id = "id"
     option_ids = [2]
     user = User(1, "", False)
     voter_chat = Chat(1, "")
 
 
-class TestPollAnswerWithoutRequest(TestPollAnswerBase):
+class TestPollAnswerWithoutRequest(PollAnswerTestBase):
     def test_de_json(self):
         json_dict = {
             "poll_id": self.poll_id,
@@ -264,25 +264,25 @@ class TestPollAnswerWithoutRequest(TestPollAnswerBase):
 @pytest.fixture(scope="module")
 def poll():
     poll = Poll(
-        TestPollBase.id_,
-        TestPollBase.question,
-        TestPollBase.options,
-        TestPollBase.total_voter_count,
-        TestPollBase.is_closed,
-        TestPollBase.is_anonymous,
-        TestPollBase.type,
-        TestPollBase.allows_multiple_answers,
-        explanation=TestPollBase.explanation,
-        explanation_entities=TestPollBase.explanation_entities,
-        open_period=TestPollBase.open_period,
-        close_date=TestPollBase.close_date,
-        question_entities=TestPollBase.question_entities,
+        PollTestBase.id_,
+        PollTestBase.question,
+        PollTestBase.options,
+        PollTestBase.total_voter_count,
+        PollTestBase.is_closed,
+        PollTestBase.is_anonymous,
+        PollTestBase.type,
+        PollTestBase.allows_multiple_answers,
+        explanation=PollTestBase.explanation,
+        explanation_entities=PollTestBase.explanation_entities,
+        open_period=PollTestBase.open_period,
+        close_date=PollTestBase.close_date,
+        question_entities=PollTestBase.question_entities,
     )
     poll._unfreeze()
     return poll
 
 
-class TestPollBase:
+class PollTestBase:
     id_ = "id"
     question = "Test Question?"
     options = [PollOption("test", 10), PollOption("test2", 11)]
@@ -304,7 +304,7 @@ class TestPollBase:
     ]
 
 
-class TestPollWithoutRequest(TestPollBase):
+class TestPollWithoutRequest(PollTestBase):
     def test_de_json(self, bot):
         json_dict = {
             "id": self.id_,

--- a/tests/test_proximityalerttriggered.py
+++ b/tests/test_proximityalerttriggered.py
@@ -25,19 +25,19 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def proximity_alert_triggered():
     return ProximityAlertTriggered(
-        TestProximityAlertTriggeredBase.traveler,
-        TestProximityAlertTriggeredBase.watcher,
-        TestProximityAlertTriggeredBase.distance,
+        ProximityAlertTriggeredTestBase.traveler,
+        ProximityAlertTriggeredTestBase.watcher,
+        ProximityAlertTriggeredTestBase.distance,
     )
 
 
-class TestProximityAlertTriggeredBase:
+class ProximityAlertTriggeredTestBase:
     traveler = User(1, "foo", False)
     watcher = User(2, "bar", False)
     distance = 42
 
 
-class TestProximityAlertTriggeredWithoutRequest(TestProximityAlertTriggeredBase):
+class TestProximityAlertTriggeredWithoutRequest(ProximityAlertTriggeredTestBase):
     def test_slot_behaviour(self, proximity_alert_triggered):
         inst = proximity_alert_triggered
         for attr in inst.__slots__:

--- a/tests/test_reply.py
+++ b/tests/test_reply.py
@@ -41,16 +41,16 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def external_reply_info():
     return ExternalReplyInfo(
-        origin=TestExternalReplyInfoBase.origin,
-        chat=TestExternalReplyInfoBase.chat,
-        message_id=TestExternalReplyInfoBase.message_id,
-        link_preview_options=TestExternalReplyInfoBase.link_preview_options,
-        giveaway=TestExternalReplyInfoBase.giveaway,
-        paid_media=TestExternalReplyInfoBase.paid_media,
+        origin=ExternalReplyInfoTestBase.origin,
+        chat=ExternalReplyInfoTestBase.chat,
+        message_id=ExternalReplyInfoTestBase.message_id,
+        link_preview_options=ExternalReplyInfoTestBase.link_preview_options,
+        giveaway=ExternalReplyInfoTestBase.giveaway,
+        paid_media=ExternalReplyInfoTestBase.paid_media,
     )
 
 
-class TestExternalReplyInfoBase:
+class ExternalReplyInfoTestBase:
     origin = MessageOriginUser(
         dtm.datetime.now(dtm.timezone.utc).replace(microsecond=0), User(1, "user", False)
     )
@@ -65,7 +65,7 @@ class TestExternalReplyInfoBase:
     paid_media = PaidMediaInfo(5, [PaidMediaPreview(10, 10, 10)])
 
 
-class TestExternalReplyInfoWithoutRequest(TestExternalReplyInfoBase):
+class TestExternalReplyInfoWithoutRequest(ExternalReplyInfoTestBase):
     def test_slot_behaviour(self, external_reply_info):
         for attr in external_reply_info.__slots__:
             assert getattr(external_reply_info, attr, "err") != "err", f"got extra slot '{attr}'"
@@ -128,14 +128,14 @@ class TestExternalReplyInfoWithoutRequest(TestExternalReplyInfoBase):
 @pytest.fixture(scope="module")
 def text_quote():
     return TextQuote(
-        text=TestTextQuoteBase.text,
-        position=TestTextQuoteBase.position,
-        entities=TestTextQuoteBase.entities,
-        is_manual=TestTextQuoteBase.is_manual,
+        text=TextQuoteTestBase.text,
+        position=TextQuoteTestBase.position,
+        entities=TextQuoteTestBase.entities,
+        is_manual=TextQuoteTestBase.is_manual,
     )
 
 
-class TestTextQuoteBase:
+class TextQuoteTestBase:
     text = "text"
     position = 1
     entities = [
@@ -145,7 +145,7 @@ class TestTextQuoteBase:
     is_manual = True
 
 
-class TestTextQuoteWithoutRequest(TestTextQuoteBase):
+class TestTextQuoteWithoutRequest(TextQuoteTestBase):
     def test_slot_behaviour(self, text_quote):
         for attr in text_quote.__slots__:
             assert getattr(text_quote, attr, "err") != "err", f"got extra slot '{attr}'"
@@ -202,17 +202,17 @@ class TestTextQuoteWithoutRequest(TestTextQuoteBase):
 @pytest.fixture(scope="module")
 def reply_parameters():
     return ReplyParameters(
-        message_id=TestReplyParametersBase.message_id,
-        chat_id=TestReplyParametersBase.chat_id,
-        allow_sending_without_reply=TestReplyParametersBase.allow_sending_without_reply,
-        quote=TestReplyParametersBase.quote,
-        quote_parse_mode=TestReplyParametersBase.quote_parse_mode,
-        quote_entities=TestReplyParametersBase.quote_entities,
-        quote_position=TestReplyParametersBase.quote_position,
+        message_id=ReplyParametersTestBase.message_id,
+        chat_id=ReplyParametersTestBase.chat_id,
+        allow_sending_without_reply=ReplyParametersTestBase.allow_sending_without_reply,
+        quote=ReplyParametersTestBase.quote,
+        quote_parse_mode=ReplyParametersTestBase.quote_parse_mode,
+        quote_entities=ReplyParametersTestBase.quote_entities,
+        quote_position=ReplyParametersTestBase.quote_position,
     )
 
 
-class TestReplyParametersBase:
+class ReplyParametersTestBase:
     message_id = 123
     chat_id = 456
     allow_sending_without_reply = True
@@ -225,7 +225,7 @@ class TestReplyParametersBase:
     quote_position = 5
 
 
-class TestReplyParametersWithoutRequest(TestReplyParametersBase):
+class TestReplyParametersWithoutRequest(ReplyParametersTestBase):
     def test_slot_behaviour(self, reply_parameters):
         for attr in reply_parameters.__slots__:
             assert getattr(reply_parameters, attr, "err") != "err", f"got extra slot '{attr}'"

--- a/tests/test_replykeyboardmarkup.py
+++ b/tests/test_replykeyboardmarkup.py
@@ -26,15 +26,15 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def reply_keyboard_markup():
     return ReplyKeyboardMarkup(
-        TestReplyKeyboardMarkupBase.keyboard,
-        resize_keyboard=TestReplyKeyboardMarkupBase.resize_keyboard,
-        one_time_keyboard=TestReplyKeyboardMarkupBase.one_time_keyboard,
-        selective=TestReplyKeyboardMarkupBase.selective,
-        is_persistent=TestReplyKeyboardMarkupBase.is_persistent,
+        ReplyKeyboardMarkupTestBase.keyboard,
+        resize_keyboard=ReplyKeyboardMarkupTestBase.resize_keyboard,
+        one_time_keyboard=ReplyKeyboardMarkupTestBase.one_time_keyboard,
+        selective=ReplyKeyboardMarkupTestBase.selective,
+        is_persistent=ReplyKeyboardMarkupTestBase.is_persistent,
     )
 
 
-class TestReplyKeyboardMarkupBase:
+class ReplyKeyboardMarkupTestBase:
     keyboard = [[KeyboardButton("button1"), KeyboardButton("button2")]]
     resize_keyboard = True
     one_time_keyboard = True
@@ -42,7 +42,7 @@ class TestReplyKeyboardMarkupBase:
     is_persistent = True
 
 
-class TestReplyKeyboardMarkupWithoutRequest(TestReplyKeyboardMarkupBase):
+class TestReplyKeyboardMarkupWithoutRequest(ReplyKeyboardMarkupTestBase):
     def test_slot_behaviour(self, reply_keyboard_markup):
         inst = reply_keyboard_markup
         for attr in inst.__slots__:
@@ -154,7 +154,7 @@ class TestReplyKeyboardMarkupWithoutRequest(TestReplyKeyboardMarkupBase):
         assert len(reply_keyboard_markup[1]) == 1
 
 
-class TestReplyKeyboardMarkupWithRequest(TestReplyKeyboardMarkupBase):
+class TestReplyKeyboardMarkupWithRequest(ReplyKeyboardMarkupTestBase):
     async def test_send_message_with_reply_keyboard_markup(
         self, bot, chat_id, reply_keyboard_markup
     ):

--- a/tests/test_replykeyboardremove.py
+++ b/tests/test_replykeyboardremove.py
@@ -24,15 +24,15 @@ from tests.auxil.slots import mro_slots
 
 @pytest.fixture(scope="module")
 def reply_keyboard_remove():
-    return ReplyKeyboardRemove(selective=TestReplyKeyboardRemoveBase.selective)
+    return ReplyKeyboardRemove(selective=ReplyKeyboardRemoveTestBase.selective)
 
 
-class TestReplyKeyboardRemoveBase:
+class ReplyKeyboardRemoveTestBase:
     remove_keyboard = True
     selective = True
 
 
-class TestReplyKeyboardRemoveWithoutRequest(TestReplyKeyboardRemoveBase):
+class TestReplyKeyboardRemoveWithoutRequest(ReplyKeyboardRemoveTestBase):
     def test_slot_behaviour(self, reply_keyboard_remove):
         inst = reply_keyboard_remove
         for attr in inst.__slots__:
@@ -52,7 +52,7 @@ class TestReplyKeyboardRemoveWithoutRequest(TestReplyKeyboardRemoveBase):
         assert reply_keyboard_remove_dict["selective"] == reply_keyboard_remove.selective
 
 
-class TestReplyKeyboardRemoveWithRequest(TestReplyKeyboardRemoveBase):
+class TestReplyKeyboardRemoveWithRequest(ReplyKeyboardRemoveTestBase):
     async def test_send_message_with_reply_keyboard_remove(
         self, bot, chat_id, reply_keyboard_remove
     ):

--- a/tests/test_sentwebappmessage.py
+++ b/tests/test_sentwebappmessage.py
@@ -25,14 +25,14 @@ from tests.auxil.slots import mro_slots
 
 @pytest.fixture(scope="module")
 def sent_web_app_message():
-    return SentWebAppMessage(inline_message_id=TestSentWebAppMessageBase.inline_message_id)
+    return SentWebAppMessage(inline_message_id=SentWebAppMessageTestBase.inline_message_id)
 
 
-class TestSentWebAppMessageBase:
+class SentWebAppMessageTestBase:
     inline_message_id = "123"
 
 
-class TestSentWebAppMessageWithoutRequest(TestSentWebAppMessageBase):
+class TestSentWebAppMessageWithoutRequest(SentWebAppMessageTestBase):
     def test_slot_behaviour(self, sent_web_app_message):
         inst = sent_web_app_message
         for attr in inst.__slots__:

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -25,16 +25,16 @@ from tests.auxil.slots import mro_slots
 
 @pytest.fixture(scope="class")
 def users_shared():
-    return UsersShared(TestUsersSharedBase.request_id, users=TestUsersSharedBase.users)
+    return UsersShared(UsersSharedTestBase.request_id, users=UsersSharedTestBase.users)
 
 
-class TestUsersSharedBase:
+class UsersSharedTestBase:
     request_id = 789
     user_ids = (101112, 101113)
     users = (SharedUser(101112, "user1"), SharedUser(101113, "user2"))
 
 
-class TestUsersSharedWithoutRequest(TestUsersSharedBase):
+class TestUsersSharedWithoutRequest(UsersSharedTestBase):
     def test_slot_behaviour(self, users_shared):
         for attr in users_shared.__slots__:
             assert getattr(users_shared, attr, "err") != "err", f"got extra slot '{attr}'"
@@ -85,17 +85,17 @@ class TestUsersSharedWithoutRequest(TestUsersSharedBase):
 @pytest.fixture(scope="class")
 def chat_shared():
     return ChatShared(
-        TestChatSharedBase.request_id,
-        TestChatSharedBase.chat_id,
+        ChatSharedTestBase.request_id,
+        ChatSharedTestBase.chat_id,
     )
 
 
-class TestChatSharedBase:
+class ChatSharedTestBase:
     request_id = 131415
     chat_id = 161718
 
 
-class TestChatSharedWithoutRequest(TestChatSharedBase):
+class TestChatSharedWithoutRequest(ChatSharedTestBase):
     def test_slot_behaviour(self, chat_shared):
         for attr in chat_shared.__slots__:
             assert getattr(chat_shared, attr, "err") != "err", f"got extra slot '{attr}'"
@@ -143,15 +143,15 @@ class TestChatSharedWithoutRequest(TestChatSharedBase):
 @pytest.fixture(scope="class")
 def shared_user():
     return SharedUser(
-        TestSharedUserBase.user_id,
-        TestSharedUserBase.first_name,
-        last_name=TestSharedUserBase.last_name,
-        username=TestSharedUserBase.username,
-        photo=TestSharedUserBase.photo,
+        SharedUserTestBase.user_id,
+        SharedUserTestBase.first_name,
+        last_name=SharedUserTestBase.last_name,
+        username=SharedUserTestBase.username,
+        photo=SharedUserTestBase.photo,
     )
 
 
-class TestSharedUserBase:
+class SharedUserTestBase:
     user_id = 101112
     first_name = "first"
     last_name = "last"
@@ -162,7 +162,7 @@ class TestSharedUserBase:
     )
 
 
-class TestSharedUserWithoutRequest(TestSharedUserBase):
+class TestSharedUserWithoutRequest(SharedUserTestBase):
     def test_slot_behaviour(self, shared_user):
         for attr in shared_user.__slots__:
             assert getattr(shared_user, attr, "err") != "err", f"got extra slot '{attr}'"

--- a/tests/test_stars.py
+++ b/tests/test_stars.py
@@ -165,9 +165,9 @@ def transaction_partner(tp_scope_class_and_type):
     return tp_scope_class_and_type[0].de_json(
         {
             "type": tp_scope_class_and_type[1],
-            "invoice_payload": TestTransactionPartnerBase.invoice_payload,
-            "withdrawal_state": TestTransactionPartnerBase.withdrawal_state.to_dict(),
-            "user": TestTransactionPartnerBase.user.to_dict(),
+            "invoice_payload": TransactionPartnerTestBase.invoice_payload,
+            "withdrawal_state": TransactionPartnerTestBase.withdrawal_state.to_dict(),
+            "user": TransactionPartnerTestBase.user.to_dict(),
         },
         bot=None,
     )
@@ -225,14 +225,14 @@ def revenue_withdrawal_state(rws_scope_class_and_type):
     return rws_scope_class_and_type[0].de_json(
         {
             "type": rws_scope_class_and_type[1],
-            "date": to_timestamp(TestRevenueWithdrawalStateBase.date),
-            "url": TestRevenueWithdrawalStateBase.url,
+            "date": to_timestamp(RevenueWithdrawalStateTestBase.date),
+            "url": RevenueWithdrawalStateTestBase.url,
         },
         bot=None,
     )
 
 
-class TestStarTransactionBase:
+class StarTransactionTestBase:
     id = "2"
     amount = 2
     date = to_timestamp(datetime.datetime(2024, 1, 1, 0, 0, 0, 0, tzinfo=UTC))
@@ -246,7 +246,7 @@ class TestStarTransactionBase:
     receiver = TransactionPartnerOther()
 
 
-class TestStarTransactionWithoutRequest(TestStarTransactionBase):
+class TestStarTransactionWithoutRequest(StarTransactionTestBase):
     def test_slot_behaviour(self):
         inst = star_transaction()
         for attr in inst.__slots__:
@@ -332,11 +332,11 @@ class TestStarTransactionWithoutRequest(TestStarTransactionBase):
         assert hash(a) != hash(c)
 
 
-class TestStarTransactionsBase:
+class StarTransactionsTestBase:
     transactions = [star_transaction(), star_transaction()]
 
 
-class TestStarTransactionsWithoutRequest(TestStarTransactionsBase):
+class TestStarTransactionsWithoutRequest(StarTransactionsTestBase):
     def test_slot_behaviour(self, star_transactions):
         inst = star_transactions
         for attr in inst.__slots__:
@@ -377,13 +377,13 @@ class TestStarTransactionsWithoutRequest(TestStarTransactionsBase):
         assert hash(a) != hash(c)
 
 
-class TestTransactionPartnerBase:
+class TransactionPartnerTestBase:
     withdrawal_state = withdrawal_state_succeeded()
     user = transaction_partner_user().user
     invoice_payload = "payload"
 
 
-class TestTransactionPartnerWithoutRequest(TestTransactionPartnerBase):
+class TestTransactionPartnerWithoutRequest(TransactionPartnerTestBase):
     def test_slot_behaviour(self, transaction_partner):
         inst = transaction_partner
         for attr in inst.__slots__:
@@ -494,12 +494,12 @@ class TestTransactionPartnerWithoutRequest(TestTransactionPartnerBase):
             assert hash(c) != hash(f)
 
 
-class TestRevenueWithdrawalStateBase:
+class RevenueWithdrawalStateTestBase:
     date = datetime.datetime(2024, 1, 1, 0, 0, 0, 0, tzinfo=UTC)
     url = "url"
 
 
-class TestRevenueWithdrawalStateWithoutRequest(TestRevenueWithdrawalStateBase):
+class TestRevenueWithdrawalStateWithoutRequest(RevenueWithdrawalStateTestBase):
     def test_slot_behaviour(self, revenue_withdrawal_state):
         inst = revenue_withdrawal_state
         for attr in inst.__slots__:

--- a/tests/test_story.py
+++ b/tests/test_story.py
@@ -24,15 +24,15 @@ from tests.auxil.slots import mro_slots
 
 @pytest.fixture(scope="module")
 def story():
-    return Story(TestStoryBase.chat, TestStoryBase.id)
+    return Story(StoryTestBase.chat, StoryTestBase.id)
 
 
-class TestStoryBase:
+class StoryTestBase:
     chat = Chat(1, "")
     id = 0
 
 
-class TestStoryWithoutRequest(TestStoryBase):
+class TestStoryWithoutRequest(StoryTestBase):
     def test_slot_behaviour(self, story):
         for attr in story.__slots__:
             assert getattr(story, attr, "err") != "err", f"got extra slot '{attr}'"

--- a/tests/test_switchinlinequerychosenchat.py
+++ b/tests/test_switchinlinequerychosenchat.py
@@ -26,15 +26,15 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def switch_inline_query_chosen_chat():
     return SwitchInlineQueryChosenChat(
-        query=TestSwitchInlineQueryChosenChatBase.query,
-        allow_user_chats=TestSwitchInlineQueryChosenChatBase.allow_user_chats,
-        allow_bot_chats=TestSwitchInlineQueryChosenChatBase.allow_bot_chats,
-        allow_channel_chats=TestSwitchInlineQueryChosenChatBase.allow_channel_chats,
-        allow_group_chats=TestSwitchInlineQueryChosenChatBase.allow_group_chats,
+        query=SwitchInlineQueryChosenChatTestBase.query,
+        allow_user_chats=SwitchInlineQueryChosenChatTestBase.allow_user_chats,
+        allow_bot_chats=SwitchInlineQueryChosenChatTestBase.allow_bot_chats,
+        allow_channel_chats=SwitchInlineQueryChosenChatTestBase.allow_channel_chats,
+        allow_group_chats=SwitchInlineQueryChosenChatTestBase.allow_group_chats,
     )
 
 
-class TestSwitchInlineQueryChosenChatBase:
+class SwitchInlineQueryChosenChatTestBase:
     query = "query"
     allow_user_chats = True
     allow_bot_chats = True
@@ -42,7 +42,7 @@ class TestSwitchInlineQueryChosenChatBase:
     allow_group_chats = True
 
 
-class TestSwitchInlineQueryChosenChat(TestSwitchInlineQueryChosenChatBase):
+class TestSwitchInlineQueryChosenChat(SwitchInlineQueryChosenChatTestBase):
     def test_slot_behaviour(self, switch_inline_query_chosen_chat):
         inst = switch_inline_query_chosen_chat
         for attr in inst.__slots__:

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -212,14 +212,14 @@ ids = (*all_types, "callback_query_without_message")
 
 @pytest.fixture(scope="module", params=params, ids=ids)
 def update(request):
-    return Update(update_id=TestUpdateBase.update_id, **request.param)
+    return Update(update_id=UpdateTestBase.update_id, **request.param)
 
 
-class TestUpdateBase:
+class UpdateTestBase:
     update_id = 868573637
 
 
-class TestUpdateWithoutRequest(TestUpdateBase):
+class TestUpdateWithoutRequest(UpdateTestBase):
     def test_slot_behaviour(self):
         update = Update(self.update_id)
         for attr in update.__slots__:

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -31,45 +31,45 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def json_dict():
     return {
-        "id": TestUserBase.id_,
-        "is_bot": TestUserBase.is_bot,
-        "first_name": TestUserBase.first_name,
-        "last_name": TestUserBase.last_name,
-        "username": TestUserBase.username,
-        "language_code": TestUserBase.language_code,
-        "can_join_groups": TestUserBase.can_join_groups,
-        "can_read_all_group_messages": TestUserBase.can_read_all_group_messages,
-        "supports_inline_queries": TestUserBase.supports_inline_queries,
-        "is_premium": TestUserBase.is_premium,
-        "added_to_attachment_menu": TestUserBase.added_to_attachment_menu,
-        "can_connect_to_business": TestUserBase.can_connect_to_business,
-        "has_main_web_app": TestUserBase.has_main_web_app,
+        "id": UserTestBase.id_,
+        "is_bot": UserTestBase.is_bot,
+        "first_name": UserTestBase.first_name,
+        "last_name": UserTestBase.last_name,
+        "username": UserTestBase.username,
+        "language_code": UserTestBase.language_code,
+        "can_join_groups": UserTestBase.can_join_groups,
+        "can_read_all_group_messages": UserTestBase.can_read_all_group_messages,
+        "supports_inline_queries": UserTestBase.supports_inline_queries,
+        "is_premium": UserTestBase.is_premium,
+        "added_to_attachment_menu": UserTestBase.added_to_attachment_menu,
+        "can_connect_to_business": UserTestBase.can_connect_to_business,
+        "has_main_web_app": UserTestBase.has_main_web_app,
     }
 
 
 @pytest.fixture
 def user(bot):
     user = User(
-        id=TestUserBase.id_,
-        first_name=TestUserBase.first_name,
-        is_bot=TestUserBase.is_bot,
-        last_name=TestUserBase.last_name,
-        username=TestUserBase.username,
-        language_code=TestUserBase.language_code,
-        can_join_groups=TestUserBase.can_join_groups,
-        can_read_all_group_messages=TestUserBase.can_read_all_group_messages,
-        supports_inline_queries=TestUserBase.supports_inline_queries,
-        is_premium=TestUserBase.is_premium,
-        added_to_attachment_menu=TestUserBase.added_to_attachment_menu,
-        can_connect_to_business=TestUserBase.can_connect_to_business,
-        has_main_web_app=TestUserBase.has_main_web_app,
+        id=UserTestBase.id_,
+        first_name=UserTestBase.first_name,
+        is_bot=UserTestBase.is_bot,
+        last_name=UserTestBase.last_name,
+        username=UserTestBase.username,
+        language_code=UserTestBase.language_code,
+        can_join_groups=UserTestBase.can_join_groups,
+        can_read_all_group_messages=UserTestBase.can_read_all_group_messages,
+        supports_inline_queries=UserTestBase.supports_inline_queries,
+        is_premium=UserTestBase.is_premium,
+        added_to_attachment_menu=UserTestBase.added_to_attachment_menu,
+        can_connect_to_business=UserTestBase.can_connect_to_business,
+        has_main_web_app=UserTestBase.has_main_web_app,
     )
     user.set_bot(bot)
     user._unfreeze()
     return user
 
 
-class TestUserBase:
+class UserTestBase:
     id_ = 1
     is_bot = True
     first_name = "first\u2022name"
@@ -85,7 +85,7 @@ class TestUserBase:
     has_main_web_app = False
 
 
-class TestUserWithoutRequest(TestUserBase):
+class TestUserWithoutRequest(UserTestBase):
     def test_slot_behaviour(self, user):
         for attr in user.__slots__:
             assert getattr(user, attr, "err") != "err", f"got extra slot '{attr}'"

--- a/tests/test_userprofilephotos.py
+++ b/tests/test_userprofilephotos.py
@@ -20,7 +20,7 @@ from telegram import PhotoSize, UserProfilePhotos
 from tests.auxil.slots import mro_slots
 
 
-class TestUserProfilePhotosBase:
+class UserProfilePhotosTestBase:
     total_count = 2
     photos = [
         [
@@ -34,7 +34,7 @@ class TestUserProfilePhotosBase:
     ]
 
 
-class TestUserProfilePhotosWithoutRequest(TestUserProfilePhotosBase):
+class TestUserProfilePhotosWithoutRequest(UserProfilePhotosTestBase):
     def test_slot_behaviour(self):
         inst = UserProfilePhotos(self.total_count, self.photos)
         for attr in inst.__slots__:

--- a/tests/test_webappdata.py
+++ b/tests/test_webappdata.py
@@ -25,15 +25,15 @@ from tests.auxil.slots import mro_slots
 
 @pytest.fixture(scope="module")
 def web_app_data():
-    return WebAppData(data=TestWebAppDataBase.data, button_text=TestWebAppDataBase.button_text)
+    return WebAppData(data=WebAppDataTestBase.data, button_text=WebAppDataTestBase.button_text)
 
 
-class TestWebAppDataBase:
+class WebAppDataTestBase:
     data = "data"
     button_text = "button_text"
 
 
-class TestWebAppDataWithoutRequest(TestWebAppDataBase):
+class TestWebAppDataWithoutRequest(WebAppDataTestBase):
     def test_slot_behaviour(self, web_app_data):
         for attr in web_app_data.__slots__:
             assert getattr(web_app_data, attr, "err") != "err", f"got extra slot '{attr}'"

--- a/tests/test_webappinfo.py
+++ b/tests/test_webappinfo.py
@@ -25,14 +25,14 @@ from tests.auxil.slots import mro_slots
 
 @pytest.fixture(scope="module")
 def web_app_info():
-    return WebAppInfo(url=TestWebAppInfoBase.url)
+    return WebAppInfo(url=WebAppInfoTestBase.url)
 
 
-class TestWebAppInfoBase:
+class WebAppInfoTestBase:
     url = "https://www.example.com"
 
 
-class TestWebAppInfoWithoutRequest(TestWebAppInfoBase):
+class TestWebAppInfoWithoutRequest(WebAppInfoTestBase):
     def test_slot_behaviour(self, web_app_info):
         for attr in web_app_info.__slots__:
             assert getattr(web_app_info, attr, "err") != "err", f"got extra slot '{attr}'"

--- a/tests/test_webhookinfo.py
+++ b/tests/test_webhookinfo.py
@@ -29,18 +29,18 @@ from tests.auxil.slots import mro_slots
 @pytest.fixture(scope="module")
 def webhook_info():
     return WebhookInfo(
-        url=TestWebhookInfoBase.url,
-        has_custom_certificate=TestWebhookInfoBase.has_custom_certificate,
-        pending_update_count=TestWebhookInfoBase.pending_update_count,
-        ip_address=TestWebhookInfoBase.ip_address,
-        last_error_date=TestWebhookInfoBase.last_error_date,
-        max_connections=TestWebhookInfoBase.max_connections,
-        allowed_updates=TestWebhookInfoBase.allowed_updates,
-        last_synchronization_error_date=TestWebhookInfoBase.last_synchronization_error_date,
+        url=WebhookInfoTestBase.url,
+        has_custom_certificate=WebhookInfoTestBase.has_custom_certificate,
+        pending_update_count=WebhookInfoTestBase.pending_update_count,
+        ip_address=WebhookInfoTestBase.ip_address,
+        last_error_date=WebhookInfoTestBase.last_error_date,
+        max_connections=WebhookInfoTestBase.max_connections,
+        allowed_updates=WebhookInfoTestBase.allowed_updates,
+        last_synchronization_error_date=WebhookInfoTestBase.last_synchronization_error_date,
     )
 
 
-class TestWebhookInfoBase:
+class WebhookInfoTestBase:
     url = "http://www.google.com"
     has_custom_certificate = False
     pending_update_count = 5
@@ -51,7 +51,7 @@ class TestWebhookInfoBase:
     last_synchronization_error_date = time.time()
 
 
-class TestWebhookInfoWithoutRequest(TestWebhookInfoBase):
+class TestWebhookInfoWithoutRequest(WebhookInfoTestBase):
     def test_slot_behaviour(self, webhook_info):
         for attr in webhook_info.__slots__:
             assert getattr(webhook_info, attr, "err") != "err", f"got extra slot '{attr}'"


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

addresses part sof #4324

Example console output before and after renaming:

```shell
(venv311) ~\PycharmProjects\python-telegram-bot git:[rename-test-classes]
pytest -v -k NoMatchTest
======================================================================= test session starts =======================================================================
platform win32 -- Python 3.11.9, pytest-8.2.2, pluggy-1.5.0 -- C:\Users\hinri\PycharmProjects\python-telegram-bot\venv311\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\hinri\PycharmProjects\python-telegram-bot
configfile: pyproject.toml
testpaths: tests
plugins: anyio-4.4.0, flaky-3.8.1, asyncio-0.21.2, socket-0.7.0, xdist-3.6.1, web3-6.18.0
asyncio: mode=Mode.AUTO
collected 6200 items / 6200 deselected / 0 selected                                                                                                                

==================================================================== 6200 deselected in 17.72s ====================================================================
(venv311) ~\PycharmProjects\python-telegram-bot git:[rename-test-classes]
pytest -v -k NoMatchTest
======================================================================= test session starts =======================================================================
platform win32 -- Python 3.11.9, pytest-8.2.2, pluggy-1.5.0 -- C:\Users\hinri\PycharmProjects\python-telegram-bot\venv311\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\hinri\PycharmProjects\python-telegram-bot
configfile: pyproject.toml
testpaths: tests
plugins: anyio-4.4.0, flaky-3.8.1, asyncio-0.21.2, socket-0.7.0, xdist-3.6.1, web3-6.18.0
asyncio: mode=Mode.AUTO
collected 6200 items / 6200 deselected / 0 selected                                                                                                                

==================================================================== 6200 deselected in 12.71s ====================================================================
```

Note that the number of collected items did *not* change. What did change is the elapsed time, however I'm not sure if this is really reproducable. In any case, it doesn't hurt to rename these classes and if on average it does speed up the collection that's a good thing :)

