### PR TITLE
Minor changes to README to ensure a streamlined setup expierience

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ You can install or upgrade ``python-telegram-bot`` via
 
 .. code:: shell
 
-    Requires Python 3.10+.
+    #Requires Python 3.10+.
     $ pip install python-telegram-bot --upgrade
 
 To install a pre-release, use the ``--pre`` `flag <https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-pre>`_ in addition.


### PR DESCRIPTION
Installing: Added another comment before $ pip install python-telegram-bot --upgrade that reinforces the need for Python 3.10+.  I know this was stated at the beginning of the README, but adding it here would just act as another safety right before install in case it was glossed over. Also, I added a short note that building PTB from source requires Python headers and a C compiler.

Optional Dependencies:  Added -U to the pip installs just in case there are outdated dependencies.

