### PR TITLE
Fix parse_lpo_and_dwpp not raising ValueError when disable_web_page_preview=False

### DIFF
--- a/changes/unreleased/5268.GKZnfBkMcLqBC4rTgznsnY.toml
+++ b/changes/unreleased/5268.GKZnfBkMcLqBC4rTgznsnY.toml
@@ -1,0 +1,5 @@
+bugfixes = "Fixed `parse_lpo_and_dwpp` silently overwriting `link_preview_options` when `disable_web_page_preview=False`."
+[[pull_requests]]
+uid = "5268"
+author_uids = ["JSap0914"]
+closes_threads = []

--- a/changes/unreleased/5268.GKZnfBkMcLqBC4rTgznsnY.toml
+++ b/changes/unreleased/5268.GKZnfBkMcLqBC4rTgznsnY.toml
@@ -1,4 +1,4 @@
-bugfixes = "Fixed `parse_lpo_and_dwpp` silently overwriting `link_preview_options` when `disable_web_page_preview=False`."
+bugfixes = "Fixed ``parse_lpo_and_dwpp`` silently overwriting ``link_preview_options`` when ``disable_web_page_preview=False``."
 [[pull_requests]]
 uid = "5268"
 author_uids = ["JSap0914"]

--- a/src/telegram/_utils/argumentparsing.py
+++ b/src/telegram/_utils/argumentparsing.py
@@ -86,7 +86,7 @@ def parse_lpo_and_dwpp(
     """Wrapper around warn_about_deprecated_arg_return_new_arg. Takes care of converting
     disable_web_page_preview to LinkPreviewOptions.
     """
-    if disable_web_page_preview and link_preview_options:
+    if disable_web_page_preview is not None and link_preview_options:
         raise ValueError(
             "Parameters `disable_web_page_preview` and `link_preview_options` are mutually "
             "exclusive."

--- a/tests/_inline/test_inputtextmessagecontent.py
+++ b/tests/_inline/test_inputtextmessagecontent.py
@@ -97,6 +97,11 @@ class TestInputTextMessageContentWithoutRequest(InputTextMessageContentTestBase)
             InputTextMessageContent(
                 "text", disable_web_page_preview=True, link_preview_options=LinkPreviewOptions()
             )
+        # disable_web_page_preview=False is also an explicit value and must conflict
+        with pytest.raises(ValueError, match="`link_preview_options` are mutually exclusive"):
+            InputTextMessageContent(
+                "text", disable_web_page_preview=False, link_preview_options=LinkPreviewOptions()
+            )
 
     def test_disable_web_page_preview_deprecation(self):
         itmc = InputTextMessageContent("text", disable_web_page_preview=True)


### PR DESCRIPTION
## Bug

`parse_lpo_and_dwpp` is documented to raise `ValueError` when both
`disable_web_page_preview` and `link_preview_options` are supplied
(they are mutually exclusive). However, when `disable_web_page_preview=False`
the guard used a truthy check:

```python
if disable_web_page_preview and link_preview_options:
```

`False and X` short-circuits to `False`, so no `ValueError` is raised.
The code then falls through to the second condition:

```python
if disable_web_page_preview is not None:
    link_preview_options = LinkPreviewOptions(is_disabled=disable_web_page_preview)
```

which **silently overwrites the caller's `link_preview_options`** with
`LinkPreviewOptions(is_disabled=False)`, discarding the user-supplied value.

## Fix

Change the guard to `is not None` so any explicit `bool` value triggers the
mutual-exclusivity check:

```python
if disable_web_page_preview is not None and link_preview_options:
```

## Verification

```
pytest tests/_inline/test_inputtextmessagecontent.py -v
```

Before fix: `test_mutually_exclusive` passes only the `True` sub-case; the new
`False` sub-case fails (`ValueError` is not raised).

After fix: all 7 tests in the file pass.

> AI-assisted: this change was prepared with the help of an AI coding assistant.