### PR TITLE
Improve Informativeness of Network Errors

### DIFF
--- a/changes/unreleased/4822.DrW3tJ3KoB8kTmHtNnNEpQ.toml
+++ b/changes/unreleased/4822.DrW3tJ3KoB8kTmHtNnNEpQ.toml
@@ -1,0 +1,5 @@
+other = "Improve Informativeness of Network Errors Raised by ``BaseRequest.post/retrieve``"
+
+[[pull_requests]]
+uid = "4822"
+author_uid = "Bibo-Joshi"

--- a/tests/request/test_request.py
+++ b/tests/request/test_request.py
@@ -331,7 +331,7 @@ class TestRequestWithoutRequest:
             mocker_factory(response=server_response, return_code=code),
         )
 
-        if not description and code not in HTTPStatus:
+        if not description and code not in list(HTTPStatus):
             match = f"Unknown HTTPError.*{code}"
         else:
             match = description or str(code.value)

--- a/tests/request/test_request.py
+++ b/tests/request/test_request.py
@@ -334,7 +334,7 @@ class TestRequestWithoutRequest:
         if not description and code not in HTTPStatus:
             match = f"Unknown HTTPError.*{code}"
         else:
-            match = description or str(code)
+            match = description or str(code.value)
 
         with pytest.raises(exception_class, match=match):
             await httpx_request.post("", None, None)

--- a/tests/request/test_request.py
+++ b/tests/request/test_request.py
@@ -316,10 +316,14 @@ class TestRequestWithoutRequest:
             (-1, NetworkError),
         ],
     )
+    @pytest.mark.parametrize("description", ["Test Message", None])
     async def test_special_errors(
-        self, monkeypatch, httpx_request: HTTPXRequest, code, exception_class
+        self, monkeypatch, httpx_request: HTTPXRequest, code, exception_class, description
     ):
-        server_response = b'{"ok": "False", "description": "Test Message"}'
+        server_response_json = {"ok": False}
+        if description:
+            server_response_json["description"] = description
+        server_response = json.dumps(server_response_json).encode(TextEncoding.UTF_8)
 
         monkeypatch.setattr(
             httpx_request,
@@ -327,7 +331,25 @@ class TestRequestWithoutRequest:
             mocker_factory(response=server_response, return_code=code),
         )
 
-        with pytest.raises(exception_class, match="Test Message"):
+        if not description and code not in HTTPStatus:
+            match = f"Unknown HTTPError.*{code}"
+        else:
+            match = description or str(code)
+
+        with pytest.raises(exception_class, match=match):
+            await httpx_request.post("", None, None)
+
+    async def test_error_parsing_payload(self, monkeypatch, httpx_request: HTTPXRequest):
+        """Test that we raise an error if the payload is not a valid JSON."""
+        server_response = b"invalid_json"
+
+        monkeypatch.setattr(
+            httpx_request,
+            "do_request",
+            mocker_factory(response=server_response, return_code=HTTPStatus.BAD_GATEWAY),
+        )
+
+        with pytest.raises(TelegramError, match=r"502.*\. Parsing.*b'invalid_json' failed"):
             await httpx_request.post("", None, None)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

Based on observations in #4821
* Uses `HTTPStatus.phrase` as more descriptive error message text
* wraps the call to `parse_json_payload` in a try-except to add information about failing to parse the server response while still raising the appropriate exception