### PR TITLE
Make instantiation of TelegramObjects 15% faster

### DIFF
--- a/changes/unreleased/5250.dTuzQhYiw2T8gfvp6Skj89.toml
+++ b/changes/unreleased/5250.dTuzQhYiw2T8gfvp6Skj89.toml
@@ -1,4 +1,4 @@
-performance = "Make instantiation of ``TelegramObject``'s 15% faster"
+other = "Make instantiation of ``TelegramObject``'s 15% faster"
 [[pull_requests]]
 uid = "5250"
 author_uids = ["harshil21"]

--- a/changes/unreleased/5250.dTuzQhYiw2T8gfvp6Skj89.toml
+++ b/changes/unreleased/5250.dTuzQhYiw2T8gfvp6Skj89.toml
@@ -1,0 +1,5 @@
+other = "Make instantiation of TelegramObjects 15% faster"
+[[pull_requests]]
+uid = "5250"
+author_uids = ["harshil21"]
+closes_threads = []

--- a/changes/unreleased/5250.dTuzQhYiw2T8gfvp6Skj89.toml
+++ b/changes/unreleased/5250.dTuzQhYiw2T8gfvp6Skj89.toml
@@ -1,5 +1,4 @@
-performance = "Make instantiation of `TelegramObject`'s 15% faster"
-
+performance = "Make instantiation of ``TelegramObject``'s 15% faster"
 [[pull_requests]]
 uid = "5250"
 author_uids = ["harshil21"]

--- a/changes/unreleased/5250.dTuzQhYiw2T8gfvp6Skj89.toml
+++ b/changes/unreleased/5250.dTuzQhYiw2T8gfvp6Skj89.toml
@@ -1,4 +1,5 @@
-other = "Make instantiation of TelegramObjects 15% faster"
+performance = "Make instantiation of `TelegramObject`'s 15% faster"
+
 [[pull_requests]]
 uid = "5250"
 author_uids = ["harshil21"]

--- a/src/telegram/_telegramobject.py
+++ b/src/telegram/_telegramobject.py
@@ -154,7 +154,7 @@ class TelegramObject:
             :exc:`AttributeError`
         """
         # protected attributes can always be set for convenient internal use
-        if key[0] == "_" or not getattr(self, "_frozen", True):
+        if key[0] == "_" or not self._frozen:
             super().__setattr__(key, value)
             return
 
@@ -169,7 +169,7 @@ class TelegramObject:
             :exc:`AttributeError`
         """
         # protected attributes can always be set for convenient internal use
-        if key[0] == "_" or not getattr(self, "_frozen", True):
+        if key[0] == "_" or not self._frozen:
             super().__delattr__(key)
             return
 


### PR DESCRIPTION
Python's getattr is slow and should be avoided if we can directly access the attribute. Running this benchmark against master showed a ~15% performance gain on average:

```py
import timeit

setup = """
from telegram import Message, User, Chat

user = User(id=123, first_name="John", is_bot=False)
chat = Chat(id=456, type="private")
"""

if __name__ == "__main__":
    direct_time = timeit.timeit(
        "Message(message_id=1, date=None, chat=chat, from_user=user, text='this', caption='wow', delete_chat_photo=True)",
        setup=setup,
        number=100000,
    )
    print(f"Direct instantiation time: {direct_time:.6f} seconds")    
```
Benched on uv shipped Python 3.14.3, x86_64
