### PR TITLE
Httpx timeout improvements

### DIFF
--- a/changes/unreleased/4882.JpgQAHHnCponMKStbC4JsG.toml
+++ b/changes/unreleased/4882.JpgQAHHnCponMKStbC4JsG.toml
@@ -1,4 +1,9 @@
-other = "Default httpx max_connections/pool size set to 256 to allow more requests by default, and dropping setting max_keepalive_connections to the same amount (so bigger pools don't have a lot of unused alive connections). If you manually build the httpx request, be aware that this also applies to you. If you want your own limits, you can set them via httpx_kwargs, as explained in https://www.python-httpx.org/advanced/resource-limits/"
+other = """
+Set the default connection pool size for ``HTTPXRequest`` to 256 to allow more concurrent requests by default. Drop the ``httpx`` parameter `max_keepalive_connections`. This way, the ``httpx`` default of 20 is used, leading to a smaller number of idle connections in large connection pools.
+
+.. hint:
+   If you manually build the ``HTTPXRequest`` objects, please be aware that these changes also applies to you. Kindly double check your settings. To specify custom limits, you can set them via the parameter ``httpx_kwargs`` of ``HTTPXRequest``. See also  `the httpx documentation <https://www.python-httpx.org/advanced/resource-limits/>`__ for more details on these settings."
+"""
 [[pull_requests]]
 uid = "4882"
 author_uid = "Poolitzer"

--- a/changes/unreleased/4882.JpgQAHHnCponMKStbC4JsG.toml
+++ b/changes/unreleased/4882.JpgQAHHnCponMKStbC4JsG.toml
@@ -1,4 +1,4 @@
-other = "Default httpx max_connections/pool size set to 256, and dropping setting max_keepalive_connections to the same amount. If you manually build the httpx request, be aware that this also applies to you. If you want your own limits, you can set them via httpx_kwargs, as explained in https://www.python-httpx.org/advanced/resource-limits/"
+other = "Default httpx max_connections/pool size set to 256 to allow more requests by default, and dropping setting max_keepalive_connections to the same amount (so bigger pools don't have a lot of unused alive connections). If you manually build the httpx request, be aware that this also applies to you. If you want your own limits, you can set them via httpx_kwargs, as explained in https://www.python-httpx.org/advanced/resource-limits/"
 [[pull_requests]]
 uid = "4882"
 author_uid = "Poolitzer"

--- a/changes/unreleased/4882.JpgQAHHnCponMKStbC4JsG.toml
+++ b/changes/unreleased/4882.JpgQAHHnCponMKStbC4JsG.toml
@@ -1,4 +1,4 @@
-other = "Httpx timeout improvements"
+other = "Default httpx max_connections/pool size set to 256, and dropping setting max_keepalive_connections to the same amount. If you manually build the httpx request, be aware that this also applies to you. If you want your own limits, you can set them via httpx_kwargs, as explained in https://www.python-httpx.org/advanced/resource-limits/"
 [[pull_requests]]
 uid = "4882"
 author_uid = "Poolitzer"

--- a/changes/unreleased/4882.JpgQAHHnCponMKStbC4JsG.toml
+++ b/changes/unreleased/4882.JpgQAHHnCponMKStbC4JsG.toml
@@ -1,7 +1,7 @@
 other = """
-Set the default connection pool size for ``HTTPXRequest`` to 256 to allow more concurrent requests by default. Drop the ``httpx`` parameter `max_keepalive_connections`. This way, the ``httpx`` default of 20 is used, leading to a smaller number of idle connections in large connection pools.
+Set the default connection pool size for ``HTTPXRequest`` to 256 to allow more concurrent requests by default. Drop the ``httpx`` parameter ``max_keepalive_connections``. This way, the ``httpx`` default of 20 is used, leading to a smaller number of idle connections in large connection pools.
 
-.. hint:
+.. hint::
    If you manually build the ``HTTPXRequest`` objects, please be aware that these changes also applies to you. Kindly double check your settings. To specify custom limits, you can set them via the parameter ``httpx_kwargs`` of ``HTTPXRequest``. See also  `the httpx documentation <https://www.python-httpx.org/advanced/resource-limits/>`__ for more details on these settings."
 """
 [[pull_requests]]

--- a/changes/unreleased/4882.JpgQAHHnCponMKStbC4JsG.toml
+++ b/changes/unreleased/4882.JpgQAHHnCponMKStbC4JsG.toml
@@ -1,0 +1,5 @@
+other = "Httpx timeout improvements"
+[[pull_requests]]
+uid = "4882"
+author_uid = "Poolitzer"
+closes_threads = []

--- a/src/telegram/_bot.py
+++ b/src/telegram/_bot.py
@@ -339,7 +339,11 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
         self._initialized: bool = False
 
         self._request: tuple[BaseRequest, BaseRequest] = (
-            HTTPXRequest() if get_updates_request is None else get_updates_request,
+            (
+                HTTPXRequest(connection_pool_size=1)
+                if get_updates_request is None
+                else get_updates_request
+            ),
             HTTPXRequest() if request is None else request,
         )
 

--- a/src/telegram/request/_httpxrequest.py
+++ b/src/telegram/request/_httpxrequest.py
@@ -49,6 +49,10 @@ class HTTPXRequest(BaseRequest):
     Args:
         connection_pool_size (:obj:`int`, optional): Number of connections to keep in the
             connection pool. Defaults to ``1``.
+
+            .. versionchanged:: NEXT.VERSION
+                Stopped applying to :paramref:`~httpx.Limits.max_keepalive_connections`.
+                Now only applys to :paramref:`~httpx.Limits.max_connections`.
         read_timeout (:obj:`float` | :obj:`None`, optional): If passed, specifies the maximum
             amount of time (in seconds) to wait for a response from Telegram's server.
             This value is used unless a different value is passed to :meth:`do_request`.
@@ -158,7 +162,6 @@ class HTTPXRequest(BaseRequest):
         )
         limits = httpx.Limits(
             max_connections=connection_pool_size,
-            max_keepalive_connections=connection_pool_size,
         )
 
         if http_version not in ("1.1", "2", "2.0"):

--- a/src/telegram/request/_httpxrequest.py
+++ b/src/telegram/request/_httpxrequest.py
@@ -52,7 +52,7 @@ class HTTPXRequest(BaseRequest):
 
             .. versionchanged:: NEXT.VERSION
                 Set the default to ``256``.
-                Stopped applying to ``httpx.Limits.max_keepalive_connections``. Now only applys to
+                Stopped applying to ``httpx.Limits.max_keepalive_connections``. Now only applies to
                 ``httpx.Limits.max_connections``. See `Resource Limits
                 <https://www.python-httpx.org/advanced/resource-limits/>`_
         read_timeout (:obj:`float` | :obj:`None`, optional): If passed, specifies the maximum

--- a/src/telegram/request/_httpxrequest.py
+++ b/src/telegram/request/_httpxrequest.py
@@ -51,8 +51,10 @@ class HTTPXRequest(BaseRequest):
             connection pool. Defaults to ``1``.
 
             .. versionchanged:: NEXT.VERSION
-                Stopped applying to :paramref:`~httpx.Limits.max_keepalive_connections`.
-                Now only applys to :paramref:`~httpx.Limits.max_connections`.
+                Set the default to ``256``.
+                Stopped applying to ``httpx.Limits.max_keepalive_connections``. Now only applys to
+                ``httpx.Limits.max_connections``. See `Resource Limits
+                <https://www.python-httpx.org/advanced/resource-limits/>`_
         read_timeout (:obj:`float` | :obj:`None`, optional): If passed, specifies the maximum
             amount of time (in seconds) to wait for a response from Telegram's server.
             This value is used unless a different value is passed to :meth:`do_request`.
@@ -141,7 +143,7 @@ class HTTPXRequest(BaseRequest):
 
     def __init__(
         self,
-        connection_pool_size: int = 1,
+        connection_pool_size: int = 256,
         read_timeout: Optional[float] = 5.0,
         write_timeout: Optional[float] = 5.0,
         connect_timeout: Optional[float] = 5.0,

--- a/src/telegram/request/_httpxrequest.py
+++ b/src/telegram/request/_httpxrequest.py
@@ -48,7 +48,7 @@ class HTTPXRequest(BaseRequest):
 
     Args:
         connection_pool_size (:obj:`int`, optional): Number of connections to keep in the
-            connection pool. Defaults to ``1``.
+            connection pool. Defaults to ``256``.
 
             .. versionchanged:: NEXT.VERSION
                 Set the default to ``256``.

--- a/tests/ext/test_applicationbuilder.py
+++ b/tests/ext/test_applicationbuilder.py
@@ -159,7 +159,7 @@ class TestApplicationBuilder:
         assert not get_updates_client.http2
 
         client = app.bot.request._client
-        assert client.limits == httpx.Limits(max_connections=256, max_keepalive_connections=256)
+        assert client.limits == httpx.Limits(max_connections=256)
         assert client.proxy is None
         assert client.timeout == httpx.Timeout(connect=5.0, read=5.0, write=5.0, pool=1.0)
         assert client.http1 is True
@@ -414,7 +414,7 @@ class TestApplicationBuilder:
         client = app.bot._request[0]._client
 
         assert client.timeout == httpx.Timeout(pool=3, connect=2, read=4, write=5)
-        assert client.limits == httpx.Limits(max_connections=1, max_keepalive_connections=1)
+        assert client.limits == httpx.Limits(max_connections=1)
         assert client.proxy == "get_updates_proxy"
         assert client.http1 is True
         assert client.http2 is False

--- a/tests/ext/test_applicationbuilder.py
+++ b/tests/ext/test_applicationbuilder.py
@@ -150,9 +150,7 @@ class TestApplicationBuilder:
         assert app.bot.local_mode is False
 
         get_updates_client = app.bot._request[0]._client
-        assert get_updates_client.limits == httpx.Limits(
-            max_connections=1, max_keepalive_connections=1
-        )
+        assert get_updates_client.limits == httpx.Limits(max_connections=1)
         assert get_updates_client.proxy is None
         assert get_updates_client.timeout == httpx.Timeout(
             connect=5.0, read=5.0, write=5.0, pool=1.0
@@ -395,7 +393,7 @@ class TestApplicationBuilder:
         client = app.bot.request._client
 
         assert client.timeout == httpx.Timeout(pool=3, connect=2, read=4, write=5)
-        assert client.limits == httpx.Limits(max_connections=1, max_keepalive_connections=1)
+        assert client.limits == httpx.Limits(max_connections=1)
         assert client.proxy == "proxy"
         assert client.http1 is True
         assert client.http2 is False

--- a/tests/request/test_request.py
+++ b/tests/request/test_request.py
@@ -438,7 +438,7 @@ class TestHTTPXRequestWithoutRequest:
         request = HTTPXRequest()
         assert request._client.timeout == httpx.Timeout(connect=5.0, read=5.0, write=5.0, pool=1.0)
         assert request._client.proxy is None
-        assert request._client.limits == httpx.Limits(max_connections=1)
+        assert request._client.limits == httpx.Limits(max_connections=256)
         assert request._client.http1 is True
         assert not request._client.http2
 

--- a/tests/request/test_request.py
+++ b/tests/request/test_request.py
@@ -438,9 +438,7 @@ class TestHTTPXRequestWithoutRequest:
         request = HTTPXRequest()
         assert request._client.timeout == httpx.Timeout(connect=5.0, read=5.0, write=5.0, pool=1.0)
         assert request._client.proxy is None
-        assert request._client.limits == httpx.Limits(
-            max_connections=1, max_keepalive_connections=1
-        )
+        assert request._client.limits == httpx.Limits(max_connections=1)
         assert request._client.http1 is True
         assert not request._client.http2
 
@@ -453,9 +451,7 @@ class TestHTTPXRequestWithoutRequest:
             pool_timeout=46,
         )
         assert request._client.proxy == "proxy"
-        assert request._client.limits == httpx.Limits(
-            max_connections=42, max_keepalive_connections=42
-        )
+        assert request._client.limits == httpx.Limits(max_connections=42)
         assert request._client.timeout == httpx.Timeout(connect=43, read=44, write=45, pool=46)
 
     async def test_multiple_inits_and_shutdowns(self, monkeypatch):


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->
As discussed, we think its appropriate to change the default timeout and drop the max_keepalive_connections
