### PR TITLE
Fix docstring Args entries that name a parameter the class does not take

### DIFF
--- a/changes/unreleased/5326.OAIUA0X9LFJzA48BR7mpvg.toml
+++ b/changes/unreleased/5326.OAIUA0X9LFJzA48BR7mpvg.toml
@@ -1,0 +1,5 @@
+documentation = """Removed six \Args\ entries that named a parameter the callable does not accept: 	ype\ on the four \PaidMedia\ subclasses, ile\ on \decrypt\, and \proxy\ on \ApplicationBuilder.get_updates_proxy\."""
+[[pull_requests]]
+uid = "5326"
+author_uids = ["darkdi"]
+closes_threads = []

--- a/changes/unreleased/5326.OAIUA0X9LFJzA48BR7mpvg.toml
+++ b/changes/unreleased/5326.OAIUA0X9LFJzA48BR7mpvg.toml
@@ -1,4 +1,4 @@
-documentation = """Removed six \Args\ entries that named a parameter the callable does not accept: 	ype\ on the four \PaidMedia\ subclasses, ile\ on \decrypt\, and \proxy\ on \ApplicationBuilder.get_updates_proxy\."""
+documentation = """Removed six ``Args`` entries that named a parameter the callable does not accept: ``type`` on the four ``PaidMedia`` subclasses, ``file`` on ``decrypt``, and ``proxy`` on ``ApplicationBuilder.get_updates_proxy``."""
 [[pull_requests]]
 uid = "5326"
 author_uids = ["darkdi"]

--- a/src/telegram/_paidmedia.py
+++ b/src/telegram/_paidmedia.py
@@ -106,7 +106,6 @@ class PaidMediaPreview(PaidMedia):
        equality comparison now considers integer durations and equivalent timedeltas as equal.
 
     Args:
-        type (:obj:`str`): Type of the paid media, always :tg-const:`telegram.PaidMedia.PREVIEW`.
         width (:obj:`int`, optional): Media width as defined by the sender.
         height (:obj:`int`, optional): Media height as defined by the sender.
         duration (:obj:`int` | :class:`datetime.timedelta`, optional): Duration of the media in
@@ -160,7 +159,6 @@ class PaidMediaPhoto(PaidMedia):
     .. versionadded:: 21.4
 
     Args:
-        type (:obj:`str`): Type of the paid media, always :tg-const:`telegram.PaidMedia.PHOTO`.
         photo (Sequence[:class:`telegram.PhotoSize`]): The photo.
 
     Attributes:
@@ -194,7 +192,6 @@ class PaidMediaVideo(PaidMedia):
     .. versionadded:: 21.4
 
     Args:
-        type (:obj:`str`): Type of the paid media, always :tg-const:`telegram.PaidMedia.VIDEO`.
         video (:class:`telegram.Video`): The video.
 
     Attributes:
@@ -228,7 +225,6 @@ class PaidMediaLivePhoto(PaidMedia):
     .. versionadded:: 22.8
 
     Args:
-        type (:obj:`str`): Type of the paid media, always :tg-const:`telegram.PaidMedia.LIVE_PHOTO`
         live_photo (:class:`telegram.LivePhoto`): The photo.
 
     Attributes:

--- a/src/telegram/_passport/credentials.py
+++ b/src/telegram/_passport/credentials.py
@@ -57,8 +57,6 @@ def decrypt(secret, hash, data):
             base64 encoded string.
         data (:obj:`str` or :obj:`bytes`): The data to decrypt, either as bytes or as a
             base64 encoded string.
-        file (:obj:`bool`): Force data to be treated as raw data, instead of trying to
-            b64decode it.
 
     Raises:
         :class:`PassportDecryptionError`: Given hash does not match hash of decrypted data.

--- a/src/telegram/ext/_applicationbuilder.py
+++ b/src/telegram/ext/_applicationbuilder.py
@@ -737,8 +737,8 @@ class ApplicationBuilder(Generic[BT, CCT, UD, CD, BD, JQ]):
         .. versionadded:: 20.7
 
         Args:
-            proxy (:obj:`str` | ``httpx.Proxy`` | ``httpx.URL``): The URL to a proxy server,
-                a ``httpx.Proxy`` object or a ``httpx.URL`` object. See
+            get_updates_proxy (:obj:`str` | ``httpx.Proxy`` | ``httpx.URL``): The URL to a
+                proxy server, a ``httpx.Proxy`` object or a ``httpx.URL`` object. See
                 :paramref:`telegram.request.HTTPXRequest.proxy` for more information.
 
         Returns:


### PR DESCRIPTION
Six `Args:` entries name something the callable does not take.

Four are the `PaidMedia` subclasses. Each documents `type` under `Args:`, but none of their `__init__` takes it: `super().__init__(type=PaidMedia.PREVIEW)` and so on. `MessageOrigin*` is built exactly the same way and documents `type` only under `Attributes:`, which is what made me read these as a slip rather than a house style. The `Attributes:` entry stays in all four.

`decrypt` documents a `file` argument it does not have, and `ApplicationBuilder.get_updates_proxy` documents `proxy`, copied from the `proxy` method above it. That one had to be rewrapped to stay under 99 characters.

`ruff check` and `ruff format --check` are clean on the three files with the pinned `ruff==0.16.0`. If the `type` entries are deliberate I will drop that part of the change.
