### PR TITLE
Remove Deprecated `InlineQueryResultArticle.hide_url`

### DIFF
--- a/telegram/_inline/inlinequeryresultarticle.py
+++ b/telegram/_inline/inlinequeryresultarticle.py
@@ -23,9 +23,7 @@ from typing import TYPE_CHECKING, Optional
 from telegram._inline.inlinekeyboardmarkup import InlineKeyboardMarkup
 from telegram._inline.inlinequeryresult import InlineQueryResult
 from telegram._utils.types import JSONDict
-from telegram._utils.warnings import warn
 from telegram.constants import InlineQueryResultType
-from telegram.warnings import PTBDeprecationWarning
 
 if TYPE_CHECKING:
     from telegram import InputMessageContent
@@ -40,6 +38,9 @@ class InlineQueryResultArticle(InlineQueryResult):
     .. versionchanged:: 20.5
       Removed the deprecated arguments and attributes ``thumb_*``.
 
+    .. versionchanged:: NEXT.VERSION
+        Removed the deprecated argument and attribute ``hide_url``.
+
     Args:
         id (:obj:`str`): Unique identifier for this result,
             :tg-const:`telegram.InlineQueryResult.MIN_ID_LENGTH`-
@@ -50,12 +51,9 @@ class InlineQueryResultArticle(InlineQueryResult):
         reply_markup (:class:`telegram.InlineKeyboardMarkup`, optional): Inline keyboard attached
             to the message.
         url (:obj:`str`, optional): URL of the result.
-        hide_url (:obj:`bool`, optional): Pass :obj:`True`, if you don't want the URL to be shown
-            in the message.
 
-            .. deprecated:: 21.10
-                This attribute will be removed in future PTB versions. Pass an empty string as URL
-                instead.
+            Tip:
+                Pass an empty string as URL if you don't want the URL to be shown in the message.
         description (:obj:`str`, optional): Short description of the result.
         thumbnail_url (:obj:`str`, optional): Url of the thumbnail for the result.
 
@@ -78,12 +76,6 @@ class InlineQueryResultArticle(InlineQueryResult):
         reply_markup (:class:`telegram.InlineKeyboardMarkup`): Optional. Inline keyboard attached
             to the message.
         url (:obj:`str`): Optional. URL of the result.
-        hide_url (:obj:`bool`): Optional. Pass :obj:`True`, if you don't want the URL to be shown
-            in the message.
-
-            .. deprecated:: 21.10
-                This attribute will be removed in future PTB versions. Pass an empty string as URL
-                instead.
         description (:obj:`str`): Optional. Short description of the result.
         thumbnail_url (:obj:`str`): Optional. Url of the thumbnail for the result.
 
@@ -99,7 +91,6 @@ class InlineQueryResultArticle(InlineQueryResult):
 
     __slots__ = (
         "description",
-        "hide_url",
         "input_message_content",
         "reply_markup",
         "thumbnail_height",
@@ -116,7 +107,6 @@ class InlineQueryResultArticle(InlineQueryResult):
         input_message_content: "InputMessageContent",
         reply_markup: Optional[InlineKeyboardMarkup] = None,
         url: Optional[str] = None,
-        hide_url: Optional[bool] = None,
         description: Optional[str] = None,
         thumbnail_url: Optional[str] = None,
         thumbnail_width: Optional[int] = None,
@@ -133,16 +123,6 @@ class InlineQueryResultArticle(InlineQueryResult):
             # Optional
             self.reply_markup: Optional[InlineKeyboardMarkup] = reply_markup
             self.url: Optional[str] = url
-            if hide_url is not None:
-                warn(
-                    PTBDeprecationWarning(
-                        "21.10",
-                        "The argument `hide_url` will be removed in future PTB"
-                        "versions. Pass an empty string as URL instead.",
-                    ),
-                    stacklevel=2,
-                )
-            self.hide_url: Optional[bool] = hide_url
             self.description: Optional[str] = description
             self.thumbnail_url: Optional[str] = thumbnail_url
             self.thumbnail_width: Optional[int] = thumbnail_width

--- a/tests/_inline/test_inlinequeryresultarticle.py
+++ b/tests/_inline/test_inlinequeryresultarticle.py
@@ -28,7 +28,6 @@ from telegram import (
     InputTextMessageContent,
 )
 from telegram.constants import InlineQueryResultType
-from telegram.warnings import PTBDeprecationWarning
 from tests.auxil.slots import mro_slots
 
 
@@ -40,7 +39,6 @@ def inline_query_result_article():
         input_message_content=InlineQueryResultArticleTestBase.input_message_content,
         reply_markup=InlineQueryResultArticleTestBase.reply_markup,
         url=InlineQueryResultArticleTestBase.url,
-        hide_url=InlineQueryResultArticleTestBase.hide_url,
         description=InlineQueryResultArticleTestBase.description,
         thumbnail_url=InlineQueryResultArticleTestBase.thumbnail_url,
         thumbnail_height=InlineQueryResultArticleTestBase.thumbnail_height,
@@ -55,7 +53,6 @@ class InlineQueryResultArticleTestBase:
     input_message_content = InputTextMessageContent("input_message_content")
     reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton("reply_markup")]])
     url = "url"
-    hide_url = True
     description = "description"
     thumbnail_url = "thumb url"
     thumbnail_height = 10
@@ -79,7 +76,6 @@ class TestInlineQueryResultArticleWithoutRequest(InlineQueryResultArticleTestBas
         )
         assert inline_query_result_article.reply_markup.to_dict() == self.reply_markup.to_dict()
         assert inline_query_result_article.url == self.url
-        assert inline_query_result_article.hide_url == self.hide_url
         assert inline_query_result_article.description == self.description
         assert inline_query_result_article.thumbnail_url == self.thumbnail_url
         assert inline_query_result_article.thumbnail_height == self.thumbnail_height
@@ -101,7 +97,6 @@ class TestInlineQueryResultArticleWithoutRequest(InlineQueryResultArticleTestBas
             == inline_query_result_article.reply_markup.to_dict()
         )
         assert inline_query_result_article_dict["url"] == inline_query_result_article.url
-        assert inline_query_result_article_dict["hide_url"] == inline_query_result_article.hide_url
         assert (
             inline_query_result_article_dict["description"]
             == inline_query_result_article.description
@@ -158,31 +153,3 @@ class TestInlineQueryResultArticleWithoutRequest(InlineQueryResultArticleTestBas
 
         assert a != e
         assert hash(a) != hash(e)
-
-    def test_deprecation_warning_for_hide_url(self):
-        with pytest.warns(PTBDeprecationWarning, match="The argument `hide_url`") as record:
-            InlineQueryResultArticle(
-                self.id_, self.title, self.input_message_content, hide_url=True
-            )
-
-        assert record[0].filename == __file__, "wrong stacklevel!"
-
-        with pytest.warns(PTBDeprecationWarning, match="The argument `hide_url`") as record:
-            InlineQueryResultArticle(
-                self.id_, self.title, self.input_message_content, hide_url=False
-            )
-
-        assert record[0].filename == __file__, "wrong stacklevel!"
-
-        assert (
-            InlineQueryResultArticle(
-                self.id_, self.title, self.input_message_content, hide_url=True
-            ).hide_url
-            is True
-        )
-        assert (
-            InlineQueryResultArticle(
-                self.id_, self.title, self.input_message_content, hide_url=False
-            ).hide_url
-            is False
-        )

--- a/tests/test_official/exceptions.py
+++ b/tests/test_official/exceptions.py
@@ -201,7 +201,6 @@ def ignored_param_requirements(object_name: str) -> set[str]:
 # Arguments that are optional arguments for now for backwards compatibility
 BACKWARDS_COMPAT_KWARGS: dict[str, set[str]] = {
     "send_invoice|create_invoice_link|InputInvoiceMessageContent": {"provider_token"},
-    "InlineQueryResultArticle": {"hide_url"},
 }
 
 


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->
Closes #4638 

Follow-up for 4633

To be merged before the next Bot API update release
