### PR TITLE
API 9.1 `InputChecklist[Task]` classes and `bot.send/edit_checklist`

### DIFF
--- a/docs/source/inclusions/bot_methods.rst
+++ b/docs/source/inclusions/bot_methods.rst
@@ -449,6 +449,8 @@
       - Used for transferring owned unique gifts to another user.
     * - :meth:`~telegram.Bot.transfer_business_account_stars`
       - Used for transfering Stars from the business account balance to the bot's balance.
+    * - :meth:`~telegram.Bot.send_checklist`
+      - Used for sending a checklist on behalf of the business account.
 
 
 .. raw:: html

--- a/docs/source/telegram.at-tree.rst
+++ b/docs/source/telegram.at-tree.rst
@@ -87,6 +87,8 @@ Available Types
     telegram.inaccessiblemessage
     telegram.inlinekeyboardbutton
     telegram.inlinekeyboardmarkup
+    telegram.inputchecklist
+    telegram.inputchecklisttask
     telegram.inputfile
     telegram.inputmedia
     telegram.inputmediaanimation

--- a/docs/source/telegram.inputchecklist.rst
+++ b/docs/source/telegram.inputchecklist.rst
@@ -1,0 +1,6 @@
+InputChecklist
+==============
+
+.. autoclass:: telegram.InputChecklist
+    :members:
+    :show-inheritance:

--- a/docs/source/telegram.inputchecklisttask.rst
+++ b/docs/source/telegram.inputchecklisttask.rst
@@ -1,0 +1,6 @@
+InputChecklistTask
+==================
+
+.. autoclass:: telegram.InputChecklistTask
+    :members:
+    :show-inheritance:

--- a/src/telegram/__init__.py
+++ b/src/telegram/__init__.py
@@ -140,6 +140,8 @@ __all__ = (
     "InlineQueryResultVideo",
     "InlineQueryResultVoice",
     "InlineQueryResultsButton",
+    "InputChecklist",
+    "InputChecklistTask",
     "InputContactMessageContent",
     "InputFile",
     "InputInvoiceMessageContent",
@@ -304,6 +306,7 @@ __all__ = (
     "warnings",
 )
 
+from telegram._inputchecklist import InputChecklist, InputChecklistTask
 from telegram._payment.stars.staramount import StarAmount
 from telegram._payment.stars.startransactions import StarTransaction, StarTransactions
 from telegram._payment.stars.transactionpartner import (

--- a/src/telegram/_bot.py
+++ b/src/telegram/_bot.py
@@ -78,6 +78,7 @@ from telegram._games.gamehighscore import GameHighScore
 from telegram._gifts import AcceptedGiftTypes, Gift, Gifts
 from telegram._inline.inlinequeryresultsbutton import InlineQueryResultsButton
 from telegram._inline.preparedinlinemessage import PreparedInlineMessage
+from telegram._inputchecklist import InputChecklist
 from telegram._menubutton import MenuButton
 from telegram._message import Message
 from telegram._messageid import MessageId
@@ -7555,6 +7556,86 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         )
         return Poll.de_json(result, self)
 
+    async def send_checklist(
+        self,
+        business_connection_id: str,
+        chat_id: Union[int, str],
+        checklist: InputChecklist,
+        disable_notification: ODVInput[bool] = DEFAULT_NONE,
+        protect_content: ODVInput[bool] = DEFAULT_NONE,
+        message_effect_id: Optional[str] = None,
+        reply_parameters: Optional["ReplyParameters"] = None,
+        reply_markup: Optional[ReplyMarkup] = None,
+        *,
+        allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
+        reply_to_message_id: Optional[int] = None,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: Optional[JSONDict] = None,
+    ) -> Message:
+        """
+        Use this method to send a checklist on behalf of a connected business account.
+
+        .. versionadded:: NEXT.VERSION
+
+        Args:
+            business_connection_id (:obj:`str`):
+                |business_id_str|.
+            chat_id (:obj:`int` | :obj:`str`):
+                Unique identifier for the target chat.
+            checklist (:class:`telegram.InputChecklist`):
+                The checklist to send.
+            disable_notification (:obj:`bool`, optional):
+                |disable_notification|
+            protect_content (:obj:`bool`, optional):
+                |protect_content|
+            message_effect_id (:obj:`str`, optional):
+                |message_effect_id|
+            reply_parameters (:class:`telegram.ReplyParameters`, optional):
+                |reply_parameters|
+            reply_markup (:class:`telegram.InlineKeyboardMarkup`, optional):
+                An object for an inline keyboard
+
+        Keyword Args:
+            allow_sending_without_reply (:obj:`bool`, optional): |allow_sending_without_reply|
+                Mutually exclusive with :paramref:`reply_parameters`, which this is a convenience
+                parameter for
+            reply_to_message_id (:obj:`int`, optional): |reply_to_msg_id|
+                Mutually exclusive with :paramref:`reply_parameters`, which this is a convenience
+                parameter for
+
+        Returns:
+            :class:`telegram.Message`: On success, the sent Message is returned.
+
+        Raises:
+            :class:`telegram.error.TelegramError`
+
+        """
+        data: JSONDict = {
+            "chat_id": chat_id,
+            "checklist": checklist,
+        }
+
+        return await self._send_message(
+            "sendChecklist",
+            data,
+            disable_notification=disable_notification,
+            reply_markup=reply_markup,
+            protect_content=protect_content,
+            reply_parameters=reply_parameters,
+            message_effect_id=message_effect_id,
+            business_connection_id=business_connection_id,
+            allow_sending_without_reply=allow_sending_without_reply,
+            reply_to_message_id=reply_to_message_id,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=api_kwargs,
+        )
+
     async def send_dice(
         self,
         chat_id: Union[int, str],
@@ -11274,6 +11355,8 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
     """Alias for :meth:`send_poll`"""
     stopPoll = stop_poll
     """Alias for :meth:`stop_poll`"""
+    sendChecklist = send_checklist
+    """Alias for :meth:`send_checklist`"""
     sendDice = send_dice
     """Alias for :meth:`send_dice`"""
     getMyCommands = get_my_commands

--- a/src/telegram/_chat.py
+++ b/src/telegram/_chat.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
         Document,
         Gift,
         InlineKeyboardMarkup,
+        InputChecklist,
         InputMediaAudio,
         InputMediaDocument,
         InputMediaPhoto,
@@ -1469,6 +1470,54 @@ class _ChatBase(TelegramObject):
             business_connection_id=business_connection_id,
             message_effect_id=message_effect_id,
             allow_paid_broadcast=allow_paid_broadcast,
+        )
+
+    async def send_checklist(
+        self,
+        business_connection_id: str,
+        checklist: "InputChecklist",
+        disable_notification: ODVInput[bool] = DEFAULT_NONE,
+        reply_markup: Optional[ReplyMarkup] = None,
+        protect_content: ODVInput[bool] = DEFAULT_NONE,
+        reply_parameters: Optional["ReplyParameters"] = None,
+        message_effect_id: Optional[str] = None,
+        *,
+        reply_to_message_id: Optional[int] = None,
+        allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: Optional[JSONDict] = None,
+    ) -> "Message":
+        """Shortcut for::
+
+             await bot.send_checklist(chat_id=update.effective_chat.id, *args, **kwargs)
+
+        For the documentation of the arguments, please see :meth:`telegram.Bot.send_checklist`.
+
+        .. versionadded:: NEXT.VERSION
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return await self.get_bot().send_checklist(
+            chat_id=self.id,
+            business_connection_id=business_connection_id,
+            checklist=checklist,
+            disable_notification=disable_notification,
+            protect_content=protect_content,
+            message_effect_id=message_effect_id,
+            reply_parameters=reply_parameters,
+            reply_markup=reply_markup,
+            reply_to_message_id=reply_to_message_id,
+            allow_sending_without_reply=allow_sending_without_reply,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=api_kwargs,
         )
 
     async def send_dice(

--- a/src/telegram/_inputchecklist.py
+++ b/src/telegram/_inputchecklist.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python
+#
+# A library that provides a Python interface to the Telegram Bot API
+# Copyright (C) 2015-2025
+# Leandro Toledo de Souza <devs@python-telegram-bot.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+"""This module contains an objects that are related to Telegram input checklists."""
+from collections.abc import Sequence
+from typing import Optional
+
+from telegram._messageentity import MessageEntity
+from telegram._telegramobject import TelegramObject
+from telegram._utils.argumentparsing import parse_sequence_arg
+from telegram._utils.defaultvalue import DEFAULT_NONE
+from telegram._utils.types import JSONDict, ODVInput
+
+
+class InputChecklistTask(TelegramObject):
+    """
+    Describes a task to add to a checklist.
+
+    Objects of this class are comparable in terms of equality.
+    Two objects of this class are considered equal if their :attr:`id` is equal.
+
+    .. versionadded:: NEXT.VERSION
+
+    Args:
+        id (:obj:`int`):
+            Unique identifier of the task; must be positive and unique among all task identifiers
+            currently present in the checklist.
+        text (:obj:`str`):
+            Text of the task;
+            :tg-const:`telegram.constants.InputChecklistLimit.MIN_TEXT_LENGTH`\
+-:tg-const:`telegram.constants.InputChecklistLimit.MAX_TEXT_LENGTH` characters after
+            entities parsing.
+        parse_mode (:obj:`str`, optional):
+            |parse_mode|
+        text_entities (Sequence[:class:`telegram.MessageEntity`], optional):
+            List of special entities that appear in the text, which can be specified instead of
+            parse_mode. Currently, only bold, italic, underline, strikethrough, spoiler, and
+            custom_emoji entities are allowed.
+
+    Attributes:
+        id (:obj:`int`):
+            Unique identifier of the task; must be positive and unique among all task identifiers
+            currently present in the checklist.
+        text (:obj:`str`):
+            Text of the task;
+            :tg-const:`telegram.constants.InputChecklistLimit.MIN_TEXT_LENGTH`\
+-:tg-const:`telegram.constants.InputChecklistLimit.MAX_TEXT_LENGTH` characters after
+            entities parsing.
+        parse_mode (:obj:`str`):
+            Optional. |parse_mode|
+        text_entities (Sequence[:class:`telegram.MessageEntity`]):
+            Optional. List of special entities that appear in the text, which can be specified
+            instead of parse_mode. Currently, only bold, italic, underline, strikethrough, spoiler,
+            and custom_emoji entities are allowed.
+
+    """
+
+    __slots__ = (
+        "id",
+        "parse_mode",
+        "text",
+        "text_entities",
+    )
+
+    def __init__(
+        self,
+        id: int,  # pylint: disable=redefined-builtin
+        text: str,
+        parse_mode: ODVInput[str] = DEFAULT_NONE,
+        text_entities: Optional[Sequence[MessageEntity]] = None,
+        *,
+        api_kwargs: Optional[JSONDict] = None,
+    ):
+        super().__init__(api_kwargs=api_kwargs)
+        self.id: int = id
+        self.text: str = text
+        self.parse_mode: ODVInput[str] = parse_mode
+        self.text_entities: tuple[MessageEntity, ...] = parse_sequence_arg(text_entities)
+
+        self._id_attrs = (self.id,)
+
+        self._freeze()
+
+
+class InputChecklist(TelegramObject):
+    """
+    Describes a checklist to create.
+
+    Objects of this class are comparable in terms of equality.
+    Two objects of this class are considered equal if their :attr:`tasks` is equal.
+
+    .. versionadded:: NEXT.VERSION
+
+    Args:
+        title (:obj:`str`):
+            Title of the checklist;
+            :tg-const:`telegram.constants.InputChecklistLimit.MIN_TITLE_LENGTH`\
+-:tg-const:`telegram.constants.InputChecklistLimit.MAX_TITLE_LENGTH` characters after
+            entities parsing.
+        parse_mode (:obj:`str`, optional):
+            |parse_mode|
+        title_entities (Sequence[:class:`telegram.MessageEntity`], optional):
+            List of special entities that appear in the title, which
+            can be specified instead of :paramref:`parse_mode`. Currently, only bold, italic,
+            underline, strikethrough, spoiler, and custom_emoji entities are allowed.
+        tasks (Sequence[:class:`telegram.InputChecklistTask`]):
+            List of
+            :tg-const:`telegram.constants.InputChecklistLimit.MIN_TASK_NUMBER`\
+-:tg-const:`telegram.constants.InputChecklistLimit.MAX_TASK_NUMBER` tasks in
+            the checklist.
+        others_can_add_tasks (:obj:`bool`, optional):
+            Pass :obj:`True` if other users can add tasks to the checklist.
+        others_can_mark_tasks_as_done (:obj:`bool`, optional):
+            Pass :obj:`True` if other users can mark tasks as done or not done in the checklist.
+
+    Attributes:
+        title (:obj:`str`):
+            Title of the checklist;
+            :tg-const:`telegram.constants.InputChecklistLimit.MIN_TITLE_LENGTH`\
+-:tg-const:`telegram.constants.InputChecklistLimit.MAX_TITLE_LENGTH` characters after
+            entities parsing.
+        parse_mode (:obj:`str`):
+            Optional. |parse_mode|
+        title_entities (Sequence[:class:`telegram.MessageEntity`]):
+            Optional. List of special entities that appear in the title, which
+            can be specified instead of :paramref:`parse_mode`. Currently, only bold, italic,
+            underline, strikethrough, spoiler, and custom_emoji entities are allowed.
+        tasks (Sequence[:class:`telegram.InputChecklistTask`]):
+            List of
+            :tg-const:`telegram.constants.InputChecklistLimit.MIN_TASK_NUMBER`\
+-:tg-const:`telegram.constants.InputChecklistLimit.MAX_TASK_NUMBER` tasks in
+            the checklist.
+        others_can_add_tasks (:obj:`bool`):
+            Optional. Pass :obj:`True` if other users can add tasks to the checklist.
+        others_can_mark_tasks_as_done (:obj:`bool`):
+            Optional. Pass :obj:`True` if other users can mark tasks as done or not done in
+            the checklist.
+
+    """
+
+    __slots__ = (
+        "others_can_add_tasks",
+        "others_can_mark_tasks_as_done",
+        "parse_mode",
+        "tasks",
+        "title",
+        "title_entities",
+    )
+
+    def __init__(
+        self,
+        title: str,
+        tasks: Sequence[InputChecklistTask],
+        parse_mode: ODVInput[str] = DEFAULT_NONE,
+        title_entities: Optional[Sequence[MessageEntity]] = None,
+        others_can_add_tasks: Optional[bool] = None,
+        others_can_mark_tasks_as_done: Optional[bool] = None,
+        *,
+        api_kwargs: Optional[JSONDict] = None,
+    ):
+        super().__init__(api_kwargs=api_kwargs)
+        self.title: str = title
+        self.tasks: tuple[InputChecklistTask, ...] = parse_sequence_arg(tasks)
+        self.parse_mode: ODVInput[str] = parse_mode
+        self.title_entities: tuple[MessageEntity, ...] = parse_sequence_arg(title_entities)
+        self.others_can_add_tasks: Optional[bool] = others_can_add_tasks
+        self.others_can_mark_tasks_as_done: Optional[bool] = others_can_mark_tasks_as_done
+
+        self._id_attrs = (self.tasks,)
+
+        self._freeze()

--- a/src/telegram/_message.py
+++ b/src/telegram/_message.py
@@ -52,6 +52,7 @@ from telegram._forumtopic import (
 from telegram._games.game import Game
 from telegram._gifts import GiftInfo
 from telegram._inline.inlinekeyboardmarkup import InlineKeyboardMarkup
+from telegram._inputchecklist import InputChecklist
 from telegram._linkpreviewoptions import LinkPreviewOptions
 from telegram._messageautodeletetimerchanged import MessageAutoDeleteTimerChanged
 from telegram._messageentity import MessageEntity
@@ -3267,6 +3268,63 @@ class Message(MaybeInaccessibleMessage):
             business_connection_id=self.business_connection_id,
             message_effect_id=message_effect_id,
             allow_paid_broadcast=allow_paid_broadcast,
+        )
+
+    async def reply_checklist(
+        self,
+        checklist: InputChecklist,
+        disable_notification: ODVInput[bool] = DEFAULT_NONE,
+        protect_content: ODVInput[bool] = DEFAULT_NONE,
+        message_effect_id: Optional[str] = None,
+        reply_parameters: Optional["ReplyParameters"] = None,
+        reply_markup: Optional[ReplyMarkup] = None,
+        *,
+        reply_to_message_id: Optional[int] = None,
+        allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
+        do_quote: Optional[Union[bool, _ReplyKwargs]] = None,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: Optional[JSONDict] = None,
+    ) -> "Message":
+        """Shortcut for::
+
+             await bot.send_checklist(
+                 business_connection_id=self.business_connection_id,
+                 chat_id=update.effective_message.chat_id,
+                 *args,
+                 **kwargs,
+             )
+
+        For the documentation of the arguments, please see :meth:`telegram.Bot.send_checklist`.
+
+        .. versionadded:: NEXT.VERSION
+
+        Keyword Args:
+            do_quote (:obj:`bool` | :obj:`dict`, optional): |do_quote|
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        chat_id, effective_reply_parameters = await self._parse_quote_arguments(
+            do_quote, reply_to_message_id, reply_parameters, allow_sending_without_reply
+        )
+        return await self.get_bot().send_checklist(
+            business_connection_id=self.business_connection_id,
+            chat_id=chat_id,
+            checklist=checklist,
+            disable_notification=disable_notification,
+            reply_parameters=effective_reply_parameters,
+            reply_markup=reply_markup,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=api_kwargs,
+            protect_content=protect_content,
+            message_effect_id=message_effect_id,
         )
 
     async def reply_chat_action(

--- a/src/telegram/constants.py
+++ b/src/telegram/constants.py
@@ -77,6 +77,7 @@ __all__ = [
     "InlineQueryResultLimit",
     "InlineQueryResultType",
     "InlineQueryResultsButtonLimit",
+    "InputChecklistLimit",
     "InputMediaType",
     "InputPaidMediaType",
     "InputProfilePhotoType",
@@ -1409,6 +1410,47 @@ class InlineKeyboardMarkupLimit(IntEnum):
 
     Note:
         This value is undocumented and might be changed by Telegram.
+    """
+
+
+class InputChecklistLimit(IntEnum):
+    """This enum contains limitations for :class:`telegram.InputChecklist`/
+    :class:`telegram.InputChecklistTask`. The enum
+    members of this enumeration are instances of :class:`int` and can be treated as such.
+
+    .. versionadded:: NEXT.VERSION
+    """
+
+    __slots__ = ()
+
+    MIN_TITLE_LENGTH = 1
+    """:obj:`int`: Minimum number of characters in a :obj:`str` passed as
+    :paramref:`~telegram.InputChecklist.title` parameter of :class:`telegram.InputChecklist`
+    """
+
+    MAX_TITLE_LENGTH = 255
+    """:obj:`int`: Maximum number of characters in a :obj:`str` passed as
+    :paramref:`~telegram.InputChecklist.title` parameter of :class:`telegram.InputChecklist`
+    """
+
+    MIN_TEXT_LENGTH = 1
+    """:obj:`int`: Minimum number of characters in a :obj:`str` passed as
+    :paramref:`~telegram.InputChecklistTask.text` parameter of :class:`telegram.InputChecklistTask`
+    """
+
+    MAX_TEXT_LENGTH = 100
+    """:obj:`int`: Maximum number of characters in a :obj:`str` passed as
+    :paramref:`~telegram.InputChecklistTask.text` parameter of :class:`telegram.InputChecklistTask`
+    """
+
+    MIN_TASK_NUMBER = 1
+    """:obj:`int`: Minimum number of tasks passed as :paramref:`~telegram.InputChecklist.tasks`
+    parameter of :class:`telegram.InputChecklist`
+    """
+
+    MAX_TASK_NUMBER = 30
+    """:obj:`int`: Maximum number of tasks passed as :paramref:`~telegram.InputChecklistTask.tasks`
+    parameter of :class:`telegram.InputChecklistTask`
     """
 
 

--- a/src/telegram/ext/_extbot.py
+++ b/src/telegram/ext/_extbot.py
@@ -62,6 +62,7 @@ from telegram import (
     Gifts,
     InlineKeyboardMarkup,
     InlineQueryResultsButton,
+    InputChecklist,
     InputMedia,
     InputPaidMedia,
     InputPollOption,
@@ -2639,6 +2640,44 @@ class ExtBot(Bot, Generic[RLARGS]):
             allow_paid_broadcast=allow_paid_broadcast,
         )
 
+    async def send_checklist(
+        self,
+        business_connection_id: str,
+        chat_id: Union[int, str],
+        checklist: InputChecklist,
+        disable_notification: ODVInput[bool] = DEFAULT_NONE,
+        protect_content: ODVInput[bool] = DEFAULT_NONE,
+        message_effect_id: Optional[str] = None,
+        reply_parameters: Optional["ReplyParameters"] = None,
+        reply_markup: Optional[ReplyMarkup] = None,
+        *,
+        reply_to_message_id: Optional[int] = None,
+        allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: Optional[JSONDict] = None,
+        rate_limit_args: Optional[RLARGS] = None,
+    ) -> Message:
+        return await super().send_checklist(
+            business_connection_id=business_connection_id,
+            chat_id=chat_id,
+            checklist=checklist,
+            disable_notification=disable_notification,
+            protect_content=protect_content,
+            message_effect_id=message_effect_id,
+            reply_parameters=reply_parameters,
+            reply_markup=reply_markup,
+            reply_to_message_id=reply_to_message_id,
+            allow_sending_without_reply=allow_sending_without_reply,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=self._merge_api_rl_kwargs(api_kwargs, rate_limit_args),
+        )
+
     async def send_dice(
         self,
         chat_id: Union[int, str],
@@ -5157,6 +5196,7 @@ class ExtBot(Bot, Generic[RLARGS]):
     setPassportDataErrors = set_passport_data_errors
     sendPoll = send_poll
     stopPoll = stop_poll
+    sendChecklist = send_checklist
     sendDice = send_dice
     getMyCommands = get_my_commands
     setMyCommands = set_my_commands

--- a/tests/test_business_methods.py
+++ b/tests/test_business_methods.py
@@ -36,7 +36,12 @@ from telegram import (
 from telegram._files._inputstorycontent import InputStoryContentVideo
 from telegram._files.sticker import Sticker
 from telegram._gifts import AcceptedGiftTypes, Gift
+from telegram._inline.inlinekeyboardbutton import InlineKeyboardButton
+from telegram._inline.inlinekeyboardmarkup import InlineKeyboardMarkup
+from telegram._inputchecklist import InputChecklist, InputChecklistTask
+from telegram._message import Message
 from telegram._ownedgift import OwnedGiftRegular, OwnedGifts
+from telegram._reply import ReplyParameters
 from telegram._utils.datetime import UTC
 from telegram._utils.defaultvalue import DEFAULT_NONE
 from telegram.constants import InputProfilePhotoType, InputStoryContentType
@@ -638,3 +643,117 @@ class TestBusinessMethodsWithoutRequest(BusinessMethodsTestBase):
 
         monkeypatch.setattr(offline_bot.request, "post", make_assertion)
         assert await offline_bot.delete_story(business_connection_id=self.bci, story_id=story_id)
+
+    async def test_send_checklist_all_args(self, offline_bot, monkeypatch):
+        chat_id = 123
+        checklist = InputChecklist(
+            title="My Checklist",
+            tasks=[InputChecklistTask(1, "Task 1"), InputChecklistTask(2, "Task 2")],
+        )
+        disable_notification = True
+        protect_content = False
+        message_effect_id = 42
+        reply_parameters = ReplyParameters(23, chat_id, allow_sending_without_reply=True)
+        reply_markup = InlineKeyboardMarkup(
+            [[InlineKeyboardButton(text="test", callback_data="test2")]]
+        )
+        json_message = Message(1, dtm.datetime.now(), Chat(1, ""), text="test").to_json()
+
+        async def make_assertions(*args, **kwargs):
+            params = kwargs.get("request_data").parameters
+            assert params.get("business_connection_id") == self.bci
+            assert params.get("chat_id") == chat_id
+            assert params.get("checklist") == checklist.to_dict()
+            assert params.get("disable_notification") is disable_notification
+            assert params.get("protect_content") is protect_content
+            assert params.get("message_effect_id") == message_effect_id
+            assert params.get("reply_parameters") == reply_parameters.to_dict()
+            assert params.get("reply_markup") == reply_markup.to_dict()
+
+            return 200, f'{{"ok": true, "result": {json_message}}}'.encode()
+
+        monkeypatch.setattr(offline_bot.request, "do_request", make_assertions)
+        obj = await offline_bot.send_checklist(
+            business_connection_id=self.bci,
+            chat_id=chat_id,
+            checklist=checklist,
+            disable_notification=disable_notification,
+            protect_content=protect_content,
+            message_effect_id=message_effect_id,
+            reply_parameters=reply_parameters,
+            reply_markup=reply_markup,
+        )
+        assert isinstance(obj, Message)
+
+    @pytest.mark.parametrize("default_bot", [{"disable_notification": True}], indirect=True)
+    @pytest.mark.parametrize(
+        ("passed_value", "expected_value"),
+        [(DEFAULT_NONE, True), (False, False), (None, None)],
+    )
+    async def test_send_checklist_default_disable_notification(
+        self, default_bot, monkeypatch, passed_value, expected_value
+    ):
+        async def make_assertion(url, request_data, *args, **kwargs):
+            assert request_data.parameters.get("disable_notification") is expected_value
+            return Message(1, dtm.datetime.now(), Chat(1, ""), text="test").to_dict()
+
+        monkeypatch.setattr(default_bot.request, "post", make_assertion)
+        kwargs = {
+            "business_connection_id": self.bci,
+            "chat_id": 123,
+            "checklist": InputChecklist(
+                title="My Checklist",
+                tasks=[InputChecklistTask(1, "Task 1")],
+            ),
+        }
+        if passed_value is not DEFAULT_NONE:
+            kwargs["disable_notification"] = passed_value
+
+        await default_bot.send_checklist(**kwargs)
+
+    @pytest.mark.parametrize("default_bot", [{"protect_content": True}], indirect=True)
+    @pytest.mark.parametrize(
+        ("passed_value", "expected_value"),
+        [(DEFAULT_NONE, True), (False, False), (None, None)],
+    )
+    async def test_send_checklist_default_protect_content(
+        self, default_bot, monkeypatch, passed_value, expected_value
+    ):
+        async def make_assertion(url, request_data, *args, **kwargs):
+            assert request_data.parameters.get("protect_content") is expected_value
+            return Message(1, dtm.datetime.now(), Chat(1, ""), text="test").to_dict()
+
+        monkeypatch.setattr(default_bot.request, "post", make_assertion)
+        kwargs = {
+            "business_connection_id": self.bci,
+            "chat_id": 123,
+            "checklist": InputChecklist(
+                title="My Checklist",
+                tasks=[InputChecklistTask(1, "Task 1")],
+            ),
+        }
+        if passed_value is not DEFAULT_NONE:
+            kwargs["protect_content"] = passed_value
+
+        await default_bot.send_checklist(**kwargs)
+
+    async def test_send_checklist_mutually_exclusive_reply_parameters(self, offline_bot, chat_id):
+        """Test that reply_to_message_id and allow_sending_without_reply are mutually exclusive
+        with reply_parameters."""
+        with pytest.raises(ValueError, match="`reply_to_message_id` and"):
+            await offline_bot.send_checklist(
+                self.bci,
+                123,
+                InputChecklist(title="My Checklist", tasks=[InputChecklistTask(1, "Task 1")]),
+                reply_to_message_id=1,
+                reply_parameters=True,
+            )
+
+        with pytest.raises(ValueError, match="`allow_sending_without_reply` and"):
+            await offline_bot.send_checklist(
+                self.bci,
+                123,
+                InputChecklist(title="My Checklist", tasks=[InputChecklistTask(1, "Task 1")]),
+                allow_sending_without_reply=True,
+                reply_parameters=True,
+            )

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -20,7 +20,15 @@
 
 import pytest
 
-from telegram import Bot, Chat, ChatPermissions, ReactionTypeEmoji, User
+from telegram import (
+    Bot,
+    Chat,
+    ChatPermissions,
+    InputChecklist,
+    InputChecklistTask,
+    ReactionTypeEmoji,
+    User,
+)
 from telegram.constants import ChatAction, ChatType, ReactionEmoji
 from telegram.helpers import escape_markdown
 from tests.auxil.bot_method_checks import (
@@ -578,6 +586,23 @@ class TestChatWithoutRequest(ChatTestBase):
 
         monkeypatch.setattr(chat.get_bot(), "send_dice", make_assertion)
         assert await chat.send_dice(emoji="test_dice")
+
+    async def test_instance_method_send_checklist(self, monkeypatch, chat):
+        checklist = InputChecklist(title="My Checklist", tasks=[InputChecklistTask(1, "Task 1")])
+
+        async def make_assertion(*_, **kwargs):
+            return (
+                kwargs["chat_id"] == chat.id
+                and kwargs["business_connection_id"] == "123"
+                and kwargs["checklist"] == checklist
+            )
+
+        assert check_shortcut_signature(Chat.send_checklist, Bot.send_checklist, ["chat_id"], [])
+        assert await check_shortcut_call(chat.send_checklist, chat.get_bot(), "send_checklist")
+        assert await check_defaults_handling(chat.send_checklist, chat.get_bot())
+
+        monkeypatch.setattr(chat.get_bot(), "send_checklist", make_assertion)
+        assert await chat.send_checklist("123", checklist)
 
     async def test_instance_method_send_game(self, monkeypatch, chat):
         async def make_assertion(*_, **kwargs):

--- a/tests/test_inputchecklist.py
+++ b/tests/test_inputchecklist.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+# A library that provides a Python interface to the Telegram Bot API
+# Copyright (C) 2015-2025
+# Leandro Toledo de Souza <devs@python-telegram-bot.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+
+import pytest
+
+from telegram import Dice, InputChecklist, InputChecklistTask, MessageEntity
+from tests.auxil.slots import mro_slots
+
+
+@pytest.fixture(scope="module")
+def input_checklist_task():
+    return InputChecklistTask(
+        id=InputChecklistTaskTestBase.id,
+        text=InputChecklistTaskTestBase.text,
+        parse_mode=InputChecklistTaskTestBase.parse_mode,
+        text_entities=InputChecklistTaskTestBase.text_entities,
+    )
+
+
+class InputChecklistTaskTestBase:
+    id = 1
+    text = "buy food"
+    parse_mode = "MarkdownV2"
+    text_entities = [
+        MessageEntity(type="bold", offset=0, length=3),
+        MessageEntity(type="italic", offset=4, length=4),
+    ]
+
+
+class TestInputChecklistTaskWithoutRequest(InputChecklistTaskTestBase):
+    def test_slot_behaviour(self, input_checklist_task):
+        for attr in input_checklist_task.__slots__:
+            assert getattr(input_checklist_task, attr, "err") != "err", f"got extra slot '{attr}'"
+        assert len(mro_slots(input_checklist_task)) == len(
+            set(mro_slots(input_checklist_task))
+        ), "duplicate slot"
+
+    def test_expected_values(self, input_checklist_task):
+        assert input_checklist_task.id == self.id
+        assert input_checklist_task.text == self.text
+        assert input_checklist_task.parse_mode == self.parse_mode
+        assert input_checklist_task.text_entities == tuple(self.text_entities)
+
+    def test_to_dict(self, input_checklist_task):
+        iclt_dict = input_checklist_task.to_dict()
+
+        assert isinstance(iclt_dict, dict)
+        assert iclt_dict["id"] == self.id
+        assert iclt_dict["text"] == self.text
+        assert iclt_dict["parse_mode"] == self.parse_mode
+        assert iclt_dict["text_entities"] == [entity.to_dict() for entity in self.text_entities]
+
+        # Test that default-value parameter `parse_mode` is handled correctly
+        input_checklist_task = InputChecklistTask(id=1, text="text")
+        iclt_dict = input_checklist_task.to_dict()
+        assert "parse_mode" not in iclt_dict
+
+    def test_equality(self, input_checklist_task):
+        a = input_checklist_task
+        b = InputChecklistTask(id=self.id, text=f"other {self.text}")
+        c = InputChecklistTask(id=self.id + 1, text=self.text)
+        d = Dice(value=1, emoji="🎲")
+
+        assert a == b
+        assert hash(a) == hash(b)
+
+        assert a != c
+        assert hash(a) != hash(c)
+
+        assert a != d
+        assert hash(a) != hash(d)
+
+
+@pytest.fixture(scope="module")
+def input_checklist():
+    return InputChecklist(
+        title=InputChecklistTestBase.title,
+        tasks=InputChecklistTestBase.tasks,
+        parse_mode=InputChecklistTestBase.parse_mode,
+        title_entities=InputChecklistTestBase.title_entities,
+        others_can_add_tasks=InputChecklistTestBase.others_can_add_tasks,
+        others_can_mark_tasks_as_done=InputChecklistTestBase.others_can_mark_tasks_as_done,
+    )
+
+
+class InputChecklistTestBase:
+    title = "test list"
+    tasks = [
+        InputChecklistTask(id=1, text="eat"),
+        InputChecklistTask(id=2, text="sleep"),
+    ]
+    parse_mode = "MarkdownV2"
+    title_entities = [
+        MessageEntity(type="bold", offset=0, length=4),
+        MessageEntity(type="italic", offset=5, length=4),
+    ]
+    others_can_add_tasks = True
+    others_can_mark_tasks_as_done = False
+
+
+class TestInputChecklistWithoutRequest(InputChecklistTestBase):
+    def test_slot_behaviour(self, input_checklist):
+        for attr in input_checklist.__slots__:
+            assert getattr(input_checklist, attr, "err") != "err", f"got extra slot '{attr}'"
+        assert len(mro_slots(input_checklist)) == len(
+            set(mro_slots(input_checklist))
+        ), "duplicate slot"
+
+    def test_expected_values(self, input_checklist):
+        assert input_checklist.title == self.title
+        assert input_checklist.tasks == tuple(self.tasks)
+        assert input_checklist.parse_mode == self.parse_mode
+        assert input_checklist.title_entities == tuple(self.title_entities)
+        assert input_checklist.others_can_add_tasks == self.others_can_add_tasks
+        assert input_checklist.others_can_mark_tasks_as_done == self.others_can_mark_tasks_as_done
+
+    def test_to_dict(self, input_checklist):
+        icl_dict = input_checklist.to_dict()
+
+        assert isinstance(icl_dict, dict)
+        assert icl_dict["title"] == self.title
+        assert icl_dict["tasks"] == [task.to_dict() for task in self.tasks]
+        assert icl_dict["parse_mode"] == self.parse_mode
+        assert icl_dict["title_entities"] == [entity.to_dict() for entity in self.title_entities]
+        assert icl_dict["others_can_add_tasks"] == self.others_can_add_tasks
+        assert icl_dict["others_can_mark_tasks_as_done"] == self.others_can_mark_tasks_as_done
+
+        # Test that default-value parameter `parse_mode` is handled correctly
+        input_checklist = InputChecklist(title=self.title, tasks=self.tasks)
+        icl_dict = input_checklist.to_dict()
+        assert "parse_mode" not in icl_dict
+
+    def test_equality(self, input_checklist):
+        a = input_checklist
+        b = InputChecklist(
+            title=f"other {self.title}",
+            tasks=[InputChecklistTask(id=1, text="eat"), InputChecklistTask(id=2, text="sleep")],
+        )
+        c = InputChecklist(
+            title=self.title,
+            tasks=[InputChecklistTask(id=9, text="Other Task")],
+        )
+        d = Dice(value=1, emoji="🎲")
+
+        assert a == b
+        assert hash(a) == hash(b)
+
+        assert a != c
+        assert hash(a) != hash(c)
+
+        assert a != d
+        assert hash(a) != hash(d)


### PR DESCRIPTION
## Check-list for PRs

- [x] Added `.. versionadded:: NEXT.VERSION`, ``.. versionchanged:: NEXT.VERSION``, ``.. deprecated:: NEXT.VERSION`` or ``.. versionremoved:: NEXT.VERSION` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [ ] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- [x] Added new classes & modules to the docs and all suitable ``__all__`` s

**~If the PR contains API changes (otherwise, you can ignore this passage)~**
- [ ] Checked the Bot API specific sections of the [Stability Policy](https://docs.python-telegram-bot.org/stability_policy.html)
- [ ] Created a PR to remove functionality deprecated in the previous Bot API release ([see here](https://docs.python-telegram-bot.org/en/stable/stability_policy.html#case-2))

- New Classes
    - [x] Added `self._id_attrs` and corresponding documentation
    - [x] `__init__` accepts `api_kwargs` as keyword-only

- Added New Shortcuts
    - [x] In [`telegram.Chat`](https://python-telegram-bot.readthedocs.io/en/stable/telegram.chat.html) \& [`telegram.User`](https://python-telegram-bot.readthedocs.io/en/stable/telegram.user.html) for all methods that accept `chat/user_id`
    - [ ] In [`telegram.Message`](https://python-telegram-bot.readthedocs.io/en/stable/telegram.message.html) for all methods that accept `chat_id` and `message_id`
    - [x] For new `telegram.Message` shortcuts: Added `quote` argument if methods accept `reply_to_message_id`
    - [ ] In [`telegram.CallbackQuery`](https://python-telegram-bot.readthedocs.io/en/stable/telegram.callbackquery.html) for all methods that accept either `chat_id` and `message_id` or `inline_message_id`

- If Relevant
    - [x] Added new constants at `telegram.constants` and shortcuts to them as class variables
    - [x] Linked new and existing constants in docstrings instead of hard-coded numbers and strings
    - [ ] Added new message types to `telegram.Message.effective_attachment`
    - [ ] Added new handlers for new update types
        - [ ] Added the handlers to the warning loop in the [`telegram.ext.ConversationHandler`](https://python-telegram-bot.readthedocs.io/en/stable/telegram.ext.conversationhandler.html)
    - [ ] Added new filters for new message (sub)types
    - [ ] Added or updated documentation for the changed class(es) and/or method(s)
    - [x] Added the new method(s) to `_extbot.py`
    - [x] Added or updated `bot_methods.rst`
    - [ ] Updated the Bot API version number in all places: `README.rst` (including the badge) and `telegram.constants.BOT_API_VERSION_INFO`
    - [ ] Added logic for arbitrary callback data in `telegram.ext.ExtBot` for new methods that either accept a `reply_markup` in some form or have a return type that is/contains [`telegram.Message`](https://python-telegram-bot.readthedocs.io/en/stable/telegram.message.html)

### API 9.1 Items:
- [x] Added the class [InputChecklistTask](https://core.telegram.org/bots/api#inputchecklisttask) representing a task to add to a checklist.
- [x] Added the class [InputChecklist](https://core.telegram.org/bots/api#inputchecklist) representing a checklist to create.
- [x] Added the method [sendChecklist](https://core.telegram.org/bots/api#sendchecklist), allowing bots to send a checklist on behalf of a business account.
- [ ] Added the method [editMessageChecklist](https://core.telegram.org/bots/api#editmessagechecklist), allowing bots to edit a checklist on behalf of a business account.


I've skipped `parse_entity` utility methods for the classes `InputChecklist[Task]` as they're implemented on the returned version of the classes, and don't make much sense here imo.
