### PR TITLE
Extend Customization Support for `Bot.base_(file_)url`

### DIFF
--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -241,6 +241,9 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
                 `test environment \
                 <https://core.telegram.org/bots/features#dedicated-test-environment>`_.
 
+                Example:
+                    ``"https://api.telegram.org/bot{token}/test"``
+
             .. versionchanged:: NEXT.VERSION
                Supports callable input and string formatting.
         base_file_url (:obj:`str`, optional): Telegram Bot API file URL.
@@ -254,6 +257,9 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
                 :wiki:`Local Bot API Server <Local-Bot-API-Server>` or using Telegrams
                 `test environment \
                 <https://core.telegram.org/bots/features#dedicated-test-environment>`_.
+
+                Example:
+                    ``"https://api.telegram.org/file/bot{token}/test"``
 
             .. versionchanged:: NEXT.VERSION
                Supports callable input and string formatting.

--- a/telegram/_utils/types.py
+++ b/telegram/_utils/types.py
@@ -25,7 +25,7 @@ Warning:
 """
 from collections.abc import Collection
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any, Literal, Optional, TypeVar, Union
+from typing import IO, TYPE_CHECKING, Any, Callable, Literal, Optional, TypeVar, Union
 
 if TYPE_CHECKING:
     from telegram import (
@@ -91,3 +91,5 @@ SocketOpt = Union[
     tuple[int, int, Union[bytes, bytearray]],
     tuple[int, int, None, int],
 ]
+
+BaseUrl = Union[str, Callable[[str], str]]

--- a/telegram/ext/_applicationbuilder.py
+++ b/telegram/ext/_applicationbuilder.py
@@ -26,7 +26,15 @@ import httpx
 
 from telegram._bot import Bot
 from telegram._utils.defaultvalue import DEFAULT_FALSE, DEFAULT_NONE, DefaultValue
-from telegram._utils.types import DVInput, DVType, FilePathInput, HTTPVersion, ODVInput, SocketOpt
+from telegram._utils.types import (
+    BaseUrl,
+    DVInput,
+    DVType,
+    FilePathInput,
+    HTTPVersion,
+    ODVInput,
+    SocketOpt,
+)
 from telegram._utils.warnings import warn
 from telegram.ext._application import Application
 from telegram.ext._baseupdateprocessor import BaseUpdateProcessor, SimpleUpdateProcessor
@@ -164,8 +172,8 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
 
     def __init__(self: "InitApplicationBuilder"):
         self._token: DVType[str] = DefaultValue("")
-        self._base_url: DVType[str] = DefaultValue("https://api.telegram.org/bot")
-        self._base_file_url: DVType[str] = DefaultValue("https://api.telegram.org/file/bot")
+        self._base_url: DVType[BaseUrl] = DefaultValue("https://api.telegram.org/bot")
+        self._base_file_url: DVType[BaseUrl] = DefaultValue("https://api.telegram.org/file/bot")
         self._connection_pool_size: DVInput[int] = DEFAULT_NONE
         self._proxy: DVInput[Union[str, httpx.Proxy, httpx.URL]] = DEFAULT_NONE
         self._socket_options: DVInput[Collection[SocketOpt]] = DEFAULT_NONE
@@ -378,15 +386,19 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         self._token = token
         return self
 
-    def base_url(self: BuilderType, base_url: str) -> BuilderType:
+    def base_url(self: BuilderType, base_url: BaseUrl) -> BuilderType:
         """Sets the base URL for :attr:`telegram.ext.Application.bot`. If not called,
         will default to ``'https://api.telegram.org/bot'``.
 
         .. seealso:: :paramref:`telegram.Bot.base_url`,
             :wiki:`Local Bot API Server <Local-Bot-API-Server>`, :meth:`base_file_url`
 
+        .. versionchanged:: NEXT.VERSION
+           Supports callable input and string formatting.
+
         Args:
-            base_url (:obj:`str`): The URL.
+            base_url (:obj:`str` | Callable[[:obj:`str`], :obj:`str`]): The URL or
+                input for the URL as accepted by :paramref:`telegram.Bot.base_url`.
 
         Returns:
             :class:`ApplicationBuilder`: The same builder with the updated argument.
@@ -396,15 +408,19 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         self._base_url = base_url
         return self
 
-    def base_file_url(self: BuilderType, base_file_url: str) -> BuilderType:
+    def base_file_url(self: BuilderType, base_file_url: BaseUrl) -> BuilderType:
         """Sets the base file URL for :attr:`telegram.ext.Application.bot`. If not
         called, will default to ``'https://api.telegram.org/file/bot'``.
 
         .. seealso:: :paramref:`telegram.Bot.base_file_url`,
             :wiki:`Local Bot API Server <Local-Bot-API-Server>`, :meth:`base_url`
 
+        .. versionchanged:: NEXT.VERSION
+           Supports callable input and string formatting.
+
         Args:
-            base_file_url (:obj:`str`): The URL.
+            base_file_url (:obj:`str` | Callable[[:obj:`str`], :obj:`str`]): The URL or
+                input for the URL as accepted by :paramref:`telegram.Bot.base_file_url`.
 
         Returns:
             :class:`ApplicationBuilder`: The same builder with the updated argument.

--- a/telegram/ext/_extbot.py
+++ b/telegram/ext/_extbot.py
@@ -93,7 +93,14 @@ from telegram._utils.datetime import to_timestamp
 from telegram._utils.defaultvalue import DEFAULT_NONE, DefaultValue
 from telegram._utils.logging import get_logger
 from telegram._utils.repr import build_repr_with_selected_attrs
-from telegram._utils.types import CorrectOptionID, FileInput, JSONDict, ODVInput, ReplyMarkup
+from telegram._utils.types import (
+    BaseUrl,
+    CorrectOptionID,
+    FileInput,
+    JSONDict,
+    ODVInput,
+    ReplyMarkup,
+)
 from telegram.ext._callbackdatacache import CallbackDataCache
 from telegram.ext._utils.types import RLARGS
 from telegram.request import BaseRequest
@@ -184,8 +191,8 @@ class ExtBot(Bot, Generic[RLARGS]):
     def __init__(
         self: "ExtBot[None]",
         token: str,
-        base_url: str = "https://api.telegram.org/bot",
-        base_file_url: str = "https://api.telegram.org/file/bot",
+        base_url: BaseUrl = "https://api.telegram.org/bot",
+        base_file_url: BaseUrl = "https://api.telegram.org/file/bot",
         request: Optional[BaseRequest] = None,
         get_updates_request: Optional[BaseRequest] = None,
         private_key: Optional[bytes] = None,
@@ -199,8 +206,8 @@ class ExtBot(Bot, Generic[RLARGS]):
     def __init__(
         self: "ExtBot[RLARGS]",
         token: str,
-        base_url: str = "https://api.telegram.org/bot",
-        base_file_url: str = "https://api.telegram.org/file/bot",
+        base_url: BaseUrl = "https://api.telegram.org/bot",
+        base_file_url: BaseUrl = "https://api.telegram.org/file/bot",
         request: Optional[BaseRequest] = None,
         get_updates_request: Optional[BaseRequest] = None,
         private_key: Optional[bytes] = None,
@@ -214,8 +221,8 @@ class ExtBot(Bot, Generic[RLARGS]):
     def __init__(
         self,
         token: str,
-        base_url: str = "https://api.telegram.org/bot",
-        base_file_url: str = "https://api.telegram.org/file/bot",
+        base_url: BaseUrl = "https://api.telegram.org/bot",
+        base_file_url: BaseUrl = "https://api.telegram.org/file/bot",
         request: Optional[BaseRequest] = None,
         get_updates_request: Optional[BaseRequest] = None,
         private_key: Optional[bytes] = None,

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -262,7 +262,7 @@ class TestBotWithoutRequest:
         assert caplog.records[1].getMessage() == "Set Bot API File URL: base/!!Test String!!"
 
     @pytest.mark.parametrize(
-        "insert_key", {"token", "TOKEN", "bot_token", "BOT_TOKEN", "bot-token", "BOT-TOKEN"}
+        "insert_key", ["token", "TOKEN", "bot_token", "BOT_TOKEN", "bot-token", "BOT-TOKEN"]
     )
     def test_base_url_parsing_string_format(self, offline_bot, insert_key, caplog):
         string = f"{{{insert_key}}}"

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -474,9 +474,10 @@ class TestBotWithoutRequest:
         ("cls", "logger_name"), [(Bot, "telegram.Bot"), (ExtBot, "telegram.ext.ExtBot")]
     )
     async def test_bot_method_logging(self, offline_bot: PytestExtBot, cls, logger_name, caplog):
+        instance = cls(offline_bot.token)
         # Second argument makes sure that we ignore logs from e.g. httpx
         with caplog.at_level(logging.DEBUG, logger="telegram"):
-            await cls(offline_bot.token).get_me()
+            await instance.get_me()
             # Only for stabilizing this test-
             if len(caplog.records) == 4:
                 for idx, record in enumerate(caplog.records):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -257,9 +257,10 @@ class TestBotWithoutRequest:
         assert bot.base_url == "base/!!Test String!!"
         assert bot.base_file_url == "base/!!Test String!!"
 
-        assert len(caplog.records) == 2
-        assert caplog.records[0].getMessage() == "Set Bot API URL: base/!!Test String!!"
-        assert caplog.records[1].getMessage() == "Set Bot API File URL: base/!!Test String!!"
+        assert len(caplog.records) >= 2
+        messages = [record.getMessage() for record in caplog.records]
+        assert "Set Bot API URL: base/!!Test String!!" in messages
+        assert "Set Bot API File URL: base/!!Test String!!" in messages
 
     @pytest.mark.parametrize(
         "insert_key", ["token", "TOKEN", "bot_token", "BOT_TOKEN", "bot-token", "BOT-TOKEN"]
@@ -279,9 +280,10 @@ class TestBotWithoutRequest:
         assert bot.base_url == "!!Test String!!"
         assert bot.base_file_url == "!!Test String!!"
 
-        assert len(caplog.records) == 2
-        assert caplog.records[0].getMessage() == "Set Bot API URL: !!Test String!!"
-        assert caplog.records[1].getMessage() == "Set Bot API File URL: !!Test String!!"
+        assert len(caplog.records) >= 2
+        messages = [record.getMessage() for record in caplog.records]
+        assert "Set Bot API URL: !!Test String!!" in messages
+        assert "Set Bot API File URL: !!Test String!!" in messages
 
         with pytest.raises(KeyError, match="unsupported insertion: unknown"):
             Bot("token", base_url="{unknown}{token}")
@@ -302,9 +304,10 @@ class TestBotWithoutRequest:
         assert bot.base_url == "!!Test String!!"
         assert bot.base_file_url == "!!Test String!!"
 
-        assert len(caplog.records) == 2
-        assert caplog.records[0].getMessage() == "Set Bot API URL: !!Test String!!"
-        assert caplog.records[1].getMessage() == "Set Bot API File URL: !!Test String!!"
+        assert len(caplog.records) >= 2
+        messages = [record.getMessage() for record in caplog.records]
+        assert "Set Bot API URL: !!Test String!!" in messages
+        assert "Set Bot API File URL: !!Test String!!" in messages
 
     async def test_repr(self):
         offline_bot = Bot(token="some_token", base_file_url="")

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -246,7 +246,7 @@ class TestBotWithoutRequest:
         with pytest.raises(InvalidToken, match="You must pass the token"):
             Bot("")
 
-    def test_base_url_parsing_basic(self, offline_bot, caplog):
+    def test_base_url_parsing_basic(self, caplog):
         with caplog.at_level(logging.DEBUG):
             bot = Bot(
                 token="!!Test String!!",
@@ -267,7 +267,7 @@ class TestBotWithoutRequest:
     @pytest.mark.parametrize(
         "insert_key", ["token", "TOKEN", "bot_token", "BOT_TOKEN", "bot-token", "BOT-TOKEN"]
     )
-    def test_base_url_parsing_string_format(self, offline_bot, insert_key, caplog):
+    def test_base_url_parsing_string_format(self, insert_key, caplog):
         string = f"{{{insert_key}}}"
 
         with caplog.at_level(logging.DEBUG):
@@ -290,7 +290,7 @@ class TestBotWithoutRequest:
         with pytest.raises(KeyError, match="unsupported insertion: unknown"):
             Bot("token", base_url="{unknown}{token}")
 
-    def test_base_url_parsing_callable(self, offline_bot, caplog):
+    def test_base_url_parsing_callable(self, caplog):
         def build_url(_: str) -> str:
             return "!!Test String!!"
 


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

Closes #3355

Given the spiked request for #3355 (see the graphic that I attached yesterday), I decided to go ahead and PR for this.
I decided *agains* the `test_env` flag and *for* customizing `base_(file_)url` because I think this will be easier to maintain.
For this, I implemented support for the following options:

```python
# backwards compatibility is ensured
Bot(token, base_url="my.tld/bot")`

# string formatting
Bot(token, base_url="my.tld/bot{token}")

# pass a callable
Bot(token, base_url=lambda t: f"my.tld/bot{t}")
```

PS: I confirmed that the file url is `https://api.telegram.org/file/bot<token>/test/…` though with this approach PTB doesn't hard-code that.
