### PR TITLE
Use `timedelta` to represent time periods in classes

### DIFF
--- a/docs/substitutions/global.rst
+++ b/docs/substitutions/global.rst
@@ -101,3 +101,5 @@
 .. |org-verify| replace:: `on behalf of the organization <https://telegram.org/verify#third-party-verification>`__
 
 .. |time-period-input| replace:: :class:`datetime.timedelta` objects are accepted in addition to plain :obj:`int` values.
+
+.. |timespan-seconds-deprecated| replace:: In a future major version this will be of type :obj:`datetime.timedelta`. You can opt-in early by setting the `PTB_TIMEDELTA` environment variable.

--- a/telegram/_chatfullinfo.py
+++ b/telegram/_chatfullinfo.py
@@ -20,7 +20,7 @@
 """This module contains an object that represents a Telegram ChatFullInfo."""
 import datetime as dtm
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Union
 
 from telegram._birthdate import Birthdate
 from telegram._chat import Chat, _ChatBase
@@ -28,9 +28,18 @@ from telegram._chatlocation import ChatLocation
 from telegram._chatpermissions import ChatPermissions
 from telegram._files.chatphoto import ChatPhoto
 from telegram._reaction import ReactionType
-from telegram._utils.argumentparsing import de_json_optional, de_list_optional, parse_sequence_arg
-from telegram._utils.datetime import extract_tzinfo_from_defaults, from_timestamp
-from telegram._utils.types import JSONDict
+from telegram._utils.argumentparsing import (
+    de_json_optional,
+    de_list_optional,
+    parse_period_arg,
+    parse_sequence_arg,
+)
+from telegram._utils.datetime import (
+    extract_tzinfo_from_defaults,
+    from_timestamp,
+    get_timedelta_value,
+)
+from telegram._utils.types import JSONDict, TimePeriod
 
 if TYPE_CHECKING:
     from telegram import Bot, BusinessIntro, BusinessLocation, BusinessOpeningHours, Message
@@ -155,17 +164,29 @@ class ChatFullInfo(_ChatBase):
             (by sending date).
         permissions (:class:`telegram.ChatPermissions`): Optional. Default chat member permissions,
             for groups and supergroups.
-        slow_mode_delay (:obj:`int`, optional): For supergroups, the minimum allowed delay between
-            consecutive messages sent by each unprivileged user.
+        slow_mode_delay (:obj:`int` | :class:`datetime.timedelta`, optional): For supergroups,
+            the minimum allowed delay between consecutive messages sent by each unprivileged user.
+
+            .. versionchanged:: NEXT.VERSION
+                |time-period-input|
+
+            .. deprecated:: NEXT.VERSION
+                |timespan-seconds-deprecated|
         unrestrict_boost_count (:obj:`int`, optional): For supergroups, the minimum number of
             boosts that a non-administrator user needs to add in order to ignore slow mode and chat
             permissions.
 
             .. versionadded:: 21.0
-        message_auto_delete_time (:obj:`int`, optional): The time after which all messages sent to
-            the chat will be automatically deleted; in seconds.
+        message_auto_delete_time (:obj:`int` | :class:`datetime.timedelta`, optional): The time
+            after which all messages sent to the chat will be automatically deleted; in seconds.
 
             .. versionadded:: 13.4
+
+            .. versionchanged:: NEXT.VERSION
+                |time-period-input|
+
+            .. deprecated:: NEXT.VERSION
+                |timespan-seconds-deprecated|
         has_aggressive_anti_spam_enabled (:obj:`bool`, optional): :obj:`True`, if aggressive
             anti-spam checks are enabled in the supergroup. The field is only available to chat
             administrators.
@@ -312,17 +333,29 @@ class ChatFullInfo(_ChatBase):
             (by sending date).
         permissions (:class:`telegram.ChatPermissions`): Optional. Default chat member permissions,
             for groups and supergroups.
-        slow_mode_delay (:obj:`int`): Optional. For supergroups, the minimum allowed delay between
-            consecutive messages sent by each unprivileged user.
+        slow_mode_delay (:obj:`int` | :class:`datetime.timedelta`): Optional. For supergroups,
+            the minimum allowed delay between consecutive messages sent by each unprivileged user.
+
+            .. versionchanged:: NEXT.VERSION
+                |time-period-input|
+
+            .. deprecated:: NEXT.VERSION
+                |timespan-seconds-deprecated|
         unrestrict_boost_count (:obj:`int`): Optional. For supergroups, the minimum number of
             boosts that a non-administrator user needs to add in order to ignore slow mode and chat
             permissions.
 
             .. versionadded:: 21.0
-        message_auto_delete_time (:obj:`int`): Optional. The time after which all messages sent to
-            the chat will be automatically deleted; in seconds.
+        message_auto_delete_time (:obj:`int` | :class:`datetime.timedelta`): Optional. The time
+            after which all messages sent to the chat will be automatically deleted; in seconds.
 
             .. versionadded:: 13.4
+
+            .. versionchanged:: NEXT.VERSION
+                |time-period-input|
+
+            .. deprecated:: NEXT.VERSION
+                |timespan-seconds-deprecated|
         has_aggressive_anti_spam_enabled (:obj:`bool`): Optional. :obj:`True`, if aggressive
             anti-spam checks are enabled in the supergroup. The field is only available to chat
             administrators.
@@ -366,6 +399,8 @@ class ChatFullInfo(_ChatBase):
     """
 
     __slots__ = (
+        "_message_auto_delete_time",
+        "_slow_mode_delay",
         "accent_color_id",
         "active_usernames",
         "available_reactions",
@@ -394,14 +429,12 @@ class ChatFullInfo(_ChatBase):
         "linked_chat_id",
         "location",
         "max_reaction_count",
-        "message_auto_delete_time",
         "permissions",
         "personal_chat",
         "photo",
         "pinned_message",
         "profile_accent_color_id",
         "profile_background_custom_emoji_id",
-        "slow_mode_delay",
         "sticker_set_name",
         "unrestrict_boost_count",
     )
@@ -439,9 +472,9 @@ class ChatFullInfo(_ChatBase):
         invite_link: Optional[str] = None,
         pinned_message: Optional["Message"] = None,
         permissions: Optional[ChatPermissions] = None,
-        slow_mode_delay: Optional[int] = None,
+        slow_mode_delay: Optional[TimePeriod] = None,
         unrestrict_boost_count: Optional[int] = None,
-        message_auto_delete_time: Optional[int] = None,
+        message_auto_delete_time: Optional[TimePeriod] = None,
         has_aggressive_anti_spam_enabled: Optional[bool] = None,
         has_hidden_members: Optional[bool] = None,
         has_protected_content: Optional[bool] = None,
@@ -477,9 +510,9 @@ class ChatFullInfo(_ChatBase):
             self.invite_link: Optional[str] = invite_link
             self.pinned_message: Optional[Message] = pinned_message
             self.permissions: Optional[ChatPermissions] = permissions
-            self.slow_mode_delay: Optional[int] = slow_mode_delay
-            self.message_auto_delete_time: Optional[int] = (
-                int(message_auto_delete_time) if message_auto_delete_time is not None else None
+            self._slow_mode_delay: Optional[dtm.timedelta] = parse_period_arg(slow_mode_delay)
+            self._message_auto_delete_time: Optional[dtm.timedelta] = parse_period_arg(
+                message_auto_delete_time
             )
             self.has_protected_content: Optional[bool] = has_protected_content
             self.has_visible_history: Optional[bool] = has_visible_history
@@ -520,6 +553,14 @@ class ChatFullInfo(_ChatBase):
             self.can_send_paid_media: Optional[bool] = can_send_paid_media
             self.can_send_gift: Optional[bool] = can_send_gift
 
+    @property
+    def slow_mode_delay(self) -> Optional[Union[int, dtm.timedelta]]:
+        return get_timedelta_value(self._slow_mode_delay)
+
+    @property
+    def message_auto_delete_time(self) -> Optional[Union[int, dtm.timedelta]]:
+        return get_timedelta_value(self._message_auto_delete_time)
+
     @classmethod
     def de_json(cls, data: JSONDict, bot: Optional["Bot"] = None) -> "ChatFullInfo":
         """See :meth:`telegram.TelegramObject.de_json`."""
@@ -541,6 +582,13 @@ class ChatFullInfo(_ChatBase):
             Message,
         )
 
+        data["slow_mode_delay"] = (
+            dtm.timedelta(seconds=s) if (s := data.get("slow_mode_delay")) else None
+        )
+        data["message_auto_delete_time"] = (
+            dtm.timedelta(seconds=s) if (s := data.get("message_auto_delete_time")) else None
+        )
+
         data["pinned_message"] = de_json_optional(data.get("pinned_message"), Message, bot)
         data["permissions"] = de_json_optional(data.get("permissions"), ChatPermissions, bot)
         data["location"] = de_json_optional(data.get("location"), ChatLocation, bot)
@@ -558,3 +606,10 @@ class ChatFullInfo(_ChatBase):
         )
 
         return super().de_json(data=data, bot=bot)
+
+    def to_dict(self, recursive: bool = True) -> JSONDict:
+        """See :meth:`telegram.TelegramObject.to_dict`."""
+        out = super().to_dict(recursive)
+        out["slow_mode_delay"] = self.slow_mode_delay
+        out["message_auto_delete_time"] = self.message_auto_delete_time
+        return out

--- a/telegram/_utils/argumentparsing.py
+++ b/telegram/_utils/argumentparsing.py
@@ -23,12 +23,15 @@ Warning:
     user. Changes to this module are not considered breaking changes and may not be documented in
     the changelog.
 """
+import datetime as dtm
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Optional, Protocol, TypeVar
+from typing import TYPE_CHECKING, Optional, Protocol, TypeVar, Union
 
 from telegram._linkpreviewoptions import LinkPreviewOptions
 from telegram._telegramobject import TelegramObject
-from telegram._utils.types import JSONDict, ODVInput
+from telegram._utils.types import JSONDict, ODVInput, TimePeriod
+from telegram._utils.warnings import warn
+from telegram.warnings import PTBDeprecationWarning
 
 if TYPE_CHECKING:
     from typing import type_check_only
@@ -48,6 +51,30 @@ def parse_sequence_arg(arg: Optional[Sequence[T]]) -> tuple[T, ...]:
         :obj:`Tuple`: The sequence converted to a tuple or an empty tuple.
     """
     return tuple(arg) if arg else ()
+
+
+def parse_period_arg(arg: Optional[TimePeriod]) -> Union[dtm.timedelta, None]:
+    """Parses an optional time period in seconds into a timedelta
+
+    Args:
+        arg (:obj:`int` | :class:`datetime.timedelta`, optional): The time period to parse.
+
+    Returns:
+        :obj:`timedelta`: The time period converted to a timedelta object or :obj:`None`.
+    """
+    if arg is None:
+        return None
+    if isinstance(arg, (int, float)):
+        warn(
+            PTBDeprecationWarning(
+                "NEXT.VERSION",
+                "In a future major version this will be of type `datetime.timedelta`."
+                " You can opt-in early by setting the `PTB_TIMEDELTA` environment variable.",
+            ),
+            stacklevel=2,
+        )
+        return dtm.timedelta(seconds=arg)
+    return arg
 
 
 def parse_lpo_and_dwpp(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 import asyncio
 import logging
+import os
 import sys
 import zoneinfo
 from pathlib import Path
@@ -40,7 +41,12 @@ from telegram.ext import Defaults
 from tests.auxil.build_messages import DATE, make_message
 from tests.auxil.ci_bots import BOT_INFO_PROVIDER, JOB_INDEX
 from tests.auxil.constants import PRIVATE_KEY, TEST_TOPIC_ICON_COLOR, TEST_TOPIC_NAME
-from tests.auxil.envvars import GITHUB_ACTIONS, RUN_TEST_OFFICIAL, TEST_WITH_OPT_DEPS
+from tests.auxil.envvars import (
+    GITHUB_ACTIONS,
+    RUN_TEST_OFFICIAL,
+    TEST_WITH_OPT_DEPS,
+    env_var_2_bool,
+)
 from tests.auxil.files import data_file
 from tests.auxil.networking import NonchalantHttpxRequest
 from tests.auxil.pytest_classes import PytestBot, make_bot
@@ -127,6 +133,18 @@ if GITHUB_ACTIONS and JOB_INDEX == 0:
                 f"Test function {request.function} in test class {name} should not have a `bot` "
                 f"fixture. Use `offline_bot` instead."
             )
+
+
+@pytest.fixture(scope="module", params=["true", "false", None])
+def PTB_TIMEDELTA(request):
+    # Here we manually use monkeypatch to give this fixture module scope
+    monkeypatch = pytest.MonkeyPatch()
+    if request.param is not None:
+        monkeypatch.setenv("PTB_TIMEDELTA", request.param)
+    else:
+        monkeypatch.delenv("PTB_TIMEDELTA", raising=False)
+    yield env_var_2_bool(os.getenv("PTB_TIMEDELTA"))
+    monkeypatch.undo()
 
 
 # Redefine the event_loop fixture to have a session scope. Otherwise `bot` fixture can't be

--- a/tests/test_chatfullinfo.py
+++ b/tests/test_chatfullinfo.py
@@ -36,6 +36,7 @@ from telegram import (
 )
 from telegram._utils.datetime import UTC, to_timestamp
 from telegram.constants import ReactionEmoji
+from telegram.warnings import PTBDeprecationWarning
 from tests.auxil.slots import mro_slots
 
 
@@ -52,6 +53,7 @@ def chat_full_info(bot):
         can_set_sticker_set=ChatFullInfoTestBase.can_set_sticker_set,
         permissions=ChatFullInfoTestBase.permissions,
         slow_mode_delay=ChatFullInfoTestBase.slow_mode_delay,
+        message_auto_delete_time=ChatFullInfoTestBase.message_auto_delete_time,
         bio=ChatFullInfoTestBase.bio,
         linked_chat_id=ChatFullInfoTestBase.linked_chat_id,
         location=ChatFullInfoTestBase.location,
@@ -104,6 +106,7 @@ class ChatFullInfoTestBase:
         can_invite_users=True,
     )
     slow_mode_delay = 30
+    message_auto_delete_time = 60
     bio = "I'm a Barbie Girl in a Barbie World"
     linked_chat_id = 11880
     location = ChatLocation(Location(123, 456), "Barbie World")
@@ -150,7 +153,7 @@ class TestChatFullInfoWithoutRequest(ChatFullInfoTestBase):
 
         assert len(mro_slots(cfi)) == len(set(mro_slots(cfi))), "duplicate slot"
 
-    def test_de_json(self, offline_bot):
+    def test_de_json(self, offline_bot, PTB_TIMEDELTA):
         json_dict = {
             "id": self.id_,
             "title": self.title,
@@ -162,6 +165,7 @@ class TestChatFullInfoWithoutRequest(ChatFullInfoTestBase):
             "can_set_sticker_set": self.can_set_sticker_set,
             "permissions": self.permissions.to_dict(),
             "slow_mode_delay": self.slow_mode_delay,
+            "message_auto_delete_time": self.message_auto_delete_time,
             "bio": self.bio,
             "business_intro": self.business_intro.to_dict(),
             "business_location": self.business_location.to_dict(),
@@ -194,6 +198,11 @@ class TestChatFullInfoWithoutRequest(ChatFullInfoTestBase):
             "last_name": self.last_name,
             "can_send_paid_media": self.can_send_paid_media,
         }
+
+        def get_period(attr):
+            value = getattr(self, attr)
+            return dtm.timedelta(seconds=value) if PTB_TIMEDELTA else value
+
         cfi = ChatFullInfo.de_json(json_dict, offline_bot)
         assert cfi.id == self.id_
         assert cfi.title == self.title
@@ -202,7 +211,8 @@ class TestChatFullInfoWithoutRequest(ChatFullInfoTestBase):
         assert cfi.sticker_set_name == self.sticker_set_name
         assert cfi.can_set_sticker_set == self.can_set_sticker_set
         assert cfi.permissions == self.permissions
-        assert cfi.slow_mode_delay == self.slow_mode_delay
+        assert cfi.slow_mode_delay == get_period("slow_mode_delay")
+        assert cfi.message_auto_delete_time == get_period("message_auto_delete_time")
         assert cfi.bio == self.bio
         assert cfi.business_intro == self.business_intro
         assert cfi.business_location == self.business_location
@@ -261,7 +271,7 @@ class TestChatFullInfoWithoutRequest(ChatFullInfoTestBase):
         assert cfi_bot_raw.emoji_status_expiration_date.tzinfo == UTC
         assert emoji_expire_offset_tz == emoji_expire_offset
 
-    def test_to_dict(self, chat_full_info):
+    def test_to_dict(self, chat_full_info, PTB_TIMEDELTA):
         cfi = chat_full_info
         cfi_dict = cfi.to_dict()
 
@@ -314,6 +324,39 @@ class TestChatFullInfoWithoutRequest(ChatFullInfoTestBase):
         assert cfi_dict["can_send_paid_media"] == cfi.can_send_paid_media
 
         assert cfi_dict["max_reaction_count"] == cfi.max_reaction_count
+
+    @pytest.mark.parametrize("field_name", ["slow_mode_delay", "message_auto_delete_time"])
+    def test_time_period_int_deprecated(self, PTB_TIMEDELTA, recwarn, field_name):
+        def get_period(field_name):
+            value = getattr(self, field_name)
+            return dtm.timedelta(seconds=value) if PTB_TIMEDELTA else value
+
+        cfi = ChatFullInfo(
+            id=123456,
+            type="dummy_type",
+            accent_color_id=1,
+            max_reaction_count=1,
+            slow_mode_delay=get_period("slow_mode_delay"),
+            message_auto_delete_time=get_period("message_auto_delete_time"),
+        )
+
+        if PTB_TIMEDELTA:
+            assert len(recwarn) == 0
+            assert isinstance(getattr(cfi, field_name), dtm.timedelta)
+            assert len(recwarn) == 0
+        else:
+            # Two warnings from constructor
+            assert len(recwarn) == 2
+            for i in range(2):
+                assert "will be of type `datetime.timedelta`" in str(recwarn[i].message)
+                assert recwarn[i].category is PTBDeprecationWarning
+
+            # Trigger another warning on property access, while at it make an assertion
+            assert isinstance(getattr(cfi, field_name), (int, float))
+
+            assert len(recwarn) == 3
+            assert "will be of type `datetime.timedelta`" in str(recwarn[1].message)
+            assert recwarn[2].category is PTBDeprecationWarning
 
     def test_always_tuples_attributes(self):
         cfi = ChatFullInfo(

--- a/tests/test_official/exceptions.py
+++ b/tests/test_official/exceptions.py
@@ -98,6 +98,10 @@ class ParamTypeCheckingExceptions:
             "thumbnail": str,  # actual: Union[str, FileInput]
             "cover": str,  # actual: Union[str, FileInput]
         },
+        "ChatFullInfo": {
+            "slow_mode_delay": int,  # actual: Union[int, dtm.timedelta]
+            "message_auto_delete_time": int,  # actual: Union[int, dtm.timedelta]
+        },
         "EncryptedPassportElement": {
             "data": str,  # actual: Union[IdDocumentData, PersonalDetails, ResidentialAddress]
         },


### PR DESCRIPTION
Second part of #4575.

<details>
<summary>Affected classes (basicaly anywhere "in seconds" appears in api docs)</summary>

| Class | attribute | docs |
| ---- | ----------- | ------- |
| - [x] ChatFullInfo | slow_mode_delay | Optional. For supergroups, the minimum allowed delay between consecutive messages sent by each unprivileged user; in seconds |
| -[x] ChatFullInfo | message_auto_delete_time | Optional. The time after which all messages sent to the chat will be automatically deleted; in seconds |
| Animation | duration | Duration of the video in seconds as defined by the sender |
| Audio | duration | Duration of the audio in seconds as defined by the sender |
| Video | duration | Duration of the video in seconds as defined by the sender |
| Video | start_timestamp | Optional. Timestamp in seconds from which the video will play in the message |
| VideoNote | duration | Duration of the video in seconds as defined by the sender |
| Voice | duration | Duration of the audio in seconds as defined by the sender |
| PaidMediaPreview | duration | Optional. Duration of the media in seconds as defined by the sender |
| Poll | open_period | Optional. Amount of time in seconds the poll will be active after creation |
| Location | live_period | Optional. Time relative to the message sending date, during which the location can be updated; in seconds. For active live locations only. |
| MessageAutoDeleteTimerChanged | message_auto_delete_time | New auto-delete time for messages in the chat; in seconds |
| VideoChatEnded | duration | Video chat duration in seconds |
| ChatInviteLink | subscription_period | Optional. The number of seconds the subscription will be active for before the next payment |
| ResponseParameters | retry_after | Optional. In case of exceeding flood control, the number of seconds left to wait before the request can be repeated |
| InputMediaVideo | duration | Optional. Video duration in seconds |
| InputMediaAnimation | duration | Optional. Animation duration in seconds |
| InputMediaAudio | duration | Optional. Duration of the audio in seconds |
| InputPaidMediaVideo | duration | Optional. Video duration in seconds |
| InlineQueryResultGif | gif_duration | Optional. Duration of the GIF in seconds |
| InlineQueryResultMpeg4Gif | mpeg4_duration | Optional. Video duration in seconds |
| InlineQueryResultVideo | video_duration | Optional. Video duration in seconds |
| InlineQueryResultAudio | audio_duration | Optional. Audio duration in seconds |
| InlineQueryResultVoice | voice_duration | Optional. Recording duration in seconds |
| InlineQueryResultLocation | live_period | Optional. Period in seconds during which the location can be updated, should be between 60 and 86400, or 0x7FFFFFFF for live locations that can be edited indefinitely. |
| InputLocationMessageContent | live_period | ptional. Period in seconds during which the location can be updated, should be between 60 and 86400, or 0x7FFFFFFF for live locations that can be edited indefinitely. |
</details>


Check-list for PRs
------------------

- [x] Added ``.. versionadded:: NEXT.VERSION``, ``.. versionchanged:: NEXT.VERSION``, ``.. deprecated:: NEXT.VERSION`` or ``.. versionremoved:: NEXT.VERSION`` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [ ] Documented code changes according to the `CSI standard <https://standards.mousepawmedia.com/en/stable/csi.html>`__
- [x] Checked the `Stability Policy <https://docs.python-telegram-bot.org/stability_policy.html>`_ in case of deprecations or changes to documented behavior

**If the PR contains API changes (otherwise, you can ignore this passage)**

- [ ] Checked the Bot API specific sections of the `Stability Policy <https://docs.python-telegram-bot.org/stability_policy.html>`_
- [ ] Created a PR to remove functionality deprecated in the previous Bot API release (`see here <https://docs.python-telegram-bot.org/en/stable/stability_policy.html#case-2>`_)


-  If relevant:
   - [x] Added or updated documentation for the changed class(es) and/or method(s)
