### PR TITLE
Add rich message send API surface

### DIFF
--- a/changes/unreleased/5275.rich-message-send-surface.toml
+++ b/changes/unreleased/5275.rich-message-send-surface.toml
@@ -1,0 +1,6 @@
+features = "Add support for sending rich messages (`Bot API 10.1 <https://core.telegram.org/bots/api#rich-message-formatting-options>`_) via :class:`telegram.InputRichMessage`, :class:`telegram.InputRichMessageContent`, :meth:`telegram.Bot.send_rich_message`, :meth:`telegram.Bot.send_rich_message_draft`, and corresponding shortcut methods."
+
+[[pull_requests]]
+uid = "5275"
+author_uids = ["tymrtn"]
+closes_threads = ["5261"]

--- a/docs/source/inclusions/bot_methods.rst
+++ b/docs/source/inclusions/bot_methods.rst
@@ -37,6 +37,10 @@
           - Used for sending text messages
         * - :meth:`~telegram.Bot.send_message_draft`
           - Used for streaming partial text messages
+        * - :meth:`~telegram.Bot.send_rich_message`
+          - Used for sending rich messages
+        * - :meth:`~telegram.Bot.send_rich_message_draft`
+          - Used for streaming partial rich messages
         * - :meth:`~telegram.Bot.send_paid_media`
           - Used for sending paid media to channels
         * - :meth:`~telegram.Bot.send_photo`

--- a/docs/source/telegram.at-tree.rst
+++ b/docs/source/telegram.at-tree.rst
@@ -116,6 +116,7 @@ Available Types
     telegram.inputprofilephoto
     telegram.inputprofilephotoanimated
     telegram.inputprofilephotostatic
+    telegram.inputrichmessage
     telegram.inputpolloption
     telegram.inputpolloptionmedia
     telegram.inputstorycontent
@@ -228,4 +229,3 @@ Available Types
     telegram.webappinfo
     telegram.webhookinfo
     telegram.writeaccessallowed
-

--- a/docs/source/telegram.inline-tree.rst
+++ b/docs/source/telegram.inline-tree.rst
@@ -37,6 +37,7 @@ To enable this option, send the ``/setinline`` command to `@BotFather <https://t
     telegram.inlinequeryresultvideo
     telegram.inlinequeryresultvoice
     telegram.inputmessagecontent
+    telegram.inputrichmessagecontent
     telegram.inputtextmessagecontent
     telegram.inputlocationmessagecontent
     telegram.inputvenuemessagecontent

--- a/docs/source/telegram.inputrichmessage.rst
+++ b/docs/source/telegram.inputrichmessage.rst
@@ -1,0 +1,5 @@
+InputRichMessage
+================
+
+.. autoclass:: telegram.InputRichMessage
+    :members:

--- a/docs/source/telegram.inputrichmessagecontent.rst
+++ b/docs/source/telegram.inputrichmessagecontent.rst
@@ -1,0 +1,5 @@
+InputRichMessageContent
+=======================
+
+.. autoclass:: telegram.InputRichMessageContent
+    :members:

--- a/src/telegram/__init__.py
+++ b/src/telegram/__init__.py
@@ -175,6 +175,8 @@ __all__ = (
     "InputProfilePhoto",
     "InputProfilePhotoAnimated",
     "InputProfilePhotoStatic",
+    "InputRichMessage",
+    "InputRichMessageContent",
     "InputSticker",
     "InputStoryContent",
     "InputStoryContentPhoto",
@@ -512,6 +514,7 @@ from ._inline.inputtextmessagecontent import InputTextMessageContent
 from ._inline.inputvenuemessagecontent import InputVenueMessageContent
 from ._inline.preparedinlinemessage import PreparedInlineMessage
 from ._inputchecklist import InputChecklist, InputChecklistTask
+from ._inputrichmessage import InputRichMessage, InputRichMessageContent
 from ._keyboardbutton import KeyboardButton
 from ._keyboardbuttonpolltype import KeyboardButtonPollType
 from ._keyboardbuttonrequest import (

--- a/src/telegram/_bot.py
+++ b/src/telegram/_bot.py
@@ -80,6 +80,7 @@ from telegram._gifts import AcceptedGiftTypes, Gift, Gifts
 from telegram._inline.inlinequeryresultsbutton import InlineQueryResultsButton
 from telegram._inline.preparedinlinemessage import PreparedInlineMessage
 from telegram._inputchecklist import InputChecklist
+from telegram._inputrichmessage import InputRichMessage
 from telegram._keyboardbutton import KeyboardButton
 from telegram._menubutton import MenuButton
 from telegram._message import Message
@@ -1159,6 +1160,88 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
             api_kwargs=api_kwargs,
         )
 
+    async def send_rich_message(
+        self,
+        chat_id: int | str,
+        rich_message: InputRichMessage,
+        disable_notification: ODVInput[bool] = DEFAULT_NONE,
+        protect_content: ODVInput[bool] = DEFAULT_NONE,
+        reply_markup: "ReplyMarkup | None" = None,
+        message_thread_id: int | None = None,
+        reply_parameters: "ReplyParameters | None" = None,
+        business_connection_id: str | None = None,
+        message_effect_id: str | None = None,
+        allow_paid_broadcast: bool | None = None,
+        direct_messages_topic_id: int | None = None,
+        suggested_post_parameters: "SuggestedPostParameters | None" = None,
+        *,
+        allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
+        reply_to_message_id: int | None = None,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: JSONDict | None = None,
+    ) -> Message:
+        """Use this method to send rich messages. If the message contains a block with a media
+        element, then the bot must have the right to send the media to the chat.
+
+        .. versionadded:: NEXT.VERSION
+
+        Args:
+            chat_id (:obj:`int` | :obj:`str`): Unique identifier for the target chat or username
+                of the target bot, supergroup or channel in the format ``@username``.
+            rich_message (:class:`telegram.InputRichMessage`): The message to be sent.
+            disable_notification (:obj:`bool`, optional): |disable_notification|
+            protect_content (:obj:`bool`, optional): |protect_content|
+            reply_markup (:class:`InlineKeyboardMarkup` | :class:`ReplyKeyboardMarkup` | \
+                :class:`ReplyKeyboardRemove` | :class:`ForceReply`, optional):
+                Additional interface options. An object for an inline keyboard, custom reply
+                keyboard, instructions to remove reply keyboard or to force a reply from the user.
+            message_thread_id (:obj:`int`, optional): |message_thread_id_arg|
+            reply_parameters (:class:`telegram.ReplyParameters`, optional): |reply_parameters|
+            business_connection_id (:obj:`str`, optional): |business_id_str|
+            message_effect_id (:obj:`str`, optional): |message_effect_id|
+            allow_paid_broadcast (:obj:`bool`, optional): |allow_paid_broadcast|
+            direct_messages_topic_id (:obj:`int`, optional): |direct_messages_topic_id|
+            suggested_post_parameters (:class:`telegram.SuggestedPostParameters`, optional):
+                |suggested_post_parameters|
+
+        Keyword Args:
+            allow_sending_without_reply (:obj:`bool`, optional): |allow_sending_without_reply|
+                Mutually exclusive with :paramref:`reply_parameters`, which this is a convenience
+                parameter for
+            reply_to_message_id (:obj:`int`, optional): |reply_to_msg_id|
+                Mutually exclusive with :paramref:`reply_parameters`, which this is a convenience
+                parameter for
+
+        Returns:
+            :class:`telegram.Message`: On success, the sent Message is returned.
+        """
+        data: JSONDict = {"chat_id": chat_id, "rich_message": rich_message}
+
+        return await self._send_message(
+            "sendRichMessage",
+            data,
+            reply_to_message_id=reply_to_message_id,
+            disable_notification=disable_notification,
+            reply_markup=reply_markup,
+            allow_sending_without_reply=allow_sending_without_reply,
+            protect_content=protect_content,
+            message_thread_id=message_thread_id,
+            business_connection_id=business_connection_id,
+            reply_parameters=reply_parameters,
+            message_effect_id=message_effect_id,
+            allow_paid_broadcast=allow_paid_broadcast,
+            direct_messages_topic_id=direct_messages_topic_id,
+            suggested_post_parameters=suggested_post_parameters,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=api_kwargs,
+        )
+
     async def delete_message(
         self,
         chat_id: str | int,
@@ -1273,6 +1356,53 @@ class Bot(TelegramObject, contextlib.AbstractAsyncContextManager["Bot"]):
             data,
             message_thread_id=message_thread_id,
             parse_mode=parse_mode,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=api_kwargs,
+        )
+
+    async def send_rich_message_draft(
+        self,
+        chat_id: int,
+        draft_id: int,
+        rich_message: InputRichMessage,
+        message_thread_id: int | None = None,
+        *,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: JSONDict | None = None,
+    ) -> bool:
+        """Use this method to stream a partial rich message to a user while the message is being
+        generated. Note that the streamed draft is ephemeral and acts as a temporary 30-second
+        preview - once the output is finalized, you must call :meth:`~Bot.send_rich_message` with
+        the complete message to persist it in the user's chat.
+
+        .. versionadded:: NEXT.VERSION
+
+        Args:
+            chat_id (:obj:`int`): Unique identifier for the target private chat.
+            draft_id (:obj:`int`): Unique identifier of the message draft; must be non-zero.
+                Changes to drafts with the same identifier are animated.
+            rich_message (:class:`telegram.InputRichMessage`): The partial message to be streamed.
+            message_thread_id (:obj:`int`, optional): Unique identifier for the target
+                message thread.
+
+        Returns:
+            :obj:`bool`: On success, :obj:`True` is returned.
+        """
+        data: JSONDict = {
+            "chat_id": chat_id,
+            "draft_id": draft_id,
+            "rich_message": rich_message,
+            "message_thread_id": message_thread_id,
+        }
+        return await self._post(
+            "sendRichMessageDraft",
+            data,
             read_timeout=read_timeout,
             write_timeout=write_timeout,
             connect_timeout=connect_timeout,
@@ -12176,6 +12306,10 @@ CHAT_ACTIVITY_TIMEOUT` seconds.
     """Alias for :meth:`send_message`"""
     sendMessageDraft = send_message_draft
     """Alias for :meth:`send_message_draft`"""
+    sendRichMessage = send_rich_message
+    """Alias for :meth:`send_rich_message`"""
+    sendRichMessageDraft = send_rich_message_draft
+    """Alias for :meth:`send_rich_message_draft`"""
     deleteMessage = delete_message
     """Alias for :meth:`delete_message`"""
     deleteMessages = delete_messages

--- a/src/telegram/_chat.py
+++ b/src/telegram/_chat.py
@@ -64,6 +64,7 @@ if TYPE_CHECKING:
         InputPaidMedia,
         InputPollMedia,
         InputPollOption,
+        InputRichMessage,
         LabeledPrice,
         LinkPreviewOptions,
         LivePhoto,
@@ -1124,6 +1125,99 @@ class _ChatBase(TelegramObject):
             message_thread_id=message_thread_id,
             parse_mode=parse_mode,
             entities=entities,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=api_kwargs,
+        )
+
+    async def send_rich_message(
+        self,
+        rich_message: "InputRichMessage",
+        disable_notification: ODVInput[bool] = DEFAULT_NONE,
+        protect_content: ODVInput[bool] = DEFAULT_NONE,
+        reply_markup: "ReplyMarkup | None" = None,
+        message_thread_id: int | None = None,
+        reply_parameters: "ReplyParameters | None" = None,
+        business_connection_id: str | None = None,
+        message_effect_id: str | None = None,
+        allow_paid_broadcast: bool | None = None,
+        direct_messages_topic_id: int | None = None,
+        suggested_post_parameters: "SuggestedPostParameters | None" = None,
+        *,
+        allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
+        reply_to_message_id: int | None = None,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: JSONDict | None = None,
+    ) -> "Message":
+        """Shortcut for::
+
+             await bot.send_rich_message(update.effective_chat.id, *args, **kwargs)
+
+        For the documentation of the arguments, please see :meth:`telegram.Bot.send_rich_message`.
+
+        .. versionadded:: NEXT.VERSION
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return await self.get_bot().send_rich_message(
+            chat_id=self.id,
+            rich_message=rich_message,
+            disable_notification=disable_notification,
+            protect_content=protect_content,
+            reply_markup=reply_markup,
+            message_thread_id=message_thread_id,
+            reply_parameters=reply_parameters,
+            business_connection_id=business_connection_id,
+            message_effect_id=message_effect_id,
+            allow_paid_broadcast=allow_paid_broadcast,
+            direct_messages_topic_id=direct_messages_topic_id,
+            suggested_post_parameters=suggested_post_parameters,
+            allow_sending_without_reply=allow_sending_without_reply,
+            reply_to_message_id=reply_to_message_id,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=api_kwargs,
+        )
+
+    async def send_rich_message_draft(
+        self,
+        draft_id: int,
+        rich_message: "InputRichMessage",
+        message_thread_id: int | None = None,
+        *,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: JSONDict | None = None,
+    ) -> bool:
+        """Shortcut for::
+
+             await bot.send_rich_message_draft(update.effective_chat.id, *args, **kwargs)
+
+        For the documentation of the arguments, please see
+        :meth:`telegram.Bot.send_rich_message_draft`.
+
+        .. versionadded:: NEXT.VERSION
+
+        Returns:
+            :obj:`bool`: On success, :obj:`True` is returned.
+
+        """
+        return await self.get_bot().send_rich_message_draft(
+            chat_id=self.id,
+            draft_id=draft_id,
+            rich_message=rich_message,
+            message_thread_id=message_thread_id,
             read_timeout=read_timeout,
             write_timeout=write_timeout,
             connect_timeout=connect_timeout,

--- a/src/telegram/_inline/inputmessagecontent.py
+++ b/src/telegram/_inline/inputmessagecontent.py
@@ -26,7 +26,7 @@ class InputMessageContent(TelegramObject):
     """Base class for Telegram InputMessageContent Objects.
 
     See: :class:`telegram.InputContactMessageContent`,
-    :class:`telegram.InputInvoiceMessageContent`,
+    :class:`telegram.InputInvoiceMessageContent`, :class:`telegram.InputRichMessageContent`,
     :class:`telegram.InputLocationMessageContent`, :class:`telegram.InputTextMessageContent` and
     :class:`telegram.InputVenueMessageContent` for more details.
 

--- a/src/telegram/_inputrichmessage.py
+++ b/src/telegram/_inputrichmessage.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+#
+# A library that provides a Python interface to the Telegram Bot API
+# Copyright (C) 2015-2026
+# Leandro Toledo de Souza <devs@python-telegram-bot.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+"""This module contains objects that are related to Telegram input rich messages."""
+
+from telegram._inline.inputmessagecontent import InputMessageContent
+from telegram._telegramobject import TelegramObject
+from telegram._utils.types import JSONDict
+
+
+class InputRichMessage(TelegramObject):
+    """
+    Describes a rich message to be sent.
+
+    Objects of this class are comparable in terms of equality. Two objects of this class are
+    considered equal, if their :attr:`html` and :attr:`markdown` are equal.
+
+    .. versionadded:: NEXT.VERSION
+
+    Args:
+        html (:obj:`str`, optional): Content of the rich message to send described using HTML
+            formatting. Mutually exclusive with :paramref:`markdown`.
+        markdown (:obj:`str`, optional): Content of the rich message to send described using
+            Markdown formatting. Mutually exclusive with :paramref:`html`.
+        is_rtl (:obj:`bool`, optional): Pass :obj:`True` if the rich message must be shown
+            right-to-left.
+        skip_entity_detection (:obj:`bool`, optional): Pass :obj:`True` to skip automatic
+            detection of entities in the text.
+
+    Attributes:
+        html (:obj:`str`): Optional. Content of the rich message to send described using HTML
+            formatting.
+        markdown (:obj:`str`): Optional. Content of the rich message to send described using
+            Markdown formatting.
+        is_rtl (:obj:`bool`): Optional. :obj:`True`, if the rich message must be shown
+            right-to-left.
+        skip_entity_detection (:obj:`bool`): Optional. :obj:`True`, if automatic detection of
+            entities in the text should be skipped.
+    """
+
+    __slots__ = ("html", "is_rtl", "markdown", "skip_entity_detection")
+
+    def __init__(
+        self,
+        html: str | None = None,
+        markdown: str | None = None,
+        is_rtl: bool | None = None,
+        skip_entity_detection: bool | None = None,
+        *,
+        api_kwargs: JSONDict | None = None,
+    ):
+        super().__init__(api_kwargs=api_kwargs)
+        self.html: str | None = html
+        self.markdown: str | None = markdown
+        self.is_rtl: bool | None = is_rtl
+        self.skip_entity_detection: bool | None = skip_entity_detection
+
+        self._id_attrs = (self.html, self.markdown)
+
+        self._freeze()
+
+
+class InputRichMessageContent(InputMessageContent):
+    """
+    Represents the content of a rich message to be sent as the result of an inline query.
+
+    Objects of this class are comparable in terms of equality. Two objects of this class are
+    considered equal, if their :attr:`rich_message` is equal.
+
+    .. versionadded:: NEXT.VERSION
+
+    Args:
+        rich_message (:class:`telegram.InputRichMessage`): The message to be sent.
+
+    Attributes:
+        rich_message (:class:`telegram.InputRichMessage`): The message to be sent.
+    """
+
+    __slots__ = ("rich_message",)
+
+    def __init__(
+        self,
+        rich_message: InputRichMessage,
+        *,
+        api_kwargs: JSONDict | None = None,
+    ):
+        super().__init__(api_kwargs=api_kwargs)
+
+        with self._unfrozen():
+            self.rich_message: InputRichMessage = rich_message
+            self._id_attrs = (self.rich_message,)

--- a/src/telegram/_message.py
+++ b/src/telegram/_message.py
@@ -57,6 +57,7 @@ from telegram._games.game import Game
 from telegram._gifts import GiftInfo
 from telegram._inline.inlinekeyboardmarkup import InlineKeyboardMarkup
 from telegram._inputchecklist import InputChecklist
+from telegram._inputrichmessage import InputRichMessage
 from telegram._linkpreviewoptions import LinkPreviewOptions
 from telegram._managedbot import ManagedBotCreated
 from telegram._messageautodeletetimerchanged import MessageAutoDeleteTimerChanged
@@ -2294,6 +2295,73 @@ class Message(MaybeInaccessibleMessage):
             parse_mode=parse_mode,
             entities=entities,
             message_thread_id=message_thread_id,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=api_kwargs,
+        )
+
+    async def reply_rich_message(
+        self,
+        rich_message: InputRichMessage,
+        disable_notification: ODVInput[bool] = DEFAULT_NONE,
+        protect_content: ODVInput[bool] = DEFAULT_NONE,
+        reply_markup: "ReplyMarkup | None" = None,
+        message_thread_id: ODVInput[int] = DEFAULT_NONE,
+        reply_parameters: "ReplyParameters | None" = None,
+        message_effect_id: str | None = None,
+        allow_paid_broadcast: bool | None = None,
+        suggested_post_parameters: "SuggestedPostParameters | None" = None,
+        *,
+        reply_to_message_id: int | None = None,
+        allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
+        do_quote: bool | (_ReplyKwargs | None) = None,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: JSONDict | None = None,
+    ) -> "Message":
+        """Shortcut for::
+
+             await bot.send_rich_message(
+                 update.effective_message.chat_id,
+                 message_thread_id=update.effective_message.message_thread_id,
+                 business_connection_id=self.business_connection_id,
+                 direct_messages_topic_id=self.direct_messages_topic.topic_id,
+                 *args,
+                 **kwargs,
+             )
+
+        For the documentation of the arguments, please see :meth:`telegram.Bot.send_rich_message`.
+
+        .. versionadded:: NEXT.VERSION
+
+        Keyword Args:
+            do_quote (:obj:`bool` | :obj:`dict`, optional): |do_quote|
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        chat_id, effective_reply_parameters = await self._parse_quote_arguments(
+            do_quote, reply_to_message_id, reply_parameters, allow_sending_without_reply
+        )
+        message_thread_id = self._parse_message_thread_id(chat_id, message_thread_id)
+        return await self.get_bot().send_rich_message(
+            chat_id=chat_id,
+            rich_message=rich_message,
+            disable_notification=disable_notification,
+            protect_content=protect_content,
+            reply_markup=reply_markup,
+            message_thread_id=message_thread_id,
+            reply_parameters=effective_reply_parameters,
+            business_connection_id=self.business_connection_id,
+            message_effect_id=message_effect_id,
+            allow_paid_broadcast=allow_paid_broadcast,
+            direct_messages_topic_id=self._extract_direct_messages_topic_id(),
+            suggested_post_parameters=suggested_post_parameters,
             read_timeout=read_timeout,
             write_timeout=write_timeout,
             connect_timeout=connect_timeout,

--- a/src/telegram/_user.py
+++ b/src/telegram/_user.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
         InputMediaVideo,
         InputPollMedia,
         InputPollOption,
+        InputRichMessage,
         LabeledPrice,
         LinkPreviewOptions,
         LivePhoto,
@@ -581,6 +582,105 @@ class User(TelegramObject):
             message_thread_id=message_thread_id,
             parse_mode=parse_mode,
             entities=entities,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=api_kwargs,
+        )
+
+    async def send_rich_message(
+        self,
+        rich_message: "InputRichMessage",
+        disable_notification: ODVInput[bool] = DEFAULT_NONE,
+        protect_content: ODVInput[bool] = DEFAULT_NONE,
+        reply_markup: "ReplyMarkup | None" = None,
+        message_thread_id: int | None = None,
+        reply_parameters: "ReplyParameters | None" = None,
+        business_connection_id: str | None = None,
+        message_effect_id: str | None = None,
+        allow_paid_broadcast: bool | None = None,
+        direct_messages_topic_id: int | None = None,
+        suggested_post_parameters: "SuggestedPostParameters | None" = None,
+        *,
+        allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
+        reply_to_message_id: int | None = None,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: JSONDict | None = None,
+    ) -> "Message":
+        """Shortcut for::
+
+             await bot.send_rich_message(update.effective_user.id, *args, **kwargs)
+
+        For the documentation of the arguments, please see :meth:`telegram.Bot.send_rich_message`.
+
+        Note:
+            |user_chat_id_note|
+
+        .. versionadded:: NEXT.VERSION
+
+        Returns:
+            :class:`telegram.Message`: On success, instance representing the message posted.
+
+        """
+        return await self.get_bot().send_rich_message(
+            chat_id=self.id,
+            rich_message=rich_message,
+            disable_notification=disable_notification,
+            protect_content=protect_content,
+            reply_markup=reply_markup,
+            message_thread_id=message_thread_id,
+            reply_parameters=reply_parameters,
+            business_connection_id=business_connection_id,
+            message_effect_id=message_effect_id,
+            allow_paid_broadcast=allow_paid_broadcast,
+            direct_messages_topic_id=direct_messages_topic_id,
+            suggested_post_parameters=suggested_post_parameters,
+            allow_sending_without_reply=allow_sending_without_reply,
+            reply_to_message_id=reply_to_message_id,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=api_kwargs,
+        )
+
+    async def send_rich_message_draft(
+        self,
+        draft_id: int,
+        rich_message: "InputRichMessage",
+        message_thread_id: int | None = None,
+        *,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: JSONDict | None = None,
+    ) -> bool:
+        """Shortcut for::
+
+             await bot.send_rich_message_draft(update.effective_user.id, *args, **kwargs)
+
+        For the documentation of the arguments, please see
+        :meth:`telegram.Bot.send_rich_message_draft`.
+
+        Note:
+            |user_chat_id_note|
+
+        .. versionadded:: NEXT.VERSION
+
+        Returns:
+            :obj:`bool`: On success, :obj:`True` is returned.
+
+        """
+        return await self.get_bot().send_rich_message_draft(
+            chat_id=self.id,
+            draft_id=draft_id,
+            rich_message=rich_message,
+            message_thread_id=message_thread_id,
             read_timeout=read_timeout,
             write_timeout=write_timeout,
             connect_timeout=connect_timeout,

--- a/src/telegram/ext/_extbot.py
+++ b/src/telegram/ext/_extbot.py
@@ -64,6 +64,7 @@ from telegram import (
     InputPaidMedia,
     InputPollOption,
     InputProfilePhoto,
+    InputRichMessage,
     KeyboardButton,
     LinkPreviewOptions,
     MaskPosition,
@@ -3173,6 +3174,52 @@ class ExtBot(Bot, Generic[RLARGS]):
             suggested_post_parameters=suggested_post_parameters,
         )
 
+    async def send_rich_message(
+        self,
+        chat_id: int | str,
+        rich_message: InputRichMessage,
+        disable_notification: ODVInput[bool] = DEFAULT_NONE,
+        protect_content: ODVInput[bool] = DEFAULT_NONE,
+        reply_markup: "ReplyMarkup | None" = None,
+        message_thread_id: int | None = None,
+        reply_parameters: "ReplyParameters | None" = None,
+        business_connection_id: str | None = None,
+        message_effect_id: str | None = None,
+        allow_paid_broadcast: bool | None = None,
+        direct_messages_topic_id: int | None = None,
+        suggested_post_parameters: "SuggestedPostParameters | None" = None,
+        *,
+        reply_to_message_id: int | None = None,
+        allow_sending_without_reply: ODVInput[bool] = DEFAULT_NONE,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: JSONDict | None = None,
+        rate_limit_args: RLARGS | None = None,
+    ) -> Message:
+        return await super().send_rich_message(
+            chat_id=chat_id,
+            rich_message=rich_message,
+            disable_notification=disable_notification,
+            protect_content=protect_content,
+            reply_markup=reply_markup,
+            message_thread_id=message_thread_id,
+            reply_parameters=reply_parameters,
+            business_connection_id=business_connection_id,
+            message_effect_id=message_effect_id,
+            allow_paid_broadcast=allow_paid_broadcast,
+            direct_messages_topic_id=direct_messages_topic_id,
+            suggested_post_parameters=suggested_post_parameters,
+            reply_to_message_id=reply_to_message_id,
+            allow_sending_without_reply=allow_sending_without_reply,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=self._merge_api_rl_kwargs(api_kwargs, rate_limit_args),
+        )
+
     async def send_message_draft(
         self,
         chat_id: int,
@@ -3196,6 +3243,32 @@ class ExtBot(Bot, Generic[RLARGS]):
             message_thread_id=message_thread_id,
             parse_mode=parse_mode,
             entities=entities,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
+            connect_timeout=connect_timeout,
+            pool_timeout=pool_timeout,
+            api_kwargs=self._merge_api_rl_kwargs(api_kwargs, rate_limit_args),
+        )
+
+    async def send_rich_message_draft(
+        self,
+        chat_id: int,
+        draft_id: int,
+        rich_message: InputRichMessage,
+        message_thread_id: int | None = None,
+        *,
+        read_timeout: ODVInput[float] = DEFAULT_NONE,
+        write_timeout: ODVInput[float] = DEFAULT_NONE,
+        connect_timeout: ODVInput[float] = DEFAULT_NONE,
+        pool_timeout: ODVInput[float] = DEFAULT_NONE,
+        api_kwargs: JSONDict | None = None,
+        rate_limit_args: RLARGS | None = None,
+    ) -> bool:
+        return await super().send_rich_message_draft(
+            chat_id=chat_id,
+            draft_id=draft_id,
+            rich_message=rich_message,
+            message_thread_id=message_thread_id,
             read_timeout=read_timeout,
             write_timeout=write_timeout,
             connect_timeout=connect_timeout,
@@ -5813,6 +5886,8 @@ class ExtBot(Bot, Generic[RLARGS]):
     getMe = get_me
     sendMessage = send_message
     sendMessageDraft = send_message_draft
+    sendRichMessage = send_rich_message
+    sendRichMessageDraft = send_rich_message_draft
     deleteMessage = delete_message
     deleteMessages = delete_messages
     forwardMessage = forward_message

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -59,6 +59,7 @@ from telegram import (
     InputMessageContent,
     InputPollOption,
     InputProfilePhotoStatic,
+    InputRichMessage,
     InputTextMessageContent,
     KeyboardButton,
     KeyboardButtonRequestManagedBot,
@@ -1655,6 +1656,64 @@ class TestBotWithoutRequest:
             parse_mode="markdown",
             entities=entities,
         )
+
+    async def test_send_rich_message_draft(self, offline_bot, monkeypatch):
+        rich_message = InputRichMessage(html="<b>test</b>")
+
+        async def make_assertions(*args, **kwargs):
+            params = kwargs.get("request_data").parameters
+            assert params.get("chat_id") == 123
+            assert params.get("draft_id") == 1
+            assert params.get("rich_message") == rich_message.to_dict()
+            assert params.get("message_thread_id") == 9
+
+            return True
+
+        monkeypatch.setattr(offline_bot.request, "post", make_assertions)
+        assert await offline_bot.send_rich_message_draft(
+            chat_id=123,
+            draft_id=1,
+            rich_message=rich_message,
+            message_thread_id=9,
+        )
+
+    async def test_send_rich_message(self, offline_bot, monkeypatch):
+        chat_id = 123
+        rich_message = InputRichMessage(markdown="**test**")
+        reply_parameters = ReplyParameters(23, chat_id, allow_sending_without_reply=True)
+        reply_markup = InlineKeyboardMarkup(
+            [[InlineKeyboardButton(text="test", callback_data="test2")]]
+        )
+
+        async def make_assertions(*args, **kwargs):
+            params = kwargs.get("request_data").parameters
+            assert params.get("business_connection_id") == "bci"
+            assert params.get("chat_id") == chat_id
+            assert params.get("rich_message") == rich_message.to_dict()
+            assert params.get("disable_notification") is True
+            assert params.get("protect_content") is False
+            assert params.get("message_effect_id") == "effect"
+            assert params.get("allow_paid_broadcast") is True
+            assert params.get("direct_messages_topic_id") == 7
+            assert params.get("reply_parameters") == reply_parameters.to_dict()
+            assert params.get("reply_markup") == reply_markup.to_dict()
+
+            return Message(1, dtm.datetime.now(), Chat(1, ""), text="test").to_dict()
+
+        monkeypatch.setattr(offline_bot.request, "post", make_assertions)
+        obj = await offline_bot.send_rich_message(
+            chat_id=chat_id,
+            rich_message=rich_message,
+            disable_notification=True,
+            protect_content=False,
+            message_effect_id="effect",
+            reply_parameters=reply_parameters,
+            reply_markup=reply_markup,
+            business_connection_id="bci",
+            allow_paid_broadcast=True,
+            direct_messages_topic_id=7,
+        )
+        assert isinstance(obj, Message)
 
     @pytest.mark.parametrize("default_bot", [{"parse_mode": "Markdown"}], indirect=True)
     @pytest.mark.parametrize(

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -26,6 +26,7 @@ from telegram import (
     ChatPermissions,
     InputChecklist,
     InputChecklistTask,
+    InputRichMessage,
     ReactionTypeEmoji,
     User,
 )
@@ -538,6 +539,44 @@ class TestChatWithoutRequest(ChatTestBase):
 
         monkeypatch.setattr(chat.get_bot(), "send_message_draft", make_assertion)
         assert await chat.send_message_draft(draft_id=1, text="test")
+
+    async def test_instance_method_send_rich_message(self, monkeypatch, chat):
+        rich_message = InputRichMessage(html="<b>test</b>")
+
+        async def make_assertion(*_, **kwargs):
+            return kwargs["chat_id"] == chat.id and kwargs["rich_message"] == rich_message
+
+        assert check_shortcut_signature(
+            Chat.send_rich_message, Bot.send_rich_message, ["chat_id"], []
+        )
+        assert await check_shortcut_call(
+            chat.send_rich_message, chat.get_bot(), "send_rich_message"
+        )
+        assert await check_defaults_handling(chat.send_rich_message, chat.get_bot())
+
+        monkeypatch.setattr(chat.get_bot(), "send_rich_message", make_assertion)
+        assert await chat.send_rich_message(rich_message)
+
+    async def test_instance_method_send_rich_message_draft(self, monkeypatch, chat):
+        rich_message = InputRichMessage(html="<b>test</b>")
+
+        async def make_assertion(*_, **kwargs):
+            return (
+                kwargs["chat_id"] == chat.id
+                and kwargs["draft_id"] == 1
+                and kwargs["rich_message"] == rich_message
+            )
+
+        assert check_shortcut_signature(
+            Chat.send_rich_message_draft, Bot.send_rich_message_draft, ["chat_id"], []
+        )
+        assert await check_shortcut_call(
+            chat.send_rich_message_draft, chat.get_bot(), "send_rich_message_draft"
+        )
+        assert await check_defaults_handling(chat.send_rich_message_draft, chat.get_bot())
+
+        monkeypatch.setattr(chat.get_bot(), "send_rich_message_draft", make_assertion)
+        assert await chat.send_rich_message_draft(1, rich_message)
 
     async def test_instance_method_send_media_group(self, monkeypatch, chat):
         async def make_assertion(*_, **kwargs):

--- a/tests/test_inputrichmessage.py
+++ b/tests/test_inputrichmessage.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+#
+# A library that provides a Python interface to the Telegram Bot API
+# Copyright (C) 2015-2026
+# Leandro Toledo de Souza <devs@python-telegram-bot.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+
+import pytest
+
+from telegram import Dice, InputRichMessage, InputRichMessageContent
+from tests.auxil.slots import mro_slots
+
+
+@pytest.fixture(scope="module")
+def input_rich_message():
+    return InputRichMessage(
+        html=InputRichMessageTestBase.html,
+        is_rtl=InputRichMessageTestBase.is_rtl,
+        skip_entity_detection=InputRichMessageTestBase.skip_entity_detection,
+    )
+
+
+class InputRichMessageTestBase:
+    html = "<b>bold</b>"
+    markdown = "**bold**"
+    is_rtl = True
+    skip_entity_detection = False
+
+
+class TestInputRichMessageWithoutRequest(InputRichMessageTestBase):
+    def test_slot_behaviour(self, input_rich_message):
+        for attr in input_rich_message.__slots__:
+            assert getattr(input_rich_message, attr, "err") != "err", f"got extra slot '{attr}'"
+        assert len(mro_slots(input_rich_message)) == len(set(mro_slots(input_rich_message))), (
+            "duplicate slot"
+        )
+
+    def test_expected_values(self, input_rich_message):
+        assert input_rich_message.html == self.html
+        assert input_rich_message.markdown is None
+        assert input_rich_message.is_rtl == self.is_rtl
+        assert input_rich_message.skip_entity_detection == self.skip_entity_detection
+
+    def test_to_dict(self, input_rich_message):
+        irm_dict = input_rich_message.to_dict()
+
+        assert isinstance(irm_dict, dict)
+        assert irm_dict["html"] == self.html
+        assert irm_dict["is_rtl"] == self.is_rtl
+        assert irm_dict["skip_entity_detection"] == self.skip_entity_detection
+        assert "markdown" not in irm_dict
+
+    def test_equality(self, input_rich_message):
+        a = input_rich_message
+        b = InputRichMessage(html=self.html, is_rtl=False)
+        c = InputRichMessage(markdown=self.markdown)
+        d = Dice(value=1, emoji="🎲")
+
+        assert a == b
+        assert hash(a) == hash(b)
+
+        assert a != c
+        assert hash(a) != hash(c)
+
+        assert a != d
+        assert hash(a) != hash(d)
+
+
+@pytest.fixture(scope="module")
+def input_rich_message_content(input_rich_message):
+    return InputRichMessageContent(input_rich_message)
+
+
+class TestInputRichMessageContentWithoutRequest:
+    def test_slot_behaviour(self, input_rich_message_content):
+        for attr in input_rich_message_content.__slots__:
+            assert getattr(input_rich_message_content, attr, "err") != "err", (
+                f"got extra slot '{attr}'"
+            )
+        assert len(mro_slots(input_rich_message_content)) == len(
+            set(mro_slots(input_rich_message_content))
+        ), "duplicate slot"
+
+    def test_expected_values(self, input_rich_message_content, input_rich_message):
+        assert input_rich_message_content.rich_message == input_rich_message
+
+    def test_to_dict(self, input_rich_message_content, input_rich_message):
+        irmc_dict = input_rich_message_content.to_dict()
+
+        assert isinstance(irmc_dict, dict)
+        assert irmc_dict["rich_message"] == input_rich_message.to_dict()
+
+    def test_equality(self, input_rich_message_content, input_rich_message):
+        a = input_rich_message_content
+        b = InputRichMessageContent(InputRichMessage(html=input_rich_message.html))
+        c = InputRichMessageContent(InputRichMessage(markdown="**other**"))
+        d = Dice(value=1, emoji="🎲")
+
+        assert a == b
+        assert hash(a) == hash(b)
+
+        assert a != c
+        assert hash(a) != hash(c)
+
+        assert a != d
+        assert hash(a) != hash(d)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -54,6 +54,7 @@ from telegram import (
     InputChecklist,
     InputChecklistTask,
     InputPaidMediaPhoto,
+    InputRichMessage,
     InputTextMessageContent,
     Invoice,
     LinkPreviewOptions,
@@ -1939,6 +1940,54 @@ class TestMessageWithoutRequest(MessageTestBase):
 
         await self.check_thread_id_parsing(
             message, message.reply_text_draft, "send_message_draft", [1, "test"], monkeypatch
+        )
+
+    async def test_reply_rich_message(self, monkeypatch, message):
+        rich_message = InputRichMessage(html="<b>test</b>")
+
+        async def make_assertion(*_, **kwargs):
+            return (
+                kwargs["chat_id"] == message.chat_id
+                and kwargs["business_connection_id"] == message.business_connection_id
+                and kwargs["rich_message"] == rich_message
+                and kwargs["disable_notification"] is True
+            )
+
+        assert check_shortcut_signature(
+            Message.reply_rich_message,
+            Bot.send_rich_message,
+            [
+                "chat_id",
+                "reply_to_message_id",
+                "business_connection_id",
+                "direct_messages_topic_id",
+            ],
+            ["do_quote", "reply_to_message_id"],
+            annotation_overrides={"message_thread_id": (ODVInput[int], DEFAULT_NONE)},
+        )
+        assert await check_shortcut_call(
+            message.reply_rich_message,
+            message.get_bot(),
+            "send_rich_message",
+            skip_params=["reply_to_message_id"],
+            shortcut_kwargs=["business_connection_id", "direct_messages_topic_id"],
+        )
+        assert await check_defaults_handling(
+            message.reply_rich_message, message.get_bot(), no_default_kwargs={"message_thread_id"}
+        )
+
+        monkeypatch.setattr(message.get_bot(), "send_rich_message", make_assertion)
+        assert await message.reply_rich_message(rich_message, disable_notification=True)
+        await self.check_quote_parsing(
+            message,
+            message.reply_rich_message,
+            "send_rich_message",
+            [rich_message, True],
+            monkeypatch,
+        )
+
+        await self.check_thread_id_parsing(
+            message, message.reply_rich_message, "send_rich_message", [rich_message], monkeypatch
         )
 
     async def test_reply_media_group(self, monkeypatch, message):

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 import pytest
 
-from telegram import Bot, InlineKeyboardButton, Update, User
+from telegram import Bot, InlineKeyboardButton, InputRichMessage, Update, User
 from telegram.helpers import escape_markdown
 from tests.auxil.bot_method_checks import (
     check_defaults_handling,
@@ -284,6 +284,44 @@ class TestUserWithoutRequest(UserTestBase):
 
         monkeypatch.setattr(user.get_bot(), "send_message_draft", make_assertion)
         assert await user.send_message_draft(123, "test")
+
+    async def test_instance_method_send_rich_message(self, monkeypatch, user):
+        rich_message = InputRichMessage(html="<b>test</b>")
+
+        async def make_assertion(*_, **kwargs):
+            return kwargs["chat_id"] == user.id and kwargs["rich_message"] == rich_message
+
+        assert check_shortcut_signature(
+            User.send_rich_message, Bot.send_rich_message, ["chat_id"], []
+        )
+        assert await check_shortcut_call(
+            user.send_rich_message, user.get_bot(), "send_rich_message"
+        )
+        assert await check_defaults_handling(user.send_rich_message, user.get_bot())
+
+        monkeypatch.setattr(user.get_bot(), "send_rich_message", make_assertion)
+        assert await user.send_rich_message(rich_message)
+
+    async def test_instance_method_send_rich_message_draft(self, monkeypatch, user):
+        rich_message = InputRichMessage(html="<b>test</b>")
+
+        async def make_assertion(*_, **kwargs):
+            return (
+                kwargs["chat_id"] == user.id
+                and kwargs["draft_id"] == 123
+                and kwargs["rich_message"] == rich_message
+            )
+
+        assert check_shortcut_signature(
+            User.send_rich_message_draft, Bot.send_rich_message_draft, ["chat_id"], []
+        )
+        assert await check_shortcut_call(
+            user.send_rich_message_draft, user.get_bot(), "send_rich_message_draft"
+        )
+        assert await check_defaults_handling(user.send_rich_message_draft, user.get_bot())
+
+        monkeypatch.setattr(user.get_bot(), "send_rich_message_draft", make_assertion)
+        assert await user.send_rich_message_draft(123, rich_message)
 
     async def test_instance_method_send_photo(self, monkeypatch, user):
         async def make_assertion(*_, **kwargs):


### PR DESCRIPTION
## Summary

Adds the first send-side Rich Messages API surface for Bot API 10.1:

- `InputRichMessage`
- `InputRichMessageContent`
- `Bot.send_rich_message`
- `Bot.send_rich_message_draft`
- `ExtBot` wrappers
- `Chat` / `User` shortcuts
- `Message.reply_rich_message`
- docs entries and targeted unit tests

This intentionally does **not** add the full `RichText*` / `RichBlock*` returned-object hierarchy yet. It is meant as a smaller first slice for sending rich markdown/html content and rich drafts.

Closes part of #5261.

## Tests

- `python -m pytest -o 'addopts=' tests/test_inputrichmessage.py tests/test_bot.py::TestBotWithoutRequest::test_send_rich_message tests/test_bot.py::TestBotWithoutRequest::test_send_rich_message_draft tests/test_chat.py::TestChatWithoutRequest::test_instance_method_send_rich_message tests/test_chat.py::TestChatWithoutRequest::test_instance_method_send_rich_message_draft tests/test_user.py::TestUserWithoutRequest::test_instance_method_send_rich_message tests/test_user.py::TestUserWithoutRequest::test_instance_method_send_rich_message_draft tests/test_message.py::TestMessageWithoutRequest::test_reply_rich_message -q`
- `python -m pytest -o 'addopts=' tests/test_inputrichmessage.py tests/test_bot.py tests/test_chat.py tests/test_user.py tests/test_message.py -k 'rich_message or inputrichmessage' -q`
- `PYTHONPATH=src python - <<'PY' ... import/export sanity for InputRichMessage/InputRichMessageContent/Bot/Chat/User/Message ... PY`
- `git diff --check`
- `python -m ruff check src/telegram/_inputrichmessage.py src/telegram/_bot.py src/telegram/_chat.py src/telegram/_user.py src/telegram/_message.py src/telegram/ext/_extbot.py tests/test_inputrichmessage.py tests/test_bot.py tests/test_chat.py tests/test_user.py tests/test_message.py`
- `python -m ruff format --check src/telegram/_inputrichmessage.py src/telegram/_bot.py src/telegram/_chat.py src/telegram/_user.py src/telegram/_message.py src/telegram/ext/_extbot.py tests/test_inputrichmessage.py tests/test_bot.py tests/test_chat.py tests/test_user.py tests/test_message.py`

## Check-list for PRs

- [x] Added `.. versionadded:: NEXT.VERSION` to user-facing changes
- [x] Created new/adapted unit tests
- [x] Documented code changes according to existing project style
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)
- [x] Added new classes & modules to docs and suitable `__all__` exports
- [x] Checked Bot API-specific PR checklist items relevant to this slice
