### PR TITLE
Api 9.0 business stars

### DIFF
--- a/changes/unreleased/4756.JT5nmUmGRG6qDEh5ScMn5f.toml
+++ b/changes/unreleased/4756.JT5nmUmGRG6qDEh5ScMn5f.toml
@@ -22,3 +22,7 @@ author_uid = "Bibo-Joshi"
 uid = "4769"
 author_uid = "aelkheir"
 closes_threads = []
+[[pull_requests]]
+uid = "4773"
+author_uid = "aelkheir"
+closes_threads = []

--- a/changes/unreleased/4756.JT5nmUmGRG6qDEh5ScMn5f.toml
+++ b/changes/unreleased/4756.JT5nmUmGRG6qDEh5ScMn5f.toml
@@ -1,4 +1,10 @@
 features = "Full Support for Bot API 9.0"
+deprecations = """This release comes with several deprecations, in line with our :ref:`stability policy <stability-policy>`.
+This includes the following:
+
+- Deprecated ``telegram.constants.StarTransactionsLimit.NANOSTAR_MIN_AMOUNT`` and ``telegram.constants.StarTransactionsLimit.NANOSTAR_MAX_AMOUNT``. These members will be replaced by ``telegram.constants.NanostarLimit.MIN_AMOUNT`` and ``telegram.constants.NanostarLimit.MAX_AMOUNT``.
+- Deprecated the class ``telegram.constants.StarTransactions``. Its only member ``telegram.constants.StarTransactions.NANOSTAR_VALUE`` will be replaced by ``telegram.constants.Nanostar.VALUE``.
+"""
 [[pull_requests]]
 uid = "4756"
 author_uid = "Bibo-Joshi"

--- a/changes/unreleased/4773.9KvDEBkqLc9MszBRTGoXbj.toml
+++ b/changes/unreleased/4773.9KvDEBkqLc9MszBRTGoXbj.toml
@@ -1,5 +1,0 @@
-other = "Api 9.0 business stars"
-[[pull_requests]]
-uid = "4773"
-author_uid = "aelkheir"
-closes_threads = []

--- a/changes/unreleased/4773.9KvDEBkqLc9MszBRTGoXbj.toml
+++ b/changes/unreleased/4773.9KvDEBkqLc9MszBRTGoXbj.toml
@@ -1,0 +1,5 @@
+other = "Api 9.0 business stars"
+[[pull_requests]]
+uid = "4773"
+author_uid = "aelkheir"
+closes_threads = []

--- a/docs/source/inclusions/bot_methods.rst
+++ b/docs/source/inclusions/bot_methods.rst
@@ -443,6 +443,8 @@
       - Used for upgrading owned regular gifts to unique ones.
     * - :meth:`~telegram.Bot.transfer_gift`
       - Used for transferring owned unique gifts to another user.
+    * - :meth:`~telegram.Bot.transfer_business_account_stars`
+      - Used for transfering Stars from the business account balance to the bot's balance.
 
 
 .. raw:: html

--- a/docs/source/inclusions/bot_methods.rst
+++ b/docs/source/inclusions/bot_methods.rst
@@ -413,6 +413,8 @@
       - Used for getting information about the business account.
     * - :meth:`~telegram.Bot.get_business_account_gifts`
       - Used for getting gifts owned by the business account.
+    * - :meth:`~telegram.Bot.get_business_account_star_balance`
+      - Used for getting the amount of Stars owned by the business account.
     * - :meth:`~telegram.Bot.read_business_message`
       - Used for marking a message as read.
     * - :meth:`~telegram.Bot.delete_story`

--- a/docs/source/telegram.payments-tree.rst
+++ b/docs/source/telegram.payments-tree.rst
@@ -22,6 +22,7 @@ Your bot can accept payments from Telegram users. Please see the `introduction t
     telegram.shippingaddress
     telegram.shippingoption
     telegram.shippingquery
+    telegram.staramount
     telegram.startransaction
     telegram.startransactions
     telegram.successfulpayment

--- a/docs/source/telegram.staramount.rst
+++ b/docs/source/telegram.staramount.rst
@@ -1,0 +1,6 @@
+StarAmount
+==========
+
+.. autoclass:: telegram.StarAmount
+    :members:
+    :show-inheritance:

--- a/telegram/__init__.py
+++ b/telegram/__init__.py
@@ -241,6 +241,7 @@ __all__ = (
     "ShippingAddress",
     "ShippingOption",
     "ShippingQuery",
+    "StarAmount",
     "StarTransaction",
     "StarTransactions",
     "Sticker",
@@ -300,6 +301,7 @@ __all__ = (
     "warnings",
 )
 
+from telegram._payment.stars.staramount import StarAmount
 from telegram._payment.stars.startransactions import StarTransaction, StarTransactions
 from telegram._payment.stars.transactionpartner import (
     TransactionPartner,

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -10257,6 +10257,50 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
             api_kwargs=api_kwargs,
         )
 
+    async def transfer_business_account_stars(
+        self,
+        business_connection_id: str,
+        star_count: int,
+        *,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: Optional[JSONDict] = None,
+    ) -> bool:
+        """
+        Transfers Telegram Stars from the business account balance to the bot's balance. Requires
+        the :attr:`~telegram.BusinessBotRights.can_transfer_stars` business bot right.
+
+        .. versionadded:: NEXT.VERSION
+
+        Args:
+            business_connection_id (:obj:`str`): Unique identifier of the business
+                connection
+            star_count (:obj:`int`): Number of Telegram Stars to transfer;
+                :tg-const:`~telegram.constants.BusinessLimit.MIN_STAR_COUNT`\
+-:tg-const:`~telegram.constants.BusinessLimit.MAX_STAR_COUNT`
+
+        Returns:
+            :obj:`bool`: On success, :obj:`True` is returned.
+
+        Raises:
+            :class:`telegram.error.TelegramError`
+        """
+        data: JSONDict = {
+            "business_connection_id": business_connection_id,
+            "star_count": star_count,
+        }
+        return await self._post(
+            "transferBusinessAccountStars",
+            data,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=api_kwargs,
+        )
+
     async def replace_sticker_in_set(
         self,
         user_id: int,
@@ -11226,6 +11270,8 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
     """Alias for :meth:`upgrade_gift`"""
     transferGift = transfer_gift
     """Alias for :meth:`transfer_gift`"""
+    transferBusinessAccountStars = transfer_business_account_stars
+    """Alias for :meth:`transfer_business_account_stars`"""
     replaceStickerInSet = replace_sticker_in_set
     """Alias for :meth:`replace_sticker_in_set`"""
     refundStarPayment = refund_star_payment

--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -82,6 +82,7 @@ from telegram._menubutton import MenuButton
 from telegram._message import Message
 from telegram._messageid import MessageId
 from telegram._ownedgift import OwnedGifts
+from telegram._payment.stars.staramount import StarAmount
 from telegram._payment.stars.startransactions import StarTransactions
 from telegram._poll import InputPollOption, Poll
 from telegram._reaction import ReactionType, ReactionTypeCustomEmoji, ReactionTypeEmoji
@@ -9480,6 +9481,45 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
             )
         )
 
+    async def get_business_account_star_balance(
+        self,
+        business_connection_id: str,
+        *,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: Optional[JSONDict] = None,
+    ) -> StarAmount:
+        """
+        Returns the amount of Telegram Stars owned by a managed business account. Requires the
+        :attr:`~telegram.BusinessBotRights.can_view_gifts_and_stars` business bot right.
+
+        .. versionadded:: NEXT.VERSION
+
+        Args:
+            business_connection_id (:obj:`str`): Unique identifier of the business connection.
+
+        Returns:
+            :class:`telegram.StarAmount`
+
+        Raises:
+            :class:`telegram.error.TelegramError`
+        """
+        data: JSONDict = {"business_connection_id": business_connection_id}
+        return StarAmount.de_json(
+            await self._post(
+                "getBusinessAccountStarBalance",
+                data,
+                read_timeout=read_timeout,
+                write_timeout=write_timeout,
+                connect_timeout=connect_timeout,
+                pool_timeout=pool_timeout,
+                api_kwargs=api_kwargs,
+            ),
+            bot=self,
+        )
+
     async def read_business_message(
         self,
         business_connection_id: str,
@@ -11154,6 +11194,8 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
     """Alias for :meth:`set_message_reaction`"""
     getBusinessAccountGifts = get_business_account_gifts
     """Alias for :meth:`get_business_account_gifts`"""
+    getBusinessAccountStarBalance = get_business_account_star_balance
+    """Alias for :meth:`get_business_account_star_balance`"""
     getBusinessConnection = get_business_connection
     """Alias for :meth:`get_business_connection`"""
     readBusinessMessage = read_business_message

--- a/telegram/_payment/stars/affiliateinfo.py
+++ b/telegram/_payment/stars/affiliateinfo.py
@@ -48,10 +48,10 @@ class AffiliateInfo(TelegramObject):
         amount (:obj:`int`): Integer amount of Telegram Stars received by the affiliate from the
             transaction, rounded to 0; can be negative for refunds
         nanostar_amount (:obj:`int`, optional): The number of
-            :tg-const:`~telegram.constants.StarTransactions.NANOSTAR_VALUE` shares of Telegram
+            :tg-const:`~telegram.constants.NanostarAmount.NANOSTAR_VALUE` shares of Telegram
             Stars received by the affiliate; from
-            :tg-const:`~telegram.constants.StarTransactionsLimit.NANOSTAR_MIN_AMOUNT` to
-            :tg-const:`~telegram.constants.StarTransactionsLimit.NANOSTAR_MAX_AMOUNT`;
+            :tg-const:`~telegram.constants.NanostarAmountLimit.NANOSTAR_MIN_AMOUNT` to
+            :tg-const:`~telegram.constants.NanostarAmountLimit.NANOSTAR_MAX_AMOUNT`;
             can be negative for refunds
 
     Attributes:
@@ -64,10 +64,10 @@ class AffiliateInfo(TelegramObject):
         amount (:obj:`int`): Integer amount of Telegram Stars received by the affiliate from the
             transaction, rounded to 0; can be negative for refunds
         nanostar_amount (:obj:`int`): Optional. The number of
-            :tg-const:`~telegram.constants.StarTransactions.NANOSTAR_VALUE` shares of Telegram
+            :tg-const:`~telegram.constants.NanostarAmount.NANOSTAR_VALUE` shares of Telegram
             Stars received by the affiliate; from
-            :tg-const:`~telegram.constants.StarTransactionsLimit.NANOSTAR_MIN_AMOUNT` to
-            :tg-const:`~telegram.constants.StarTransactionsLimit.NANOSTAR_MAX_AMOUNT`;
+            :tg-const:`~telegram.constants.NanostarAmountLimit.NANOSTAR_MIN_AMOUNT` to
+            :tg-const:`~telegram.constants.NanostarAmountLimit.NANOSTAR_MAX_AMOUNT`;
             can be negative for refunds
     """
 

--- a/telegram/_payment/stars/affiliateinfo.py
+++ b/telegram/_payment/stars/affiliateinfo.py
@@ -48,10 +48,10 @@ class AffiliateInfo(TelegramObject):
         amount (:obj:`int`): Integer amount of Telegram Stars received by the affiliate from the
             transaction, rounded to 0; can be negative for refunds
         nanostar_amount (:obj:`int`, optional): The number of
-            :tg-const:`~telegram.constants.NanostarAmount.NANOSTAR_VALUE` shares of Telegram
+            :tg-const:`~telegram.constants.Nanostar.VALUE` shares of Telegram
             Stars received by the affiliate; from
-            :tg-const:`~telegram.constants.NanostarAmountLimit.NANOSTAR_MIN_AMOUNT` to
-            :tg-const:`~telegram.constants.NanostarAmountLimit.NANOSTAR_MAX_AMOUNT`;
+            :tg-const:`~telegram.constants.NanostarLimit.MIN_AMOUNT` to
+            :tg-const:`~telegram.constants.NanostarLimit.MAX_AMOUNT`;
             can be negative for refunds
 
     Attributes:
@@ -64,10 +64,10 @@ class AffiliateInfo(TelegramObject):
         amount (:obj:`int`): Integer amount of Telegram Stars received by the affiliate from the
             transaction, rounded to 0; can be negative for refunds
         nanostar_amount (:obj:`int`): Optional. The number of
-            :tg-const:`~telegram.constants.NanostarAmount.NANOSTAR_VALUE` shares of Telegram
+            :tg-const:`~telegram.constants.Nanostar.VALUE` shares of Telegram
             Stars received by the affiliate; from
-            :tg-const:`~telegram.constants.NanostarAmountLimit.NANOSTAR_MIN_AMOUNT` to
-            :tg-const:`~telegram.constants.NanostarAmountLimit.NANOSTAR_MAX_AMOUNT`;
+            :tg-const:`~telegram.constants.NanostarLimit.MIN_AMOUNT` to
+            :tg-const:`~telegram.constants.NanostarLimit.MAX_AMOUNT`;
             can be negative for refunds
     """
 

--- a/telegram/_payment/stars/staramount.py
+++ b/telegram/_payment/stars/staramount.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+#
+# A library that provides a Python interface to the Telegram Bot API
+# Copyright (C) 2015-2025
+# Leandro Toledo de Souza <devs@python-telegram-bot.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program. If not, see [http://www.gnu.org/licenses/].
+# pylint: disable=redefined-builtin
+"""This module contains an object that represents a Telegram StarAmount."""
+
+
+from typing import Optional
+
+from telegram._telegramobject import TelegramObject
+from telegram._utils.types import JSONDict
+
+
+class StarAmount(TelegramObject):
+    """Describes an amount of Telegram Stars.
+
+    Objects of this class are comparable in terms of equality. Two objects of this class are
+    considered equal, if their :attr:`amount` and :attr:`nanostar_amount` are equal.
+
+    Args:
+        amount (:obj:`int`): Integer amount of Telegram Stars, rounded to ``0``; can be negative.
+        nanostar_amount (:obj:`int`, optional): The number of
+            :tg-const:`telegram.constants.StarAmount.NANOSTAR_VALUE` shares of Telegram
+            Stars; from :tg-const:`telegram.constants.StarAmountLimit.NANOSTAR_MIN_AMOUNT`
+            to :tg-const:`telegram.constants.StarAmountLimit.NANOSTAR_MAX_AMOUNT`; can be negative
+            if and only if :attr:`amount` is non-positive.
+
+    Attributes:
+        amount (:obj:`int`): Integer amount of Telegram Stars, rounded to ``0``; can be negative.
+        nanostar_amount (:obj:`int`): Optional. The number of
+            :tg-const:`telegram.constants.StarAmount.NANOSTAR_VALUE` shares of Telegram
+            Stars; from :tg-const:`telegram.constants.StarAmountLimit.NANOSTAR_MIN_AMOUNT`
+            to :tg-const:`telegram.constants.StarAmountLimit.NANOSTAR_MAX_AMOUNT`; can be negative
+            if and only if :attr:`amount` is non-positive.
+
+    """
+
+    __slots__ = ("amount", "nanostar_amount")
+
+    def __init__(
+        self,
+        amount: int,
+        nanostar_amount: Optional[int] = None,
+        *,
+        api_kwargs: Optional[JSONDict] = None,
+    ):
+        super().__init__(api_kwargs=api_kwargs)
+        self.amount: int = amount
+        self.nanostar_amount: Optional[int] = nanostar_amount
+
+        self._id_attrs = (self.amount, self.nanostar_amount)
+
+        self._freeze()

--- a/telegram/_payment/stars/staramount.py
+++ b/telegram/_payment/stars/staramount.py
@@ -35,17 +35,17 @@ class StarAmount(TelegramObject):
     Args:
         amount (:obj:`int`): Integer amount of Telegram Stars, rounded to ``0``; can be negative.
         nanostar_amount (:obj:`int`, optional): The number of
-            :tg-const:`telegram.constants.NanostarAmount.NANOSTAR_VALUE` shares of Telegram
-            Stars; from :tg-const:`telegram.constants.NanostarAmountLimit.NANOSTAR_MIN_AMOUNT`
-            to :tg-const:`telegram.constants.NanostarAmountLimit.NANOSTAR_MAX_AMOUNT`; can be
+            :tg-const:`telegram.constants.Nanostar.VALUE` shares of Telegram
+            Stars; from :tg-const:`telegram.constants.NanostarLimit.MIN_AMOUNT`
+            to :tg-const:`telegram.constants.NanostarLimit.MAX_AMOUNT`; can be
             negative if and only if :attr:`amount` is non-positive.
 
     Attributes:
         amount (:obj:`int`): Integer amount of Telegram Stars, rounded to ``0``; can be negative.
         nanostar_amount (:obj:`int`): Optional. The number of
-            :tg-const:`telegram.constants.NanostarAmount.NANOSTAR_VALUE` shares of Telegram
-            Stars; from :tg-const:`telegram.constants.NanostarAmountLimit.NANOSTAR_MIN_AMOUNT`
-            to :tg-const:`telegram.constants.NanostarAmountLimit.NANOSTAR_MAX_AMOUNT`; can be
+            :tg-const:`telegram.constants.Nanostar.VALUE` shares of Telegram
+            Stars; from :tg-const:`telegram.constants.NanostarLimit.MIN_AMOUNT`
+            to :tg-const:`telegram.constants.NanostarLimit.MAX_AMOUNT`; can be
             negative if and only if :attr:`amount` is non-positive.
 
     """

--- a/telegram/_payment/stars/staramount.py
+++ b/telegram/_payment/stars/staramount.py
@@ -35,18 +35,18 @@ class StarAmount(TelegramObject):
     Args:
         amount (:obj:`int`): Integer amount of Telegram Stars, rounded to ``0``; can be negative.
         nanostar_amount (:obj:`int`, optional): The number of
-            :tg-const:`telegram.constants.StarAmount.NANOSTAR_VALUE` shares of Telegram
-            Stars; from :tg-const:`telegram.constants.StarAmountLimit.NANOSTAR_MIN_AMOUNT`
-            to :tg-const:`telegram.constants.StarAmountLimit.NANOSTAR_MAX_AMOUNT`; can be negative
-            if and only if :attr:`amount` is non-positive.
+            :tg-const:`telegram.constants.NanostarAmount.NANOSTAR_VALUE` shares of Telegram
+            Stars; from :tg-const:`telegram.constants.NanostarAmountLimit.NANOSTAR_MIN_AMOUNT`
+            to :tg-const:`telegram.constants.NanostarAmountLimit.NANOSTAR_MAX_AMOUNT`; can be
+            negative if and only if :attr:`amount` is non-positive.
 
     Attributes:
         amount (:obj:`int`): Integer amount of Telegram Stars, rounded to ``0``; can be negative.
         nanostar_amount (:obj:`int`): Optional. The number of
-            :tg-const:`telegram.constants.StarAmount.NANOSTAR_VALUE` shares of Telegram
-            Stars; from :tg-const:`telegram.constants.StarAmountLimit.NANOSTAR_MIN_AMOUNT`
-            to :tg-const:`telegram.constants.StarAmountLimit.NANOSTAR_MAX_AMOUNT`; can be negative
-            if and only if :attr:`amount` is non-positive.
+            :tg-const:`telegram.constants.NanostarAmount.NANOSTAR_VALUE` shares of Telegram
+            Stars; from :tg-const:`telegram.constants.NanostarAmountLimit.NANOSTAR_MIN_AMOUNT`
+            to :tg-const:`telegram.constants.NanostarAmountLimit.NANOSTAR_MAX_AMOUNT`; can be
+            negative if and only if :attr:`amount` is non-positive.
 
     """
 

--- a/telegram/_payment/stars/startransactions.py
+++ b/telegram/_payment/stars/startransactions.py
@@ -52,9 +52,9 @@ class StarTransaction(TelegramObject):
             successful incoming payments from users.
         amount (:obj:`int`): Integer amount of Telegram Stars transferred by the transaction.
         nanostar_amount (:obj:`int`, optional): The number of
-            :tg-const:`~telegram.constants.StarTransactions.NANOSTAR_VALUE` shares of Telegram
+            :tg-const:`~telegram.constants.NanostarAmount.NANOSTAR_VALUE` shares of Telegram
             Stars transferred by the transaction; from 0 to
-            :tg-const:`~telegram.constants.StarTransactionsLimit.NANOSTAR_MAX_AMOUNT`
+            :tg-const:`~telegram.constants.NanostarAmountLimit.NANOSTAR_MAX_AMOUNT`
 
             .. versionadded:: 21.9
         date (:obj:`datetime.datetime`): Date the transaction was created as a datetime object.
@@ -72,9 +72,9 @@ class StarTransaction(TelegramObject):
             successful incoming payments from users.
         amount (:obj:`int`): Integer amount of Telegram Stars transferred by the transaction.
         nanostar_amount (:obj:`int`): Optional. The number of
-            :tg-const:`~telegram.constants.StarTransactions.NANOSTAR_VALUE` shares of Telegram
+            :tg-const:`~telegram.constants.NanostarAmount.NANOSTAR_VALUE` shares of Telegram
             Stars transferred by the transaction; from 0 to
-            :tg-const:`~telegram.constants.StarTransactionsLimit.NANOSTAR_MAX_AMOUNT`
+            :tg-const:`~telegram.constants.NanostarAmountLimit.NANOSTAR_MAX_AMOUNT`
 
             .. versionadded:: 21.9
         date (:obj:`datetime.datetime`): Date the transaction was created as a datetime object.

--- a/telegram/_payment/stars/startransactions.py
+++ b/telegram/_payment/stars/startransactions.py
@@ -52,9 +52,9 @@ class StarTransaction(TelegramObject):
             successful incoming payments from users.
         amount (:obj:`int`): Integer amount of Telegram Stars transferred by the transaction.
         nanostar_amount (:obj:`int`, optional): The number of
-            :tg-const:`~telegram.constants.NanostarAmount.NANOSTAR_VALUE` shares of Telegram
+            :tg-const:`~telegram.constants.Nanostar.VALUE` shares of Telegram
             Stars transferred by the transaction; from 0 to
-            :tg-const:`~telegram.constants.NanostarAmountLimit.NANOSTAR_MAX_AMOUNT`
+            :tg-const:`~telegram.constants.NanostarLimit.MAX_AMOUNT`
 
             .. versionadded:: 21.9
         date (:obj:`datetime.datetime`): Date the transaction was created as a datetime object.
@@ -72,9 +72,9 @@ class StarTransaction(TelegramObject):
             successful incoming payments from users.
         amount (:obj:`int`): Integer amount of Telegram Stars transferred by the transaction.
         nanostar_amount (:obj:`int`): Optional. The number of
-            :tg-const:`~telegram.constants.NanostarAmount.NANOSTAR_VALUE` shares of Telegram
+            :tg-const:`~telegram.constants.Nanostar.VALUE` shares of Telegram
             Stars transferred by the transaction; from 0 to
-            :tg-const:`~telegram.constants.NanostarAmountLimit.NANOSTAR_MAX_AMOUNT`
+            :tg-const:`~telegram.constants.NanostarLimit.MAX_AMOUNT`
 
             .. versionadded:: 21.9
         date (:obj:`datetime.datetime`): Date the transaction was created as a datetime object.

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -89,8 +89,8 @@ __all__ = [
     "MessageLimit",
     "MessageOriginType",
     "MessageType",
-    "NanostarAmount",
-    "NanostarAmountLimit",
+    "Nanostar",
+    "NanostarLimit",
     "OwnedGiftType",
     "PaidMediaType",
     "ParseMode",
@@ -2221,7 +2221,7 @@ class MessageType(StringEnum):
     """
 
 
-class NanostarAmount(FloatEnum):
+class Nanostar(FloatEnum):
     """This enum contains constants for ``nanostar_amount`` parameter of
     :class:`telegram.StarAmount`, :class:`telegram.StarTransaction`
     and :class:`telegram.AffiliateInfo`.
@@ -2233,7 +2233,7 @@ class NanostarAmount(FloatEnum):
 
     __slots__ = ()
 
-    NANOSTAR_VALUE = 1 / 1000000000
+    VALUE = 1 / 1000000000
     """:obj:`float`: The value of one nanostar as used in
     :paramref:`telegram.StarTransaction.nanostar_amount`
     parameter of :class:`telegram.StarTransaction`,
@@ -2243,7 +2243,7 @@ class NanostarAmount(FloatEnum):
     """
 
 
-class NanostarAmountLimit(IntEnum):
+class NanostarLimit(IntEnum):
     """This enum contains limitations for ``nanostar_amount`` parameter of
     :class:`telegram.AffiliateInfo`, :class:`telegram.StarTransaction`
     and :class:`telegram.StarAmount`.
@@ -2254,13 +2254,13 @@ class NanostarAmountLimit(IntEnum):
 
     __slots__ = ()
 
-    NANOSTAR_MIN_AMOUNT = -999999999
+    MIN_AMOUNT = -999999999
     """:obj:`int`: Minimum value allowed for :paramref:`~telegram.AffiliateInfo.nanostar_amount`
     parameter of :class:`telegram.AffiliateInfo`
     and :paramref:`~telegram.StarAmount.nanostar_amount`
     parameter of :class:`telegram.StarAmount`.
     """
-    NANOSTAR_MAX_AMOUNT = 999999999
+    MAX_AMOUNT = 999999999
     """:obj:`int`: Maximum value allowed for :paramref:`~telegram.StarTransaction.nanostar_amount`
     parameter of :class:`telegram.StarTransaction`,
     :paramref:`~telegram.AffiliateInfo.nanostar_amount` parameter of
@@ -2683,18 +2683,18 @@ class StarTransactions(FloatEnum):
     .. versionadded:: 21.9
 
     .. deprecated:: NEXT.VERSION
-        This class will be removed as its only member :attr:`NANOSTAR_VALUE` will be moved
-        to :class:`telegram.constants.NanostarAmount`
+        This class will be removed as its only member :attr:`NANOSTAR_VALUE` will be replaced
+        by :attr:`telegram.constants.Nanostar.VALUE`.
     """
 
     __slots__ = ()
 
-    NANOSTAR_VALUE = NanostarAmount.NANOSTAR_VALUE
+    NANOSTAR_VALUE = Nanostar.VALUE
     """:obj:`float`: The value of one nanostar as used in
     :attr:`telegram.StarTransaction.nanostar_amount`.
 
     .. deprecated:: NEXT.VERSION
-        This member will be moved to :class:`telegram.constants.NanostarAmount`
+        This member will be replaced by :attr:`telegram.constants.Nanostar.VALUE`.
     """
 
 
@@ -2717,17 +2717,17 @@ class StarTransactionsLimit(IntEnum):
     :paramref:`~telegram.Bot.get_star_transactions.limit` parameter of
     :meth:`telegram.Bot.get_star_transactions`."""
     # tags: deprecated NEXT.VERSION, bot api 9.0
-    NANOSTAR_MIN_AMOUNT = NanostarAmountLimit.NANOSTAR_MIN_AMOUNT
+    NANOSTAR_MIN_AMOUNT = NanostarLimit.MIN_AMOUNT
     """:obj:`int`: Minimum value allowed for :paramref:`~telegram.AffiliateInfo.nanostar_amount`
     parameter of :class:`telegram.AffiliateInfo`.
 
     .. versionadded:: 21.9
 
     .. deprecated:: NEXT.VERSION
-        This member will be moved to :class:`telegram.constants.NanostarAmountLimit`
+        This member will be replaced by :attr:`telegram.constants.NanostarLimit.MIN_AMOUNT`.
     """
     # tags: deprecated NEXT.VERSION, bot api 9.0
-    NANOSTAR_MAX_AMOUNT = NanostarAmountLimit.NANOSTAR_MAX_AMOUNT
+    NANOSTAR_MAX_AMOUNT = NanostarLimit.MAX_AMOUNT
     """:obj:`int`: Maximum value allowed for :paramref:`~telegram.StarTransaction.nanostar_amount`
     parameter of :class:`telegram.StarTransaction` and
     :paramref:`~telegram.AffiliateInfo.nanostar_amount` parameter of
@@ -2736,7 +2736,7 @@ class StarTransactionsLimit(IntEnum):
     .. versionadded:: 21.9
 
     .. deprecated:: NEXT.VERSION
-        This member will be moved to :class:`telegram.constants.NanostarAmountLimit`
+        This member will be replaced by :attr:`telegram.constants.NanostarLimit.MAX_AMOUNT`.
     """
 
 

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -759,6 +759,16 @@ class BusinessLimit(IntEnum):
     :paramref:`~telegram.Bot.get_business_account_gifts.limit` of
     :meth:`telegram.Bot.get_business_account_gifts`.
     """
+    MIN_STAR_COUNT = 1
+    """:obj:`int`: Minimum number of Telegram Stars to be transfered. Relevant for
+    :paramref:`~telegram.Bot.transfer_business_account_stars.star_count` of
+    :meth:`telegram.Bot.transfer_business_account_stars`.
+    """
+    MAX_STAR_COUNT = 10000
+    """:obj:`int`: Maximum number of Telegram Stars to be transfered. Relevant for
+    :paramref:`~telegram.Bot.transfer_business_account_stars.star_count` of
+    :meth:`telegram.Bot.transfer_business_account_stars`.
+    """
 
 
 class CallbackQueryLimit(IntEnum):

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -89,6 +89,8 @@ __all__ = [
     "MessageLimit",
     "MessageOriginType",
     "MessageType",
+    "NanostarAmount",
+    "NanostarAmountLimit",
     "OwnedGiftType",
     "PaidMediaType",
     "ParseMode",
@@ -100,8 +102,6 @@ __all__ = [
     "ReactionType",
     "ReplyLimit",
     "RevenueWithdrawalStateType",
-    "StarAmount",
-    "StarAmountLimit",
     "StarTransactions",
     "StarTransactionsLimit",
     "StickerFormat",
@@ -2221,6 +2221,54 @@ class MessageType(StringEnum):
     """
 
 
+class NanostarAmount(FloatEnum):
+    """This enum contains constants for ``nanostar_amount`` parameter of
+    :class:`telegram.StarAmount`, :class:`telegram.StarTransaction`
+    and :class:`telegram.AffiliateInfo`.
+    The enum members of this enumeration are instances of :class:`float` and can be treated as
+    such.
+
+    .. versionadded:: NEXT.VERSION
+    """
+
+    __slots__ = ()
+
+    NANOSTAR_VALUE = 1 / 1000000000
+    """:obj:`float`: The value of one nanostar as used in
+    :paramref:`telegram.StarTransaction.nanostar_amount`
+    parameter of :class:`telegram.StarTransaction`,
+    :paramref:`telegram.StarAmount.nanostar_amount` parameter of :class:`telegram.StarAmount`
+    and :paramref:`telegram.AffiliateInfo.nanostar_amount`
+    parameter of :class:`telegram.AffiliateInfo`
+    """
+
+
+class NanostarAmountLimit(IntEnum):
+    """This enum contains limitations for ``nanostar_amount`` parameter of
+    :class:`telegram.AffiliateInfo`, :class:`telegram.StarTransaction`
+    and :class:`telegram.StarAmount`.
+    The enum members of this enumeration are instances of :class:`int` and can be treated as such.
+
+    .. versionadded:: NEXT.VERSION
+    """
+
+    __slots__ = ()
+
+    NANOSTAR_MIN_AMOUNT = -999999999
+    """:obj:`int`: Minimum value allowed for :paramref:`~telegram.AffiliateInfo.nanostar_amount`
+    parameter of :class:`telegram.AffiliateInfo`
+    and :paramref:`~telegram.StarAmount.nanostar_amount`
+    parameter of :class:`telegram.StarAmount`.
+    """
+    NANOSTAR_MAX_AMOUNT = 999999999
+    """:obj:`int`: Maximum value allowed for :paramref:`~telegram.StarTransaction.nanostar_amount`
+    parameter of :class:`telegram.StarTransaction`,
+    :paramref:`~telegram.AffiliateInfo.nanostar_amount` parameter of
+    :class:`telegram.AffiliateInfo` and :paramref:`~telegram.StarAmount.nanostar_amount`
+    parameter of :class:`telegram.StarAmount`.
+    """
+
+
 class OwnedGiftType(StringEnum):
     """This enum contains the available types of :class:`telegram.OwnedGift`. The enum
     members of this enumeration are instances of :class:`str` and can be treated as such.
@@ -2626,54 +2674,27 @@ class RevenueWithdrawalStateType(StringEnum):
     """:obj:`str`: A withdrawal failed and the transaction was refunded."""
 
 
-class StarAmount(FloatEnum):
-    """This enum contains constants for :class:`telegram.StarAmount`.
-    The enum members of this enumeration are instances of :class:`float` and can be treated as
-    such.
-
-    .. versionadded:: NEXT.VERSION
-    """
-
-    __slots__ = ()
-
-    NANOSTAR_VALUE = 1 / 1000000000
-    """:obj:`float`: The value of one nanostar as used in
-    :attr:`telegram.StarAmount.nanostar_amount`.
-    """
-
-
-class StarAmountLimit(IntEnum):
-    """This enum contains limitations for :class:`telegram.StarAmount`.
-    The enum members of this enumeration are instances of :class:`int` and can be treated as such.
-
-    .. versionadded:: NEXT.VERSION
-    """
-
-    __slots__ = ()
-
-    NANOSTAR_MIN_AMOUNT = -999999999
-    """:obj:`int`: Minimum value allowed for :paramref:`~telegram.StarAmount.nanostar_amount`
-    parameter of :class:`telegram.StarAmount`.
-    """
-    NANOSTAR_MAX_AMOUNT = 999999999
-    """:obj:`int`: Maximum value allowed for :paramref:`~telegram.StarAmount.nanostar_amount`
-    parameter of :class:`telegram.StarAmount`.
-    """
-
-
+# tags: deprecated NEXT.VERSION, bot api 9.0
 class StarTransactions(FloatEnum):
     """This enum contains constants for :class:`telegram.StarTransaction`.
     The enum members of this enumeration are instances of :class:`float` and can be treated as
     such.
 
     .. versionadded:: 21.9
+
+    .. deprecated:: NEXT.VERSION
+        This class will be removed as its only member :attr:`NANOSTAR_VALUE` will be moved
+        to :class:`telegram.constants.NanostarAmount`
     """
 
     __slots__ = ()
 
-    NANOSTAR_VALUE = 1 / 1000000000
+    NANOSTAR_VALUE = NanostarAmount.NANOSTAR_VALUE
     """:obj:`float`: The value of one nanostar as used in
     :attr:`telegram.StarTransaction.nanostar_amount`.
+
+    .. deprecated:: NEXT.VERSION
+        This member will be moved to :class:`telegram.constants.NanostarAmount`
     """
 
 
@@ -2695,19 +2716,27 @@ class StarTransactionsLimit(IntEnum):
     """:obj:`int`: Maximum value allowed for the
     :paramref:`~telegram.Bot.get_star_transactions.limit` parameter of
     :meth:`telegram.Bot.get_star_transactions`."""
-    NANOSTAR_MIN_AMOUNT = -999999999
+    # tags: deprecated NEXT.VERSION, bot api 9.0
+    NANOSTAR_MIN_AMOUNT = NanostarAmountLimit.NANOSTAR_MIN_AMOUNT
     """:obj:`int`: Minimum value allowed for :paramref:`~telegram.AffiliateInfo.nanostar_amount`
     parameter of :class:`telegram.AffiliateInfo`.
 
     .. versionadded:: 21.9
+
+    .. deprecated:: NEXT.VERSION
+        This member will be moved to :class:`telegram.constants.NanostarAmountLimit`
     """
-    NANOSTAR_MAX_AMOUNT = 999999999
+    # tags: deprecated NEXT.VERSION, bot api 9.0
+    NANOSTAR_MAX_AMOUNT = NanostarAmountLimit.NANOSTAR_MAX_AMOUNT
     """:obj:`int`: Maximum value allowed for :paramref:`~telegram.StarTransaction.nanostar_amount`
     parameter of :class:`telegram.StarTransaction` and
     :paramref:`~telegram.AffiliateInfo.nanostar_amount` parameter of
     :class:`telegram.AffiliateInfo`.
 
     .. versionadded:: 21.9
+
+    .. deprecated:: NEXT.VERSION
+        This member will be moved to :class:`telegram.constants.NanostarAmountLimit`
     """
 
 

--- a/telegram/constants.py
+++ b/telegram/constants.py
@@ -100,6 +100,8 @@ __all__ = [
     "ReactionType",
     "ReplyLimit",
     "RevenueWithdrawalStateType",
+    "StarAmount",
+    "StarAmountLimit",
     "StarTransactions",
     "StarTransactionsLimit",
     "StickerFormat",
@@ -2612,6 +2614,41 @@ class RevenueWithdrawalStateType(StringEnum):
     """:obj:`str`: A withdrawal succeeded."""
     FAILED = "failed"
     """:obj:`str`: A withdrawal failed and the transaction was refunded."""
+
+
+class StarAmount(FloatEnum):
+    """This enum contains constants for :class:`telegram.StarAmount`.
+    The enum members of this enumeration are instances of :class:`float` and can be treated as
+    such.
+
+    .. versionadded:: NEXT.VERSION
+    """
+
+    __slots__ = ()
+
+    NANOSTAR_VALUE = 1 / 1000000000
+    """:obj:`float`: The value of one nanostar as used in
+    :attr:`telegram.StarAmount.nanostar_amount`.
+    """
+
+
+class StarAmountLimit(IntEnum):
+    """This enum contains limitations for :class:`telegram.StarAmount`.
+    The enum members of this enumeration are instances of :class:`int` and can be treated as such.
+
+    .. versionadded:: NEXT.VERSION
+    """
+
+    __slots__ = ()
+
+    NANOSTAR_MIN_AMOUNT = -999999999
+    """:obj:`int`: Minimum value allowed for :paramref:`~telegram.StarAmount.nanostar_amount`
+    parameter of :class:`telegram.StarAmount`.
+    """
+    NANOSTAR_MAX_AMOUNT = 999999999
+    """:obj:`int`: Maximum value allowed for :paramref:`~telegram.StarAmount.nanostar_amount`
+    parameter of :class:`telegram.StarAmount`.
+    """
 
 
 class StarTransactions(FloatEnum):

--- a/telegram/ext/_extbot.py
+++ b/telegram/ext/_extbot.py
@@ -79,6 +79,7 @@ from telegram import (
     ReactionType,
     ReplyParameters,
     SentWebAppMessage,
+    StarAmount,
     StarTransactions,
     Sticker,
     StickerSet,
@@ -4308,6 +4309,26 @@ class ExtBot(Bot, Generic[RLARGS]):
             api_kwargs=self._merge_api_rl_kwargs(api_kwargs, rate_limit_args),
         )
 
+    async def get_business_account_star_balance(
+        self,
+        business_connection_id: str,
+        *,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: Optional[JSONDict] = None,
+        rate_limit_args: Optional[RLARGS] = None,
+    ) -> StarAmount:
+        return await super().get_business_account_star_balance(
+            business_connection_id=business_connection_id,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=self._merge_api_rl_kwargs(api_kwargs, rate_limit_args),
+        )
+
     async def read_business_message(
         self,
         business_connection_id: str,
@@ -5107,6 +5128,7 @@ class ExtBot(Bot, Generic[RLARGS]):
     setMessageReaction = set_message_reaction
     getBusinessConnection = get_business_connection
     getBusinessAccountGifts = get_business_account_gifts
+    getBusinessAccountStarBalance = get_business_account_star_balance
     readBusinessMessage = read_business_message
     deleteBusinessMessages = delete_business_messages
     postStory = post_story

--- a/telegram/ext/_extbot.py
+++ b/telegram/ext/_extbot.py
@@ -4677,6 +4677,28 @@ class ExtBot(Bot, Generic[RLARGS]):
             api_kwargs=self._merge_api_rl_kwargs(api_kwargs, rate_limit_args),
         )
 
+    async def transfer_business_account_stars(
+        self,
+        business_connection_id: str,
+        star_count: int,
+        *,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: Optional[JSONDict] = None,
+        rate_limit_args: Optional[RLARGS] = None,
+    ) -> bool:
+        return await super().transfer_business_account_stars(
+            business_connection_id=business_connection_id,
+            star_count=star_count,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=self._merge_api_rl_kwargs(api_kwargs, rate_limit_args),
+        )
+
     async def replace_sticker_in_set(
         self,
         user_id: int,
@@ -5143,6 +5165,7 @@ class ExtBot(Bot, Generic[RLARGS]):
     convertGiftToStars = convert_gift_to_stars
     upgradeGift = upgrade_gift
     transferGift = transfer_gift
+    transferBusinessAccountStars = transfer_business_account_stars
     replaceStickerInSet = replace_sticker_in_set
     refundStarPayment = refund_star_payment
     getStarTransactions = get_star_transactions

--- a/tests/_payment/stars/test_staramount.py
+++ b/tests/_payment/stars/test_staramount.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+#
+# A library that provides a Python interface to the Telegram Bot API
+# Copyright (C) 2015-2025
+# Leandro Toledo de Souza <devs@python-telegram-bot.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program. If not, see [http://www.gnu.org/licenses/].
+
+import pytest
+
+from telegram import StarAmount
+from tests.auxil.slots import mro_slots
+
+
+@pytest.fixture(scope="module")
+def star_amount():
+    return StarAmount(
+        amount=StarTransactionTestBase.amount,
+        nanostar_amount=StarTransactionTestBase.nanostar_amount,
+    )
+
+
+class StarTransactionTestBase:
+    amount = 100
+    nanostar_amount = 356
+
+
+class TestStarAmountWithoutRequest(StarTransactionTestBase):
+    def test_slot_behaviour(self, star_amount):
+        inst = star_amount
+        for attr in inst.__slots__:
+            assert getattr(inst, attr, "err") != "err", f"got extra slot '{attr}'"
+        assert len(mro_slots(inst)) == len(set(mro_slots(inst))), "duplicate slot"
+
+    def test_de_json(self, offline_bot):
+        json_dict = {
+            "amount": self.amount,
+            "nanostar_amount": self.nanostar_amount,
+        }
+        st = StarAmount.de_json(json_dict, offline_bot)
+        assert st.api_kwargs == {}
+        assert st.amount == self.amount
+        assert st.nanostar_amount == self.nanostar_amount
+
+    def test_to_dict(self, star_amount):
+        expected_dict = {
+            "amount": self.amount,
+            "nanostar_amount": self.nanostar_amount,
+        }
+        assert star_amount.to_dict() == expected_dict
+
+    def test_equality(self, star_amount):
+        a = star_amount
+        b = StarAmount(amount=self.amount, nanostar_amount=self.nanostar_amount)
+        c = StarAmount(amount=99, nanostar_amount=99)
+
+        assert a == b
+        assert hash(a) == hash(b)
+
+        assert a != c
+        assert hash(a) != hash(c)

--- a/tests/auxil/dummy_objects.py
+++ b/tests/auxil/dummy_objects.py
@@ -29,6 +29,7 @@ from telegram import (
     PollOption,
     PreparedInlineMessage,
     SentWebAppMessage,
+    StarAmount,
     StarTransaction,
     StarTransactions,
     Sticker,
@@ -126,6 +127,7 @@ _PREPARED_DUMMY_OBJECTS: dict[str, object] = {
     ),
     "PreparedInlineMessage": PreparedInlineMessage(id="dummy_id", expiration_date=_DUMMY_DATE),
     "SentWebAppMessage": SentWebAppMessage(inline_message_id="dummy_inline_message_id"),
+    "StarAmount": StarAmount(amount=100, nanostar_amount=356),
     "StarTransactions": StarTransactions(
         transactions=[StarTransaction(id="dummy_id", amount=1, date=_DUMMY_DATE)]
     ),

--- a/tests/test_business_methods.py
+++ b/tests/test_business_methods.py
@@ -277,6 +277,22 @@ class TestBusinessMethodsWithoutRequest(BusinessMethodsTestBase):
             star_count=star_count,
         )
 
+    async def test_transfer_business_account_stars(self, offline_bot, monkeypatch):
+        star_count = 100
+
+        async def make_assertion(*args, **kwargs):
+            data = kwargs.get("request_data").parameters
+            assert data.get("business_connection_id") == self.bci
+            assert data.get("star_count") == star_count
+
+            return True
+
+        monkeypatch.setattr(offline_bot.request, "post", make_assertion)
+        assert await offline_bot.transfer_business_account_stars(
+            business_connection_id=self.bci,
+            star_count=star_count,
+        )
+
     @pytest.mark.parametrize("is_public", [True, False, None, DEFAULT_NONE])
     async def test_set_business_account_profile_photo(self, offline_bot, monkeypatch, is_public):
         async def make_assertion(*args, **kwargs):

--- a/tests/test_business_methods.py
+++ b/tests/test_business_methods.py
@@ -26,6 +26,7 @@ from telegram import (
     InputProfilePhotoStatic,
     InputStoryContentPhoto,
     MessageEntity,
+    StarAmount,
     Story,
     StoryAreaTypeLink,
     StoryAreaTypeUniqueGift,
@@ -114,6 +115,20 @@ class TestBusinessMethodsWithoutRequest(BusinessMethodsTestBase):
             limit=limit,
         )
         assert isinstance(obj, OwnedGifts)
+
+    async def test_get_business_account_star_balance(self, offline_bot, monkeypatch):
+        star_amount_json = StarAmount(amount=100, nanostar_amount=356).to_json()
+
+        async def do_request(*args, **kwargs):
+            data = kwargs.get("request_data")
+            obj = data.parameters.get("business_connection_id")
+            if obj == self.bci:
+                return 200, f'{{"ok": true, "result": {star_amount_json}}}'.encode()
+            return 400, b'{"ok": false, "result": []}'
+
+        monkeypatch.setattr(offline_bot.request, "do_request", do_request)
+        obj = await offline_bot.get_business_account_star_balance(business_connection_id=self.bci)
+        assert isinstance(obj, StarAmount)
 
     async def test_read_business_message(self, offline_bot, monkeypatch):
         chat_id = 43


### PR DESCRIPTION
Check-list for PRs
------------------

- [x] Added ``.. versionadded:: NEXT.VERSION``, ``.. versionchanged:: NEXT.VERSION``, ``.. deprecated:: NEXT.VERSION`` or ``.. versionremoved:: NEXT.VERSION`` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [ ] Documented code changes according to the `CSI standard <https://standards.mousepawmedia.com/en/stable/csi.html>`__
- [x] Added new classes & modules to the docs and all suitable ``__all__`` s
- [ ] Checked the `Stability Policy <https://docs.python-telegram-bot.org/stability_policy.html>`_ in case of deprecations or changes to documented behavior

**~If the PR contains API changes (otherwise, you can ignore this passage)~**

- [ ] Checked the Bot API specific sections of the `Stability Policy <https://docs.python-telegram-bot.org/stability_policy.html>`_
- [ ] Created a PR to remove functionality deprecated in the previous Bot API release (`see here <https://docs.python-telegram-bot.org/en/stable/stability_policy.html#case-2>`_)

-  New classes:
   - [x] Added ``self._id_attrs`` and corresponding documentation
   - [x] ``__init__`` accepts ``api_kwargs`` as kw-only

-  ~Added new shortcuts~:
   - [ ] In :class:`~telegram.Chat` & :class:`~telegram.User` for all methods that accept ``chat/user_id``
   - [ ] In :class:`~telegram.Message` for all methods that accept ``chat_id`` and ``message_id``
   - [ ] For new :class:`~telegram.Message` shortcuts: Added ``quote`` argument if methods accepts ``reply_to_message_id``
   - [ ] In :class:`~telegram.CallbackQuery` for all methods that accept either ``chat_id`` and ``message_id`` or ``inline_message_id``

-  If relevant:
   - [x] Added new constants at :mod:`telegram.constants` and shortcuts to them as class variables
   - [x] Link new and existing constants in docstrings instead of hard-coded numbers and strings
   - [x] Added the new method(s) to ``_extbot.py``
   - [x] Added or updated ``bot_methods.rst``

### Business Accounts

- [x] Added the class [StarAmount](https://core.telegram.org/bots/api#staramount) and the method [getBusinessAccountStarBalance](https://core.telegram.org/bots/api#getbusinessaccountstarbalance), allowing bots to check the current Telegram Star balance of a managed business account.
- [x] Added the method [transferBusinessAccountStars](https://core.telegram.org/bots/api#transferbusinessaccountstars), allowing bots to transfer Telegram Stars from the balance of a managed business account to their own balance for withdrawal.
