### PR TITLE
Check `channel_post` and `edited_channel_post` in `Update.effective_user`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -75,6 +75,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `jossalgon <https://github.com/jossalgon>`_
 - `JRoot3D <https://github.com/JRoot3D>`_
 - `Juan Cuevas <https://github.com/cuevasrja>`
+- `karin0 <https://github.com/karin0>`_
 - `kenjitagawa <https://github.com/kenjitagawa>`_
 - `kennethcheo <https://github.com/kennethcheo>`_
 - `Kirill Vasin <https://github.com/vasinkd>`_

--- a/changes/unreleased/5237.effective-user-fix.toml
+++ b/changes/unreleased/5237.effective-user-fix.toml
@@ -1,0 +1,5 @@
+bugfixes = "`Update.effective_user` now checks for `channel_post` and `edited_channel_post`"
+[[pull_requests]]
+uid = "5237"
+author_uids = ["karin0"]
+closes_threads = ["5236"]

--- a/src/telegram/_update.py
+++ b/src/telegram/_update.py
@@ -500,8 +500,6 @@ class Update(TelegramObject):
         is. If no user is associated with this update, this gives :obj:`None`. This is the case
         if any of
 
-        * :attr:`channel_post`
-        * :attr:`edited_channel_post`
         * :attr:`poll`
         * :attr:`chat_boost`
         * :attr:`removed_chat_boost`
@@ -518,7 +516,8 @@ class Update(TelegramObject):
             This property now also considers :attr:`purchased_paid_media`.
 
         .. versionchanged:: NEXT.VERSION
-            This property now also considers :attr:`managed_bot`.
+            This property now also considers :attr:`managed_bot`, :attr:`channel_post`
+            and :attr:`edited_channel_post`.
 
         Example:
             * If :attr:`message` is present, this will give
@@ -536,6 +535,12 @@ class Update(TelegramObject):
 
         elif self.edited_message:
             user = self.edited_message.from_user
+
+        elif self.channel_post:
+            user = self.channel_post.from_user
+
+        elif self.edited_channel_post:
+            user = self.edited_channel_post.from_user
 
         elif self.inline_query:
             user = self.inline_query.from_user

--- a/tests/ext/test_messagehandler.py
+++ b/tests/ext/test_messagehandler.py
@@ -95,22 +95,7 @@ class TestMessageHandler:
             and isinstance(context.job_queue, JobQueue)
             and isinstance(context.chat_data, dict)
             and isinstance(context.bot_data, dict)
-            and (
-                (
-                    isinstance(context.user_data, dict)
-                    and (
-                        isinstance(update.message, Message)
-                        or isinstance(update.edited_message, Message)
-                    )
-                )
-                or (
-                    context.user_data is None
-                    and (
-                        isinstance(update.channel_post, Message)
-                        or isinstance(update.edited_channel_post, Message)
-                    )
-                )
-            )
+            and isinstance(context.user_data, dict)
         )
 
     def callback_regex1(self, update, context):

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -401,6 +401,18 @@ class TestUpdateWithoutRequest(UpdateTestBase):
         cached = update.effective_sender
         assert cached is sender
 
+    def test_effective_sender_signed_channel_post(self):
+        # channel_post with signatures can have its from_user
+        user = User(1, "", False)
+        post = Message(
+            1, dtm.datetime.utcnow(), Chat(1, ""), author_signature="", from_user=user, text="Text"
+        )
+        update = Update(update_id=1, channel_post=post)
+        assert update.effective_sender == update.effective_user == user
+
+        update = Update(update_id=2, edited_channel_post=post)
+        assert update.effective_sender == update.effective_user == user
+
     def test_effective_message(self, update):
         # Test that it's sometimes None per docstring
         eff_message = update.effective_message


### PR DESCRIPTION
Closes #5236.

Channel posts from channels with "Sign messages" may carry a `Message.from_user`. We check it in `Update.effective_user`, so `Update.effective_user` and `Update.effective_sender` return the signing user.

## Check-list for PRs

- [x] Added `.. versionadded:: NEXT.VERSION`, ``.. versionchanged:: NEXT.VERSION``, ``.. deprecated:: NEXT.VERSION`` or ``.. versionremoved:: NEXT.VERSION` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [x] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- [x] Added myself alphabetically to `AUTHORS.rst` (optional)
- [ ] Added new classes & modules to the docs and all suitable ``__all__`` s
- [x] Checked the [Stability Policy](https://docs.python-telegram-bot.org/stability_policy.html) in case of deprecations or changes to documented behavior
