### PR TITLE
Fix: InputPaidMedia default parse_mode insertation

### DIFF
--- a/changes/unreleased/4761.mmsngFA6b4ccdEzEpFTZS3.toml
+++ b/changes/unreleased/4761.mmsngFA6b4ccdEzEpFTZS3.toml
@@ -1,0 +1,6 @@
+bugfixes = "Fix Handling of ``Defaults`` for ``InputPaidMedia``"
+
+[[pull_requests]]
+uid = "4761"
+author_uid = "ngrogolev"
+closes_threads = ["4753"]

--- a/telegram/ext/_extbot.py
+++ b/telegram/ext/_extbot.py
@@ -62,6 +62,7 @@ from telegram import (
     InlineKeyboardMarkup,
     InlineQueryResultsButton,
     InputMedia,
+    InputPaidMedia,
     InputPollOption,
     LinkPreviewOptions,
     Location,
@@ -114,7 +115,6 @@ if TYPE_CHECKING:
         InputMediaDocument,
         InputMediaPhoto,
         InputMediaVideo,
-        InputPaidMedia,
         InputSticker,
         LabeledPrice,
         MessageEntity,
@@ -466,7 +466,11 @@ class ExtBot(Bot, Generic[RLARGS]):
                 with copied_val._unfrozen():
                     copied_val.parse_mode = self.defaults.parse_mode
                 data[key] = copied_val
-            elif key == "media" and isinstance(val, Sequence):
+            elif (
+                key == "media"
+                and isinstance(val, Sequence)
+                and not isinstance(val[0], InputPaidMedia)
+            ):
                 # Copy objects as not to edit them in-place
                 copy_list = [copy(media) for media in val]
                 for media in copy_list:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -543,7 +543,7 @@ class TestBotWithoutRequest:
         if bot_method_name.replace("_", "").lower() != "getupdates" and bot_class is ExtBot:
             assert rate_arg in param_names, f"{bot_method} is missing the parameter `{rate_arg}`"
 
-    @bot_methods(ext_bot=False)
+    @bot_methods()
     async def test_defaults_handling(
         self,
         bot_class,


### PR DESCRIPTION
Fixes #4753 

For some reason, ExtBot methods were excluded from testing in the [test_defaults_handling](https://github.com/python-telegram-bot/python-telegram-bot/compare/master...ngrogolev:python-telegram-bot:paid-media-defaults-insertation-fix?expand=1#diff-16435365ee487202cae42fc85f2bcb3f6d3883545fbdce46cf68fd5c74abffbb)

If there is any reason that these methods were initially excluded that I might have missed, please let me know