### PR TITLE
Rename `BusinessBotRights.can_delete_sent_messages` to `BusinessBotRights.can_delete_outgoing_messages`

### DIFF
--- a/changes/unreleased/4844.U5uCRxj7QurJtLf3gvsrAa.toml
+++ b/changes/unreleased/4844.U5uCRxj7QurJtLf3gvsrAa.toml
@@ -1,0 +1,6 @@
+breaking = "Renamed argument and attribute ``BusinessBotRights.can_delete_sent_messages`` to ``BusinessBotRights.can_delete_outgoing_messages``. This is due to a change in the Bot API docs that was not announced in the changelog, but was introduced between Bot API 9.0 and 9.1. "
+
+[[pull_requests]]
+uid = "4844"
+author_uid = "Bibo-Joshi"
+closes_threads = []

--- a/src/telegram/_bot.py
+++ b/src/telegram/_bot.py
@@ -9667,7 +9667,7 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
     ) -> bool:
         """
         Delete messages on behalf of a business account. Requires the
-        :attr:`~telegram.BusinessBotRights.can_delete_sent_messages` business bot right to
+        :attr:`~telegram.BusinessBotRights.can_delete_outgoing_messages` business bot right to
         delete messages sent by the bot itself, or the
         :attr:`~telegram.BusinessBotRights.can_delete_all_messages` business bot right to delete
         any message.

--- a/src/telegram/_business.py
+++ b/src/telegram/_business.py
@@ -49,13 +49,17 @@ class BusinessBotRights(TelegramObject):
     Two objects of this class are considered equal, if all their attributes are equal.
 
     .. versionadded:: 22.1
+    .. versionchanged:: NEXT.VERSION::
+       Renamed argument and attribute ``can_delete_sent_messages`` to
+       ``can_delete_outgoing_messages``. This is due to a change in the Bot API docs that was not
+       announced in the changelog, but was introduced between Bot API 9.0 and 9.1.
 
     Args:
         can_reply (:obj:`bool`, optional): True, if the bot can send and edit messages in the
             private chats that had incoming messages in the last 24 hours.
         can_read_messages (:obj:`bool`, optional): True, if the bot can mark incoming private
             messages as read.
-        can_delete_sent_messages (:obj:`bool`, optional): True, if the bot can delete messages
+        can_delete_outgoing_messages (:obj:`bool`, optional): True, if the bot can delete messages
             sent by the bot.
         can_delete_all_messages (:obj:`bool`, optional): True, if the bot can delete all private
             messages in managed chats.
@@ -86,7 +90,7 @@ class BusinessBotRights(TelegramObject):
             private chats that had incoming messages in the last 24 hours.
         can_read_messages (:obj:`bool`): Optional. True, if the bot can mark incoming private
             messages as read.
-        can_delete_sent_messages (:obj:`bool`): Optional. True, if the bot can delete messages
+        can_delete_outgoing_messages (:obj:`bool`): Optional. True, if the bot can delete messages
             sent by the bot.
         can_delete_all_messages (:obj:`bool`): Optional. True, if the bot can delete all private
             messages in managed chats.
@@ -117,7 +121,7 @@ class BusinessBotRights(TelegramObject):
         "can_change_gift_settings",
         "can_convert_gifts_to_stars",
         "can_delete_all_messages",
-        "can_delete_sent_messages",
+        "can_delete_outgoing_messages",
         "can_edit_bio",
         "can_edit_name",
         "can_edit_profile_photo",
@@ -134,7 +138,7 @@ class BusinessBotRights(TelegramObject):
         self,
         can_reply: Optional[bool] = None,
         can_read_messages: Optional[bool] = None,
-        can_delete_sent_messages: Optional[bool] = None,
+        can_delete_outgoing_messages: Optional[bool] = None,
         can_delete_all_messages: Optional[bool] = None,
         can_edit_name: Optional[bool] = None,
         can_edit_bio: Optional[bool] = None,
@@ -152,7 +156,7 @@ class BusinessBotRights(TelegramObject):
         super().__init__(api_kwargs=api_kwargs)
         self.can_reply: Optional[bool] = can_reply
         self.can_read_messages: Optional[bool] = can_read_messages
-        self.can_delete_sent_messages: Optional[bool] = can_delete_sent_messages
+        self.can_delete_outgoing_messages: Optional[bool] = can_delete_outgoing_messages
         self.can_delete_all_messages: Optional[bool] = can_delete_all_messages
         self.can_edit_name: Optional[bool] = can_edit_name
         self.can_edit_bio: Optional[bool] = can_edit_bio
@@ -168,7 +172,7 @@ class BusinessBotRights(TelegramObject):
         self._id_attrs = (
             self.can_reply,
             self.can_read_messages,
-            self.can_delete_sent_messages,
+            self.can_delete_outgoing_messages,
             self.can_delete_all_messages,
             self.can_edit_name,
             self.can_edit_bio,

--- a/tests/test_business_classes.py
+++ b/tests/test_business_classes.py
@@ -46,7 +46,7 @@ class BusinessTestBase:
     can_change_gift_settings = True
     can_convert_gifts_to_stars = True
     can_delete_all_messages = True
-    can_delete_sent_messages = True
+    can_delete_outgoing_messages = True
     can_edit_bio = True
     can_edit_name = True
     can_edit_profile_photo = True
@@ -80,7 +80,7 @@ def business_bot_rights():
         can_change_gift_settings=BusinessTestBase.can_change_gift_settings,
         can_convert_gifts_to_stars=BusinessTestBase.can_convert_gifts_to_stars,
         can_delete_all_messages=BusinessTestBase.can_delete_all_messages,
-        can_delete_sent_messages=BusinessTestBase.can_delete_sent_messages,
+        can_delete_outgoing_messages=BusinessTestBase.can_delete_outgoing_messages,
         can_edit_bio=BusinessTestBase.can_edit_bio,
         can_edit_name=BusinessTestBase.can_edit_name,
         can_edit_profile_photo=BusinessTestBase.can_edit_profile_photo,
@@ -162,7 +162,7 @@ class TestBusinessBotRightsWithoutRequest(BusinessTestBase):
         assert isinstance(rights_dict, dict)
         assert rights_dict["can_reply"] is self.can_reply
         assert rights_dict["can_read_messages"] is self.can_read_messages
-        assert rights_dict["can_delete_sent_messages"] is self.can_delete_sent_messages
+        assert rights_dict["can_delete_outgoing_messages"] is self.can_delete_outgoing_messages
         assert rights_dict["can_delete_all_messages"] is self.can_delete_all_messages
         assert rights_dict["can_edit_name"] is self.can_edit_name
         assert rights_dict["can_edit_bio"] is self.can_edit_bio
@@ -179,7 +179,7 @@ class TestBusinessBotRightsWithoutRequest(BusinessTestBase):
         json_dict = {
             "can_reply": self.can_reply,
             "can_read_messages": self.can_read_messages,
-            "can_delete_sent_messages": self.can_delete_sent_messages,
+            "can_delete_outgoing_messages": self.can_delete_outgoing_messages,
             "can_delete_all_messages": self.can_delete_all_messages,
             "can_edit_name": self.can_edit_name,
             "can_edit_bio": self.can_edit_bio,
@@ -196,7 +196,7 @@ class TestBusinessBotRightsWithoutRequest(BusinessTestBase):
         rights = BusinessBotRights.de_json(json_dict, None)
         assert rights.can_reply is self.can_reply
         assert rights.can_read_messages is self.can_read_messages
-        assert rights.can_delete_sent_messages is self.can_delete_sent_messages
+        assert rights.can_delete_outgoing_messages is self.can_delete_outgoing_messages
         assert rights.can_delete_all_messages is self.can_delete_all_messages
         assert rights.can_edit_name is self.can_edit_name
         assert rights.can_edit_bio is self.can_edit_bio


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

Based on https://t.me/bot_api_changes/244
Awaiting confirmation from manual testing by @harshil

Note that I did *not* make this change backward compatible. Our [stability policy](https://docs.python-telegram-bot.org/en/stable/stability_policy.html#bot-api-versioning) does say that we keep API functionality available for the current and the next major version of PTB or until the next version of the Bot API. However, as this change is more of a Bot API bug-fix _without proper deprecation note or even changelog_, I find it hard to put it into this category. Please let me know if you see an issue with this.