### PR TITLE
Fix create_deep_linked_url accepting 4-char usernames below Telegram's 5-char minimum

### DIFF
--- a/changes/unreleased/5285.3x2uKLIG59gJe4TLjQgYUq.toml
+++ b/changes/unreleased/5285.3x2uKLIG59gJe4TLjQgYUq.toml
@@ -1,0 +1,5 @@
+bugfixes = "Fixed ``create_deep_linked_url`` silently accepting 4-character bot usernames, which are invalid per Telegram's 5-character minimum."
+[[pull_requests]]
+uid = "5285"
+author_uids = ["JSap0914"]
+closes_threads = ["5284"]

--- a/src/telegram/helpers.py
+++ b/src/telegram/helpers.py
@@ -178,10 +178,10 @@ def create_deep_linked_url(
     Raises:
         :exc:`ValueError`: If the length of the :paramref:`payload` exceeds \
         :tg-const:`telegram.constants.MessageLimit.DEEP_LINK_LENGTH` characters,
-            contains invalid characters, or if the :paramref:`bot_username` is less than 4
+            contains invalid characters, or if the :paramref:`bot_username` is less than 5
             characters.
     """
-    if bot_username is None or len(bot_username) <= 3:
+    if bot_username is None or len(bot_username) < 5:
         raise ValueError("You must provide a valid bot_username.")
 
     base_url = f"https://t.me/{bot_username}"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -113,8 +113,10 @@ class TestHelpers:
 
         with pytest.raises(ValueError, match="valid bot_username"):
             helpers.create_deep_linked_url(None, None)
-        with pytest.raises(ValueError, match="valid bot_username"):  # too short username, 4 is min
+        with pytest.raises(ValueError, match="valid bot_username"):  # too short username, 5 is min
             helpers.create_deep_linked_url("abc", None)
+        with pytest.raises(ValueError, match="valid bot_username"):  # 4 chars is still too short
+            helpers.create_deep_linked_url("abcd", None)
 
     @pytest.mark.parametrize("message_type", list(MessageType))
     @pytest.mark.parametrize("entity_type", [Update, Message])


### PR DESCRIPTION
Closes #5284

## Bug

`create_deep_linked_url` validated `bot_username` with `len(bot_username) <= 3`, so a 4-character username (e.g. `"xbot"`) passed without error. The [Telegram docs](https://core.telegram.org/bots/features#deep-linking) explicitly state that usernames must be **5-32 characters long**.

## Fix

- Changed the guard from `len(bot_username) <= 3` to `len(bot_username) < 5`.
- Updated the Raises docstring from "less than 4 characters" to "less than 5 characters".
- Added a new test case confirming that a 4-character username raises `ValueError`.

## Verification

All 183 tests in `tests/test_helpers.py` pass.