### PR TITLE
Fix: move initialize flag up in _bot.py

### DIFF
--- a/changes/unreleased/4733.BRLwsEuh76974FPJRuiBjf.toml
+++ b/changes/unreleased/4733.BRLwsEuh76974FPJRuiBjf.toml
@@ -1,4 +1,4 @@
-other = "Fix: move initialize flag up in _bot.py"
+bugfixes = "Ensure execution of ``Bot.shutdown`` even if ``Bot.get_me()`` fails in ``Bot.initialize()``"
 [[pull_requests]]
 uid = "4733"
 author_uid = "Poolitzer"

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -829,13 +829,13 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
             return
 
         await asyncio.gather(self._request[0].initialize(), self._request[1].initialize())
+        self._initialized = True
         # Since the bot is to be initialized only once, we can also use it for
         # verifying the token passed and raising an exception if it's invalid.
         try:
             await self.get_me()
         except InvalidToken as exc:
             raise InvalidToken(f"The token `{self._token}` was rejected by the server.") from exc
-        self._initialized = True
 
     async def shutdown(self) -> None:
         """Stop & clear resources used by this class. Currently just calls

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -829,6 +829,8 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
             return
 
         await asyncio.gather(self._request[0].initialize(), self._request[1].initialize())
+        # this needs to be set before we call get_me, since this can trigger an error in the
+        # request backend, which would then NOT lead to a proper shutdown if this flag isn't set
         self._initialized = True
         # Since the bot is to be initialized only once, we can also use it for
         # verifying the token passed and raising an exception if it's invalid.

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -402,6 +402,21 @@ class TestBotWithoutRequest:
 
         assert self.test_flag == "stop"
 
+    async def test_shutdown_at_error_in_request_in_init(self, monkeypatch, offline_bot):
+        async def get_me_error():
+            raise httpx.HTTPError("BadRequest wrong token sry :(")
+
+        async def shutdown(*args):
+            self.test_flag = "stop"
+
+        monkeypatch.setattr(offline_bot, "get_me", get_me_error)
+        monkeypatch.setattr(offline_bot, "shutdown", shutdown)
+
+        async with offline_bot:
+            pass
+
+        assert self.test_flag == "stop"
+
     async def test_equality(self):
         async with (
             make_bot(token=FALLBACKS[0]["token"]) as a,


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

I am unsure if I should test this, because I can't really rewrite the initialize, so I think the only appropriate way would be to pick an invalid token, but unsure if this is worth it (its a really short function after all)