### PR TITLE
Update pylint pre-commit hook to support py3.13 venvs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     hooks:
     -   id: flake8
 -   repo: https://github.com/PyCQA/pylint
-    rev: v3.2.4
+    rev: v3.3.2
     hooks:
     -   id: pylint
         files: ^(?!(tests|docs)).*\.py$

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -81,6 +81,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `LRezende <https://github.com/lrezende>`_
 - `Luca Bellanti <https://github.com/Trifase>`_
 - `Lucas Molinari <https://github.com/lucasmolinari>`_
+- `Luis Pérez <https://github.com/nemacysts>`_
 - `macrojames <https://github.com/macrojames>`_
 - `Matheus Lemos <https://github.com/mlemosf>`_
 - `Michael Dix <https://github.com/Eisberge>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,8 @@ enable = ["useless-suppression"]
 disable = ["duplicate-code", "too-many-arguments", "too-many-public-methods",
         "too-few-public-methods", "broad-exception-caught", "too-many-instance-attributes",
         "fixme", "missing-function-docstring", "missing-class-docstring", "too-many-locals",
-        "too-many-lines", "too-many-branches", "too-many-statements", "cyclic-import"
+        "too-many-lines", "too-many-branches", "too-many-statements", "cyclic-import",
+        "too-many-positional-arguments",
 ]
 
 [tool.pylint.main]


### PR DESCRIPTION
Without this change, running `pre-commit` inside a Python 3.13 venv results in errors as described in pylint-dev/pylint#10000

e.g.:
```
************* Module telegram._bot
telegram/_bot.py:26:0: E0611: No name 'Sequence' in module 'collections.abc' (no-name-in-module)
```

Bumping this hook required ignoring a new check added in pylint 3.3.0: `too-many-positional-arguments` as there's a significant amount of violations and picking a value for `--max-positional-arguments` seems non-trivial as there are functions with 80+ args (e.g., `Message::__init__()` in `telegram/_message.py`)

- [x] run pre-commit
- [x] run tests
- [x] add self to AUTHORS.rst
