### PR TITLE
Add support for Python 3.14 beta

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14.0-beta.2']
         os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: False
     steps:
@@ -62,8 +62,6 @@ jobs:
 
           # Test the rest
           export TEST_WITH_OPT_DEPS='true'
-          # need to manually install pytz here, because it's no longer in the optional reqs
-          pip install .[all] pytz
           # `-n auto --dist worksteal` uses pytest-xdist to run tests on multiple CPU
           # workers. Increasing number of workers has little effect on test duration, but it seems
           # to increase flakyness.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,11 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "httpx >=0.27,<0.29",
+    "httpcore >=1.0.9; python_version >= '3.14'"  # httpx needs an update so 3.14 support works
 ]
 
 [project.urls]
@@ -111,6 +113,8 @@ tests = [
     # For testing with timezones. Might not be needed on all systems, but to ensure that unit tests
     # run correctly on all systems, we include it here.
     "tzdata",
+    # We've deprecated support pytz, but we still need it for testing that it works with the library.
+    "pytz",
 ]
 docs = [
     "chango~=0.4.0; python_version >= '3.12'",
@@ -123,6 +127,7 @@ docs = [
     "sphinx-inline-tabs==2023.4.21",
     # Temporary. See #4387
     "sphinx-build-compatibility @ git+https://github.com/readthedocs/sphinx-build-compatibility.git@58aabc5f207c6c2421f23d3578adc0b14af57047",
+    "pydantic @ git+https://github.com/pydantic/pydantic; python_version >= '3.14'"  # Temporary for 3.14 support, we're waiting for a new pydantic version
 ]
 all = ["pre-commit", { include-group = "tests" }, { include-group = "docs" }]
 

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -42,7 +42,7 @@ such that tests marked with ``@pytest.mark.xdist_group("name")`` are run on the 
 
 .. code-block:: bash
 
-    $ pytest -n auto --dist=loadgroup
+    $ pytest -n auto --dist=worksteal
 
 This will result in a significant speedup, but may cause some tests to fail. If you want to run
 the failed tests in isolation, you can use the ``--lf`` flag:


### PR DESCRIPTION
Also adds pytz to the test dependency group since it was impossible to run the test suite without it.

Tested locally with uv's python 3.14, and with JIT enabled. Also confirmed that test official passes on 3.14 with the changes to annotations. 