### PR TITLE
Reduce Frequence of Renovate Updates for Development Dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -62,6 +62,17 @@
     {
       "matchDepTypes": ["project.optional-dependencies", "project.dependencies"],
       "labels": ["⚙️ dependencies"]
+    },
+
+    // Workflow and dev-dependencies update once a month
+    // https://docs.renovatebot.com/presets-schedule/#schedulemonthly
+    {
+      "matchPaths": [".github/workflows/**"],
+      "schedule": ["* 0-3 1 * *"]
+    },
+    {
+      "matchDepTypes": ["dependency-groups"],
+      "schedule": ["* 0-3 1 * *"]
     }
   ],
 
@@ -72,6 +83,6 @@
   "ignoreDeps": ["pytest-asyncio"],
 
   // schedule to allow PR's from Renovate:
-  "schedule": ["* * * * 0,6"]  // Every weekend
+  "schedule": ["* * * * 0"]  // Every Sunday
 
 }

--- a/changes/unreleased/5043.QdtCmSghVutBX7hdFxy39Y.toml
+++ b/changes/unreleased/5043.QdtCmSghVutBX7hdFxy39Y.toml
@@ -1,0 +1,4 @@
+internal = "Reduce Frequence of Renovate Updates for Development Dependencies"
+[[pull_requests]]
+uid = "5043"
+author_uids = ["Bibo-Joshi"]


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

The amount of renovate-commits is getting a bit ludicrous IMHO 😅 