### PR TITLE
Widen specified type for `allowed_updates` Application/Updater parameter

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -81,6 +81,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `LRezende <https://github.com/lrezende>`_
 - `Luca Bellanti <https://github.com/Trifase>`_
 - `Lucas Molinari <https://github.com/lucasmolinari>`_
+- `Luis Pérez <https://github.com/nemacysts>`_
 - `macrojames <https://github.com/macrojames>`_
 - `Matheus Lemos <https://github.com/mlemosf>`_
 - `Michael Dix <https://github.com/Eisberge>`_

--- a/telegram/_webhookinfo.py
+++ b/telegram/_webhookinfo.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains an object that represents a Telegram WebhookInfo."""
+
 from collections.abc import Sequence
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional
@@ -60,7 +61,7 @@ class WebhookInfo(TelegramObject):
             most recent error that happened when trying to deliver an update via webhook.
         max_connections (:obj:`int`, optional): Maximum allowed number of simultaneous HTTPS
             connections to the webhook for update delivery.
-        allowed_updates (Sequence[:obj:`str`], optional): A list of update types the bot is
+        allowed_updates (Sequence[:obj:`str`], optional): A sequence of update types the bot is
             subscribed to. Defaults to all update types, except
             :attr:`telegram.Update.chat_member`.
 
@@ -90,7 +91,7 @@ class WebhookInfo(TelegramObject):
             most recent error that happened when trying to deliver an update via webhook.
         max_connections (:obj:`int`): Optional. Maximum allowed number of simultaneous HTTPS
             connections to the webhook for update delivery.
-        allowed_updates (tuple[:obj:`str`]): Optional. A list of update types the bot is
+        allowed_updates (tuple[:obj:`str`]): Optional. A tuple of update types the bot is
             subscribed to. Defaults to all update types, except
             :attr:`telegram.Update.chat_member`.
 

--- a/telegram/ext/_application.py
+++ b/telegram/ext/_application.py
@@ -746,7 +746,7 @@ class Application(
         write_timeout: ODVInput[float] = DEFAULT_NONE,
         connect_timeout: ODVInput[float] = DEFAULT_NONE,
         pool_timeout: ODVInput[float] = DEFAULT_NONE,
-        allowed_updates: Optional[list[str]] = None,
+        allowed_updates: Optional[Sequence[str]] = None,
         drop_pending_updates: Optional[bool] = None,
         close_loop: bool = True,
         stop_signals: ODVInput[Sequence[int]] = DEFAULT_NONE,
@@ -823,8 +823,11 @@ class Application(
                     :meth:`telegram.ext.ApplicationBuilder.get_updates_pool_timeout`.
             drop_pending_updates (:obj:`bool`, optional): Whether to clean any pending updates on
                 Telegram servers before actually starting to poll. Default is :obj:`False`.
-            allowed_updates (list[:obj:`str`], optional): Passed to
+            allowed_updates (Sequence[:obj:`str`], optional): Passed to
                 :meth:`telegram.Bot.get_updates`.
+
+                .. versionchanged:: NEXT.VERSION
+                    Accepts any :class:`collections.abc.Sequence` as input instead of just a list
             close_loop (:obj:`bool`, optional): If :obj:`True`, the current event loop will be
                 closed upon shutdown. Defaults to :obj:`True`.
 
@@ -888,7 +891,7 @@ class Application(
         key: Optional[Union[str, Path]] = None,
         bootstrap_retries: int = 0,
         webhook_url: Optional[str] = None,
-        allowed_updates: Optional[list[str]] = None,
+        allowed_updates: Optional[Sequence[str]] = None,
         drop_pending_updates: Optional[bool] = None,
         ip_address: Optional[str] = None,
         max_connections: int = 40,
@@ -954,8 +957,11 @@ class Application(
             webhook_url (:obj:`str`, optional): Explicitly specify the webhook url. Useful behind
                 NAT, reverse proxy, etc. Default is derived from :paramref:`listen`,
                 :paramref:`port`, :paramref:`url_path`, :paramref:`cert`, and :paramref:`key`.
-            allowed_updates (list[:obj:`str`], optional): Passed to
+            allowed_updates (Sequence[:obj:`str`], optional): Passed to
                 :meth:`telegram.Bot.set_webhook`.
+
+                .. versionchanged:: NEXT.VERSION
+                    Accepts any :class:`collections.abc.Sequence` as input instead of just a list
             drop_pending_updates (:obj:`bool`, optional): Whether to clean any pending updates on
                 Telegram servers before actually starting to poll. Default is :obj:`False`.
             ip_address (:obj:`str`, optional): Passed to :meth:`telegram.Bot.set_webhook`.

--- a/telegram/ext/_updater.py
+++ b/telegram/ext/_updater.py
@@ -17,10 +17,11 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains the class Updater, which tries to make creating Telegram bots intuitive."""
+
 import asyncio
 import contextlib
 import ssl
-from collections.abc import Coroutine
+from collections.abc import Coroutine, Sequence
 from pathlib import Path
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union
@@ -210,7 +211,7 @@ class Updater(contextlib.AbstractAsyncContextManager["Updater"]):
         write_timeout: ODVInput[float] = DEFAULT_NONE,
         connect_timeout: ODVInput[float] = DEFAULT_NONE,
         pool_timeout: ODVInput[float] = DEFAULT_NONE,
-        allowed_updates: Optional[list[str]] = None,
+        allowed_updates: Optional[Sequence[str]] = None,
         drop_pending_updates: Optional[bool] = None,
         error_callback: Optional[Callable[[TelegramError], None]] = None,
     ) -> "asyncio.Queue[object]":
@@ -265,8 +266,11 @@ class Updater(contextlib.AbstractAsyncContextManager["Updater"]):
                     Deprecated in favor of setting the timeout via
                     :meth:`telegram.ext.ApplicationBuilder.get_updates_pool_timeout` or
                     :paramref:`telegram.Bot.get_updates_request`.
-            allowed_updates (list[:obj:`str`], optional): Passed to
+            allowed_updates (Sequence[:obj:`str`], optional): Passed to
                 :meth:`telegram.Bot.get_updates`.
+
+                .. versionchanged:: NEXT.VERSION
+                    Accepts any :class:`collections.abc.Sequence` as input instead of just a list
             drop_pending_updates (:obj:`bool`, optional): Whether to clean any pending updates on
                 Telegram servers before actually starting to poll. Default is :obj:`False`.
 
@@ -344,7 +348,7 @@ class Updater(contextlib.AbstractAsyncContextManager["Updater"]):
         pool_timeout: ODVInput[float],
         bootstrap_retries: int,
         drop_pending_updates: Optional[bool],
-        allowed_updates: Optional[list[str]],
+        allowed_updates: Optional[Sequence[str]],
         ready: asyncio.Event,
         error_callback: Optional[Callable[[TelegramError], None]],
     ) -> None:
@@ -457,7 +461,7 @@ class Updater(contextlib.AbstractAsyncContextManager["Updater"]):
         key: Optional[Union[str, Path]] = None,
         bootstrap_retries: int = 0,
         webhook_url: Optional[str] = None,
-        allowed_updates: Optional[list[str]] = None,
+        allowed_updates: Optional[Sequence[str]] = None,
         drop_pending_updates: Optional[bool] = None,
         ip_address: Optional[str] = None,
         max_connections: int = 40,
@@ -516,8 +520,11 @@ class Updater(contextlib.AbstractAsyncContextManager["Updater"]):
                 Defaults to :obj:`None`.
 
                 .. versionadded :: 13.4
-            allowed_updates (list[:obj:`str`], optional): Passed to
+            allowed_updates (Sequence[:obj:`str`], optional): Passed to
                 :meth:`telegram.Bot.set_webhook`. Defaults to :obj:`None`.
+
+                .. versionchanged:: NEXT.VERSION
+                    Accepts any :class:`collections.abc.Sequence` as input instead of just a list
             max_connections (:obj:`int`, optional): Passed to
                 :meth:`telegram.Bot.set_webhook`. Defaults to ``40``.
 
@@ -624,7 +631,7 @@ class Updater(contextlib.AbstractAsyncContextManager["Updater"]):
         port: int,
         url_path: str,
         bootstrap_retries: int,
-        allowed_updates: Optional[list[str]],
+        allowed_updates: Optional[Sequence[str]],
         cert: Optional[Union[str, Path]] = None,
         key: Optional[Union[str, Path]] = None,
         drop_pending_updates: Optional[bool] = None,
@@ -767,7 +774,7 @@ class Updater(contextlib.AbstractAsyncContextManager["Updater"]):
         self,
         max_retries: int,
         webhook_url: Optional[str],
-        allowed_updates: Optional[list[str]],
+        allowed_updates: Optional[Sequence[str]],
         drop_pending_updates: Optional[bool] = None,
         cert: Optional[bytes] = None,
         bootstrap_interval: float = 1,


### PR DESCRIPTION
This parameter has been inconsistently typed as either list[str] or tuple[str] - as either is acceptable, we can widen the type to Sequence[str] to satisfy `mypy` and/or other type checkers.

This will allow for constructs like:
```Python
application.run_polling(
    allowed_updates=(
        UpdateType.MESSAGE,
        UpdateType.EDITED_MESSAGE,
    )
)
```
which currently fails mypy (and likely other typecheckers) with an error like:
`error: Argument "allowed_updates" to "run_polling" of "Application" hasincompatible type "tuple[UpdateType, UpdateType]"; expected "list[str] | None"  [arg-type]`

- [x] run pre-commit
- [x] run tests
- [x] add self to AUTHORS.rst
- [x] add versionchanged to existing docstrings