### PR TITLE
Avoid leaking raw webhook secret token in debug logs

### DIFF
--- a/src/telegram/ext/_utils/webhookhandler.py
+++ b/src/telegram/ext/_utils/webhookhandler.py
@@ -203,7 +203,7 @@ class TelegramHandler(tornado.web.RequestHandler):
                     HTTPStatus.FORBIDDEN, reason="Request did not include the secret token"
                 )
             if token != self.secret_token:
-                _LOGGER.debug("Request had the wrong secret token: %s", token)
+                _LOGGER.debug("Request had the wrong secret token")
                 raise tornado.web.HTTPError(
                     HTTPStatus.FORBIDDEN, reason="Request had the wrong secret token"
                 )


### PR DESCRIPTION
Noticed that the raw `X-Telegram-Bot-Api-Secret-Token` was being included in debug logs when a token mismatch occurred. Removed it from the log message to prevent sensitive information leakage and potential log injection. The log still indicates that a mismatch happened, which is sufficient for debugging.