### PR TITLE
Auto insert raises block, fix `Bot` kwargs insertion regression

### DIFF
--- a/changes/unreleased/5240.iJXyH8RNWNNQpC47SfNHzw.toml
+++ b/changes/unreleased/5240.iJXyH8RNWNNQpC47SfNHzw.toml
@@ -1,5 +1,6 @@
 documentation = "Documentation Improvements"
-[[pull_requests]]
-uid = "5240"
-author_uids = ["harshil21"]
-closes_threads = []
+
+pull_requests = [
+    { uid = "5240", author_uids = ["harshil21", "Poolitzer"] },
+    { uid = "5241", author_uids = ["harshil21"] },
+]

--- a/docs/auxil/bot_insertion.py
+++ b/docs/auxil/bot_insertion.py
@@ -83,6 +83,13 @@ get_updates_read_timeout_addition = [
     "           ``2``.",
 ]
 
+RAISES_BLOCK = [
+    "Raises:",
+    "",
+    "    :class:`telegram.error.TelegramError`",
+    "",
+]
+
 
 def find_insert_pos_for_kwargs(lines: list[str]) -> int:
     """Finds the correct position to insert the keyword arguments and returns the index."""
@@ -90,6 +97,13 @@ def find_insert_pos_for_kwargs(lines: list[str]) -> int:
         if value.startswith("Returns"):
             return idx
     return False
+
+
+def find_insert_pos_for_raises(lines: list[str]) -> int:
+    """Finds the correct position to insert the Raises block and returns the index."""
+    if "Raises:" in lines:
+        return -1  # Don't insert if there's already a Raises block
+    return len(lines)  # Insert at the end if there's no Raises block
 
 
 def check_timeout_and_api_kwargs_presence(obj: object) -> int:

--- a/docs/auxil/sphinx_hooks.py
+++ b/docs/auxil/sphinx_hooks.py
@@ -27,9 +27,11 @@ from sphinx.application import Sphinx
 import telegram
 import telegram.ext
 from docs.auxil.admonition_inserter import AdmonitionInserter
-from docs.auxil.kwargs_insertion import (
+from docs.auxil.bot_insertion import (
+    RAISES_BLOCK,
     check_timeout_and_api_kwargs_presence,
     find_insert_pos_for_kwargs,
+    find_insert_pos_for_raises,
     get_updates_read_timeout_addition,
     keyword_args,
     media_write_timeout_change,
@@ -84,8 +86,8 @@ def autodoc_process_docstring(
     app: Sphinx, what, name: str, obj: object, options, lines: list[str]
 ):
     """We do the following things:
-    1) Use this method to automatically insert the Keyword Args and "Shortcuts" admonitions
-       for the Bot methods.
+    1) Use this method to automatically insert the Keyword Args, "Shortcuts" admonitions,
+       and the Raises block, wherever applicable, for the Bot methods.
 
     2) Use this method to automatically insert "Returned in" admonition into classes
        that are returned from the Bot methods
@@ -101,13 +103,15 @@ def autodoc_process_docstring(
     """
 
     # 1) Insert the Keyword Args and "Shortcuts" admonitions for the Bot methods
-    method_name = name.rsplit(".", maxsplit=1)[0]
+    method_name = name.rsplit(".", maxsplit=1)[-1]
     if (
         name.startswith("telegram.Bot.")
         and what == "method"
         and method_name.islower()
         and check_timeout_and_api_kwargs_presence(obj)
     ):
+        # Logic for inserting keyword args into docstrings:
+        # -------------------------------------------------
         insert_index = find_insert_pos_for_kwargs(lines)
         if not insert_index:
             raise ValueError(
@@ -133,6 +137,16 @@ def autodoc_process_docstring(
             lines[insert_idx:insert_idx] = effective_insert
             insert_idx += len(effective_insert)
 
+        # Logic for inserting Raises:
+        # -------------------------------------------------
+        # We will only insert the Raises block if there isn't already one.
+
+        insert_index = find_insert_pos_for_raises(lines)
+        if insert_index != -1:
+            lines[insert_index:insert_index] = RAISES_BLOCK
+
+        # Logic for inserting "Shortcuts" admonition:
+        # -------------------------------------------
         ADMONITION_INSERTER.insert_admonitions(
             obj=typing.cast("collections.abc.Callable", obj),
             docstring_lines=lines,

--- a/src/telegram/_bot.py
+++ b/src/telegram/_bot.py
@@ -921,6 +921,20 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
                 instances of this class. If not specified, the raw result of the API call will be
                 returned.
 
+        Keyword Args:
+            read_timeout (:obj:`float` | :obj:`None`, optional): Value to pass to
+                :paramref:`telegram.request.BaseRequest.post.read_timeout`. Defaults to
+                :attr:`~telegram.request.BaseRequest.DEFAULT_NONE`.
+            write_timeout (:obj:`float` | :obj:`None`, optional): Value to pass to
+                :paramref:`telegram.request.BaseRequest.post.write_timeout`. Defaults to
+                :attr:`~telegram.request.BaseRequest.DEFAULT_NONE`.
+            connect_timeout (:obj:`float` | :obj:`None`, optional): Value to pass to
+                :paramref:`telegram.request.BaseRequest.post.connect_timeout`. Defaults to
+                :attr:`~telegram.request.BaseRequest.DEFAULT_NONE`.
+            pool_timeout (:obj:`float` | :obj:`None`, optional): Value to pass to
+                :paramref:`telegram.request.BaseRequest.post.pool_timeout`. Defaults to
+                :attr:`~telegram.request.BaseRequest.DEFAULT_NONE`.
+
         Returns:
             The result of the API call. If :paramref:`return_type` is not specified, this is a
             :obj:`dict` or :obj:`bool`, otherwise an instance of :paramref:`return_type` or a

--- a/src/telegram/_bot.py
+++ b/src/telegram/_bot.py
@@ -925,9 +925,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
             The result of the API call. If :paramref:`return_type` is not specified, this is a
             :obj:`dict` or :obj:`bool`, otherwise an instance of :paramref:`return_type` or a
             tuple of :paramref:`return_type`.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         if hasattr(self, endpoint):
             self._warn(
@@ -985,10 +982,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
         Returns:
             :class:`telegram.User`: A :class:`telegram.User` instance representing that bot if the
             credentials are valid, :obj:`None` otherwise.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         result = await self._post(
             "getMe",
@@ -1189,10 +1182,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"chat_id": chat_id, "message_id": message_id}
         return await self._post(
@@ -1249,10 +1238,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -1299,9 +1284,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {"chat_id": chat_id, "message_ids": message_ids}
         return await self._post(
@@ -1378,9 +1360,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :class:`telegram.Message`: On success, the sent Message is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -1449,9 +1428,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
         Returns:
             tuple[:class:`telegram.Message`]: On success, a tuple of ``MessageId`` of sent messages
             is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -1600,9 +1576,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :class:`telegram.Message`: On success, the sent Message is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
 
         """
         data: JSONDict = {
@@ -1776,9 +1749,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
         Returns:
             :class:`telegram.Message`: On success, the sent Message is returned.
 
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -1944,9 +1914,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
         Returns:
             :class:`telegram.Message`: On success, the sent Message is returned.
 
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -2082,10 +2049,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :class:`telegram.Message`: On success, the sent Message is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -2275,10 +2238,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :class:`telegram.Message`: On success, the sent Message is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -2447,10 +2406,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :class:`telegram.Message`: On success, the sent Message is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -2627,10 +2582,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :class:`telegram.Message`: On success, the sent Message is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -2799,10 +2750,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :class:`telegram.Message`: On success, the sent Message is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -2952,9 +2899,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             tuple[:class:`telegram.Message`]: An array of the sent Messages.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         if caption and any(
             [
@@ -3137,10 +3081,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :class:`telegram.Message`: On success, the sent Message is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         if not ((latitude is not None and longitude is not None) or location):
             raise ValueError(
@@ -3464,10 +3404,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :class:`telegram.Message`: On success, the sent Message is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         # The venue parameter is a convenience functionality added by us, so enforcing the
         # mutual exclusivity here is nothing that Telegram would handle anyway
@@ -3622,10 +3558,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :class:`telegram.Message`: On success, the sent Message is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         # The contact parameter is a convenience functionality added by us, so enforcing the
         # mutual exclusivity here is nothing that Telegram would handle anyway
@@ -3748,10 +3680,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :class:`telegram.Message`: On success, the sent Message is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"chat_id": chat_id, "game_short_name": game_short_name}
 
@@ -3808,10 +3736,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`:  On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -3988,10 +3912,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         effective_results, next_offset = self._effective_inline_results(
             results=results, next_offset=next_offset, current_offset=current_offset
@@ -4055,9 +3975,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :class:`telegram.PreparedInlineMessage`: On success, the prepared message is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "user_id": user_id,
@@ -4105,10 +4022,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :class:`telegram.UserProfilePhotos`
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"user_id": user_id, "offset": offset, "limit": limit}
 
@@ -4171,10 +4084,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :class:`telegram.File`
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         # Try to get the file_id from the object, if it fails, assume it's a string
         with contextlib.suppress(AttributeError):
@@ -4237,10 +4146,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -4285,10 +4190,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"chat_id": chat_id, "sender_chat_id": sender_chat_id}
 
@@ -4329,10 +4230,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"chat_id": chat_id, "user_id": user_id, "only_if_banned": only_if_banned}
 
@@ -4369,10 +4266,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"chat_id": chat_id, "sender_chat_id": sender_chat_id}
 
@@ -4432,10 +4325,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool` On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "callback_query_id": callback_query_id,
@@ -4615,10 +4504,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
         Returns:
             :class:`telegram.Message`: On success, if edited message is not an inline message, the
             edited message is returned, otherwise :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -4689,9 +4574,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
         Returns:
             :class:`telegram.Message`: On success, if edited message is not an inline message, the
             edited Message is returned, otherwise :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "media": media,
@@ -4750,10 +4632,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
         Returns:
             :class:`telegram.Message`: On success, if edited message is not an inline message, the
             edited message is returned, otherwise :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -4834,10 +4712,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             tuple[:class:`telegram.Update`]
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "timeout": timeout,
@@ -4984,8 +4858,7 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
         Returns:
             :obj:`bool` On success, :obj:`True` is returned.
 
-        Raises:
-            :class:`telegram.error.TelegramError`
+
 
         .. _`guide to Webhooks`: https://core.telegram.org/bots/webhooks
 
@@ -5030,10 +4903,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data = {"drop_pending_updates": drop_pending_updates}
 
@@ -5064,10 +4933,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"chat_id": chat_id}
 
@@ -5103,10 +4968,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :class:`telegram.ChatFullInfo`
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"chat_id": chat_id}
 
@@ -5146,10 +5007,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
             objects that contains information about all chat administrators except
             other bots. If the chat is a group or a supergroup and no administrators were
             appointed, only the creator will be returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"chat_id": chat_id}
         result = await self._post(
@@ -5182,10 +5039,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`int`: Number of members in the chat.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"chat_id": chat_id}
         return await self._post(
@@ -5218,10 +5071,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :class:`telegram.ChatMember`
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"chat_id": chat_id, "user_id": user_id}
         result = await self._post(
@@ -5430,10 +5279,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             tuple[:class:`telegram.GameHighScore`]
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "user_id": user_id,
@@ -5637,10 +5482,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :class:`telegram.Message`: On success, the sent Message is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -5724,10 +5565,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "shipping_query_id": shipping_query_id,
@@ -5781,10 +5618,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "pre_checkout_query_id": pre_checkout_query_id,
@@ -5826,10 +5659,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
         Returns:
             :class:`telegram.SentWebAppMessage`: On success, a sent
             :class:`telegram.SentWebAppMessage` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "web_app_query_id": web_app_query_id,
@@ -5897,9 +5726,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -6021,10 +5847,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -6096,10 +5918,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -6141,10 +5959,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"chat_id": chat_id, "user_id": user_id, "custom_title": custom_title}
 
@@ -6185,10 +5999,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`str`: New invite link on success.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"chat_id": chat_id}
         return await self._post(
@@ -6251,10 +6061,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :class:`telegram.ChatInviteLink`
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -6328,10 +6134,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :class:`telegram.ChatInviteLink`
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         link = invite_link.invite_link if isinstance(invite_link, ChatInviteLink) else invite_link
         data: JSONDict = {
@@ -6382,10 +6184,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :class:`telegram.ChatInviteLink`
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         link = invite_link.invite_link if isinstance(invite_link, ChatInviteLink) else invite_link
         data: JSONDict = {"chat_id": chat_id, "invite_link": link}
@@ -6426,9 +6224,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {"chat_id": chat_id, "user_id": user_id}
 
@@ -6466,9 +6261,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {"chat_id": chat_id, "user_id": user_id}
 
@@ -6512,10 +6304,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"chat_id": chat_id, "photo": self._parse_file_input(photo)}
         return await self._post(
@@ -6548,10 +6336,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"chat_id": chat_id}
         return await self._post(
@@ -6588,10 +6372,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"chat_id": chat_id, "title": title}
         return await self._post(
@@ -6628,10 +6408,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"chat_id": chat_id, "description": description}
 
@@ -6675,10 +6451,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "user_id": user_id,
@@ -6728,10 +6500,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -6781,10 +6549,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -6824,10 +6588,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"chat_id": chat_id}
         return await self._post(
@@ -6857,10 +6617,6 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
 
         Returns:
             :class:`telegram.StickerSet`
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"name": name}
         result = await self._post(
@@ -6900,10 +6656,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             tuple[:class:`telegram.Sticker`]
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"custom_emoji_ids": custom_emoji_ids}
         result = await self._post(
@@ -6956,10 +6708,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :class:`telegram.File`: On success, the uploaded File is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "user_id": user_id,
@@ -7015,10 +6763,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "user_id": user_id,
@@ -7059,10 +6803,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "sticker": sticker if isinstance(sticker, str) else sticker.file_id,
@@ -7147,9 +6887,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "user_id": user_id,
@@ -7191,10 +6928,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"sticker": sticker if isinstance(sticker, str) else sticker.file_id}
         return await self._post(
@@ -7227,10 +6960,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"name": name}
         return await self._post(
@@ -7300,10 +7029,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "name": name,
@@ -7346,10 +7071,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"name": name, "title": title}
         return await self._post(
@@ -7392,9 +7113,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "sticker": sticker if isinstance(sticker, str) else sticker.file_id,
@@ -7440,9 +7158,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "sticker": sticker if isinstance(sticker, str) else sticker.file_id,
@@ -7487,9 +7202,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "sticker": sticker if isinstance(sticker, str) else sticker.file_id,
@@ -7529,10 +7241,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"name": name, "custom_emoji_id": custom_emoji_id}
 
@@ -7576,10 +7284,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"user_id": user_id, "errors": errors}
         return await self._post(
@@ -7793,10 +7497,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :class:`telegram.Message`: On success, the sent Message is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
 
         if correct_option_id is not None:
@@ -7886,10 +7586,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :class:`telegram.Poll`: On success, the stopped Poll is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -7961,10 +7657,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :class:`telegram.Message`: On success, the sent Message is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -8022,10 +7714,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :class:`telegram.Message`: On success, the sent Message is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -8142,10 +7830,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :class:`telegram.Message`: On success, the sent Message is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"chat_id": chat_id, "emoji": emoji}
 
@@ -8194,9 +7878,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :class:`telegram.ChatAdministratorRights`: On success.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {"for_channels": for_channels}
 
@@ -8292,10 +7973,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         Returns:
             tuple[:class:`telegram.BotCommand`]: On success, the commands set for the bot. An empty
             tuple is returned if commands are not set.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"scope": scope, "language_code": language_code}
 
@@ -8357,10 +8034,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         cmds = [c if isinstance(c, BotCommand) else BotCommand(c[0], c[1]) for c in commands]
         data: JSONDict = {"commands": cmds, "scope": scope, "language_code": language_code}
@@ -8406,9 +8079,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {"scope": scope, "language_code": language_code}
 
@@ -8440,10 +8110,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`True`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         return await self._post(
             "logOut",
@@ -8471,10 +8137,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`True`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         return await self._post(
             "close",
@@ -8593,10 +8255,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         Returns:
             :class:`telegram.MessageId`: On success, the :class:`telegram.MessageId` of the sent
                 message is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         if allow_sending_without_reply is not DEFAULT_NONE and reply_parameters is not None:
             raise ValueError(
@@ -8697,10 +8355,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         Returns:
             tuple[:class:`telegram.MessageId`]: On success, a tuple of :class:`~telegram.MessageId`
             of the sent messages is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -8977,10 +8631,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             tuple[:class:`telegram.Sticker`]
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         result = await self._post(
             "getForumTopicIconStickers",
@@ -9030,9 +8680,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :class:`telegram.ForumTopic`
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -9087,10 +8734,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -9133,10 +8776,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -9177,10 +8816,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -9221,10 +8856,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -9266,10 +8897,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -9308,9 +8935,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {"chat_id": chat_id}
 
@@ -9350,10 +8974,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"chat_id": chat_id, "name": name}
 
@@ -9389,10 +9009,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"chat_id": chat_id}
 
@@ -9429,10 +9045,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"chat_id": chat_id}
 
@@ -9469,10 +9081,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"chat_id": chat_id}
 
@@ -9508,10 +9116,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"chat_id": chat_id}
 
@@ -9553,10 +9157,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"description": description, "language_code": language_code}
 
@@ -9598,10 +9198,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"short_description": short_description, "language_code": language_code}
 
@@ -9634,10 +9230,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :class:`telegram.BotDescription`: On success, the bot description is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data = {"language_code": language_code}
         return BotDescription.de_json(
@@ -9673,10 +9265,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         Returns:
             :class:`telegram.BotShortDescription`: On success, the bot short description is
                 returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data = {"language_code": language_code}
         return BotShortDescription.de_json(
@@ -9723,10 +9311,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {"name": name, "language_code": language_code}
 
@@ -9759,10 +9343,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :class:`telegram.BotName`: On success, the bot name is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data = {"language_code": language_code}
         return BotName.de_json(
@@ -9802,9 +9382,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         Returns:
             :class:`telegram.UserChatBoosts`: On success, the object containing the list of boosts
                 is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {"chat_id": chat_id, "user_id": user_id}
         return UserChatBoosts.de_json(
@@ -9865,9 +9442,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool` On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         allowed_reactions: set[str] = set(ReactionEmoji)
         parsed_reaction = (
@@ -9961,9 +9535,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "user_id": user_id,
@@ -10004,9 +9575,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
         Returns:
             :class:`telegram.BusinessConnection`: On success, the object containing the business
                 connection information is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {"business_connection_id": business_connection_id}
         return BusinessConnection.de_json(
@@ -10087,9 +9655,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :class:`telegram.OwnedGifts`
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "business_connection_id": business_connection_id,
@@ -10138,9 +9703,6 @@ CUSTOM_EMOJI_IDENTIFIER_LIMIT` custom emoji identifiers can be specified.
 
         Returns:
             :class:`telegram.StarAmount`
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {"business_connection_id": business_connection_id}
         return StarAmount.de_json(
@@ -10185,9 +9747,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "business_connection_id": business_connection_id,
@@ -10235,9 +9794,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "business_connection_id": business_connection_id,
@@ -10317,9 +9873,6 @@ MAX_UNIQUE_GIFT_AREAS` of :class:`telegram.StoryAreaTypeUniqueGift`.
 
         Returns:
             :class:`Story`
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "business_connection_id": business_connection_id,
@@ -10397,9 +9950,6 @@ MAX_UNIQUE_GIFT_AREAS` of :class:`telegram.StoryAreaTypeUniqueGift`.
 
         Returns:
             :class:`Story`
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "business_connection_id": business_connection_id,
@@ -10445,9 +9995,6 @@ MAX_UNIQUE_GIFT_AREAS` of :class:`telegram.StoryAreaTypeUniqueGift`.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "business_connection_id": business_connection_id,
@@ -10492,9 +10039,6 @@ MAX_UNIQUE_GIFT_AREAS` of :class:`telegram.StoryAreaTypeUniqueGift`.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "business_connection_id": business_connection_id,
@@ -10535,9 +10079,6 @@ MAX_UNIQUE_GIFT_AREAS` of :class:`telegram.StoryAreaTypeUniqueGift`.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "business_connection_id": business_connection_id,
@@ -10577,9 +10118,6 @@ MAX_UNIQUE_GIFT_AREAS` of :class:`telegram.StoryAreaTypeUniqueGift`.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "business_connection_id": business_connection_id,
@@ -10624,9 +10162,6 @@ MAX_UNIQUE_GIFT_AREAS` of :class:`telegram.StoryAreaTypeUniqueGift`.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "business_connection_id": business_connection_id,
@@ -10671,10 +10206,6 @@ MAX_UNIQUE_GIFT_AREAS` of :class:`telegram.StoryAreaTypeUniqueGift`.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "business_connection_id": business_connection_id,
@@ -10718,9 +10249,6 @@ MAX_UNIQUE_GIFT_AREAS` of :class:`telegram.StoryAreaTypeUniqueGift`.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "business_connection_id": business_connection_id,
@@ -10761,9 +10289,6 @@ MAX_UNIQUE_GIFT_AREAS` of :class:`telegram.StoryAreaTypeUniqueGift`.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "business_connection_id": business_connection_id,
@@ -10816,9 +10341,6 @@ MAX_UNIQUE_GIFT_AREAS` of :class:`telegram.StoryAreaTypeUniqueGift`.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "business_connection_id": business_connection_id,
@@ -10873,9 +10395,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "business_connection_id": business_connection_id,
@@ -10919,9 +10438,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "business_connection_id": business_connection_id,
@@ -10970,9 +10486,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "user_id": user_id,
@@ -11012,10 +10525,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "user_id": user_id,
@@ -11056,9 +10565,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :class:`telegram.StarTransactions`: On success.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
 
         data: JSONDict = {"offset": offset, "limit": limit}
@@ -11104,9 +10610,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "user_id": user_id,
@@ -11210,9 +10713,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :class:`telegram.Message`: On success, the sent message is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
 
         data: JSONDict = {
@@ -11287,10 +10787,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :class:`telegram.ChatInviteLink`
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -11340,10 +10836,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :class:`telegram.ChatInviteLink`
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         link = invite_link.invite_link if isinstance(invite_link, ChatInviteLink) else invite_link
         data: JSONDict = {
@@ -11380,9 +10872,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :class:`telegram.Gifts`
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         return Gifts.de_json(
             await self._post(
@@ -11455,9 +10944,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "user_id": user_id,
@@ -11502,9 +10988,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -11544,9 +11027,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "user_id": user_id,
@@ -11582,9 +11062,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -11619,9 +11096,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "user_id": user_id,
@@ -11651,9 +11125,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :class:`telegram.StarAmount`
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         return StarAmount.de_json(
             await self._post(
@@ -11698,9 +11169,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -11745,9 +11213,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -11807,9 +11272,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :class:`telegram.Story`
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "business_connection_id": business_connection_id,
@@ -11878,9 +11340,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :class:`telegram.OwnedGifts`: The owned gifts for the user.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "user_id": user_id,
@@ -11961,9 +11420,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :class:`telegram.OwnedGifts`: The owned gifts for the chat.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
 
         data: JSONDict = {
@@ -12011,10 +11467,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
         data: JSONDict = {
             "photo": photo,
@@ -12045,10 +11497,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
-
         """
 
         return await self._post(
@@ -12088,9 +11536,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :class:`telegram.UserProfileAudios`
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
 
         data = {
@@ -12139,9 +11584,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :obj:`bool`: On success, :obj:`True` is returned.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "chat_id": chat_id,
@@ -12179,9 +11621,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :obj:`str`: The token of the managed bot.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "user_id": user_id,
@@ -12217,9 +11656,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :obj:`str`: The new token of the managed bot.
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "user_id": user_id,
@@ -12261,9 +11697,6 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
 
         Returns:
             :class:`telegram.PreparedKeyboardButton`
-
-        Raises:
-            :class:`telegram.error.TelegramError`
         """
         data: JSONDict = {
             "user_id": user_id,


### PR DESCRIPTION
This PR does two things:

1) Fixes a regression from #5124 and #5122 which causes no Shortcut admonitions to generate, and no keyword arguments for the bot methods to be inserted in the documentation.
2) Expands the insertion logic to now also automatically add the `Raises:` block for bot methods which have a standard Raises message. Thus, the `Raises:` block in `set_game_score` is untouched, for example.

This helps reduce the LoC and makes implementing new API updates just a little bit more faster.

- [x] Manually check if doc built properly as intended