### PR TITLE
Fix create_deep_linked_url accepting 4-character bot usernames

### DIFF
--- a/src/telegram/helpers.py
+++ b/src/telegram/helpers.py
@@ -178,10 +178,10 @@ def create_deep_linked_url(
     Raises:
         :exc:`ValueError`: If the length of the :paramref:`payload` exceeds \
         :tg-const:`telegram.constants.MessageLimit.DEEP_LINK_LENGTH` characters,
-            contains invalid characters, or if the :paramref:`bot_username` is less than 4
+            contains invalid characters, or if the :paramref:`bot_username` is less than 5
             characters.
     """
-    if bot_username is None or len(bot_username) <= 3:
+    if bot_username is None or len(bot_username) <= 4:
         raise ValueError("You must provide a valid bot_username.")
 
     base_url = f"https://t.me/{bot_username}"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -113,8 +113,8 @@ class TestHelpers:
 
         with pytest.raises(ValueError, match="valid bot_username"):
             helpers.create_deep_linked_url(None, None)
-        with pytest.raises(ValueError, match="valid bot_username"):  # too short username, 4 is min
-            helpers.create_deep_linked_url("abc", None)
+        with pytest.raises(ValueError, match="valid bot_username"):  # too short username, 5 is min
+            helpers.create_deep_linked_url("abcd", None)
 
     @pytest.mark.parametrize("message_type", list(MessageType))
     @pytest.mark.parametrize("entity_type", [Update, Message])


### PR DESCRIPTION
Closes #5284

`create_deep_linked_url` guarded `bot_username` with `len(bot_username) <= 3`, so a 4-character username was accepted and produced a URL Telegram cannot resolve; [Telegram requires usernames to be 5-32 characters](https://core.telegram.org/bots/features#deep-linking). The guard now rejects anything under 5 characters, and the docstring states the correct minimum.

Per @harshil21's review on the earlier #5285, I kept a single test: the existing too-short-username assertion in `tests/test_helpers.py` now uses a 4-character name. It fails without the source change (`DID NOT RAISE ValueError`) and passes with it; `tests/test_helpers.py` is 183 passed, ruff check and format clean.

I did not add the `changes/unreleased/*.toml` chango fragment — happy to push it, or it can be added with the suggested wording: `bugfixes = "Fixed ``create_deep_linked_url`` silently accepting 4-character bot usernames"`.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
