### PR TITLE
Use PR label to pass repo secrets to contributor forks

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,12 +1,14 @@
 name: Unit Tests
 on:
-  pull_request:
+  pull_request:  # Runs on the PR merge commit, has no access to repo secrets for forks
     types: [synchronize, reopened, ready_for_review]
     paths:
       - src/telegram/**
       - tests/**
       - .github/workflows/unit_tests.yml
       - pyproject.toml
+  pull_request_target:  # Runs on base branch, has access to repo secrets for forks
+    types: [labeled]
   push:
     branches:
       - master
@@ -15,6 +17,18 @@ permissions: {}
 
 jobs:
   pytest:
+    # Only run on repo pushes, and on PR's labeled `contrib: safe for tests`.
+    if: >-
+        github.event_name == 'push' ||
+        (
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        ) ||
+        (
+          github.event_name == 'pull_request_target' &&
+          github.event.label.name == 'contrib: safe for tests' &&
+          github.event.pull_request.head.repo.full_name != github.repository
+        )
     name: pytest
     runs-on: ${{matrix.os}}
     strategy:
@@ -28,6 +42,14 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          repository: >-
+            ${{ github.event_name == 'pull_request_target'
+                && github.event.pull_request.head.repo.full_name
+                || github.repository }}
+          ref: >-
+            ${{ github.event_name == 'pull_request_target'
+                && github.event.pull_request.head.sha
+                || github.sha }}
           persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/changes/unreleased/5302.bhpiKviDS5QTSKncz35DN2.toml
+++ b/changes/unreleased/5302.bhpiKviDS5QTSKncz35DN2.toml
@@ -1,0 +1,5 @@
+internal = "Use PR label to pass repo secrets to contributor forks"
+[[pull_requests]]
+uid = "5302"
+author_uids = ["harshil21"]
+closes_threads = []


### PR DESCRIPTION
Something overlooked in #5280 was that contributor forks would not get the BOTS environment variable in github actions. The secret is only available if you do a `pull_request_target`. So from now on, we will have to label the PR: `contrib: safe for tests` on every new commit we want to run tests on. 

Not sure if there is a better solution which doesn't require us doing that, but this manual control is okay with me. 

Only way to test this would be to merge I suppose.. Should hopefully fix the failures in #5297 