### PR TITLE
API 9.2 Suggested Post Methods

### DIFF
--- a/changes/unreleased/4911.kiF45Y4cfPGMq5cuLpa5da.toml
+++ b/changes/unreleased/4911.kiF45Y4cfPGMq5cuLpa5da.toml
@@ -5,6 +5,7 @@ pull_requests = [
     { uid = "4918", author_uid = "Poolitzer" },
     { uid = "4917", author_uid = "Poolitzer" },
     { uid = "4914", author_uid = "harshil21"},
+    { uid = "4916", author_uid = "harshil21"},
     { uid = "4912", author_uid = "aelkheir" },
     { uid = "4921", author_uid = "aelkheir" },
 ]

--- a/docs/source/inclusions/bot_methods.rst
+++ b/docs/source/inclusions/bot_methods.rst
@@ -121,6 +121,10 @@
       - Used for approving a chat join request
     * - :meth:`~telegram.Bot.decline_chat_join_request`
       - Used for declining a chat join request
+    * - :meth:`~telegram.Bot.approve_suggested_post`
+      - Used for approving a suggested post
+    * - :meth:`~telegram.Bot.decline_suggested_post`
+      - Used for declining a suggested post
     * - :meth:`~telegram.Bot.ban_chat_member`
       - Used for banning a member from the chat
     * - :meth:`~telegram.Bot.unban_chat_member`

--- a/src/telegram/_bot.py
+++ b/src/telegram/_bot.py
@@ -11481,9 +11481,8 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
             send_date (:obj:`int` | :obj:`datetime.datetime`, optional): Date when the post is
                 expected to be published; omit if the date has already been specified when the
                 suggested post was created. If specified, then the date must be not more than
-                2678400 seconds (30 days) in the future.
-
-                Todo: use constant for 30 days, waiting for #4912.
+                :tg-const:`telegram.constants.SuggestedPost.MAX_SEND_DATE` seconds (30 days)
+                in the future.
 
                 |tz-naive-dtms|
 
@@ -11532,9 +11531,7 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
             chat_id (:obj:`int`): Unique identifier of the target direct messages chat.
             message_id (:obj:`int`): Identifier of a suggested post message to decline.
             comment (:obj:`str`, optional): Comment for the creator of the suggested post.
-                0-128 characters.
-
-                todo: update the 128 character to a constant
+                0-:tg-const:`telegram.constants.SuggestedPost.MAX_COMMENT_LENGTH` characters.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.

--- a/src/telegram/_bot.py
+++ b/src/telegram/_bot.py
@@ -11147,8 +11147,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
         """Removes verification from a chat that is currently verified |org-verify|
         represented by the bot.
 
-
-
         .. versionadded:: 21.10
 
         Args:
@@ -11185,8 +11183,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
     ) -> bool:
         """Removes verification from a user who is currently verified |org-verify|
         represented by the bot.
-
-
 
         .. versionadded:: 21.10
 
@@ -11240,6 +11236,108 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
                 pool_timeout=pool_timeout,
                 api_kwargs=api_kwargs,
             )
+        )
+
+    async def approve_suggested_post(
+        self,
+        chat_id: int,
+        message_id: int,
+        send_date: Optional[Union[int, dtm.datetime]] = None,
+        *,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: Optional[JSONDict] = None,
+    ) -> bool:
+        """
+        Use this method to approve a suggested post in a direct messages chat.
+        The bot must have the :attr:`~telegram.ChatMemberAdministrator.can_post_messages`
+        administrator right in the corresponding channel chat.
+
+        .. versionadded:: NEXT.VERSION
+
+        Args:
+            chat_id (:obj:`int`): Unique identifier of the target direct messages chat.
+            message_id (:obj:`int`): Identifier of a suggested post message to approve.
+            send_date (:obj:`int` | :obj:`datetime.datetime`, optional): Date when the post is
+                expected to be published; omit if the date has already been specified when the
+                suggested post was created. If specified, then the date must be not more than
+                2678400 seconds (30 days) in the future.
+
+                Todo: use constant for 30 days, waiting for #4912.
+
+                |tz-naive-dtms|
+
+        Returns:
+            :obj:`bool`: On success, :obj:`True` is returned.
+
+        Raises:
+            :class:`telegram.error.TelegramError`
+        """
+        data: JSONDict = {
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "send_date": send_date,
+        }
+
+        return await self._post(
+            "approveSuggestedPost",
+            data,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=api_kwargs,
+        )
+
+    async def decline_suggested_post(
+        self,
+        chat_id: int,
+        message_id: int,
+        comment: Optional[str] = None,
+        *,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: Optional[JSONDict] = None,
+    ) -> bool:
+        """
+        Use this method to decline a suggested post in a direct messages chat.
+        The bot must have the :attr:`~telegram.ChatMemberAdministrator.can_manage_direct_messages`
+        administrator right in the corresponding channel chat.
+
+        .. versionadded:: NEXT.VERSION
+
+        Args:
+            chat_id (:obj:`int`): Unique identifier of the target direct messages chat.
+            message_id (:obj:`int`): Identifier of a suggested post message to decline.
+            comment (:obj:`str`, optional): Comment for the creator of the suggested post.
+                0-128 characters.
+
+                todo: update the 128 character to a constant
+
+        Returns:
+            :obj:`bool`: On success, :obj:`True` is returned.
+
+        Raises:
+            :class:`telegram.error.TelegramError`
+        """
+        data: JSONDict = {
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "comment": comment,
+        }
+
+        return await self._post(
+            "declineSuggestedPost",
+            data,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=api_kwargs,
         )
 
     def to_dict(self, recursive: bool = True) -> JSONDict:  # noqa: ARG002
@@ -11562,3 +11660,7 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
     """Alias for :meth:`remove_user_verification`"""
     getMyStarBalance = get_my_star_balance
     """Alias for :meth:`get_my_star_balance`"""
+    approveSuggestedPost = approve_suggested_post
+    """Alias for :meth:`approve_suggested_post`"""
+    declineSuggestedPost = decline_suggested_post
+    """Alias for :meth:`decline_suggested_post`"""

--- a/src/telegram/_chat.py
+++ b/src/telegram/_chat.py
@@ -3682,6 +3682,76 @@ class _ChatBase(TelegramObject):
             api_kwargs=api_kwargs,
         )
 
+    async def approve_suggested_post(
+        self,
+        message_id: int,
+        send_date: Optional[Union[int, dtm.datetime]] = None,
+        *,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: Optional[JSONDict] = None,
+    ) -> bool:
+        """
+        Shortcut for::
+
+             await bot.approve_suggested_post(chat_id=update.effective_chat.id, *args, **kwargs)
+
+        For the documentation of the arguments, please see
+        :meth:`telegram.Bot.approve_suggested_post`.
+
+        .. versionadded:: NEXT.VERSION
+
+        Returns:
+            :obj:`bool`: On success, :obj:`True` is returned.
+        """
+        return await self.get_bot().approve_suggested_post(
+            chat_id=self.id,
+            message_id=message_id,
+            send_date=send_date,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=api_kwargs,
+        )
+
+    async def decline_suggested_post(
+        self,
+        message_id: int,
+        comment: Optional[str] = None,
+        *,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: Optional[JSONDict] = None,
+    ) -> bool:
+        """
+        Shortcut for::
+
+             await bot.decline_suggested_post(chat_id=update.effective_chat.id, *args, **kwargs)
+
+        For the documentation of the arguments, please see
+        :meth:`telegram.Bot.decline_suggested_post`.
+
+        .. versionadded:: NEXT.VERSION
+
+        Returns:
+            :obj:`bool`: On success, :obj:`True` is returned.
+        """
+        return await self.get_bot().decline_suggested_post(
+            chat_id=self.id,
+            message_id=message_id,
+            comment=comment,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=api_kwargs,
+        )
+
 
 class Chat(_ChatBase):
     """This object represents a chat.

--- a/src/telegram/_message.py
+++ b/src/telegram/_message.py
@@ -4712,6 +4712,80 @@ class Message(MaybeInaccessibleMessage):
             api_kwargs=api_kwargs,
         )
 
+    async def approve_suggested_post(
+        self,
+        send_date: Optional[Union[int, dtm.datetime]] = None,
+        *,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: Optional[JSONDict] = None,
+    ) -> bool:
+        """Shortcut for::
+
+             await bot.approve_suggested_post(
+                 chat_id=message.chat_id,
+                 message_id=message.message_id,
+                 *args, **kwargs
+             )
+
+        For the documentation of the arguments, please see
+        :meth:`telegram.Bot.approve_suggested_post`.
+
+        .. versionadded:: NEXT.VERSION
+
+        Returns:
+            :obj:`bool` On success, :obj:`True` is returned.
+        """
+        return await self.get_bot().approve_suggested_post(
+            chat_id=self.chat_id,
+            message_id=self.message_id,
+            send_date=send_date,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=api_kwargs,
+        )
+
+    async def decline_suggested_post(
+        self,
+        comment: Optional[str] = None,
+        *,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: Optional[JSONDict] = None,
+    ) -> bool:
+        """Shortcut for::
+
+             await bot.decline_suggested_post(
+                 chat_id=message.chat_id,
+                 message_id=message.message_id,
+                 *args, **kwargs
+             )
+
+        For the documentation of the arguments, please see
+        :meth:`telegram.Bot.decline_suggested_post`.
+
+        .. versionadded:: NEXT.VERSION
+
+        Returns:
+            :obj:`bool` On success, :obj:`True` is returned.
+        """
+        return await self.get_bot().decline_suggested_post(
+            chat_id=self.chat_id,
+            message_id=self.message_id,
+            comment=comment,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=api_kwargs,
+        )
+
     def parse_entity(self, entity: MessageEntity) -> str:
         """Returns the text from a given :class:`telegram.MessageEntity`.
 

--- a/src/telegram/constants.py
+++ b/src/telegram/constants.py
@@ -3073,7 +3073,7 @@ class StoryLimit(StringEnum):
 
 class SuggestedPost(IntEnum):
     """This enum contains limitations for :class:`telegram.SuggestedPostPrice`\
-/:class:`telegram.SuggestedPostParameters`. The enum
+/:class:`telegram.SuggestedPostParameters`/:meth:`telegram.Bot.decline_suggested_post`. The enum
     members of this enumeration are instances of :class:`int` and can be treated as such.
 
     .. versionadded:: NEXT.VERSION
@@ -3109,6 +3109,10 @@ class SuggestedPost(IntEnum):
     """:obj:`int`: Maximum number of seconds in the future for
     the :paramref:`~telegram.SuggestedPostParameters.send_date` parameter of
     :class:`telegram.SuggestedPostParameters`."""
+    MAX_COMMENT_LENGTH = 128
+    """:obj:`int`: Maximum number of characters in the
+    :paramref:`telegram.Bot.decline_suggested_post.comment` parameter.
+    """
 
 
 class SuggestedPostRefunded(StringEnum):

--- a/src/telegram/ext/_extbot.py
+++ b/src/telegram/ext/_extbot.py
@@ -5143,6 +5143,54 @@ class ExtBot(Bot, Generic[RLARGS]):
             api_kwargs=self._merge_api_rl_kwargs(api_kwargs, rate_limit_args),
         )
 
+    async def decline_suggested_post(
+        self,
+        chat_id: int,
+        message_id: int,
+        comment: Optional[str] = None,
+        *,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: Optional[JSONDict] = None,
+        rate_limit_args: Optional[RLARGS] = None,
+    ) -> bool:
+        return await super().decline_suggested_post(
+            chat_id=chat_id,
+            message_id=message_id,
+            comment=comment,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=self._merge_api_rl_kwargs(api_kwargs, rate_limit_args),
+        )
+
+    async def approve_suggested_post(
+        self,
+        chat_id: int,
+        message_id: int,
+        send_date: Optional[Union[int, dtm.datetime]] = None,
+        *,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: Optional[JSONDict] = None,
+        rate_limit_args: Optional[RLARGS] = None,
+    ) -> bool:
+        return await super().approve_suggested_post(
+            chat_id=chat_id,
+            message_id=message_id,
+            send_date=send_date,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=self._merge_api_rl_kwargs(api_kwargs, rate_limit_args),
+        )
+
     # updated camelCase aliases
     getMe = get_me
     sendMessage = send_message
@@ -5299,3 +5347,5 @@ class ExtBot(Bot, Generic[RLARGS]):
     removeChatVerification = remove_chat_verification
     removeUserVerification = remove_user_verification
     getMyStarBalance = get_my_star_balance
+    approveSuggestedPost = approve_suggested_post
+    declineSuggestedPost = decline_suggested_post

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1452,6 +1452,44 @@ class TestChatWithoutRequest(ChatTestBase):
             message_id="message_id", business_connection_id="business_connection_id"
         )
 
+    async def test_instance_method_approve_suggested_post(self, monkeypatch, chat):
+        async def make_assertion(*_, **kwargs):
+            return (
+                kwargs["chat_id"] == chat.id
+                and kwargs["message_id"] == "message_id"
+                and kwargs["send_date"] == "send_date"
+            )
+
+        assert check_shortcut_signature(
+            Chat.approve_suggested_post, Bot.approve_suggested_post, ["chat_id"], []
+        )
+        assert await check_shortcut_call(
+            chat.approve_suggested_post, chat.get_bot(), "approve_suggested_post"
+        )
+        assert await check_defaults_handling(chat.approve_suggested_post, chat.get_bot())
+
+        monkeypatch.setattr(chat.get_bot(), "approve_suggested_post", make_assertion)
+        assert await chat.approve_suggested_post(message_id="message_id", send_date="send_date")
+
+    async def test_instance_method_decline_suggested_post(self, monkeypatch, chat):
+        async def make_assertion(*_, **kwargs):
+            return (
+                kwargs["chat_id"] == chat.id
+                and kwargs["message_id"] == "message_id"
+                and kwargs["comment"] == "comment"
+            )
+
+        assert check_shortcut_signature(
+            Chat.decline_suggested_post, Bot.decline_suggested_post, ["chat_id"], []
+        )
+        assert await check_shortcut_call(
+            chat.decline_suggested_post, chat.get_bot(), "decline_suggested_post"
+        )
+        assert await check_defaults_handling(chat.decline_suggested_post, chat.get_bot())
+
+        monkeypatch.setattr(chat.get_bot(), "decline_suggested_post", make_assertion)
+        assert await chat.decline_suggested_post(message_id="message_id", comment="comment")
+
     def test_mention_html(self):
         chat = Chat(id=1, type="foo")
         with pytest.raises(TypeError, match="Can not create a mention to a private group chat"):

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -3049,3 +3049,53 @@ class TestMessageWithoutRequest(MessageTestBase):
         )
         assert recwarn[0].category is PTBDeprecationWarning
         assert recwarn[0].filename == __file__
+
+    async def test_approve_suggested_post(self, monkeypatch, message):
+        async def make_assertion(*_, **kwargs):
+            return (
+                kwargs["chat_id"] == message.chat_id
+                and kwargs["message_id"] == message.message_id
+                and kwargs["send_date"] == 1234567890
+            )
+
+        assert check_shortcut_signature(
+            Message.approve_suggested_post,
+            Bot.approve_suggested_post,
+            ["chat_id", "message_id"],
+            [],
+        )
+        assert await check_shortcut_call(
+            message.approve_suggested_post,
+            message.get_bot(),
+            "approve_suggested_post",
+            shortcut_kwargs=["chat_id", "message_id"],
+        )
+        assert await check_defaults_handling(message.approve_suggested_post, message.get_bot())
+
+        monkeypatch.setattr(message.get_bot(), "approve_suggested_post", make_assertion)
+        assert await message.approve_suggested_post(send_date=1234567890)
+
+    async def test_decline_suggested_post(self, monkeypatch, message):
+        async def make_assertion(*_, **kwargs):
+            return (
+                kwargs["chat_id"] == message.chat_id
+                and kwargs["message_id"] == message.message_id
+                and kwargs["comment"] == "some comment"
+            )
+
+        assert check_shortcut_signature(
+            Message.decline_suggested_post,
+            Bot.decline_suggested_post,
+            ["chat_id", "message_id"],
+            [],
+        )
+        assert await check_shortcut_call(
+            message.decline_suggested_post,
+            message.get_bot(),
+            "decline_suggested_post",
+            shortcut_kwargs=["chat_id", "message_id"],
+        )
+        assert await check_defaults_handling(message.decline_suggested_post, message.get_bot())
+
+        monkeypatch.setattr(message.get_bot(), "decline_suggested_post", make_assertion)
+        assert await message.decline_suggested_post(comment="some comment")


### PR DESCRIPTION
Waiting for #4912 to add new Enums so I can reference the constant in the bot methods.

## Check-list for PRs

- [x] Added `.. versionadded:: NEXT.VERSION`, ``.. versionchanged:: NEXT.VERSION``, ``.. deprecated:: NEXT.VERSION`` or ``.. versionremoved:: NEXT.VERSION` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [ ] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)
- [ ] Added new classes & modules to the docs and all suitable ``__all__`` s
- [ ] Checked the [Stability Policy](https://docs.python-telegram-bot.org/stability_policy.html) in case of deprecations or changes to documented behavior

**If the PR contains API changes (otherwise, you can ignore this passage)**

- [ ] Checked the Bot API specific sections of the [Stability Policy](https://docs.python-telegram-bot.org/stability_policy.html)
- [ ] Created a PR to remove functionality deprecated in the previous Bot API release ([see here](https://docs.python-telegram-bot.org/en/stable/stability_policy.html#case-2))

- New Classes

    - [ ] Added `self._id_attrs` and corresponding documentation
    - [ ] `__init__` accepts `api_kwargs` as keyword-only

- Added New Shortcuts

    - [x] In [`telegram.Chat`](https://python-telegram-bot.readthedocs.io/en/stable/telegram.chat.html) \& [`telegram.User`](https://python-telegram-bot.readthedocs.io/en/stable/telegram.user.html) for all methods that accept `chat/user_id`
    - [x] In [`telegram.Message`](https://python-telegram-bot.readthedocs.io/en/stable/telegram.message.html) for all methods that accept `chat_id` and `message_id`
    - [ ] For new `telegram.Message` shortcuts: Added `quote` argument if methods accept `reply_to_message_id`
    - [ ] In [`telegram.CallbackQuery`](https://python-telegram-bot.readthedocs.io/en/stable/telegram.callbackquery.html) for all methods that accept either `chat_id` and `message_id` or `inline_message_id`

- If Relevant

    - [ ] Added new constants at `telegram.constants` and shortcuts to them as class variables
    - [ ] Linked new and existing constants in docstrings instead of hard-coded numbers and strings
    - [ ] Added new message types to `telegram.Message.effective_attachment`
    - [ ] Added new handlers for new update types
        - [ ] Added the handlers to the warning loop in the [`telegram.ext.ConversationHandler`](https://python-telegram-bot.readthedocs.io/en/stable/telegram.ext.conversationhandler.html)
    - [ ] Added new filters for new message (sub)types
    - [ ] Added or updated documentation for the changed class(es) and/or method(s)
    - [ ] Added the new method(s) to `_extbot.py`
    - [x] Added or updated `bot_methods.rst`
    - [ ] Updated the Bot API version number in all places: `README.rst` (including the badge) and `telegram.constants.BOT_API_VERSION_INFO`
    - [ ] Added logic for arbitrary callback data in `telegram.ext.ExtBot` for new methods that either accept a `reply_markup` in some form or have a return type that is/contains [`telegram.Message`](https://python-telegram-bot.readthedocs.io/en/stable/telegram.message.html)

