### PR TITLE
feat: add `show_caption_above_media` parameter to `(Ext)Defaults`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -88,6 +88,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `miles <https://github.com/miles170>`_
 - `Mischa Krüger <https://github.com/Makman2>`_
 - `Mohd Yusuf <https://github.com/mohdyusuf2312>`_
+- `Nathanael Bracy <https://github.com/servusdei2018>`_
 - `naveenvhegde <https://github.com/naveenvhegde>`_
 - `neurrone <https://github.com/neurrone>`_
 - `NikitaPirate <https://github.com/NikitaPirate>`_

--- a/telegram/ext/_defaults.py
+++ b/telegram/ext/_defaults.py
@@ -114,6 +114,11 @@ class Defaults:
         do_quote(:obj:`bool`, optional): |reply_quote|
 
             .. versionadded:: 20.8
+
+        show_caption_above_media (:obj:`bool`, optional): Indicates whether the caption should be
+        shown above the media. Defaults to `None`.
+
+            .. versionadded:: 21.7
     """
 
     __slots__ = (
@@ -125,6 +130,7 @@ class Defaults:
         "_link_preview_options",
         "_parse_mode",
         "_protect_content",
+        "_show_caption_above_media",
         "_tzinfo",
     )
 
@@ -140,6 +146,7 @@ class Defaults:
         protect_content: Optional[bool] = None,
         link_preview_options: Optional["LinkPreviewOptions"] = None,
         do_quote: Optional[bool] = None,
+        show_caption_above_media: Optional[bool] = None,
     ):
         self._parse_mode: Optional[str] = parse_mode
         self._disable_notification: Optional[bool] = disable_notification
@@ -147,6 +154,7 @@ class Defaults:
         self._tzinfo: datetime.tzinfo = tzinfo
         self._block: bool = block
         self._protect_content: Optional[bool] = protect_content
+        self._show_caption_above_media: Optional[bool] = show_caption_above_media
 
         if disable_web_page_preview is not None and link_preview_options is not None:
             raise ValueError(
@@ -190,6 +198,7 @@ class Defaults:
             "parse_mode",
             "protect_content",
             "question_parse_mode",
+            "show_caption_above_media",
         ):
             value = getattr(self, kwarg)
             if value is not None:
@@ -409,3 +418,12 @@ class Defaults:
         .. versionadded:: 20.8
         """
         return self._do_quote
+
+    @property
+    def show_caption_above_media(self) -> Optional[bool]:
+        """:obj:`bool`: Optional. Indicates whether the caption should be
+        shown above the media. Defaults to `None`.
+
+        .. versionadded:: 21.7
+        """
+        return self._show_caption_above_media

--- a/telegram/ext/_defaults.py
+++ b/telegram/ext/_defaults.py
@@ -118,7 +118,7 @@ class Defaults:
         show_caption_above_media (:obj:`bool`, optional): Indicates whether the caption should be
         shown above the media. Defaults to `None`.
 
-            .. versionadded:: 21.7
+            .. versionadded:: NEXT.VERSION
     """
 
     __slots__ = (
@@ -424,6 +424,6 @@ class Defaults:
         """:obj:`bool`: Optional. Indicates whether the caption should be
         shown above the media. Defaults to `None`.
 
-        .. versionadded:: 21.7
+        .. versionadded:: NEXT.VERSION
         """
         return self._show_caption_above_media

--- a/telegram/ext/_extbot.py
+++ b/telegram/ext/_extbot.py
@@ -835,7 +835,11 @@ class ExtBot(Bot, Generic[RLARGS]):
             connect_timeout=connect_timeout,
             pool_timeout=pool_timeout,
             api_kwargs=self._merge_api_rl_kwargs(api_kwargs, rate_limit_args),
-            show_caption_above_media=show_caption_above_media,
+            show_caption_above_media=(
+                show_caption_above_media
+                if show_caption_above_media is not None
+                else (self.defaults.show_caption_above_media if self.defaults else None)
+            ),
         )
 
     async def copy_messages(
@@ -1538,7 +1542,11 @@ class ExtBot(Bot, Generic[RLARGS]):
             connect_timeout=connect_timeout,
             pool_timeout=pool_timeout,
             api_kwargs=self._merge_api_rl_kwargs(api_kwargs, rate_limit_args),
-            show_caption_above_media=show_caption_above_media,
+            show_caption_above_media=(
+                show_caption_above_media
+                if show_caption_above_media is not None
+                else (self.defaults.show_caption_above_media if self.defaults else None)
+            ),
         )
 
     async def edit_message_live_location(
@@ -2440,7 +2448,11 @@ class ExtBot(Bot, Generic[RLARGS]):
             pool_timeout=pool_timeout,
             api_kwargs=self._merge_api_rl_kwargs(api_kwargs, rate_limit_args),
             message_effect_id=message_effect_id,
-            show_caption_above_media=show_caption_above_media,
+            show_caption_above_media=(
+                show_caption_above_media
+                if show_caption_above_media is not None
+                else (self.defaults.show_caption_above_media if self.defaults else None)
+            ),
         )
 
     async def send_audio(
@@ -2978,7 +2990,11 @@ class ExtBot(Bot, Generic[RLARGS]):
             pool_timeout=pool_timeout,
             api_kwargs=self._merge_api_rl_kwargs(api_kwargs, rate_limit_args),
             message_effect_id=message_effect_id,
-            show_caption_above_media=show_caption_above_media,
+            show_caption_above_media=(
+                show_caption_above_media
+                if show_caption_above_media is not None
+                else (self.defaults.show_caption_above_media if self.defaults else None)
+            ),
         )
 
     async def send_poll(
@@ -3204,7 +3220,11 @@ class ExtBot(Bot, Generic[RLARGS]):
             pool_timeout=pool_timeout,
             api_kwargs=self._merge_api_rl_kwargs(api_kwargs, rate_limit_args),
             message_effect_id=message_effect_id,
-            show_caption_above_media=show_caption_above_media,
+            show_caption_above_media=(
+                show_caption_above_media
+                if show_caption_above_media is not None
+                else (self.defaults.show_caption_above_media if self.defaults else None)
+            ),
         )
 
     async def send_video_note(
@@ -4253,7 +4273,11 @@ class ExtBot(Bot, Generic[RLARGS]):
             caption=caption,
             parse_mode=parse_mode,
             caption_entities=caption_entities,
-            show_caption_above_media=show_caption_above_media,
+            show_caption_above_media=(
+                show_caption_above_media
+                if show_caption_above_media is not None
+                else (self.defaults.show_caption_above_media if self.defaults else None)
+            ),
             disable_notification=disable_notification,
             protect_content=protect_content,
             reply_parameters=reply_parameters,


### PR DESCRIPTION
Fixes #4306

## Summary

This patch introduces a default setting for the `show_caption_above_media` parameter in the `telegram.ext.Defaults` class. This enhancement streamlines the process of setting this parameter across various bot methods that support it, such as `send_video`, `send_photo`, and `edit_message_caption`.

## Changes Made

- A new property `show_caption_above_media` has been added to the `(Ext)Bot` class.