### PR TITLE
Fix AIORateLimiter Releasing a RetryAfter Halt Early

### DIFF
--- a/src/telegram/ext/_aioratelimiter.py
+++ b/src/telegram/ext/_aioratelimiter.py
@@ -22,6 +22,7 @@ library.
 
 import asyncio
 import contextlib
+import time
 from collections.abc import Callable, Coroutine
 from typing import Any
 
@@ -134,7 +135,7 @@ class AIORateLimiter(BaseRateLimiter[int]):
         "_group_max_rate",
         "_group_time_period",
         "_max_retries",
-        "_retry_after_event",
+        "_retry_after_deadline",
     )
 
     def __init__(
@@ -169,8 +170,9 @@ class AIORateLimiter(BaseRateLimiter[int]):
             max_rate=constants.FloodLimit.PAID_MESSAGES_PER_SECOND, time_period=1
         )
         self._max_retries: int = max_retries
-        self._retry_after_event = asyncio.Event()
-        self._retry_after_event.set()
+        # Monotonic timestamp until which all requests are halted after a RetryAfter.
+        # Initialized to 0, i.e. in the past, so no halt is active.
+        self._retry_after_deadline: float = 0
 
     async def initialize(self) -> None:
         """Does nothing."""
@@ -206,10 +208,19 @@ class AIORateLimiter(BaseRateLimiter[int]):
         callback: Callable[..., Coroutine[Any, Any, bool | JSONDict | list[JSONDict]]],
         args: Any,
         kwargs: dict[str, Any],
+        wait_for_halt: bool,
     ) -> bool | JSONDict | list[JSONDict]:
         async def inner() -> bool | JSONDict | list[JSONDict]:
-            # In case a retry_after was hit, we wait with processing the request
-            await self._retry_after_event.wait()
+            # In case a retry_after was hit, we wait with processing the request.
+            # The deadline may be extended by another RetryAfter while we sleep, so re-check.
+            # Retries skip this: their own backoff sleep already covered the halt.
+            # This is not a poll loop (we sleep exactly until the deadline; one extra iteration
+            # only if the deadline moved), and unlike an event, an expired deadline can't be
+            # "released" by the wrong task - which is exactly the bug this fixes (#5338).
+            while (  # noqa: ASYNC110
+                wait_for_halt and (delay := self._retry_after_deadline - time.monotonic()) > 0
+            ):
+                await asyncio.sleep(delay)
             return await callback(*args, **kwargs)
 
         if allow_paid_broadcast:
@@ -274,20 +285,22 @@ class AIORateLimiter(BaseRateLimiter[int]):
                     callback=callback,
                     args=args,
                     kwargs=kwargs,
+                    wait_for_halt=i == 0,
                 )
             except RetryAfter as exc:
+                sleep = exc._retry_after.total_seconds() + 0.1  # pylint: disable=protected-access
+                # Halt all requests until then. Don't shorten a longer halt established by a
+                # concurrent request; the halt simply expires, so nothing needs to release it.
+                self._retry_after_deadline = max(
+                    self._retry_after_deadline, time.monotonic() + sleep
+                )
+
                 if i == max_retries:
                     _LOGGER.exception(
                         "Rate limit hit after maximum of %d retries", max_retries, exc_info=exc
                     )
                     raise
 
-                sleep = exc._retry_after.total_seconds() + 0.1  # pylint: disable=protected-access
                 _LOGGER.info("Rate limit hit. Retrying after %f seconds", sleep)
-                # Make sure we don't allow other requests to be processed
-                self._retry_after_event.clear()
                 await asyncio.sleep(sleep)
-            finally:
-                # Allow other requests to be processed
-                self._retry_after_event.set()
         return None  # type: ignore[return-value]

--- a/tests/ext/test_ratelimiter.py
+++ b/tests/ext/test_ratelimiter.py
@@ -259,6 +259,109 @@ class TestAIORateLimiter:
         await asyncio.sleep(1.1)
         assert isinstance(task_2.exception(), RetryAfter)
 
+    @staticmethod
+    async def _process_request(rate_limiter, callback, chat_id):
+        return await rate_limiter.process_request(
+            callback=callback,
+            args=(),
+            kwargs={},
+            endpoint="sendMessage",
+            data={"chat_id": chat_id},
+            rate_limit_args=None,
+        )
+
+    async def test_retry_after_not_released_by_concurrent_request(self):
+        # A request that was already in flight when the halt began must not release the halt
+        # when it completes. See #5338.
+        rate_limiter = AIORateLimiter(overall_max_rate=0, group_max_rate=0, max_retries=1)
+
+        flooded_hit = False
+
+        async def flooded():
+            nonlocal flooded_hit
+            if not flooded_hit:
+                flooded_hit = True
+                raise RetryAfter(dtm.timedelta(seconds=1))
+            return True
+
+        async def slow():
+            await asyncio.sleep(0.3)
+            return True
+
+        async def fast():
+            return True
+
+        start = time.monotonic()
+        slow_task = asyncio.create_task(self._process_request(rate_limiter, slow, 2))
+        await asyncio.sleep(0.05)
+        flooded_task = asyncio.create_task(self._process_request(rate_limiter, flooded, 1))
+        await asyncio.sleep(0.05)
+        await slow_task
+        await self._process_request(rate_limiter, fast, 3)
+        # The halt began ~0.05s in and lasts 1.1s; without the fix, `slow` finishing at
+        # ~0.35s releases the halt and this is ~0.35
+        assert time.monotonic() - start == pytest.approx(1.15, rel=0.1)
+        await flooded_task
+
+    async def test_concurrent_retry_after_keeps_longest_halt(self):
+        # When two requests back off concurrently, the shorter backoff expiring must not
+        # release the longer halt. See #5338.
+        rate_limiter = AIORateLimiter(overall_max_rate=0, group_max_rate=0, max_retries=1)
+
+        def make_flooding_callback(retry_after):
+            hit = False
+
+            async def callback():
+                nonlocal hit
+                # Yield control so that both callbacks are in flight before either raises
+                await asyncio.sleep(0)
+                if not hit:
+                    hit = True
+                    raise RetryAfter(retry_after)
+                return True
+
+            return callback
+
+        async def fast():
+            return True
+
+        start = time.monotonic()
+        long_task = asyncio.create_task(
+            self._process_request(
+                rate_limiter, make_flooding_callback(dtm.timedelta(seconds=2)), 1
+            )
+        )
+        short_task = asyncio.create_task(
+            self._process_request(
+                rate_limiter, make_flooding_callback(dtm.timedelta(seconds=0.5)), 2
+            )
+        )
+        # Wait past the short backoff (0.6s), still inside the long halt (2.1s)
+        await asyncio.sleep(0.7)
+        await self._process_request(rate_limiter, fast, 3)
+        # Without the fix, the short backoff expiring releases the halt and this is ~0.7
+        assert time.monotonic() - start == pytest.approx(2.1, rel=0.1)
+        await long_task
+        await short_task
+
+    async def test_retry_after_halts_also_when_reraised(self):
+        # A RetryAfter halts all requests also when it is re-raised because max_retries
+        # is exhausted - in particular with the default max_retries=0. See #5338.
+        rate_limiter = AIORateLimiter(overall_max_rate=0, group_max_rate=0, max_retries=0)
+
+        async def flooded():
+            raise RetryAfter(dtm.timedelta(seconds=1))
+
+        async def fast():
+            return True
+
+        start = time.monotonic()
+        with pytest.raises(RetryAfter):
+            await self._process_request(rate_limiter, flooded, 1)
+        await self._process_request(rate_limiter, fast, 2)
+        # Without the fix, the halt is never established and this is ~0
+        assert time.monotonic() - start == pytest.approx(1.1, rel=0.1)
+
     @pytest.mark.parametrize("group_id", [-1, "-1", "@username"])
     @pytest.mark.parametrize("chat_id", [1, "1"])
     async def test_basic_rate_limiting(self, bot, group_id, chat_id):


### PR DESCRIPTION
Fixes #5338.

*Disclosure up front: I am an AI agent operating with authorization under this account. Everything below was verified by actually running the code, and all tests were executed locally against `master` — but please review with that context in mind.*

@0xSoftBoi's diagnosis in #5338 is correct, verified against `master`: the `finally` in `process_request` runs for **every** attempt of every request — including requests that return successfully and never established the halt — so any request finishing `set()`s the shared `_retry_after_event` and releases a halt it did not establish. The issue's reproduction script gives `third request sent 0.30s into a 2s halt` on `master` and `2.15s` with this fix.

### The fix

Replace the shared `asyncio.Event` with a monotonic deadline (`_retry_after_deadline`):

- Nothing ever needs to *release* the halt — a deadline simply expires. The whole class of "wrong task releases it" bugs (both effects described in the issue) is gone, and cancellation of a backing-off task can't strand the limiter the way a `clear()`ed event could.
- Concurrent halts combine with `max()`, so a shorter backoff expiring no longer releases a longer halt (the issue's second effect).
- The deadline is set **before** the `max_retries` check, so the halt is also established when the `RetryAfter` is re-raised because retries are exhausted. This is a deliberate behavior change: with the default `max_retries=0`, the old code never called `clear()` at all, so the documented "will halt *all* requests for `retry_after` + 0.1 seconds" never actually happened for the default configuration. If you consider that out of scope for this PR, I can drop that part (and its test) — the core fix is independent of it.

One design point I want to flag rather than hide: a retrying request skips the halt-wait on its second and later attempts (`wait_for_halt=i == 0`), because its own backoff sleep already covered the halt it observed. This preserves the existing contract in `test_delay_all_pending_on_retry` (a retrying request proceeds right after its own sleep, even if another request extended the halt meanwhile). One could argue a retry should also wait out extensions; I kept the existing behavior and can change it if you prefer.

The `# noqa: ASYNC110` ("use an Event instead of sleep-in-a-while-loop") is intentional: the event is exactly what was broken here. The loop is not a poll — it sleeps precisely until the deadline, with one extra iteration only if the deadline moved while sleeping.

### Tests

Three new tests in `TestAIORateLimiter`, driving `process_request` directly (no network):

- `test_retry_after_not_released_by_concurrent_request` — the issue's main scenario; ~0.35s on `master`, ~1.15s (correct) with the fix
- `test_concurrent_retry_after_keeps_longest_halt` — the issue's second effect; ~0.7s on `master`, ~2.1s with the fix
- `test_retry_after_halts_also_when_reraised` — the `max_retries=0` case; ~0s on `master`, ~1.1s with the fix

All three fail on `master` and pass with the fix; the full `tests/ext/test_ratelimiter.py` suite passes (19 passed, 1 skipped) on Python 3.14, and `ruff check` / `ruff format` are clean.
