### PR TITLE
Api 7.10 Docs Fixes

### DIFF
--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -9211,7 +9211,8 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
                 Telegram Star proceeds from this media will be credited to the chat's balance.
                 Otherwise, they will be credited to the bot's balance.
             star_count (:obj:`int`): The number of Telegram Stars that must be paid to buy access
-                to the media.
+                to the media; :tg-const:`telegram.constants.InvoiceLimit.MIN_STAR_COUNT` -
+                :tg-const:`telegram.constants.InvoiceLimit.MAX_STAR_COUNT`.
             media (Sequence[:class:`telegram.InputPaidMedia`]): A list describing the media to be
                 sent; up to :tg-const:`telegram.constants.MediaGroupLimit.MAX_MEDIA_LENGTH` items.
             caption (:obj:`str`, optional): Caption of the media to be sent,

--- a/telegram/_giveaway.py
+++ b/telegram/_giveaway.py
@@ -57,7 +57,8 @@ class Giveaway(TelegramObject):
             come. If empty, then all users can participate in the giveaway. Users with a phone
             number that was bought on Fragment can always participate in giveaways.
         premium_subscription_month_count (:obj:`int`, optional): The number of months the Telegram
-            Premium subscription won from the giveaway will be active for.
+            Premium subscription won from the giveaway will be active for; for Telegram Premium
+            giveaways only.
 
     Attributes:
         chats (Sequence[:class:`telegram.Chat`]): The list of chats which the user must join to
@@ -76,7 +77,8 @@ class Giveaway(TelegramObject):
             come. If empty, then all users can participate in the giveaway. Users with a phone
             number that was bought on Fragment can always participate in giveaways.
         premium_subscription_month_count (:obj:`int`): Optional. The number of months the Telegram
-            Premium subscription won from the giveaway will be active for.
+            Premium subscription won from the giveaway will be active for; for Telegram Premium
+            giveaways only.
     """
 
     __slots__ = (

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -552,6 +552,42 @@ class AccentColor(Enum):
     """
 
 
+class BackgroundTypeType(StringEnum):
+    """This enum contains the available types of :class:`telegram.BackgroundType`. The enum
+    members of this enumeration are instances of :class:`str` and can be treated as such.
+
+    .. versionadded:: 21.2
+    """
+
+    __slots__ = ()
+
+    FILL = "fill"
+    """:obj:`str`: A :class:`telegram.BackgroundType` with fill background."""
+    WALLPAPER = "wallpaper"
+    """:obj:`str`: A :class:`telegram.BackgroundType` with wallpaper background."""
+    PATTERN = "pattern"
+    """:obj:`str`: A :class:`telegram.BackgroundType` with pattern background."""
+    CHAT_THEME = "chat_theme"
+    """:obj:`str`: A :class:`telegram.BackgroundType` with chat_theme background."""
+
+
+class BackgroundFillType(StringEnum):
+    """This enum contains the available types of :class:`telegram.BackgroundFill`. The enum
+    members of this enumeration are instances of :class:`str` and can be treated as such.
+
+    .. versionadded:: 21.2
+    """
+
+    __slots__ = ()
+
+    SOLID = "solid"
+    """:obj:`str`: A :class:`telegram.BackgroundFill` with solid fill."""
+    GRADIENT = "gradient"
+    """:obj:`str`: A :class:`telegram.BackgroundFill` with gradient fill."""
+    FREEFORM_GRADIENT = "freeform_gradient"
+    """:obj:`str`: A :class:`telegram.BackgroundFill` with freeform_gradient fill."""
+
+
 class BotCommandLimit(IntEnum):
     """This enum contains limitations for :class:`telegram.BotCommand` and
     :meth:`telegram.Bot.set_my_commands`.
@@ -831,6 +867,25 @@ class ChatLimit(IntEnum):
     :paramref:`~telegram.Bot.set_chat_title.title` parameter of
     :meth:`telegram.Bot.set_chat_title`.
     """
+
+
+class ChatSubscriptionLimit(IntEnum):
+    """This enum contains limitations for
+    :paramref:`telegram.Bot.create_chat_subscription_invite_link.subscription_period` and
+    :paramref:`telegram.Bot.create_chat_subscription_invite_link.subscription_price`.
+    The enum members of this enumeration are instances of :class:`int` and can be treated as such.
+
+    .. versionadded:: 21.5
+    """
+
+    __slots__ = ()
+
+    SUBSCRIPTION_PERIOD = 2592000
+    """:obj:`int`: The number of seconds the subscription will be active."""
+    MIN_PRICE = 1
+    """:obj:`int`: Amount of stars a user pays, minimum amount the subscription can be set to."""
+    MAX_PRICE = 2500
+    """:obj:`int`: Amount of stars a user pays, maximum amount the subscription can be set to."""
 
 
 class BackgroundTypeLimit(IntEnum):
@@ -2804,6 +2859,20 @@ class InvoiceLimit(IntEnum):
     * :paramref:`~telegram.Bot.create_invoice_link.suggested_tip_amounts` parameter of
       :meth:`telegram.Bot.create_invoice_link`.
     """
+    MIN_STAR_COUNT = 1
+    """:obj:`int`: Minimum amount of starts that must be paid to buy access to a paid media
+    passed as :paramref:`~telegram.Bot.send_paid_media.star_count` parameter of
+    :meth:`telegram.Bot.send_paid_media`.
+
+    .. versionadded:: NEXT.VERSION
+    """
+    MAX_STAR_COUNT = 2500
+    """:obj:`int`: Maximum amount of starts that must be paid to buy access to a paid media
+    passed as :paramref:`~telegram.Bot.send_paid_media.star_count` parameter of
+    :meth:`telegram.Bot.send_paid_media`.
+
+    .. versionadded:: NEXT.VERSION
+    """
 
 
 class UserProfilePhotosLimit(IntEnum):
@@ -3066,58 +3135,3 @@ class ReactionEmoji(StringEnum):
     """:obj:`str`: Woman Shrugging"""
     POUTING_FACE = "😡"
     """:obj:`str`: Pouting face"""
-
-
-class BackgroundTypeType(StringEnum):
-    """This enum contains the available types of :class:`telegram.BackgroundType`. The enum
-    members of this enumeration are instances of :class:`str` and can be treated as such.
-
-    .. versionadded:: 21.2
-    """
-
-    __slots__ = ()
-
-    FILL = "fill"
-    """:obj:`str`: A :class:`telegram.BackgroundType` with fill background."""
-    WALLPAPER = "wallpaper"
-    """:obj:`str`: A :class:`telegram.BackgroundType` with wallpaper background."""
-    PATTERN = "pattern"
-    """:obj:`str`: A :class:`telegram.BackgroundType` with pattern background."""
-    CHAT_THEME = "chat_theme"
-    """:obj:`str`: A :class:`telegram.BackgroundType` with chat_theme background."""
-
-
-class BackgroundFillType(StringEnum):
-    """This enum contains the available types of :class:`telegram.BackgroundFill`. The enum
-    members of this enumeration are instances of :class:`str` and can be treated as such.
-
-    .. versionadded:: 21.2
-    """
-
-    __slots__ = ()
-
-    SOLID = "solid"
-    """:obj:`str`: A :class:`telegram.BackgroundFill` with solid fill."""
-    GRADIENT = "gradient"
-    """:obj:`str`: A :class:`telegram.BackgroundFill` with gradient fill."""
-    FREEFORM_GRADIENT = "freeform_gradient"
-    """:obj:`str`: A :class:`telegram.BackgroundFill` with freeform_gradient fill."""
-
-
-class ChatSubscriptionLimit(IntEnum):
-    """This enum contains limitations for
-    :paramref:`telegram.Bot.create_chat_subscription_invite_link.subscription_period` and
-    :paramref:`telegram.Bot.create_chat_subscription_invite_link.subscription_price`.
-    The enum members of this enumeration are instances of :class:`int` and can be treated as such.
-
-    .. versionadded:: 21.5
-    """
-
-    __slots__ = ()
-
-    SUBSCRIPTION_PERIOD = 2592000
-    """:obj:`int`: The number of seconds the subscription will be active."""
-    MIN_PRICE = 1
-    """:obj:`int`: Amount of stars a user pays, minimum amount the subscription can be set to."""
-    MAX_PRICE = 2500
-    """:obj:`int`: Amount of stars a user pays, maximum amount the subscription can be set to."""

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -72,7 +72,7 @@ complete and correct. To run it, export an environment variable first:
 
     $ export TEST_OFFICIAL=true
 
-and then run ``pytest tests/test_official.py``. Note: You need py 3.10+ to run this test.
+and then run ``pytest tests/test_official/test_official.py``. Note: You need py 3.10+ to run this test.
 
 We also have another marker, ``@pytest.mark.dev``, which you can add to tests that you want to run selectively.
 Use as follows:


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

Adds a few smaller doc changes and two new constants from https://t.me/bot_api_changes/190 that are not covered by #4463 and #4460.
Only the fly also restores alphabetical sorting of the constants enums
