### PR TITLE
Reduce Creation of HTTP Clients in Tests

### DIFF
--- a/tests/auxil/build_messages.py
+++ b/tests/auxil/build_messages.py
@@ -27,16 +27,17 @@ CMD_PATTERN = re.compile(r"/[\da-z_]{1,32}(?:@\w{1,32})?")
 DATE = datetime.datetime.now()
 
 
-def make_message(text, **kwargs):
+def make_message(text: str, offline: bool = True, **kwargs):
     """
     Testing utility factory to create a fake ``telegram.Message`` with
     reasonable defaults for mimicking a real message.
     :param text: (str) message text
+    :param offline: (bool) whether the bot should be offline
     :return: a (fake) ``telegram.Message``
     """
     bot = kwargs.pop("bot", None)
     if bot is None:
-        bot = make_bot(BOT_INFO_PROVIDER.get_info())
+        bot = make_bot(BOT_INFO_PROVIDER.get_info(), offline=offline)
     message = Message(
         message_id=1,
         from_user=kwargs.pop("user", User(id=1, first_name="", is_bot=False)),

--- a/tests/auxil/pytest_classes.py
+++ b/tests/auxil/pytest_classes.py
@@ -93,7 +93,7 @@ class PytestUpdater(Updater):
     pass
 
 
-def make_bot(bot_info=None, offline: bool = False, **kwargs):
+def make_bot(bot_info=None, offline: bool = True, **kwargs):
     """
     Tests are executed on tg.ext.ExtBot, as that class only extends the functionality of tg.bot
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,7 +152,7 @@ def bot_info() -> Dict[str, str]:
 @pytest.fixture(scope="session")
 async def bot(bot_info):
     """Makes an ExtBot instance with the given bot_info"""
-    async with make_bot(bot_info) as _bot:
+    async with make_bot(bot_info, offline=False) as _bot:
         yield _bot
 
 
@@ -168,13 +168,13 @@ async def offline_bot(bot_info):
 @pytest.fixture
 def one_time_bot(bot_info):
     """A function scoped bot since the session bot would shutdown when `async with app` finishes"""
-    return make_bot(bot_info)
+    return make_bot(bot_info, offline=False)
 
 
 @pytest.fixture(scope="session")
 async def cdc_bot(bot_info):
     """Makes an ExtBot instance with the given bot_info that uses arbitrary callback_data"""
-    async with make_bot(bot_info, arbitrary_callback_data=True) as _bot:
+    async with make_bot(bot_info, arbitrary_callback_data=True, offline=False) as _bot:
         yield _bot
 
 
@@ -204,7 +204,7 @@ async def default_bot(request, bot_info):
     # If the bot is already created, return it. Else make a new one.
     default_bot = _default_bots.get(defaults)
     if default_bot is None:
-        default_bot = make_bot(bot_info, defaults=defaults)
+        default_bot = make_bot(bot_info, defaults=defaults, offline=False)
         await default_bot.initialize()
         _default_bots[defaults] = default_bot  # Defaults object is hashable
     return default_bot
@@ -216,7 +216,7 @@ async def tz_bot(timezone, bot_info):
     try:  # If the bot is already created, return it. Saves time since get_me is not called again.
         return _default_bots[defaults]
     except KeyError:
-        default_bot = make_bot(bot_info, defaults=defaults)
+        default_bot = make_bot(bot_info, defaults=defaults, offline=False)
         await default_bot.initialize()
         _default_bots[defaults] = default_bot
         return default_bot

--- a/tests/ext/test_callbackcontext.py
+++ b/tests/ext/test_callbackcontext.py
@@ -211,7 +211,7 @@ class TestCallbackContext:
             app.bot = bot
 
     async def test_drop_callback_data(self, bot, chat_id):
-        new_bot = make_bot(token=bot.token, arbitrary_callback_data=True)
+        new_bot = make_bot(token=bot.token, arbitrary_callback_data=True, offline=False)
         app = ApplicationBuilder().bot(new_bot).build()
 
         update = Update(

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -361,13 +361,13 @@ class TestBotWithoutRequest:
             "link",
         ],
     )
-    async def test_get_me_and_properties_not_initialized(self, offline_bot: Bot, attribute):
-        offline_bot = Bot(token=offline_bot.token)
+    async def test_get_me_and_properties_not_initialized(self, attribute):
+        bot = make_bot(offline=True, token="randomtoken")
         try:
             with pytest.raises(RuntimeError, match="not properly initialized"):
-                offline_bot[attribute]
+                bot[attribute]
         finally:
-            await offline_bot.shutdown()
+            await bot.shutdown()
 
     async def test_get_me_and_properties(self, offline_bot):
         get_me_bot = await ExtBot(offline_bot.token).get_me()

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1564,7 +1564,7 @@ class TestBotWithoutRequest:
         [(True, 1024), (False, 1024), (0, 0), (None, None)],
     )
     async def test_callback_data_maxsize(self, bot_info, acd_in, maxsize):
-        async with make_bot(bot_info, arbitrary_callback_data=acd_in) as acd_bot:
+        async with make_bot(bot_info, arbitrary_callback_data=acd_in, offline=True) as acd_bot:
             if acd_in is not False:
                 assert acd_bot.callback_data_cache.maxsize == maxsize
             else:


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

Apparently the function `load_ssl_context_verify` that's called upon the creation of `httpx.AsyncClient` takes quite a bit of time so that creating new `HTTPXRequest` objects (indirectly via `Bot`) is a performance bottleneck in the tests.

Hence, this changing `make_bot` to use `offline=True` by default and allowing online only in the tests that make requests.

This is just one small step on test performance improvement, but hey it's something :)
