### PR TITLE
fix: correct bot_username length validation in create_deep_linked_url()

### DIFF
--- a/src/telegram/helpers.py
+++ b/src/telegram/helpers.py
@@ -178,10 +178,10 @@ def create_deep_linked_url(
     Raises:
         :exc:`ValueError`: If the length of the :paramref:`payload` exceeds \
         :tg-const:`telegram.constants.MessageLimit.DEEP_LINK_LENGTH` characters,
-            contains invalid characters, or if the :paramref:`bot_username` is less than 4
+            contains invalid characters, or if the :paramref:`bot_username` is less than 5
             characters.
     """
-    if bot_username is None or len(bot_username) <= 3:
+    if bot_username is None or len(bot_username) < 5:
         raise ValueError("You must provide a valid bot_username.")
 
     base_url = f"https://t.me/{bot_username}"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -113,8 +113,10 @@ class TestHelpers:
 
         with pytest.raises(ValueError, match="valid bot_username"):
             helpers.create_deep_linked_url(None, None)
-        with pytest.raises(ValueError, match="valid bot_username"):  # too short username, 4 is min
+        with pytest.raises(ValueError, match="valid bot_username"):  # too short username, 5 is min
             helpers.create_deep_linked_url("abc", None)
+        with pytest.raises(ValueError, match="valid bot_username"):  # 4 chars, still too short
+            helpers.create_deep_linked_url("abcd", None)
 
     @pytest.mark.parametrize("message_type", list(MessageType))
     @pytest.mark.parametrize("entity_type", [Update, Message])


### PR DESCRIPTION
## Description

Telegram requires bot usernames to be 5-32 characters long.
The previous check `len(bot_username) <= 3` incorrectly accepted
4-character usernames. Changed to `len(bot_username) < 5` to match
Telegram's actual minimum.

Also updated the docstring and added a test case for 4-char usernames.

Fixes python-telegram-bot/python-telegram-bot#5284