### PR TITLE
Start using MessageLimit.DEEP_LINK_LENGTH constant

### DIFF
--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -1835,7 +1835,6 @@ class MessageLimit(IntEnum):
     :paramref:`~telegram.Bot.edit_message_text.text` parameter of
     :meth:`telegram.Bot.edit_message_text`.
     """
-    # TODO this constant is not used. helpers.py contains 64 as a number
     DEEP_LINK_LENGTH = 64
     """:obj:`int`: Maximum number of characters for a deep link."""
     # TODO this constant is not used anywhere

--- a/telegram/helpers.py
+++ b/telegram/helpers.py
@@ -36,7 +36,7 @@ from html import escape
 from typing import TYPE_CHECKING, Optional, Union
 
 from telegram._utils.types import MarkdownVersion
-from telegram.constants import MessageType
+from telegram.constants import MessageLimit, MessageType
 
 if TYPE_CHECKING:
     from telegram import Message, Update
@@ -173,7 +173,8 @@ def create_deep_linked_url(
         :obj:`str`: An URL to start the bot with specific parameters.
 
     Raises:
-        :exc:`ValueError`: If the length of the :paramref:`payload` exceeds 64 characters,
+        :exc:`ValueError`: If the length of the :paramref:`payload` exceeds \
+        :tg-const:`telegram.constants.MessageLimit.DEEP_LINK_LENGTH` characters,
             contains invalid characters, or if the :paramref:`bot_username` is less than 4
             characters.
     """
@@ -184,8 +185,10 @@ def create_deep_linked_url(
     if not payload:
         return base_url
 
-    if len(payload) > 64:
-        raise ValueError("The deep-linking payload must not exceed 64 characters.")
+    if len(payload) > MessageLimit.DEEP_LINK_LENGTH:
+        raise ValueError(
+            f"The deep-linking payload must not exceed {MessageLimit.DEEP_LINK_LENGTH} characters."
+        )
 
     if not re.match(r"^[A-Za-z0-9_-]+$", payload):
         raise ValueError(


### PR DESCRIPTION
This constant was added back in #3315 - but it was never referenced in the ptb codebase.

However, as mentioned in a comment added in #3351 - there was at least one place that was hardcoding this value rather than referencing the named constant

As far as I can tell (with the help of `git grep`), this is likely the only 64->MessageLimit.DEEP_LINK_LENGTH swap that can be made :)

NOTE: I've verified that the formatting of the documentation looks the same in terms of line breaks after breaking the ValueError exception text into two lines (i.e., there's no extraneous newlines)

Verification:
- [x] run precommit
- [x] run tests
- [x] `make -C docs/ singlehtml` and inspected the generated docs