### PR TITLE
Agent/fix falsy callback data

### DIFF
--- a/changes/unreleased/3.falsy-callback-data.toml
+++ b/changes/unreleased/3.falsy-callback-data.toml
@@ -1,0 +1,5 @@
+bugfixes = "Fixed ``CallbackQueryHandler`` incorrectly ignoring falsy ``callback_data`` values when a ``pattern`` is configured."
+[[pull_requests]]
+uid = "3"
+author_uids = ["Vamp1reAchao"]
+closes_threads = []

--- a/src/telegram/ext/_handlers/callbackqueryhandler.py
+++ b/src/telegram/ext/_handlers/callbackqueryhandler.py
@@ -170,7 +170,7 @@ class CallbackQueryHandler(BaseHandler[Update, CCT, RT]):
 
         # we check for .data or .game_short_name from update to filter based on whats coming
         # this gives xor-like behavior
-        if callback_data:
+        if callback_data is not None:
             if not self.pattern:
                 return False
             if isinstance(self.pattern, type):

--- a/tests/ext/test_callbackqueryhandler.py
+++ b/tests/ext/test_callbackqueryhandler.py
@@ -145,6 +145,34 @@ class TestCallbackQueryHandler:
         callback_query.callback_query.data = InvalidCallbackData()
         assert not handler.check_update(callback_query)
 
+    @pytest.mark.parametrize(
+        ("data", "pattern"),
+        [
+            (False, str),
+            (0, str),
+            ("", ".+"),
+        ],
+    )
+    def test_falsy_callback_data_is_filtered(self, callback_query, data, pattern):
+        handler = CallbackQueryHandler(self.callback_basic, pattern=pattern)
+
+        callback_query.callback_query.data = data
+
+        assert not handler.check_update(callback_query)
+
+    def test_falsy_callback_data_is_passed_to_callable_pattern(self, callback_query):
+        seen = []
+
+        def pattern(callback_data):
+            seen.append(callback_data)
+            return False
+
+        handler = CallbackQueryHandler(self.callback_basic, pattern=pattern)
+        callback_query.callback_query.data = False
+
+        assert not handler.check_update(callback_query)
+        assert seen == [False]
+
     def test_with_callable_pattern(self, callback_query):
         class CallbackData:
             pass


### PR DESCRIPTION
Fixed CallbackQueryHandler incorrectly ignoring falsy callback_data values such as False, 0, and "" when a pattern is configured. Added regression tests.