### PR TITLE
Ensure Safe Handler Looping in `Application.process_update/error`

### DIFF
--- a/changes/unreleased/4801.RMLufX4UazobYg5aZojyoD.toml
+++ b/changes/unreleased/4801.RMLufX4UazobYg5aZojyoD.toml
@@ -1,5 +1,0 @@
-bugfixes = "Fixed a bug where calling ``Application.remove/add_handler`` during update handling can cause a ``RuntimeError`` in ``Application.process_update``. This is now prevented by raising a ``RuntimeError`` in ``Application.add_handler`` and ``Application.remove_handler`` if the application is already processing an update."
-
-[[pull_requests]]
-uid = "4802"
-author_uid = "Bibo-Joshi"

--- a/changes/unreleased/4801.RMLufX4UazobYg5aZojyoD.toml
+++ b/changes/unreleased/4801.RMLufX4UazobYg5aZojyoD.toml
@@ -1,0 +1,5 @@
+bugfixes = "Fixed a bug where calling ``Application.remove/add_handler`` during update handling can cause a ``RuntimeError`` in ``Application.process_update``. This is now prevented by raising a ``RuntimeError`` in ``Application.add_handler`` and ``Application.remove_handler`` if the application is already processing an update."
+
+[[pull_requests]]
+uid = "4802"
+author_uid = "Bibo-Joshi"

--- a/changes/unreleased/4802.RMLufX4UazobYg5aZojyoD.toml
+++ b/changes/unreleased/4802.RMLufX4UazobYg5aZojyoD.toml
@@ -1,0 +1,5 @@
+other = "Ensure Safe Handler Looping in `Application.process_update`"
+[[pull_requests]]
+uid = "4802"
+author_uid = "Bibo-Joshi"
+closes_threads = []

--- a/changes/unreleased/4802.RMLufX4UazobYg5aZojyoD.toml
+++ b/changes/unreleased/4802.RMLufX4UazobYg5aZojyoD.toml
@@ -3,3 +3,4 @@ bugfixes = "Fixed a bug where calling ``Application.remove/add_handler`` during 
 [[pull_requests]]
 uid = "4802"
 author_uid = "Bibo-Joshi"
+closes_threads = ["4803"]

--- a/changes/unreleased/4802.RMLufX4UazobYg5aZojyoD.toml
+++ b/changes/unreleased/4802.RMLufX4UazobYg5aZojyoD.toml
@@ -1,5 +1,5 @@
-other = "Ensure Safe Handler Looping in `Application.process_update`"
+bugfixes = "Fixed a bug where calling ``Application.remove/add_handler`` during update handling can cause a ``RuntimeError`` in ``Application.process_update``. This is now prevented by raising a ``RuntimeError`` in ``Application.add_handler`` and ``Application.remove_handler`` if the application is already processing an update."
+
 [[pull_requests]]
 uid = "4802"
 author_uid = "Bibo-Joshi"
-closes_threads = []

--- a/changes/unreleased/4802.RMLufX4UazobYg5aZojyoD.toml
+++ b/changes/unreleased/4802.RMLufX4UazobYg5aZojyoD.toml
@@ -1,5 +1,13 @@
-bugfixes = "Fixed a bug where calling ``Application.remove/add_handler`` during update handling can cause a ``RuntimeError`` in ``Application.process_update``. This is now prevented by raising a ``RuntimeError`` in ``Application.add_handler`` and ``Application.remove_handler`` if the application is already processing an update."
+bugfixes = """
+Fixed a bug where calling ``Application.remove/add_handler`` during update handling can cause a ``RuntimeError`` in ``Application.process_update``.
 
+.. hint::
+    Calling ``Application.add/remove_handler`` now has no influence on calls to :meth:`process_update` that are
+    already in progress. The same holds for ``Application.add/remove_error_handler`` and ``Application.process_error``, respectively.
+
+    .. warning::
+        This behavior should currently be considered an implementation detail and not as guaranteed behavior.
+"""
 [[pull_requests]]
 uid = "4802"
 author_uid = "Bibo-Joshi"

--- a/src/telegram/ext/_application.py
+++ b/src/telegram/ext/_application.py
@@ -1256,13 +1256,14 @@ class Application(
         context = None
         any_blocking = False  # Flag which is set to True if any handler specifies block=True
 
-        # We deepcopy the dict to avoid issues with concurrent modification of the
+        # We "deepcopy" the dict to avoid issues with concurrent modification of the
         # handlers (groups or handlers in groups) while iterating over it via add/remove_handler.
         # Currently considered implementation detail as described in docstrings of
         # add/remove_handler
-        for handlers in deepcopy(self.handlers).values():
+        # do *not* use `copy.deepcopy` here, as we don't want to deepcopy the handlers themselves
+        for handlers in [v.copy() for v in self.handlers.values()]:
             try:
-                # no copy needed b/c we deepcopy above
+                # no copy needed b/c we copy above
                 for handler in handlers:
                     check = handler.check_update(update)  # Should the handler handle this update?
                     if check is None or check is False:

--- a/src/telegram/ext/_application.py
+++ b/src/telegram/ext/_application.py
@@ -1256,7 +1256,7 @@ class Application(
         context = None
         any_blocking = False  # Flag which is set to True if any handler specifies block=True
 
-        # We "deepcopy" the dict to avoid issues with concurrent modification of the
+        # We copy the lists to avoid issues with concurrent modification of the
         # handlers (groups or handlers in groups) while iterating over it via add/remove_handler.
         # Currently considered implementation detail as described in docstrings of
         # add/remove_handler

--- a/src/telegram/ext/_application.py
+++ b/src/telegram/ext/_application.py
@@ -1353,7 +1353,7 @@ class Application(
             This method currently has no influence on calls to :meth:`process_update` that are
             already in progress.
 
-            Warning:
+            .. warning::
                 This behavior should currently be considered an implementation detail and not as
                 guaranteed behavior.
 
@@ -1462,7 +1462,7 @@ class Application(
             This method currently has no influence on calls to :meth:`process_update` that are
             already in progress.
 
-            Warning:
+            .. warning::
                 This behavior should currently be considered an implementation detail and not as
                 guaranteed behavior.
 
@@ -1800,7 +1800,7 @@ class Application(
             This method currently has no influence on calls to :meth:`process_error` that are
             already in progress.
 
-            Warning:
+            .. warning::
                 This behavior should currently be considered an implementation detail and not as
                 guaranteed behavior.
 
@@ -1831,7 +1831,7 @@ class Application(
             This method currently has no influence on calls to :meth:`process_error` that are
             already in progress.
 
-            Warning:
+            .. warning::
                 This behavior should currently be considered an implementation detail and not as
                 guaranteed behavior.
 

--- a/src/telegram/ext/_application.py
+++ b/src/telegram/ext/_application.py
@@ -1256,7 +1256,9 @@ class Application(
         context = None
         any_blocking = False  # Flag which is set to True if any handler specifies block=True
 
-        for handlers in self.handlers.values():
+        # We copy the values to a list to avoid issues with concurrent modification of the
+        # handlers dict while iterating over it via add/remove_handler.
+        for handlers in list(self.handlers.values()):
             try:
                 for handler in handlers:
                     check = handler.check_update(update)  # Should the handler handle this update?


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

Based on user input https://t.me/pythontelegrambotgroup/779167

Closes #4803

<details>

```python
No error handlers are registered, logging exception.

Traceback (most recent call last):

  File "/home/kuzunohalit/.local/lib/python3.12/site-packages/telegram/ext/_application.py", line 1170, in _create_task_callback
    return await coroutine  # type: ignore[misc]

  File "/home/kuzunohalit/.local/lib/python3.12/site-packages/telegram/ext/_application.py", line 1232, in _process_update_wrapper
    await self._update_processor.process_update(update, self.process_update(update))

  File "/home/kuzunohalit/.local/lib/python3.12/site-packages/telegram/ext/_baseupdateprocessor.py", line 170, in process_update
    await self.do_process_update(update, coroutine)

  File "/home/kuzunohalit/.local/lib/python3.12/site-packages/telegram/ext/_baseupdateprocessor.py", line 195, in do_process_update
    await coroutine

  File "/home/kuzunohalit/.local/lib/python3.12/site-packages/telegram/ext/_application.py", line 1259, in process_update
    for handlers in self.handlers.values():
RuntimeError: dictionary changed size during iteration
```

</details>