### PR TITLE
Bump Bibo-Joshi/chango from 0.3.2 to 0.4.0

### DIFF
--- a/.github/workflows/chango_fragment.yml
+++ b/.github/workflows/chango_fragment.yml
@@ -4,6 +4,7 @@ on:
     types:
       - opened
       - reopened
+      - synchronize
 
 permissions: {}
 

--- a/.github/workflows/chango_fragment.yml
+++ b/.github/workflows/chango_fragment.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: Bibo-Joshi/chango@969684469005dd2e03451f15bfd810f2338bf072 # v0.3.2
+      - uses: Bibo-Joshi/chango@9d6bd9d7612eca5fab2c5161687011be59baaf19 # v0.4.0
         with:
           github-token: ${{ secrets.CHANGO_PAT }}
           query-issue-types: true

--- a/changes/unreleased/4712.8ckkAPAXGzedityWEyv363.toml
+++ b/changes/unreleased/4712.8ckkAPAXGzedityWEyv363.toml
@@ -1,0 +1,5 @@
+internal = "Bump Bibo-Joshi/chango from 0.3.2 to 0.4.0"
+[[pull_requests]]
+uid = "4712"
+author_uid = "Bibo-Joshi"
+closes_threads = []

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,4 +1,4 @@
-chango~=0.3.2
+chango~=0.4.0
 sphinx==8.2.3
 furo==2024.8.6
 furo-sphinx-search @ git+https://github.com/harshil21/furo-sphinx-search@v0.2.0.1


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

The new release adds a workaround for PRs comint from forks. B/c permissions are more tricky there and one usually wants to avoid the `pull_request_target` trigger, this now simply fails the workflow and prints the suggested fragment to the job summary.
Also now each commit can re-trigger the fragment creating - unless it was manually edited in between, then chango will not override that.

creating this pr from a fork to demonstrate
