### PR TITLE
Add note contributing guide

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -24,6 +24,8 @@ Setting things up
 
 4. Install the package in development mode as well as optional dependencies and development dependencies.
    Note that the `--group` argument requires `pip` 25.1 or later.
+   
+   Alternatively, you can use your preferred package manager (such as uv, hatch, poetry, etc.) instead of pip.
 
    .. code-block:: bash
 

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -109,6 +109,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `Patrick Hofmann <https://github.com/PH89>`_
 - `Paul Larsen <https://github.com/PaulSonOfLars>`_
 - `Pawan <https://github.com/pawanrai9999>`_
+- `Philipp Isachenko <https://github.com/Aweryc>`_
 - `Pieter Schutz <https://github.com/eldinnie>`_
 - `Piraty <https://github.com/piraty>`_
 - `Poolitzer <https://github.com/Poolitzer>`_

--- a/README.rst
+++ b/README.rst
@@ -114,6 +114,8 @@ You can also install ``python-telegram-bot`` from source, though this is usually
     $ pip install build
     $ python -m build
 
+Or you can use you favored package manager (such as uv, hatch, poetry, etc.) instead of pip.
+
 Verifying Releases
 ~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,7 @@ You can also install ``python-telegram-bot`` from source, though this is usually
     $ pip install build
     $ python -m build
 
-Or you can use you favored package manager (such as uv, hatch, poetry, etc.) instead of pip.
+Or use your favored package manager (such as uv, hatch, poetry, etc.) instead of pip.
 
 Verifying Releases
 ~~~~~~~~~~~~~~~~~~

--- a/changes/unreleased/4824.EJe3fPD4qVGVNy2mWbwTfs.toml
+++ b/changes/unreleased/4824.EJe3fPD4qVGVNy2mWbwTfs.toml
@@ -1,0 +1,5 @@
+documentation = "Mention alternative package managers in README and contribution guide"
+[[pull_requests]]
+uid = "4824"
+author_uid = "Aweryc"
+closes_threads = ["4823"]


### PR DESCRIPTION
Add a hint for users in the setup section of the contribution guide allowing them to use any preferred package manager instead of pip. 