### PR TITLE
Allow for pattern matching empty inline queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,8 @@ telegram.jpg
 
 # virtual env
 venv*
+pyvenv.cfg
+Scripts/
 
 # environment manager:
 .mise.toml

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -80,6 +80,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Kirill Vasin <https://github.com/vasinkd>`_
 - `Kjwon15 <https://github.com/kjwon15>`_
 - `Li-aung Yip <https://github.com/LiaungYip>`_
+- `locobott <https://github.com/locobott>`_
 - `Loo Zheng Yuan <https://github.com/loozhengyuan>`_
 - `LRezende <https://github.com/lrezende>`_
 - `Luca Bellanti <https://github.com/Trifase>`_

--- a/changes/unreleased/4817.ZHx38jvj9zKRNZfQh9Xrpb.toml
+++ b/changes/unreleased/4817.ZHx38jvj9zKRNZfQh9Xrpb.toml
@@ -1,0 +1,5 @@
+other = "Allow for pattern matching empty inline queries"
+[[pull_requests]]
+uid = "4817"
+author_uid = "locobott"
+closes_threads = []

--- a/changes/unreleased/4817.ZHx38jvj9zKRNZfQh9Xrpb.toml
+++ b/changes/unreleased/4817.ZHx38jvj9zKRNZfQh9Xrpb.toml
@@ -1,4 +1,4 @@
-other = "Allow for pattern matching empty inline queries"
+bugfixes = "Allow for pattern matching empty inline queries"
 [[pull_requests]]
 uid = "4817"
 author_uid = "locobott"

--- a/src/telegram/ext/_handlers/inlinequeryhandler.py
+++ b/src/telegram/ext/_handlers/inlinequeryhandler.py
@@ -118,10 +118,7 @@ class InlineQueryHandler(BaseHandler[Update, CCT, RT]):
                 update.inline_query.chat_type not in self.chat_types
             ):
                 return False
-            if (
-                self.pattern
-                and (match := re.match(self.pattern, update.inline_query.query))
-            ):
+            if self.pattern and (match := re.match(self.pattern, update.inline_query.query)):
                 return match
             if not self.pattern:
                 return True

--- a/src/telegram/ext/_handlers/inlinequeryhandler.py
+++ b/src/telegram/ext/_handlers/inlinequeryhandler.py
@@ -120,7 +120,6 @@ class InlineQueryHandler(BaseHandler[Update, CCT, RT]):
                 return False
             if (
                 self.pattern
-                and update.inline_query.query
                 and (match := re.match(self.pattern, update.inline_query.query))
             ):
                 return match

--- a/tests/ext/test_inlinequeryhandler.py
+++ b/tests/ext/test_inlinequeryhandler.py
@@ -153,11 +153,11 @@ class TestInlineQueryHandler:
             assert not handler.check_update(update)
 
     @pytest.mark.parametrize(
-        "query,expected_result",
+    "query,expected_result",
         [
             pytest.param("", True, id="empty string"),
             pytest.param("not empty", False, id="non_empty_string"),
-        ]
+        ],
     )
     async def test_empty_inline_query_pattern(self, app, query, expected_result):
         handler = InlineQueryHandler(self.callback, pattern=r"^$")
@@ -166,27 +166,13 @@ class TestInlineQueryHandler:
         update = Update(
             update_id=0,
             inline_query=InlineQuery(
-                id="id", from_user=User(1, "test", False), query="", offset=""
+                id="id", from_user=User(1, "test", False), query=query, offset=""
             ),
         )
 
         async with app:
             await app.process_update(update)
-
-        assert self.test_flag
-
-        self.test_flag = False
-        update_non_empty = Update(
-            update_id=1,
-            inline_query=InlineQuery(
-                id="id2", from_user=User(1, "test", False), query="not empty", offset=""
-            ),
-        )
-
-        async with app:
-            await app.process_update(update_non_empty)
-
-        assert not self.test_flag
+        assert self.test_flag == expected_result
 
     @pytest.mark.parametrize("chat_types", [[Chat.SENDER], [Chat.SENDER, Chat.SUPERGROUP], []])
     @pytest.mark.parametrize(

--- a/tests/ext/test_inlinequeryhandler.py
+++ b/tests/ext/test_inlinequeryhandler.py
@@ -158,12 +158,14 @@ class TestInlineQueryHandler:
 
         update = Update(
             update_id=0,
-            inline_query=InlineQuery(id="id", from_user=User(1, "test", False), query="", offset=""),
+            inline_query=InlineQuery(
+                id="id", from_user=User(1, "test", False), query="", offset=""
+            ),
         )
 
         async with app:
             await app.process_update(update)
-        
+
         assert self.test_flag
 
         self.test_flag = False
@@ -176,7 +178,7 @@ class TestInlineQueryHandler:
 
         async with app:
             await app.process_update(update_non_empty)
-            
+
         assert not self.test_flag
 
     @pytest.mark.parametrize("chat_types", [[Chat.SENDER], [Chat.SENDER, Chat.SUPERGROUP], []])

--- a/tests/ext/test_inlinequeryhandler.py
+++ b/tests/ext/test_inlinequeryhandler.py
@@ -152,7 +152,14 @@ class TestInlineQueryHandler:
             update.inline_query.query = "not_a_match"
             assert not handler.check_update(update)
 
-    async def test_empty_inline_query_pattern(self, app):
+    @pytest.mark.parametrize(
+        "query,expected_result",
+        [
+            pytest.param("", True, id="empty string"),
+            pytest.param("not empty", False, id="non_empty_string"),
+        ]
+    )
+    async def test_empty_inline_query_pattern(self, app, query, expected_result):
         handler = InlineQueryHandler(self.callback, pattern=r"^$")
         app.add_handler(handler)
 

--- a/tests/ext/test_inlinequeryhandler.py
+++ b/tests/ext/test_inlinequeryhandler.py
@@ -153,7 +153,7 @@ class TestInlineQueryHandler:
             assert not handler.check_update(update)
 
     @pytest.mark.parametrize(
-    "query,expected_result",
+        ("query", "expected_result"),
         [
             pytest.param("", True, id="empty string"),
             pytest.param("not empty", False, id="non_empty_string"),


### PR DESCRIPTION
I just removed the line of code that prevents empty inline queries from being matched using the `pattern` parameter when creating an instance of an `InlineQueryHandler`. 

`update.inline_query` is assumed to always have the `query` property, which I can only assume is always the case, as the `update.inline_query` object must not be None in this case anyway.

Also added myself to AUTHORS.rst

I haven't modified any of the documentation as I feel like this changes makes the documentation more accurate, as the expected behavior is now in place.
