### PR TITLE
docs: running test_ofiicial instructions.

### DIFF
--- a/tests/README.rst
+++ b/tests/README.rst
@@ -72,7 +72,7 @@ complete and correct. To run it, export an environment variable first:
 
     $ export TEST_OFFICIAL=true
 
-and then run ``pytest tests/test_official.py``. Note: You need py 3.10+ to run this test.
+and then run ``pytest tests/test_official/test_official.py``. Note: You need py 3.10+ to run this test.
 
 We also have another marker, ``@pytest.mark.dev``, which you can add to tests that you want to run selectively.
 Use as follows:


### PR DESCRIPTION

Small typo in the command to run test_official.py.
