### PR TITLE
Fix improper Sequence check for empty string input

### DIFF
--- a/changes/unreleased/5308.HzaS8Voh4Avaaq8yieH55r.toml
+++ b/changes/unreleased/5308.HzaS8Voh4Avaaq8yieH55r.toml
@@ -1,4 +1,4 @@
-bugfixes = "Handle caption='' correctly ``copy_message`` when using ``telegram.ext.Defaults``"
+bugfixes = "Handle caption='' correctly for ``copy_message`` when using ``telegram.ext.Defaults``"
 [[pull_requests]]
 uid = "5308"
 author_uids = ["harshil21"]

--- a/changes/unreleased/5308.HzaS8Voh4Avaaq8yieH55r.toml
+++ b/changes/unreleased/5308.HzaS8Voh4Avaaq8yieH55r.toml
@@ -1,4 +1,4 @@
-other = "Fix improper Sequence check for empty string input"
+bugfixes = "Handle caption='' correctly ``copy_message`` when using ``telegram.ext.Defaults``"
 [[pull_requests]]
 uid = "5308"
 author_uids = ["harshil21"]

--- a/changes/unreleased/5308.HzaS8Voh4Avaaq8yieH55r.toml
+++ b/changes/unreleased/5308.HzaS8Voh4Avaaq8yieH55r.toml
@@ -1,0 +1,5 @@
+other = "Fix improper Sequence check for empty string input"
+[[pull_requests]]
+uid = "5308"
+author_uids = ["harshil21"]
+closes_threads = ["5307"]

--- a/src/telegram/ext/_extbot.py
+++ b/src/telegram/ext/_extbot.py
@@ -519,8 +519,10 @@ class ExtBot(Bot, Generic[RLARGS]):
                 data[key] = new_value
 
             # 6)
-            elif isinstance(val, Sequence) and all(
-                isinstance(obj, InputPollOption) for obj in val
+            elif (
+                isinstance(val, Sequence)
+                and val  # Check that the sequence is not empty, as all() returns True for []
+                and all(isinstance(obj, InputPollOption) for obj in val)
             ):
                 new_val = []
                 for option in val:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2520,6 +2520,20 @@ class TestBotWithoutRequest:
         monkeypatch.setattr(default_bot.request, "post", make_assertion)
         await default_bot.copy_message(chat_id, 1, 1, reply_parameters=ReplyParameters(**kwargs))
 
+    @pytest.mark.parametrize("default_bot", [{"allow_sending_without_reply": True}], indirect=True)
+    async def test_copy_message_empty_caption_with_defaults(
+        self, default_bot, chat_id, monkeypatch
+    ):
+        async def make_assertion(url, request_data: RequestData, *args, **kwargs):
+            assert request_data.parameters["caption"] == ""
+            assert request_data.json_parameters["caption"] == ""
+            return {"message_id": 1}
+
+        monkeypatch.setattr(default_bot.request, "post", make_assertion)
+        message_id = await default_bot.copy_message(chat_id, chat_id, 1, caption="")
+
+        assert message_id.message_id == 1
+
     async def test_do_api_request_camel_case_conversion(self, offline_bot, monkeypatch):
         async def make_assertion(url, request_data: RequestData, *args, **kwargs):
             return url.endswith("camelCase")


### PR DESCRIPTION
Closes #5307 

Hard to notice immediately, but this bug happened because: `""` is a `Sequence` type, and `all([])` returns True, so everything in the block runs. 