### PR TITLE
Fix mention_html not HTML-escaping string user_id

### DIFF
--- a/changes/unreleased/5282.YffAA4aX1jYEkwW3lhmgbQ.toml
+++ b/changes/unreleased/5282.YffAA4aX1jYEkwW3lhmgbQ.toml
@@ -1,5 +1,5 @@
 bugfixes = "Fixed ``mention_html`` not HTML-escaping the ``user_id`` argument, which could produce malformed HTML when ``user_id`` is a string containing special characters such as ``\"``."
 [[pull_requests]]
-uid = "PLACEHOLDER"
+uid = "5282"
 author_uids = ["JSap0914"]
 closes_threads = ["5281"]

--- a/changes/unreleased/PLACEHOLDER.YffAA4aX1jYEkwW3lhmgbQ.toml
+++ b/changes/unreleased/PLACEHOLDER.YffAA4aX1jYEkwW3lhmgbQ.toml
@@ -1,0 +1,5 @@
+bugfixes = "Fixed ``mention_html`` not HTML-escaping the ``user_id`` argument, which could produce malformed HTML when ``user_id`` is a string containing special characters such as ``\"``."
+[[pull_requests]]
+uid = "PLACEHOLDER"
+author_uids = ["JSap0914"]
+closes_threads = ["5281"]

--- a/src/telegram/helpers.py
+++ b/src/telegram/helpers.py
@@ -88,7 +88,7 @@ def mention_html(user_id: int | str, name: str) -> str:
     Returns:
         :obj:`str`: The inline mention for the user as HTML.
     """
-    return f'<a href="tg://user?id={user_id}">{escape(name)}</a>'
+    return f'<a href="tg://user?id={escape(str(user_id))}">{escape(name)}</a>'
 
 
 def mention_markdown(user_id: int | str, name: str, version: MarkdownVersion = 1) -> str:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -144,8 +144,18 @@ class TestHelpers:
 
     def test_mention_html(self):
         expected = '<a href="tg://user?id=1">the name</a>'
-
         assert expected == helpers.mention_html(1, "the name")
+
+    def test_mention_html_escapes_str_user_id(self):
+        """mention_html must HTML-escape special chars in a string user_id.
+
+        A double-quote in user_id broke the href attribute, producing malformed HTML:
+          <a href="tg://user?id=123"bad">name</a>
+        After the fix the quote is rendered as &quot;.
+        """
+        assert helpers.mention_html('123"bad', "name") == (
+            '<a href="tg://user?id=123&quot;bad">name</a>'
+        )
 
     @pytest.mark.parametrize(
         ("test_str", "expected"),


### PR DESCRIPTION
## Bug

`helpers.mention_html(user_id, name)` accepts `user_id: int | str`. The `name` argument is correctly passed through `html.escape()`, but `user_id` was interpolated raw into the `href` attribute.

When `user_id` is a string containing a double-quote the output is malformed HTML:

```python
>>> helpers.mention_html('123"bad', 'name')
'<a href="tg://user?id=123"bad">name</a>'   # broken href
```

Closes #5281

## Fix

One-line change — apply `html.escape(str(user_id))` consistently, matching how `name` is already escaped:

```diff
-    return f'<a href="tg://user?id={user_id}">{escape(name)}</a>'
+    return f'<a href="tg://user?id={escape(str(user_id))}">{escape(name)}</a>'
```

For integer `user_id` values (the common case) the output is **unchanged**, since integers have no HTML-special characters.

## Verification

```
pytest tests/test_helpers.py -v
# 184 passed in 0.62s
```

> AI-assisted contribution.