### PR TITLE
Correct isinstance check variable in _MergedFilter.__init__

### DIFF
--- a/changes/unreleased/5125.filter-fix.toml
+++ b/changes/unreleased/5125.filter-fix.toml
@@ -1,0 +1,5 @@
+bugfixes = "Fixed incorrect isinstance check in class telegram.ext.filters._MergedFilter for or_filter."
+[[pull_requests]]
+uid = "5125"
+author_uids = ["gistrec"]
+closes_threads = []

--- a/src/telegram/ext/filters.py
+++ b/src/telegram/ext/filters.py
@@ -430,7 +430,11 @@ class _MergedFilter(UpdateFilter):
         ):
             self.data_filter = True
         self.or_filter = or_filter
-        if self.or_filter and not isinstance(self.and_filter, bool) and self.or_filter.data_filter:
+        if (
+            self.or_filter
+            and not isinstance(self.or_filter, bool)
+            and self.or_filter.data_filter
+        ):
             self.data_filter = True
 
     @staticmethod

--- a/src/telegram/ext/filters.py
+++ b/src/telegram/ext/filters.py
@@ -430,11 +430,7 @@ class _MergedFilter(UpdateFilter):
         ):
             self.data_filter = True
         self.or_filter = or_filter
-        if (
-            self.or_filter
-            and not isinstance(self.or_filter, bool)
-            and self.or_filter.data_filter
-        ):
+        if self.or_filter and not isinstance(self.or_filter, bool) and self.or_filter.data_filter:
             self.data_filter = True
 
     @staticmethod

--- a/tests/ext/test_filters.py
+++ b/tests/ext/test_filters.py
@@ -276,6 +276,18 @@ class TestFilters:
         result = (filters.COMMAND | filters.Regex(r"linked param")).check_update(update)
         assert result is True
 
+    def test_merged_filter_or_data_filter(self, update):
+        sre_type = type(re.match("", ""))
+        update.message.text = "deep-linked param"
+        update.message.entities = []
+        # COMMAND doesn't match; or_filter (Regex, a data filter) should return match data
+        result = (filters.COMMAND | filters.Regex(r"linked param")).check_update(update)
+        assert result
+        assert isinstance(result, dict)
+        matches = result["matches"]
+        assert isinstance(matches, list)
+        assert all(type(res) is sre_type for res in matches)
+
     def test_regex_complex_merges(self, update, message_origin_user):
         sre_type = type(re.match("", ""))
         update.message.text = "test it out"


### PR DESCRIPTION
Use self.or_filter instead of self.and_filter in the isinstance guard for the or_filter branch (copy-paste error, no functional impact)