### PR TITLE
Add `filters.IS_BOT`

### DIFF
--- a/src/telegram/ext/filters.py
+++ b/src/telegram/ext/filters.py
@@ -60,6 +60,7 @@ __all__ = (
     "HAS_PROTECTED_CONTENT",
     "INVOICE",
     "IS_AUTOMATIC_FORWARD",
+    "IS_BOT",
     "IS_FROM_OFFLINE",
     "IS_TOPIC_MESSAGE",
     "LIVE_PHOTO",
@@ -1590,6 +1591,31 @@ IS_AUTOMATIC_FORWARD = _IsAutomaticForward(name="filters.IS_AUTOMATIC_FORWARD")
 """Messages that contain :attr:`telegram.Message.is_automatic_forward`.
 
     .. versionadded:: 13.9
+"""
+
+
+class _IsBot(UpdateFilter):
+    __slots__ = ()
+
+    def filter(self, update: Update) -> bool:
+        # Updates without a user, e.g. channel posts, are not sent by a bot
+        return bool(update.effective_user) and bool(
+            update.effective_user.is_bot  # type: ignore
+        )
+
+
+IS_BOT = _IsBot(name="filters.IS_BOT")
+"""This filter filters *any* message that has a :attr:`bot <telegram.User.is_bot>` as
+:attr:`telegram.Update.effective_user`.
+
+Note:
+    In groups, a bot only receives messages sent by other bots if
+    :attr:`telegram.User.can_read_all_group_messages` is :obj:`True` for it, i.e. if privacy
+    mode is disabled.
+
+.. seealso:: :attr:`telegram.ext.filters.VIA_BOT`
+
+.. versionadded:: NEXT.VERSION
 """
 
 

--- a/tests/ext/test_filters.py
+++ b/tests/ext/test_filters.py
@@ -2161,6 +2161,16 @@ class TestFilters:
         update.message.is_automatic_forward = True
         assert filters.IS_AUTOMATIC_FORWARD.check_update(update)
 
+    def test_filters_is_bot(self, update):
+        assert not filters.IS_BOT.check_update(update)
+        update.message.from_user.is_bot = True
+        assert filters.IS_BOT.check_update(update)
+
+    def test_filters_is_bot_without_user(self):
+        # channel posts have no `from_user`, so there is no user to look at
+        update = Update(0, channel_post=Message(0, dtm.datetime.utcnow(), Chat(0, Chat.CHANNEL)))
+        assert not filters.IS_BOT.check_update(update)
+
     def test_filters_is_from_offline(self, update):
         assert not filters.IS_FROM_OFFLINE.check_update(update)
         update.message.is_from_offline = True


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

Adds `filters.IS_BOT`, a ready to use filter that matches updates whose `telegram.Update.effective_user` is a bot. Until now nothing in the filters module exposed `telegram.User.is_bot`, so telling bot authored messages apart from human ones had to happen inside the callback. With this filter the decision can be made at handler registration time, and `~filters.IS_BOT` covers the human only case.

The filter is implemented as an `UpdateFilter` over `Update.effective_user`, which is the same approach the existing `PREMIUM_USER` and `USER_ATTACHMENT` filters take for other `telegram.User` attributes. It returns `False` when the update carries no user at all, for example for channel posts.

The docstring also points out that in groups a bot only receives messages from other bots when privacy mode is disabled, since that is the setting that decides whether the filter can ever match in a multi bot chat.

Fixes #5315.

## Check-list for PRs

- [x] Added `.. versionadded:: NEXT.VERSION`, ``.. versionchanged:: NEXT.VERSION``, ``.. deprecated:: NEXT.VERSION`` or ``.. versionremoved:: NEXT.VERSION` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [x] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)
- [x] Added new classes & modules to the docs and all suitable ``__all__`` s
- [ ] Checked the [Stability Policy](https://docs.python-telegram-bot.org/stability_policy.html) in case of deprecations or changes to documented behavior