### PR TITLE
Fix: Handle current_offset "[]" value in inline results

### DIFF
--- a/telegram/_bot.py
+++ b/telegram/_bot.py
@@ -3592,7 +3592,7 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         if current_offset is not None:
             # Convert the string input to integer
-            current_offset_int = 0 if not current_offset else int(current_offset)
+            current_offset_int = 0 if not current_offset or current_offset == "[]" else int(current_offset)
 
             # for now set to empty string, stating that there are no more results
             # might change later


### PR DESCRIPTION
Fixes #4295

```
site-packages/telegram/_bot.py",
 line 3593, in _effective_inline_results
    current_offset_int = 0 if not current_offset else int(current_offset)
                                                      ^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '[]'
```

This issue started happening from v21.2 as noted by [users](https://t.me/pythontelegrambotgroup/763054).

I couldn't find the reason / code change, but seems it's a server-side thing from Telegram.