### PR TITLE
Use `sphinx-build-compatibility` to Keep Sphinx Compatibility

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -5,3 +5,5 @@ sphinx-paramlinks==0.6.0
 sphinxcontrib-mermaid==0.9.2
 sphinx-copybutton==0.5.2
 sphinx-inline-tabs==2023.4.21
+# Temporary. See #4387
+sphinx-build-compatibility @ git+https://github.com/readthedocs/sphinx-build-compatibility.git@58aabc5f207c6c2421f23d3578adc0b14af57047

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,6 +45,8 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_inline_tabs",
     "sphinxcontrib.mermaid",
+    # Temporary. See #4387
+    "sphinx_build_compatibility.extension",
     "sphinx_search.extension",
 ]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,10 +45,12 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_inline_tabs",
     "sphinxcontrib.mermaid",
-    # Temporary. See #4387
-    "sphinx_build_compatibility.extension",
     "sphinx_search.extension",
 ]
+
+# Temporary. See #4387
+if os.environ.get("READTHEDOCS", "") == "True":
+    extensions.append("sphinx_build_compatibility.extension")
 
 # For shorter links to Wiki in docstrings
 extlinks = {


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

See #4387. 2024-10-07 is coming up fast and there seems to be little movement in https://github.com/pradyunsg/furo/issues/795 so far. So let's try if this backward compatibility thingy works.
