### PR TITLE
Reduce pytest collection time by 80%

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -82,9 +82,6 @@
   // Increase the number of PR's Renovate can create in a hour. Default is 2.
   "prHourlyLimit": 5,
 
-  // Temporarily disabled:
-  "ignoreDeps": ["pytest-asyncio"],
-
   // schedule to allow PR's from Renovate:
   "schedule": ["* * * * 0"]  // Every Sunday
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ tests = [
     # For the test suite
     "pytest==9.1.1",
     # needed because pytest doesn't come with native support for coroutines as tests
-    "pytest-asyncio==0.21.2",
+    "pytest-asyncio==1.4.0",
     # xdist runs tests in parallel
     "pytest-xdist==3.8.0",
     # no_req tests must be fully offline, including during higher-scoped fixture setup
@@ -231,6 +231,8 @@ markers = [
     "req",
 ]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "session"
+asyncio_default_test_loop_scope = "session"
 log_cli_format = "%(funcName)s - Line %(lineno)d - %(message)s"
 # log_cli_level = "DEBUG"  # uncomment to see DEBUG logs
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,9 +16,7 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-import asyncio
 import os
-import sys
 import zoneinfo
 from pathlib import Path
 from uuid import uuid4
@@ -103,19 +101,6 @@ def PTB_TIMEDELTA(request):
         monkeypatch.delenv("PTB_TIMEDELTA", raising=False)
     yield env_var_2_bool(os.getenv("PTB_TIMEDELTA"))
     monkeypatch.undo()
-
-
-# Redefine the event_loop fixture to have a session scope. Otherwise `bot` fixture can't be
-# session. See https://github.com/pytest-dev/pytest-asyncio/issues/68 for more details.
-@pytest.fixture(scope="session")
-def event_loop(request):
-    # ever since ProactorEventLoop became the default in Win 3.8+, the app crashes after the loop
-    # is closed. Hence, we use SelectorEventLoop on Windows to avoid this. See
-    # https://github.com/python/cpython/issues/83413, https://github.com/encode/httpx/issues/914
-    if sys.platform.startswith("win"):
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-    return asyncio.get_event_loop_policy().new_event_loop()
-    # loop.close() # instead of closing here, do that at the every end of the test session
 
 
 @pytest.fixture(scope="session")

--- a/uv.lock
+++ b/uv.lock
@@ -110,6 +110,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1461,14 +1470,16 @@ wheels = [
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.21.2"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
     { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/53/57663d99acaac2fcdafdc697e52a9b1b7d6fcf36616281ff9768a44e7ff3/pytest_asyncio-0.21.2.tar.gz", hash = "sha256:d67738fc232b94b326b9d060750beb16e0074210b98dd8b58a5239fa2a154f45", size = 30656, upload-time = "2024-04-29T13:23:24.738Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/ce/1e4b53c213dce25d6e8b163697fbce2d43799d76fa08eea6ad270451c370/pytest_asyncio-0.21.2-py3-none-any.whl", hash = "sha256:ab664c88bb7998f711d8039cacd4884da6430886ae8bbd4eded552ed2004f16b", size = 13368, upload-time = "2024-04-29T13:23:23.126Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]
@@ -1661,7 +1672,7 @@ all = [
     { name = "pydantic", marker = "python_full_version >= '3.14'", specifier = ">=2.12.0a1" },
     { name = "pylint", specifier = "==4.0.6" },
     { name = "pytest", specifier = "==9.1.1" },
-    { name = "pytest-asyncio", specifier = "==0.21.2" },
+    { name = "pytest-asyncio", specifier = "==1.4.0" },
     { name = "pytest-cov" },
     { name = "pytest-socket", specifier = "==0.8.0" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
@@ -1697,7 +1708,7 @@ tests = [
     { name = "build" },
     { name = "flaky", specifier = ">=3.8.1" },
     { name = "pytest", specifier = "==9.1.1" },
-    { name = "pytest-asyncio", specifier = "==0.21.2" },
+    { name = "pytest-asyncio", specifier = "==1.4.0" },
     { name = "pytest-cov" },
     { name = "pytest-socket", specifier = "==0.8.0" },
     { name = "pytest-xdist", specifier = "==3.8.0" },


### PR DESCRIPTION
One of the annoying things about running pytest now is that the collection time on my computer takes a really long time, over 8 seconds for me. I thought this was a good exploratory problem for AI to solve and damn did it do a good job - collection time is now less than 2 seconds for me.

It bumps `pytest-asyncio` to the latest version which solves the collection time issue, so I guess this is a 2 birds 1 stone situation.

Also deleted the windows event loop workaround, let's see if those tests pass normally now. 
