### PR TITLE
Forward pool timeouts to polling error callbacks

### DIFF
--- a/src/telegram/error.py
+++ b/src/telegram/error.py
@@ -37,6 +37,7 @@ __all__ = (
     "InvalidToken",
     "NetworkError",
     "PassportDecryptionError",
+    "PoolTimeout",
     "RetryAfter",
     "TelegramError",
     "TimedOut",
@@ -177,6 +178,24 @@ class TimedOut(NetworkError):
 
     def __init__(self, message: str | None = None) -> None:
         super().__init__(message or "Timed out")
+
+
+class PoolTimeout(TimedOut):
+    """Raised when a request could not acquire a connection from the connection pool in time.
+
+    This is a subclass of :class:`TimedOut` to preserve compatibility with code handling all
+    request timeouts.
+
+    .. versionadded:: NEXT.VERSION
+
+    Args:
+        message (:obj:`str`, optional): Any additional information about the exception.
+    """
+
+    __slots__ = ()
+
+    def __init__(self, message: str | None = None) -> None:
+        super().__init__(message or "Pool timed out")
 
 
 class ChatMigrated(TelegramError):

--- a/src/telegram/ext/_utils/networkloop.py
+++ b/src/telegram/ext/_utils/networkloop.py
@@ -36,7 +36,7 @@ import contextlib
 from collections.abc import Callable, Coroutine
 
 from telegram._utils.logging import get_logger
-from telegram.error import InvalidToken, RetryAfter, TelegramError, TimedOut
+from telegram.error import InvalidToken, PoolTimeout, RetryAfter, TelegramError, TimedOut
 
 _LOGGER = get_logger(__name__)
 
@@ -169,6 +169,17 @@ async def network_retry_loop(
             exception_info = f"{exc}. Adding {slack_time} seconds to the specified time."
 
             # Check max_retries for RetryAfter as well
+            if check_max_retries_and_log(retries, exception_info):
+                raise
+        except PoolTimeout as pool_timeout:
+            # Unlike regular request timeouts, pool exhaustion should be observable by callers.
+            if on_err_cb:
+                on_err_cb(pool_timeout)
+
+            # If failure is due to timeout, we should retry asap.
+            cur_interval = 0
+            exception_info = f"Pool timed out: {pool_timeout}."
+
             if check_max_retries_and_log(retries, exception_info):
                 raise
         except TimedOut as toe:

--- a/src/telegram/request/_httpxrequest.py
+++ b/src/telegram/request/_httpxrequest.py
@@ -26,7 +26,7 @@ import httpx
 from telegram._utils.defaultvalue import DefaultValue
 from telegram._utils.logging import get_logger
 from telegram._utils.types import HTTPVersion, ODVInput, SocketOpt
-from telegram.error import NetworkError, TimedOut
+from telegram.error import NetworkError, PoolTimeout, TimedOut
 from telegram.request._baserequest import BaseRequest
 from telegram.request._requestdata import RequestData
 
@@ -79,9 +79,13 @@ class HTTPXRequest(BaseRequest):
             Defaults to ``1``.
 
             Warning:
-                With a finite pool timeout, you must expect :exc:`telegram.error.TimedOut`
+                With a finite pool timeout, you must expect :exc:`telegram.error.PoolTimeout`
                 exceptions to be thrown when more requests are made simultaneously than there are
                 connections in the connection pool!
+
+                .. versionchanged:: NEXT.VERSION
+                    Raises :exc:`telegram.error.PoolTimeout`, a subclass of
+                    :exc:`telegram.error.TimedOut`, instead of :exc:`telegram.error.TimedOut`.
         http_version (:obj:`str`, optional): If ``"2"`` or ``"2.0"``, HTTP/2 will be used instead
             of HTTP/1.1. Defaults to ``"1.1"``.
 
@@ -286,7 +290,7 @@ class HTTPXRequest(BaseRequest):
             )
         except httpx.TimeoutException as err:
             if isinstance(err, httpx.PoolTimeout):
-                raise TimedOut(
+                raise PoolTimeout(
                     message=(
                         "Pool timeout: All connections in the connection pool are occupied. "
                         "Request was *not* sent to Telegram. Consider adjusting the connection "

--- a/tests/ext/_utils/test_networkloop.py
+++ b/tests/ext/_utils/test_networkloop.py
@@ -26,7 +26,7 @@ Note:
 
 import pytest
 
-from telegram.error import InvalidToken, RetryAfter, TelegramError, TimedOut
+from telegram.error import InvalidToken, PoolTimeout, RetryAfter, TelegramError, TimedOut
 from telegram.ext._utils.networkloop import network_retry_loop
 
 
@@ -193,6 +193,30 @@ class TestNetworkRetryLoop:
         # Should be called 3 times (initial + 2 retries)
         assert error_callback_count == 3
         assert isinstance(caught_exception, TelegramError)
+
+    async def test_error_callback_called_for_pool_timeout(self):
+        """Test that pool timeouts are observable while regular timeouts remain silent."""
+        pool_timeout = PoolTimeout("Test pool timeout")
+        error_callback_count = 0
+
+        def error_callback(exc):
+            nonlocal error_callback_count
+            error_callback_count += 1
+            assert exc is pool_timeout
+
+        async def action_with_pool_timeout():
+            raise pool_timeout
+
+        with pytest.raises(PoolTimeout):
+            await network_retry_loop(
+                action_cb=action_with_pool_timeout,
+                on_err_cb=error_callback,
+                description="Test PoolTimeout callback",
+                interval=0,
+                max_retries=2,
+            )
+
+        assert error_callback_count == 3
 
     async def test_success_after_retries(self):
         """Test that action succeeds after some retries."""

--- a/tests/ext/test_updater.py
+++ b/tests/ext/test_updater.py
@@ -28,7 +28,7 @@ from random import randrange
 import pytest
 
 from telegram import Bot, InlineKeyboardButton, InlineKeyboardMarkup, Update
-from telegram.error import InvalidToken, RetryAfter, TelegramError, TimedOut
+from telegram.error import InvalidToken, PoolTimeout, RetryAfter, TelegramError, TimedOut
 from telegram.ext import ExtBot, InvalidCallbackData, Updater
 from tests.auxil.build_messages import make_message, make_message_update
 from tests.auxil.envvars import TEST_WITH_OPT_DEPS
@@ -492,10 +492,11 @@ class TestUpdater:
         ("error", "callback_should_be_called"),
         argvalues=[
             (TelegramError("TestMessage"), True),
+            (PoolTimeout("TestMessage"), True),
             (RetryAfter(1), False),
             (TimedOut("TestMessage"), False),
         ],
-        ids=("TelegramError", "RetryAfter", "TimedOut"),
+        ids=("TelegramError", "PoolTimeout", "RetryAfter", "TimedOut"),
     )
     @pytest.mark.parametrize("custom_error_callback", [True, False])
     async def test_start_polling_exceptions_and_error_callback(

--- a/tests/request/test_request.py
+++ b/tests/request/test_request.py
@@ -43,6 +43,7 @@ from telegram.error import (
     Forbidden,
     InvalidToken,
     NetworkError,
+    PoolTimeout,
     RetryAfter,
     TelegramError,
     TimedOut,
@@ -658,13 +659,14 @@ class TestHTTPXRequestWithoutRequest:
         monkeypatch.setattr(httpx.AsyncClient, "request", request)
 
         async with HTTPXRequest(pool_timeout=0.02) as httpx_request:
-            with pytest.raises(TimedOut, match="Pool timeout") as exc_info:
+            with pytest.raises(PoolTimeout, match="Pool timeout") as exc_info:
                 await asyncio.gather(
                     httpx_request.do_request(method="GET", url="URL"),
                     httpx_request.do_request(method="GET", url="URL"),
                 )
 
             assert exc_info.value.__cause__ is pool_timeout
+            assert isinstance(exc_info.value, TimedOut)
 
     @pytest.mark.parametrize("media", [True, False])
     async def test_do_request_write_timeout(

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -31,6 +31,7 @@ from telegram.error import (
     InvalidToken,
     NetworkError,
     PassportDecryptionError,
+    PoolTimeout,
     RetryAfter,
     TelegramError,
     TimedOut,
@@ -89,6 +90,10 @@ class TestErrors:
         with pytest.raises(TimedOut, match=r"^Timed out$"):
             raise TimedOut
 
+    def test_pool_timeout(self):
+        with pytest.raises(PoolTimeout, match=r"^Pool timed out$"):
+            raise PoolTimeout
+
     def test_chat_migrated(self):
         with pytest.raises(ChatMigrated, match="New chat id: 1234") as e:
             raise ChatMigrated(1234)
@@ -130,6 +135,7 @@ class TestErrors:
             (NetworkError("test message"), ["message"]),
             (BadRequest("test message"), ["message"]),
             (TimedOut(), ["message"]),
+            (PoolTimeout(), ["message"]),
             (ChatMigrated(1234), ["message", "new_chat_id"]),
             (RetryAfter(12), ["message", "retry_after"]),
             (RetryAfter(dtm.timedelta(seconds=12)), ["message", "retry_after"]),
@@ -157,6 +163,7 @@ class TestErrors:
             (NetworkError("test message")),
             (BadRequest("test message")),
             (TimedOut()),
+            (PoolTimeout()),
             (ChatMigrated(1234)),
             (RetryAfter(dtm.timedelta(seconds=12))),
             (Conflict("test message")),
@@ -198,6 +205,7 @@ class TestErrors:
                     EndPointNotFound,
                 },
                 NetworkError: {BadRequest, TimedOut},
+                TimedOut: {PoolTimeout},
             }
         )
 


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool!
Please be sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
Especially, please have a look at the check list for PRs (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst#check-list-for-prs). Feel free to copy (parts of) the checklist to the PR description to remind you or the maintainers of open points or if you have questions on anything.
-->

This PR makes connection-pool exhaustion observable through polling error callbacks without changing the handling of regular request timeouts.

`HTTPXRequest` currently maps `httpx.PoolTimeout` to `TimedOut`. The polling retry loop intentionally handles every `TimedOut` as an expected request timeout and retries it silently. As a result, `Updater.start_polling(error_callback=...)` cannot distinguish or react to a request that was never sent because no connection was available from the pool.

The change introduces `telegram.error.PoolTimeout` as a subclass of `TimedOut`, translates `httpx.PoolTimeout` to that backend-independent exception, and forwards only `PoolTimeout` to the polling error callback. Existing `except TimedOut` and `isinstance(error, TimedOut)` checks remain compatible, while regular long-poll timeouts retain their current behavior.

## Check-list for PRs

- [x] Added `.. versionadded:: NEXT.VERSION`, ``.. versionchanged:: NEXT.VERSION``, ``.. deprecated:: NEXT.VERSION`` or ``.. versionremoved:: NEXT.VERSION`` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [x] Created new or adapted existing unit tests
- [x] Documented code changes according to the [CSI standard](https://standards.mousepawmedia.com/en/stable/csi.html)
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)
- [x] Added new classes & modules to the docs and all suitable ``__all__`` s
- [x] Checked the [Stability Policy](https://docs.python-telegram-bot.org/stability_policy.html) in case of deprecations or changes to documented behavior

- If Relevant

    - [x] Added or updated documentation for the changed class(es) and/or method(s)