### PR TITLE
Monthly lockfile update, automerge major non-deps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,9 +19,12 @@
   // Update the lock files:
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["* * * * 1,4"],  // Run sometime on Monday and Thursday
+    "schedule": ["* 0-3 1 * *"],  // https://docs.renovatebot.com/presets-schedule/#schedulemonthly
     "automerge": true
   },
+
+  // Enable automerge globally:
+  "automerge": true,
 
   // Group package updates together:
   "packageRules": [
@@ -47,16 +50,17 @@
       "matchPackageNames": ["chango", "Bibo-Joshi/chango"],
       "groupName": "Chango"
     },
-    // Automerge PR's for minor/patch/pin/digest (except major) updates:
+
+    // Don't automerge major updates for project dependencies:
     {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true
+      "matchUpdateTypes": ["major"],
+      "matchDepTypes": ["project.dependencies", "project.optional-dependencies"],
+      "automerge": false
     },
 
-    // Apply the "dependencies" label to all updates of optional-dependencies:
+    // Apply the "dependencies" label to all updates of optional/required dependencies:
     {
-      "matchDepTypes": ["project.optional-dependencies"],
-      "automerge": false,
+      "matchDepTypes": ["project.optional-dependencies", "project.dependencies"],
       "labels": ["⚙️ dependencies"]
     }
   ],

--- a/changes/unreleased/4968.ecxiPBroDpMUkab6uBCUde.toml
+++ b/changes/unreleased/4968.ecxiPBroDpMUkab6uBCUde.toml
@@ -1,0 +1,5 @@
+internal = "Monthly lockfile update, automerge major non-deps"
+[[pull_requests]]
+uid = "4968"
+author_uids = ["harshil21"]
+closes_threads = []

--- a/changes/unreleased/4968.ecxiPBroDpMUkab6uBCUde.toml
+++ b/changes/unreleased/4968.ecxiPBroDpMUkab6uBCUde.toml
@@ -1,4 +1,4 @@
-internal = "Monthly lockfile update, automerge major non-deps"
+internal = "Tune Renovate Configuration"
 [[pull_requests]]
 uid = "4968"
 author_uids = ["harshil21"]


### PR DESCRIPTION
Changes lock file update frequency to once a month, and enables automerging for major versions of CI tools like setup-python.
