### PR TITLE
Add classes `SuggestedPost[Parameters/Price]`.

### DIFF
--- a/src/telegram/_suggestedpost.py
+++ b/src/telegram/_suggestedpost.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+#
+# A library that provides a Python interface to the Telegram Bot API
+# Copyright (C) 2015-2025
+# Leandro Toledo de Souza <devs@python-telegram-bot.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+"""This module contains objects related to Telegram suggested posts."""
+
+import datetime as dtm
+from typing import TYPE_CHECKING, Optional
+
+from telegram._telegramobject import TelegramObject
+from telegram._utils.argumentparsing import de_json_optional
+from telegram._utils.datetime import extract_tzinfo_from_defaults, from_timestamp
+from telegram._utils.types import JSONDict
+
+if TYPE_CHECKING:
+    from telegram import Bot
+
+
+class SuggestedPostPrice(TelegramObject):
+    """
+    Desribes price of a suggested post.
+
+    Objects of this class are comparable in terms of equality. Two objects of this class are
+    considered equal, if their :attr:`currency` and :attr:`amount` are equal.
+
+    Args:
+        currency (:obj:`str`):
+            Currency in which the post will be paid. Currently, must be one of “XTR” for Telegram
+            Stars or “TON” for toncoins.
+        amount (:obj:`int`):
+            The amount of the currency that will be paid for the post in the smallest units of the
+            currency, i.e. Telegram Stars or nanotoncoins. Currently, price in Telegram Stars must
+            be between 5 and 100000, and price in nanotoncoins must be between
+            10000000 and 10000000000000.
+
+    Attributes:
+        currency (:obj:`str`):
+            Currency in which the post will be paid. Currently, must be one of “XTR” for Telegram
+            Stars or “TON” for toncoins.
+        amount (:obj:`int`):
+            The amount of the currency that will be paid for the post in the smallest units of the
+            currency, i.e. Telegram Stars or nanotoncoins. Currently, price in Telegram Stars must
+            be between 5 and 100000, and price in nanotoncoins must be between
+            10000000 and 10000000000000.
+
+    """
+
+    __slots__ = ("amount", "currency")
+
+    def __init__(
+        self,
+        currency: str,
+        amount: int,
+        *,
+        api_kwargs: Optional[JSONDict] = None,
+    ):
+        super().__init__(api_kwargs=api_kwargs)
+        self.currency: str = currency
+        self.amount: Optional[dtm.datetime] = amount
+
+        self._id_attrs = (self.currency, self.amount)
+
+        self._freeze()
+
+
+class SuggestedPostParameters(TelegramObject):
+    """
+    Contains parameters of a post that is being suggested by the bot.
+
+    Objects of this class are comparable in terms of equality. Two objects of this class are
+    considered equal, if their :attr:`price` and :attr:`send_date` are equal.
+
+    Args:
+        price (:class:`telegram.SuggestedPostPrice`, optional):
+            Proposed price for the post. If the field is omitted, then the post is unpaid..
+        send_date (:class:`datetime.datetime`, optional):
+            Proposed send date of the post. If specified, then the date
+            must be between 300 second and 2678400 seconds (30 days) in the future. If the field is
+            omitted, then the post can be published at any time within 30 days at the sole
+            discretion of the user who approves it.
+
+            |datetime_localization|
+
+    Attributes:
+        price (:class:`telegram.SuggestedPostPrice`):
+            Optional. Proposed price for the post. If the field is omitted, then the post
+            is unpaid.
+        send_date (:obj:`d`):
+            Optional. Proposed send date of the post. If specified, then the date
+            must be between 300 second and 2678400 seconds (30 days) in the future. If the field is
+            omitted, then the post can be published at any time within 30 days at the sole
+            discretion of the user who approves it.
+
+            |datetime_localization|
+
+    """
+
+    __slots__ = ("price", "send_date")
+
+    def __init__(
+        self,
+        price: Optional[SuggestedPostPrice],
+        send_date: Optional[dtm.datetime] = None,
+        *,
+        api_kwargs: Optional[JSONDict] = None,
+    ):
+        super().__init__(api_kwargs=api_kwargs)
+        self.price: Optional[SuggestedPostPrice] = price
+        self.send_date: Optional[dtm.datetime] = send_date
+
+        self._id_attrs = (self.price, self.send_date)
+
+        self._freeze()
+
+    @classmethod
+    def de_json(
+        cls, data: JSONDict, bot: Optional["Bot"] = None
+    ) -> "SuggestedPostParameters":
+        """See :meth:`telegram.TelegramObject.de_json`."""
+        data = cls._parse_data(data)
+
+        data["price"] = de_json_optional(data.get("price"), SuggestedPostPrice, bot)
+
+        # Get the local timezone from the bot if it has defaults
+        loc_tzinfo = extract_tzinfo_from_defaults(bot)
+
+        data["send_date"] = from_timestamp(data.get("send_date"), tzinfo=loc_tzinfo)
+
+        return super().de_json(data=data, bot=bot)


### PR DESCRIPTION
## Check-list for PRs
- [ ] Added `.. versionadded:: NEXT.VERSION`, ``.. versionchanged:: NEXT.VERSION``, ``.. deprecated:: NEXT.VERSION`` or ``.. versionremoved:: NEXT.VERSION` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [ ] Created new or adapted existing unit tests
- [ ] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)
- [ ] Added new classes & modules to the docs and all suitable ``__all__`` s
- [ ] Checked the [Stability Policy](https://docs.python-telegram-bot.org/stability_policy.html) in case of deprecations or changes to documented behavior

**If the PR contains API changes (otherwise, you can ignore this passage)**
- [ ] Checked the Bot API specific sections of the [Stability Policy](https://docs.python-telegram-bot.org/stability_policy.html)
- [ ] Created a PR to remove functionality deprecated in the previous Bot API release ([see here](https://docs.python-telegram-bot.org/en/stable/stability_policy.html#case-2))

- New Classes
  - [ ] Added `self._id_attrs` and corresponding documentation
  - [ ] `__init__` accepts `api_kwargs` as keyword-only

- Added New Shortcuts
  - [ ] In [`telegram.Chat`](https://python-telegram-bot.readthedocs.io/en/stable/telegram.chat.html) \& [`telegram.User`](https://python-telegram-bot.readthedocs.io/en/stable/telegram.user.html) for all methods that accept `chat/user_id`
  - [ ] In [`telegram.Message`](https://python-telegram-bot.readthedocs.io/en/stable/telegram.message.html) for all methods that accept `chat_id` and `message_id`
  - [ ] For new `telegram.Message` shortcuts: Added `quote` argument if methods accept `reply_to_message_id`
  - [ ] In [`telegram.CallbackQuery`](https://python-telegram-bot.readthedocs.io/en/stable/telegram.callbackquery.html) for all methods that accept either `chat_id` and `message_id` or `inline_message_id`

- If Relevant
  - [ ] Added new constants at `telegram.constants` and shortcuts to them as class variables
  - [ ] Linked new and existing constants in docstrings instead of hard-coded numbers and strings
  - [ ] Added new message types to `telegram.Message.effective_attachment`
  - [ ] Added new handlers for new update types
  - [ ] Added the handlers to the warning loop in the [`telegram.ext.ConversationHandler`](https://python-telegram-bot.readthedocs.io/en/stable/telegram.ext.conversationhandler.html)
  - [ ] Added new filters for new message (sub)types
  - [ ] Added or updated documentation for the changed class(es) and/or method(s)
  - [ ] Added the new method(s) to `_extbot.py`
  - [ ] Added or updated `bot_methods.rst`
  - [ ] Updated the Bot API version number in all places: `README.rst` (including the badge) and `telegram.constants.BOT_API_VERSION_INFO`
  - [ ] Added logic for arbitrary callback data in `telegram.ext.ExtBot` for new methods that either accept a `reply_markup` in some form or have a return type that is/contains [`telegram.Message`](https://python-telegram-bot.readthedocs.io/en/stable/telegram.message.html)
------------------------------
### API 9.2 Items:
#### Suggested Posts
- [ ] Added the class [SuggestedPostParameters](https://core.telegram.org/bots/api#suggestedpostparameters) and the parameter suggested_post_parameters to the methods [sendMessage](https://core.telegram.org/bots/api#sendmessage), [sendPhoto](https://core.telegram.org/bots/api#sendphoto), [sendVideo](https://core.telegram.org/bots/api#sendvideo), [sendAnimation](https://core.telegram.org/bots/api#sendanimation), [sendAudio](https://core.telegram.org/bots/api#sendaudio), [sendDocument](https://core.telegram.org/bots/api#senddocument), [sendPaidMedia](https://core.telegram.org/bots/api#sendpaidmedia), [sendSticker](https://core.telegram.org/bots/api#sendsticker), [sendVideoNote](https://core.telegram.org/bots/api#sendvideonote), [sendVoice](https://core.telegram.org/bots/api#sendvoice), [sendLocation](https://core.telegram.org/bots/api#sendlocation), [sendVenue](https://core.telegram.org/bots/api#sendvenue), [sendContact](https://core.telegram.org/bots/api#sendcontact), [sendDice](https://core.telegram.org/bots/api#senddice), [sendInvoice](https://core.telegram.org/bots/api#sendinvoice), [copyMessage](https://core.telegram.org/bots/api#copymessage), [forwardMessage](https://core.telegram.org/bots/api#forwardmessage). This parameter can be used to send a suggested post to a direct messages chat topic.
- [ ] Added the class [SuggestedPostPrice](https://core.telegram.org/bots/api#suggestedpostprice), describing the price of a suggested post.