### PR TITLE
API 7.10

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@
    :target: https://pypi.org/project/python-telegram-bot/
    :alt: Supported Python versions
 
-.. image:: https://img.shields.io/badge/Bot%20API-7.9-blue?logo=telegram
+.. image:: https://img.shields.io/badge/Bot%20API-7.10-blue?logo=telegram
    :target: https://core.telegram.org/bots/api-changelog
    :alt: Supported Bot API version
 
@@ -81,7 +81,7 @@ After installing_ the library, be sure to check out the section on `working with
 Telegram API support
 ~~~~~~~~~~~~~~~~~~~~
 
-All types and methods of the Telegram Bot API **7.9** are natively supported by this library.
+All types and methods of the Telegram Bot API **7.10** are natively supported by this library.
 In addition, Bot API functionality not yet natively included can still be used as described `in our wiki <https://github.com/python-telegram-bot/python-telegram-bot/wiki/Bot-API-Forward-Compatibility>`_.
 
 Notable Features

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -152,7 +152,7 @@ class _AccentColor(NamedTuple):
 #: :data:`telegram.__bot_api_version_info__`.
 #:
 #: .. versionadded:: 20.0
-BOT_API_VERSION_INFO: Final[_BotAPIVersion] = _BotAPIVersion(major=7, minor=9)
+BOT_API_VERSION_INFO: Final[_BotAPIVersion] = _BotAPIVersion(major=7, minor=10)
 #: :obj:`str`: Telegram Bot API
 #: version supported by this version of `python-telegram-bot`. Also available as
 #: :data:`telegram.__bot_api_version__`.


### PR DESCRIPTION
Closes #4459

Checklist for PRs
- [ ] Added ``.. versionadded:: NEXT.VERSION``, ``.. versionchanged:: NEXT.VERSION``, ``.. deprecated:: NEXT.VERSION`` or ``.. versionremoved:: NEXT.VERSION`` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [ ] Created new or adapted existing unit tests
- [ ] Documented code changes according to the `CSI standard <https://standards.mousepawmedia.com/en/stable/csi.html>`__
- [ ] Added myself alphabetically to ``AUTHORS.rst`` (optional)
- [ ] Added new classes & modules to the docs and all suitable ``__all__`` s
- [ ] Checked the `Stability Policy <https://docs.python-telegram-bot.org/stability_policy.html>`_ in case of deprecations or changes to documented behavior

**If the PR contains API changes (otherwise, you can ignore this passage)**

- [ ] Checked the Bot API specific sections of the `Stability Policy <https://docs.python-telegram-bot.org/stability_policy.html>`_
- [ ] Created a PR to remove functionality deprecated in the previous Bot API release (`see here <https://docs.python-telegram-bot.org/en/stable/stability_policy.html#case-2>`_)

- [ ] New classes:

   - [ ] Added ``self._id_attrs`` and corresponding documentation
   - [ ] ``__init__`` accepts ``api_kwargs`` as kw-only

- [ ]  Added new shortcuts:

   - [ ] In :class:`~telegram.Chat` & :class:`~telegram.User` for all methods that accept ``chat/user_id``
   - [ ] In :class:`~telegram.Message` for all methods that accept ``chat_id`` and ``message_id``
   - [ ] For new :class:`~telegram.Message` shortcuts: Added ``quote`` argument if methods accepts ``reply_to_message_id``
   - [ ] In :class:`~telegram.CallbackQuery` for all methods that accept either ``chat_id`` and ``message_id`` or ``inline_message_id``

- [ ]  If relevant:

   - [ ] Added new constants at :mod:`telegram.constants` and shortcuts to them as class variables
   - [ ] Link new and existing constants in docstrings instead of hard-coded numbers and strings
   - [ ] Add new message types to :attr:`telegram.Message.effective_attachment`
   - [ ] Added new handlers for new update types

     - [ ] Add the handlers to the warning loop in the :class:`~telegram.ext.ConversationHandler`

   - [ ] Added new filters for new message (sub)types
   - [ ] Added or updated documentation for the changed class(es) and/or method(s)
   - [ ] Added the new method(s) to ``_extbot.py``
   - [ ] Added or updated ``bot_methods.rst``
   - [x] Updated the Bot API version number in all places: ``README.rst`` (including the badge) and ``telegram.constants.BOT_API_VERSION_INFO``
   - [ ] Added logic for arbitrary callback data in :class:`telegram.ext.ExtBot` for new methods that either accept a ``reply_markup`` in some form or have a return type that is/contains :class:`~telegram.Message`
