### PR TITLE
Add IS_BOT message filter

### DIFF
--- a/src/telegram/ext/filters.py
+++ b/src/telegram/ext/filters.py
@@ -60,6 +60,7 @@ __all__ = (
     "HAS_PROTECTED_CONTENT",
     "INVOICE",
     "IS_AUTOMATIC_FORWARD",
+    "IS_BOT",
     "IS_FROM_OFFLINE",
     "IS_TOPIC_MESSAGE",
     "LIVE_PHOTO",
@@ -1591,6 +1592,16 @@ IS_AUTOMATIC_FORWARD = _IsAutomaticForward(name="filters.IS_AUTOMATIC_FORWARD")
 
     .. versionadded:: 13.9
 """
+class _IsBot(MessageFilter):
+    __slots__ = ()
+
+    def filter(self, message: Message) -> bool:
+        return bool(message.from_user and message.from_user.is_bot)
+
+
+IS_BOT = _IsBot(name="filters.IS_BOT")
+"""Messages that are sent by a bot.
+""" 
 
 
 class _IsTopicMessage(MessageFilter):

--- a/tests/ext/test_filters.py
+++ b/tests/ext/test_filters.py
@@ -2161,6 +2161,11 @@ class TestFilters:
         update.message.is_automatic_forward = True
         assert filters.IS_AUTOMATIC_FORWARD.check_update(update)
 
+    def test_filters_is_bot(self, update):
+        assert not filters.IS_BOT.check_update(update)
+        update.message.from_user.is_bot = True
+        assert filters.IS_BOT.check_update(update) 
+
     def test_filters_is_from_offline(self, update):
         assert not filters.IS_FROM_OFFLINE.check_update(update)
         update.message.is_from_offline = True


### PR DESCRIPTION
## Summary

- Add an `IS_BOT` message filter to identify messages sent by bots.
- Add tests covering bot and non-bot messages.

## Testing

- `uv run pytest tests/ext/test_filters.py -k "is_bot"`
- 1 passed, 215 deselected
