### PR TITLE
Add `Message.reply_paid_media`

### DIFF
--- a/telegram/_message.py
+++ b/telegram/_message.py
@@ -3682,6 +3682,7 @@ class Message(MaybeInaccessibleMessage):
         reply_parameters: Optional["ReplyParameters"] = None,
         reply_markup: Optional[ReplyMarkup] = None,
         payload: Optional[str] = None,
+        allow_paid_broadcast: Optional[bool] = None,
         *,
         reply_to_message_id: Optional[int] = None,
         allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
@@ -3736,6 +3737,7 @@ class Message(MaybeInaccessibleMessage):
             api_kwargs=api_kwargs,
             protect_content=protect_content,
             show_caption_above_media=show_caption_above_media,
+            allow_paid_broadcast=allow_paid_broadcast,
         )
 
     async def edit_text(

--- a/telegram/_message.py
+++ b/telegram/_message.py
@@ -3653,14 +3653,14 @@ class Message(MaybeInaccessibleMessage):
 
         For the documentation of the arguments, please see :meth:`telegram.Bot.send_paid_media`.
 
+        .. versionadded:: NEXT.VERSION
+
         Keyword Args:
             do_quote (:obj:`bool` | :obj:`dict`, optional): |do_quote|
                 Mutually exclusive with :paramref:`quote`.
 
-                .. versionadded:: 20.8
-
         Returns:
-            :class:`telegram.MessageId`: On success, returns the MessageId of the sent message.
+            :class:`telegram.Message`: On success, the sent message is returned.
 
         """
         chat_id, effective_reply_parameters = await self._parse_quote_arguments(

--- a/telegram/_message.py
+++ b/telegram/_message.py
@@ -105,6 +105,7 @@ if TYPE_CHECKING:
         InputMediaDocument,
         InputMediaPhoto,
         InputMediaVideo,
+        InputPaidMedia,
         InputPollOption,
         LabeledPrice,
         MessageId,
@@ -3615,6 +3616,75 @@ class Message(MaybeInaccessibleMessage):
             api_kwargs=api_kwargs,
             protect_content=protect_content,
             message_thread_id=message_thread_id,
+            show_caption_above_media=show_caption_above_media,
+        )
+
+    async def reply_paid_media(
+        self,
+        star_count: int,
+        media: Sequence["InputPaidMedia"],
+        caption: Optional[str] = None,
+        parse_mode: ODVInput[str] = DEFAULT_NONE,
+        caption_entities: Optional[Sequence["MessageEntity"]] = None,
+        show_caption_above_media: Optional[bool] = None,
+        disable_notification: ODVInput[bool] = DEFAULT_NONE,
+        protect_content: ODVInput[bool] = DEFAULT_NONE,
+        reply_parameters: Optional["ReplyParameters"] = None,
+        reply_markup: Optional[ReplyMarkup] = None,
+        payload: Optional[str] = None,
+        *,
+        reply_to_message_id: Optional[int] = None,
+        allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
+        do_quote: Optional[Union[bool, _ReplyKwargs]] = None,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: Optional[JSONDict] = None,
+    ) -> "Message":
+        """Shortcut for::
+
+             await bot.send_paid_media(
+                 chat_id=message.chat.id,
+                 business_connection_id=message.business_connection_id,
+                 *args,
+                 **kwargs
+             )
+
+        For the documentation of the arguments, please see :meth:`telegram.Bot.send_paid_media`.
+
+        Keyword Args:
+            do_quote (:obj:`bool` | :obj:`dict`, optional): |do_quote|
+                Mutually exclusive with :paramref:`quote`.
+
+                .. versionadded:: 20.8
+
+        Returns:
+            :class:`telegram.MessageId`: On success, returns the MessageId of the sent message.
+
+        """
+        chat_id, effective_reply_parameters = await self._parse_quote_arguments(
+            do_quote, None, reply_to_message_id, reply_parameters
+        )
+        return await self.get_bot().send_paid_media(
+            chat_id=chat_id,
+            caption=caption,
+            star_count=star_count,
+            media=media,
+            payload=payload,
+            business_connection_id=self.business_connection_id,
+            parse_mode=parse_mode,
+            caption_entities=caption_entities,
+            disable_notification=disable_notification,
+            reply_parameters=effective_reply_parameters,
+            allow_sending_without_reply=allow_sending_without_reply,
+            reply_markup=reply_markup,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=api_kwargs,
+            protect_content=protect_content,
             show_caption_above_media=show_caption_above_media,
         )
 


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

Apparently this was forgotten in some earlier api update …

- [x] Added .. versionadded:: NEXT.VERSION, .. versionchanged:: NEXT.VERSION, .. deprecated:: NEXT.VERSION or .. versionremoved:: NEXT.VERSION to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [x] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- ~[ ] Added myself alphabetically to AUTHORS.rst (optional)~
- [ ] ~Added new classes & modules to the docs and all suitable __all__ s~
- [x] Checked the [Stability Policy](https://docs.python-telegram-bot.org/stability_policy.html) in case of deprecations or changes to documented behavior


ToDo:

- [ ] Update to use `allow_paid_broadcast` after #4550 / #4546 is merged
